### PR TITLE
fix: do not require OP_SERVICE_ACCOUNT_TOKEN for 1password

### DIFF
--- a/src/providers/onepassword.rs
+++ b/src/providers/onepassword.rs
@@ -7,9 +7,8 @@ use std::{path::Path, sync::LazyLock};
 
 /// Precompiled regex to remove leading error prefixes from stderr output of `op`.
 /// [ERROR] YYYY/MM/DD HH:MM:SS message
-static ERROR_PREFIX_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(?m)^\[ERROR\] \d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2} ").unwrap()
-});
+static ERROR_PREFIX_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?m)^\[ERROR\] \d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2} ").unwrap());
 
 pub struct OnePasswordProvider {
     vault: String,

--- a/src/providers/onepassword.rs
+++ b/src/providers/onepassword.rs
@@ -8,7 +8,7 @@ use std::{path::Path, sync::LazyLock};
 /// Precompiled regex to remove leading error prefixes from stderr output of `op`.
 /// [ERROR] YYYY/MM/DD HH:MM:SS message
 static ERROR_PREFIX_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(?m)^\[ERROR\]\s\d{4}/\d{2}/\d{2}\s\d{2}:\d{2}:\d{2}\s").unwrap()
+    Regex::new(r"(?m)^\[ERROR\] \d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2} ").unwrap()
 });
 
 pub struct OnePasswordProvider {

--- a/src/providers/onepassword.rs
+++ b/src/providers/onepassword.rs
@@ -1,8 +1,15 @@
 use crate::env;
 use crate::error::{FnoxError, Result};
 use async_trait::async_trait;
+use regex::Regex;
 use std::process::Command;
 use std::{path::Path, sync::LazyLock};
+
+/// Precompiled regex to remove leading error prefixes from stderr output of `op`.
+/// [ERROR] YYYY/MM/DD HH:MM:SS message
+static ERROR_PREFIX_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?m)^\[ERROR\]\s\d{4}/\d{2}/\d{2}\s\d{2}:\d{2}:\d{2}\s").unwrap()
+});
 
 pub struct OnePasswordProvider {
     vault: String,
@@ -25,8 +32,6 @@ impl OnePasswordProvider {
                 token.len()
             );
             cmd.env("OP_SERVICE_ACCOUNT_TOKEN", token);
-        } else {
-            tracing::warn!("OP_SERVICE_ACCOUNT_TOKEN not found in environment");
         }
         cmd.args(args);
 
@@ -47,10 +52,12 @@ impl OnePasswordProvider {
         })?;
 
         if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
+            let cow = String::from_utf8_lossy(&output.stderr);
+            let replaced = ERROR_PREFIX_RE.replace_all(&cow, "");
+
             return Err(FnoxError::Provider(format!(
                 "1Password CLI command failed: {}",
-                stderr.trim()
+                replaced.trim(),
             )));
         }
 
@@ -93,6 +100,17 @@ impl crate::providers::Provider for OnePasswordProvider {
 
         // Use 'op read' to fetch the secret
         self.execute_op_command(&["read", &reference])
+    }
+
+    async fn test_connection(&self) -> Result<()> {
+        tracing::debug!("Testing connection to 1Password");
+
+        // Try to get the current user as a basic connectivity test
+        let output = self.execute_op_command(&["whoami"])?;
+
+        tracing::debug!("1Password whoami output: {}", output);
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Early warning note: this is my ~first~ second ever Rust PR

This removes the warning message about not having `OP_SERVICE_ACCOUNT_TOKEN` set, as you can still authenticate with `op` interactive.

To deal with this a bit better, I added a connection test that does `op whoami` to ensure things work.

Fixes point 1 in https://github.com/jdx/fnox/discussions/10

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables 1Password usage without OP_SERVICE_ACCOUNT_TOKEN, adds an `op whoami` connectivity check, and strips noisy error prefixes from `op` stderr.
> 
> - **OnePassword provider**:
>   - Allow interactive auth by removing the warning/requirement for `OP_SERVICE_ACCOUNT_TOKEN` (still used if present).
>   - Add `test_connection` that runs `op whoami` to verify connectivity.
>   - Clean up `op` error messages by stripping `[ERROR] YYYY/MM/DD HH:MM:SS` prefixes via a precompiled regex.
>   - Improve error handling in `execute_op_command` to return sanitized stderr.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ad278080e453c6f669e2de665552a3fe84c68f4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->