### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.2.1](https://github.com/jdx/fnox/compare/v0.2.0..v0.2.1) - 2025-10-20
+
+### 🐛 Bug Fixes
+
+- Enable vendored OpenSSL for cross-compilation by [@jdx](https://github.com/jdx) in [#3](https://github.com/jdx/fnox/pull/3)
+
 ## [0.2.0](https://github.com/jdx/fnox/compare/v0.1.0..v0.2.0) - 2025-10-20
 
 ### 🚀 Features
@@ -16,6 +22,10 @@
 ### 🔍 Other Changes
 
 - Fix Bitwarden provider to use --session flag and close stdin by [@jdx](https://github.com/jdx) in [9dcfe86](https://github.com/jdx/fnox/commit/9dcfe86c4791c6f7cc4dcc9e5439c70a6b587c78)
+
+### New Contributors
+
+- @mise-en-dev made their first contribution in [#2](https://github.com/jdx/fnox/pull/2)
 
 ## [0.1.0] - 2025-10-20
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1701,7 +1701,7 @@ dependencies = [
 
 [[package]]
 name = "fnox"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "age",
  "anyhow",
@@ -3454,9 +3454,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-src"
-version = "300.5.0+3.5.0"
+version = "300.5.3+3.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8ce546f549326b0e6052b649198487d91320875da901e7bd11a06d1ee3f9c2f"
+checksum = "dc6bad8cd0233b63971e232cc9c5e83039375b8586d2312f31fda85db8f888c2"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fnox"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 authors = ["@jdx"]
 description = "A flexible secret management tool supporting multiple providers and encryption methods"


### PR DESCRIPTION
## [0.2.1](https://github.com/jdx/fnox/compare/v0.2.0..v0.2.1) - 2025-10-20

### 🐛 Bug Fixes

- Enable vendored OpenSSL for cross-compilation by [@jdx](https://github.com/jdx) in [#3](https://github.com/jdx/fnox/pull/3)