### PR TITLE
chore: release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.2.2](https://github.com/jdx/fnox/compare/v0.2.1..v0.2.2) - 2025-10-20
+
+### 🐛 Bug Fixes
+
+- Clean up Azure CLI directory in test teardown by [@jdx](https://github.com/jdx) in [#5](https://github.com/jdx/fnox/pull/5)
+- Make vendored OpenSSL Linux-only to fix Windows builds by [@jdx](https://github.com/jdx) in [#6](https://github.com/jdx/fnox/pull/6)
+
 ## [0.2.1](https://github.com/jdx/fnox/compare/v0.2.0..v0.2.1) - 2025-10-20
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1701,7 +1701,7 @@ dependencies = [
 
 [[package]]
 name = "fnox"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "age",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fnox"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 authors = ["@jdx"]
 description = "A flexible secret management tool supporting multiple providers and encryption methods"


### PR DESCRIPTION
## [0.2.2](https://github.com/jdx/fnox/compare/v0.2.1..v0.2.2) - 2025-10-20

### 🐛 Bug Fixes

- Clean up Azure CLI directory in test teardown by [@jdx](https://github.com/jdx) in [#5](https://github.com/jdx/fnox/pull/5)
- Make vendored OpenSSL Linux-only to fix Windows builds by [@jdx](https://github.com/jdx) in [#6](https://github.com/jdx/fnox/pull/6)