### PR TITLE
ci: skip age setup and redact tests for fork PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,10 @@ jobs:
       - name: Build
         run: cargo build
       - name: Setup age key for fnox
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         run: mkdir -p ~/.config/fnox && echo "${{ secrets.AGE_SECRET }}" > ~/.config/fnox/age.txt
       - name: Redact secrets in CI output
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         run: |
           fnox ci-redact
           # shellcheck disable=SC2016
@@ -91,8 +93,10 @@ jobs:
       - name: Build
         run: cargo build
       - name: Setup age key for fnox
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         run: mkdir -p ~/.config/fnox && echo "${{ secrets.AGE_SECRET }}" > ~/.config/fnox/age.txt
       - name: Redact secrets in CI output
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         run: |
           fnox ci-redact
           # shellcheck disable=SC2016


### PR DESCRIPTION
## Summary
In fork PRs, GitHub Actions doesn't provide access to secrets for security reasons. This causes the workflow to fail when trying to setup the age key and run the ci-redact test.

## Changes
This PR adds conditional guards to skip the following steps when the PR is from a fork:
- Setup age key for fnox
- Redact secrets in CI output

The conditions check:
1. If it's not a pull_request event (direct pushes to main), run the steps
2. If it's a pull_request AND the head repo matches the base repo (not a fork), run the steps
3. If it's a pull_request from a fork, skip the steps

## Test Plan
- Fork PRs will now skip the age setup and redact test steps
- Non-fork PRs and direct pushes will continue to run these steps as before
- All other tests will continue to run normally for fork PRs

Fixes https://github.com/jdx/fnox/actions/runs/18806407122/job/53695542849

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add conditional guards to skip age key setup and secret redaction steps for fork pull requests in CI.
> 
> - **CI Workflow (`.github/workflows/ci.yml`)**:
>   - **macOS `ci-macos` and Ubuntu `ci-ubuntu` jobs**:
>     - Add conditional `if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository` to:
>       - `Setup age key for fnox`
>       - `Redact secrets in CI output`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc761a6efb323b3290a8a1650e0222808075eaca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->