### PR TITLE
chore: release v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.2.3](https://github.com/jdx/fnox/compare/v0.2.2..v0.2.3) - 2025-10-20
+
+### 🐛 Bug Fixes
+
+- Remove duplicate openssl-sys from main dependencies by [@jdx](https://github.com/jdx) in [8b4c8c7](https://github.com/jdx/fnox/commit/8b4c8c787a0c301c6d4a4910001c7515a5c4a6a4)
+
 ## [0.2.2](https://github.com/jdx/fnox/compare/v0.2.1..v0.2.2) - 2025-10-20
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1701,7 +1701,7 @@ dependencies = [
 
 [[package]]
 name = "fnox"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "age",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fnox"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2024"
 authors = ["@jdx"]
 description = "A flexible secret management tool supporting multiple providers and encryption methods"


### PR DESCRIPTION
## [0.2.3](https://github.com/jdx/fnox/compare/v0.2.2..v0.2.3) - 2025-10-20

### 🐛 Bug Fixes

- Remove duplicate openssl-sys from main dependencies by [@jdx](https://github.com/jdx) in [8b4c8c7](https://github.com/jdx/fnox/commit/8b4c8c787a0c301c6d4a4910001c7515a5c4a6a4)