### PR TITLE
chore: make the onepassword vault name optional

### DIFF
--- a/ONEPASSWORD.md
+++ b/ONEPASSWORD.md
@@ -33,6 +33,15 @@ Add the 1Password provider to your `fnox.toml`:
 ```toml
 [providers.onepass]
 type = "1password"
+```
+
+### With Vault Parameter
+
+If you want to specify a vault to allow for short hand syntax, add it to the provider configuration:
+
+```toml
+[providers.onepass]
+type = "1password"
 vault = "your-vault-name"
 ```
 
@@ -109,14 +118,14 @@ value = "api-credentials/api_key"  # Fetch specific field
 
 The `value` field supports three formats:
 
-1. **Item name only** - fetches the password field
+1. **Item name only** (requires `vault` in provider config) - fetches the password field
 
    ```toml
    value = "my-item"
    # Resolves to: op://vault/my-item/password
    ```
 
-2. **Item and field** - fetches a specific field
+2. **Item and field** (requires `vault` in provider config) - fetches a specific field
 
    ```toml
    value = "my-item/username"
@@ -229,6 +238,10 @@ Ensure your value follows one of these formats:
 - `"item-name"`
 - `"item-name/field-name"`
 - `"op://vault/item/field"`
+
+### "Unknown secret vault"
+
+Ensure you have the `vault` parameter set in your provider configuration, or use the full `op://` reference format.
 
 ## Testing
 

--- a/ONEPASSWORD.md
+++ b/ONEPASSWORD.md
@@ -37,7 +37,7 @@ type = "1password"
 
 ### With Vault Parameter
 
-If you want to specify a vault to allow for short hand syntax, add it to the provider configuration:
+If you want to specify a vault to allow for shorthand syntax, add it to the provider configuration:
 
 ```toml
 [providers.onepass]

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -229,10 +229,11 @@ impl InitCommand {
                 println!("   Requires: 1Password CLI (op) and a service account token");
                 println!("   Set token: export OP_SERVICE_ACCOUNT_TOKEN=<token>\n");
 
-                let vault = Input::new("Vault name:")
-                    .placeholder("my-vault")
+                let vault = Input::new("Vault name (optional):")
+                    .placeholder("")
                     .run()
-                    .map_err(|e| FnoxError::Config(format!("Wizard cancelled: {}", e)))?;
+                    .ok()
+                    .filter(|s| !s.is_empty());
 
                 let account = Input::new("Account (optional, e.g., my.1password.com):")
                     .placeholder("")

--- a/src/commands/provider/add.rs
+++ b/src/commands/provider/add.rs
@@ -34,7 +34,7 @@ impl AddCommand {
         // Create a template provider config based on type
         let provider_config = match self.provider_type {
             ProviderType::OnePassword => crate::config::ProviderConfig::OnePassword {
-                vault: "default".to_string(),
+                vault: Some("default".to_string()),
                 account: None,
             },
             ProviderType::Aws => crate::config::ProviderConfig::AwsSecretsManager {

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -35,7 +35,8 @@ pub enum ProviderConfig {
     #[serde(rename = "1password")]
     #[strum(serialize = "1password")]
     OnePassword {
-        vault: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        vault: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         account: Option<String>,
     },

--- a/src/providers/onepassword.rs
+++ b/src/providers/onepassword.rs
@@ -79,8 +79,17 @@ impl crate::providers::Provider for OnePasswordProvider {
             // Default field is "password" if not specified
             let parts: Vec<&str> = value.split('/').collect();
             match parts.len() {
-                1 => format!("op://{}/{}/password", self.vault.as_ref().unwrap(), parts[0]),
-                2 => format!("op://{}/{}/{}", self.vault.as_ref().unwrap(), parts[0], parts[1]),
+                1 => format!(
+                    "op://{}/{}/password",
+                    self.vault.as_ref().unwrap(),
+                    parts[0]
+                ),
+                2 => format!(
+                    "op://{}/{}/{}",
+                    self.vault.as_ref().unwrap(),
+                    parts[0],
+                    parts[1]
+                ),
                 _ => {
                     return Err(FnoxError::Provider(format!(
                         "Invalid secret reference format: '{}'. Expected 'item' or 'item/field'",

--- a/src/providers/onepassword.rs
+++ b/src/providers/onepassword.rs
@@ -79,8 +79,8 @@ impl crate::providers::Provider for OnePasswordProvider {
             // Default field is "password" if not specified
             let parts: Vec<&str> = value.split('/').collect();
             match parts.len() {
-                1 => format!("op://{:?}/{}/password", self.vault, parts[0]),
-                2 => format!("op://{:?}/{}/{}", self.vault, parts[0], parts[1]),
+                1 => format!("op://{}/{}/password", self.vault.as_ref().unwrap(), parts[0]),
+                2 => format!("op://{}/{}/{}", self.vault.as_ref().unwrap(), parts[0], parts[1]),
                 _ => {
                     return Err(FnoxError::Provider(format!(
                         "Invalid secret reference format: '{}'. Expected 'item' or 'item/field'",

--- a/src/providers/onepassword.rs
+++ b/src/providers/onepassword.rs
@@ -5,12 +5,12 @@ use std::process::Command;
 use std::{path::Path, sync::LazyLock};
 
 pub struct OnePasswordProvider {
-    vault: String,
+    vault: Option<String>,
     account: Option<String>,
 }
 
 impl OnePasswordProvider {
-    pub fn new(vault: String, account: Option<String>) -> Self {
+    pub fn new(vault: Option<String>, account: Option<String>) -> Self {
         Self { vault, account }
     }
 
@@ -64,22 +64,23 @@ impl OnePasswordProvider {
 #[async_trait]
 impl crate::providers::Provider for OnePasswordProvider {
     async fn get_secret(&self, value: &str, _key_file: Option<&Path>) -> Result<String> {
-        tracing::debug!(
-            "Getting secret '{}' from 1Password vault '{}'",
-            value,
-            self.vault
-        );
+        tracing::debug!("Getting secret '{}' from 1Password", value);
 
         // Check if value is already a full op:// reference
         let reference = if value.starts_with("op://") {
             value.to_string()
+        } else if self.vault.is_none() {
+            return Err(FnoxError::Provider(format!(
+                "Unknown secret vault for: '{}'. Expected value starting with 'op://' or a vault specified in the provider configuration.",
+                value
+            )));
         } else {
             // Parse value as "item/field" or just "item"
             // Default field is "password" if not specified
             let parts: Vec<&str> = value.split('/').collect();
             match parts.len() {
-                1 => format!("op://{}/{}/password", self.vault, parts[0]),
-                2 => format!("op://{}/{}/{}", self.vault, parts[0], parts[1]),
+                1 => format!("op://{:?}/{}/password", self.vault, parts[0]),
+                2 => format!("op://{:?}/{}/{}", self.vault, parts[0], parts[1]),
                 _ => {
                     return Err(FnoxError::Provider(format!(
                         "Invalid secret reference format: '{}'. Expected 'item' or 'item/field'",


### PR DESCRIPTION
Early warning note: this is my first ever Rust PR

This makes the 1password vault name optional. If you specify all of your secrets with the full `op://` reference then you're good. If you use a shorthand syntax and _do not_ include the `vault` property, then you get a new error. Documentation added and updated accordingly.

Fixes point 2 in https://github.com/jdx/fnox/discussions/10

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make 1Password vault optional; shorthand requires a configured vault, otherwise use full op://; update wizard, config schema, error handling, and docs.
> 
> - **1Password provider**:
>   - Make `vault` optional; build `op://` refs only when `vault` is set, otherwise error if shorthand (`item` or `item/field`) is used.
>   - Improved error and debug messages; enforce format validation.
> - **Config/schema**:
>   - `ProviderConfig::OnePassword` now uses `vault: Option<String>` (skips serialization when None).
>   - Provider factory updated to pass optional `vault` to `OnePasswordProvider`.
> - **CLI setup**:
>   - Init wizard: prompt "Vault name (optional)" and store as optional; account remains optional.
>   - `provider add`: template sets `vault: Some("default")` for 1Password.
> - **Docs** (`ONEPASSWORD.md`):
>   - Add basic config without `vault`; clarify shorthand formats require `vault` in provider config; add troubleshooting for "Unknown secret vault".
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39550d2304ead2a49089055c3af93b21adbf725c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->