### PR TITLE
fix: Make vendored OpenSSL Linux-only to fix Windows builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1729,6 +1729,7 @@ dependencies = [
  "keyring",
  "miette",
  "miniz_oxide",
+ "openssl-sys",
  "proc-macro2",
  "quote",
  "regex",
@@ -3452,6 +3453,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
+name = "openssl-src"
+version = "300.5.0+3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8ce546f549326b0e6052b649198487d91320875da901e7bd11a06d1ee3f9c2f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3459,6 +3469,7 @@ checksum = "0a9f0075ba3c21b09f8e8b2026584b1d18d49388648f2fbbf3c97ea8deced8e2"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,8 @@ gcp_auth = { version = "0.12" }
 keyring = { version = "3", features = ["apple-native", "windows-native", "linux-native"] }
 # Required for rustls crypto provider (used by GCP SDKs)
 rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs", "std"] }
+# Required for cross-compilation - vendored OpenSSL builds from source
+openssl-sys = { version = "0.9", features = ["vendored"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,10 @@ gcp_auth = { version = "0.12" }
 keyring = { version = "3", features = ["apple-native", "windows-native", "linux-native"] }
 # Required for rustls crypto provider (used by GCP SDKs)
 rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs", "std"] }
-# Required for cross-compilation - vendored OpenSSL builds from source
+
+# Linux-specific dependencies for cross-compilation
+[target.'cfg(target_os = "linux")'.dependencies]
+# Vendored OpenSSL builds from source to support cross-compilation
 openssl-sys = { version = "0.9", features = ["vendored"] }
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary
- Moves `openssl-sys` vendored feature to Linux-only target-specific dependencies
- Fixes Windows build failures from PR #3

## Problem
PR #3 added vendored OpenSSL globally, which broke Windows builds because the Windows CI environment doesn't have the Perl modules required to compile OpenSSL from source:
```
Can't locate Locale/Maketext/Simple.pm in @INC
```

## Solution
Use Cargo's target-specific dependencies to only enable vendored OpenSSL on Linux:
```toml
[target.'cfg(target_os = "linux")'.dependencies]
openssl-sys = { version = "0.9", features = ["vendored"] }
```

This way:
- **Linux targets** use vendored OpenSSL for cross-compilation support ✅
- **Windows targets** use native-tls with system OpenSSL ✅
- **macOS targets** use native-tls with system OpenSSL ✅

## Test plan
- [x] Local macOS build succeeds
- [ ] CI builds succeed for all targets (Linux, Windows, macOS)

Fixes the Windows build error from the v0.2.0 release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Limit `openssl-sys` vendored builds to Linux using target-specific dependencies to avoid breaking Windows/macOS builds.
> 
> - **Build/Dependencies**:
>   - Add Linux-only target-specific dependency for `openssl-sys` with `features = ["vendored"]` in `Cargo.toml` to confine vendored OpenSSL to Linux.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24f6b3265affc9a44f4299abf9dd8656724e341a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->