### PR TITLE
fix: expand tilde (~) in FNOX_AGE_KEY_FILE path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1738,6 +1738,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "shellexpand",
  "strum",
  "tabled",
  "tempfile",
@@ -4727,6 +4728,15 @@ name = "shell-words"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
+name = "shellexpand"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1fdf65dd6331831494dd616b30351c38e96e45921a27745cf98490458b90bb"
+dependencies = [
+ "dirs",
+]
 
 [[package]]
 name = "shlex"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ rmp-serde = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
+shellexpand = "3"
 strum = { version = "0.27", features = ["derive"] }
 tabled = {version = "0.20", features = ["ansi"]}
 terminal_size = "0.4"

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -93,10 +93,7 @@ impl Settings {
 
     /// Expand tilde (~) in path strings to the user's home directory
     fn expand_path(path: &str) -> std::path::PathBuf {
-        match shellexpand::tilde(path) {
-            std::borrow::Cow::Borrowed(s) => s.into(),
-            std::borrow::Cow::Owned(s) => s.into(),
-        }
+        shellexpand::tilde(path).into_owned().into()
     }
 
     /// Collect settings from environment variables

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -91,6 +91,14 @@ impl Settings {
         Ok(Self::merge_settings(&defaults, &env_map, &cli_map))
     }
 
+    /// Expand tilde (~) in path strings to the user's home directory
+    fn expand_path(path: &str) -> std::path::PathBuf {
+        match shellexpand::tilde(path) {
+            std::borrow::Cow::Borrowed(s) => s.into(),
+            std::borrow::Cow::Owned(s) => s.into(),
+        }
+    }
+
     /// Collect settings from environment variables
     fn collect_env_map() -> Result<SourceMap> {
         let mut map = SourceMap::new();
@@ -106,10 +114,10 @@ impl Settings {
                             map.insert(setting_name, SettingValue::OptionString(Some(val)));
                         }
                         "path" => {
-                            map.insert(setting_name, SettingValue::Path(val.into()));
+                            map.insert(setting_name, SettingValue::Path(Self::expand_path(&val)));
                         }
                         "option<path>" => {
-                            map.insert(setting_name, SettingValue::OptionPath(Some(val.into())));
+                            map.insert(setting_name, SettingValue::OptionPath(Some(Self::expand_path(&val))));
                         }
                         "bool" => {
                             // Parse bool from env var (accept "true", "1", "yes", "on")
@@ -257,5 +265,17 @@ mod tests {
         );
         // Default profile should remain
         assert_eq!(merged.profile, "default");
+    }
+
+    #[test]
+    fn test_expand_path_with_tilde() {
+        // Test tilde expansion
+        let expanded = Settings::expand_path("~/test/path");
+        let home = dirs::home_dir().unwrap();
+        assert_eq!(expanded, home.join("test/path"));
+
+        // Test without tilde (should remain unchanged)
+        let expanded = Settings::expand_path("/absolute/path");
+        assert_eq!(expanded, std::path::PathBuf::from("/absolute/path"));
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -114,7 +114,10 @@ impl Settings {
                             map.insert(setting_name, SettingValue::Path(Self::expand_path(&val)));
                         }
                         "option<path>" => {
-                            map.insert(setting_name, SettingValue::OptionPath(Some(Self::expand_path(&val))));
+                            map.insert(
+                                setting_name,
+                                SettingValue::OptionPath(Some(Self::expand_path(&val))),
+                            );
                         }
                         "bool" => {
                             // Parse bool from env var (accept "true", "1", "yes", "on")


### PR DESCRIPTION
## Summary
Fixes an issue where `FNOX_AGE_KEY_FILE` environment variable does not expand the tilde (`~`) character to the user's home directory.

## Problem
When setting `FNOX_AGE_KEY_FILE=~/.age/key.txt`, the path was being treated as a literal string `"~/.age/key.txt"` instead of expanding to `/Users/username/.age/key.txt`, causing age decryption to fail with "file not found" errors.

## Solution
- Added the `shellexpand` crate (v3.1.1) to handle tilde expansion
- Created an `expand_path()` helper function in `settings.rs`
- Updated `collect_env_map()` to expand all path-type environment variables
- Added test to verify tilde expansion works correctly

## Changes
- `Cargo.toml`: Added `shellexpand = "3"` dependency
- `src/settings.rs`: 
  - Added `expand_path()` helper function (line 95-100)
  - Updated path handling in `collect_env_map()` (lines 117, 120)
  - Added `test_expand_path_with_tilde()` test (lines 270-280)

## Testing
- ✅ New unit test passes: `cargo test settings::tests::test_expand_path_with_tilde`
- ✅ Verifies both tilde expansion and absolute path preservation

## Example
```bash
# Before: Would fail with "file not found"
export FNOX_AGE_KEY_FILE=~/.age/key.txt
fnox get MY_SECRET

# After: Works correctly, expands to /Users/username/.age/key.txt
export FNOX_AGE_KEY_FILE=~/.age/key.txt
fnox get MY_SECRET
```

Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expand `~` in path-type env settings using `shellexpand`, with tests added.
> 
> - **Settings**:
>   - Expand `~` in environment `path` and `option<path>` values via `shellexpand::tilde` using new `Settings::expand_path`, applied in `collect_env_map`.
>   - Add unit test `test_expand_path_with_tilde` verifying tilde expansion and absolute path preservation.
> - **Dependencies**:
>   - Add `shellexpand = "3"` to `Cargo.toml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f3e2b0a157f3b45fb67e0a1eaf4296c79e028c51. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->