### PR TITLE
feat(release): add macOS code signing to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,12 +50,19 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: rust-${{ matrix.target }}
+      - if: matrix.os == 'macos-latest'
+        uses: apple-actions/import-codesign-certs@v3
+        with:
+          p12-file-base64: ${{ secrets.CERTIFICATES_P12 }}
+          p12-password: ${{ secrets.CERTIFICATES_P12_PASS }}
       - uses: taiki-e/upload-rust-binary-action@v1
         with:
           bin: fnox
           target: ${{ matrix.target }}
           build-tool: ${{ matrix.build-tool }}
           token: ${{ secrets.FNOX_GH_TOKEN }}
+          codesign: "Developer ID Application: Jeffrey Dickey (4993Y37DX6)"
+          codesign_prefix: dev.jdx.
           dry-run: true # Always dry-run to just build without uploading
       - name: Upload binary artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- Add macOS code signing support to the release workflow
- Import Apple Developer ID certificate on macOS runners
- Sign binaries with Developer ID Application identity for both aarch64 and x86_64 macOS targets

## Changes
- Added `apple-actions/import-codesign-certs@v3` step to import certificates on macOS runners
- Added `codesign` and `codesign_prefix` parameters to `taiki-e/upload-rust-binary-action`
- Signing only runs for macOS builds via conditional check

## Required Secrets
This PR requires two GitHub repository secrets to be configured:
- `CERTIFICATES_P12` - Base64-encoded Apple Developer ID Application certificate (P12 file)
- `CERTIFICATES_P12_PASS` - Password for the P12 certificate

## Test Plan
- [ ] Verify workflow syntax passes validation (actionlint passed in pre-commit)
- [ ] After secrets are configured, test release workflow with a test tag
- [ ] Verify signed binaries work on macOS without Gatekeeper warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds macOS code signing to the release workflow by importing Apple certificates on macOS runners and signing binaries during upload.
> 
> - **Workflow: `/.github/workflows/release.yml`**
>   - **macOS code signing**:
>     - Import Apple certificates on macOS runners via `apple-actions/import-codesign-certs@v3` using `CERTIFICATES_P12` and `CERTIFICATES_P12_PASS`.
>     - Configure `taiki-e/upload-rust-binary-action@v1` with `codesign` (Developer ID identity) and `codesign_prefix` for macOS targets.
>   - Dry-run build and artifact upload behavior unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 63bf7e72848b75c3e4cd108fd498b6eab209bbba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->