### PR TITLE
fix: Enable vendored OpenSSL for cross-compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1729,6 +1729,7 @@ dependencies = [
  "keyring",
  "miette",
  "miniz_oxide",
+ "openssl-sys",
  "proc-macro2",
  "quote",
  "regex",
@@ -3452,6 +3453,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
+name = "openssl-src"
+version = "300.5.0+3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8ce546f549326b0e6052b649198487d91320875da901e7bd11a06d1ee3f9c2f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3459,6 +3469,7 @@ checksum = "0a9f0075ba3c21b09f8e8b2026584b1d18d49388648f2fbbf3c97ea8deced8e2"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,8 @@ gcp_auth = { version = "0.12" }
 keyring = { version = "3", features = ["apple-native", "windows-native", "linux-native"] }
 # Required for rustls crypto provider (used by GCP SDKs)
 rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs", "std"] }
+# Required for cross-compilation - vendored OpenSSL builds from source
+openssl-sys = { version = "0.9", features = ["vendored"] }
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
## Summary
- Adds `openssl-sys` with `vendored` feature to fix cross-compilation failures
- Resolves missing OpenSSL development libraries error during ARM64 Linux builds

## Problem
The release workflow was failing when cross-compiling for `aarch64-unknown-linux-gnu` and `x86_64-unknown-linux-gnu` targets because OpenSSL development libraries weren't available for the target platforms.

The dependency chain is:
- fnox → Azure/Google Cloud SDKs → reqwest → native-tls → openssl-sys

## Solution
Enable the `vendored` feature for `openssl-sys`, which compiles OpenSSL from source instead of linking to system libraries. This makes cross-compilation self-contained and independent of system library availability.

## Test plan
- [x] Local build succeeds
- [ ] CI build succeeds for all targets

Fixes https://github.com/jdx/fnox/actions/runs/18640611588

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable vendored OpenSSL by adding `openssl-sys` with `vendored` feature; update lockfile to include `openssl-src`.
> 
> - **Dependencies**:
>   - Add `openssl-sys` with `vendored` feature in `Cargo.toml` to compile OpenSSL from source.
>   - Update `Cargo.lock` to include `openssl-src` and wire it into `openssl-sys`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c830f1a50d3d8eab1f9abf52909f15e85955d94b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->