### PR TITLE
fix: default to warn instead of error for missing secrets

### DIFF
--- a/CRUSH.md
+++ b/CRUSH.md
@@ -167,6 +167,31 @@ mise run test:bats -- test/bitwarden.bats
 - Each profile can have its own providers and encryption
 - Environment variable: `FNOX_PROFILE`
 
+### Secret Configuration
+
+Secrets support an `if_missing` field to control behavior when a secret cannot be resolved:
+
+```toml
+[secrets.MY_SECRET]
+provider = "age"
+value = "..."
+if_missing = "warn"  # Options: "error", "warn", "ignore"
+```
+
+**Default behavior**: When `if_missing` is not specified, fnox defaults to `"warn"`. This means:
+
+- Missing secrets will print a warning message
+- Commands will continue execution (useful for CI environments where some secrets may not be available)
+- The secret will not be set in the environment
+
+**Available options**:
+
+- `"error"` - Fail the command if the secret cannot be resolved (use for required secrets)
+- `"warn"` - Print a warning and continue (default, useful for optional secrets)
+- `"ignore"` - Silently skip the secret if it cannot be resolved
+
+**Example use case**: In forked PRs, CI environments don't have access to secrets. Using `if_missing = "warn"` (or omitting it for the default) allows tests to run without failing on missing secrets.
+
 ### CLI Flags
 
 - `-p, --profile` for profile selection

--- a/mise.toml
+++ b/mise.toml
@@ -30,6 +30,12 @@ description = "Run bats tests only"
 depends = ["build"]
 run = "fnox exec -- bats --jobs 4 --no-parallelize-within-files {{arg(name='test', var=true, default='test')}}"
 
+[tasks."test:bats:fork"]
+description = "Run bats tests simulating forked PR (no age key access)"
+depends = ["build"]
+env = { FNOX_AGE_KEY = "/tmp/nonexistent-age-key.txt" }
+run = "fnox exec -- bats --jobs 4 --no-parallelize-within-files {{arg(name='test', var=true, default='test')}}"
+
 [tasks.cargo-test]
 description = "Run cargo tests only"
 run = "cargo test"

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -55,11 +55,12 @@ impl ExecCommand {
                     cmd.env(key, value);
                 }
                 Ok(None) => {
-                    // Secret not found, ignore
+                    // Secret not found, already handled by resolve_secret
                 }
                 Err(e) => {
                     eprintln!("Error resolving secret '{}': {}", key, e);
-                    if matches!(secret_config.if_missing, Some(IfMissing::Error) | None) {
+                    // Only fail if explicitly marked as required
+                    if matches!(secret_config.if_missing, Some(IfMissing::Error)) {
                         return Err(e);
                     }
                 }

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -62,12 +62,12 @@ impl ExecCommand {
                     // Respect if_missing to decide whether to fail or continue
                     match secret_config.if_missing {
                         Some(IfMissing::Error) => {
-                            eprintln!("Error resolving secret '{}': {}", key, e);
+                            tracing::error!("Error resolving secret '{}': {}", key, e);
                             return Err(e);
                         }
                         Some(IfMissing::Warn) | None => {
                             // Default (None) is Warn
-                            eprintln!("Warning: Error resolving secret '{}': {}", key, e);
+                            tracing::warn!("Error resolving secret '{}': {}", key, e);
                         }
                         Some(IfMissing::Ignore) => {
                             // Silently skip

--- a/src/commands/export.rs
+++ b/src/commands/export.rs
@@ -145,11 +145,12 @@ impl ExportCommand {
 
         // Handle missing secrets
         match secret_config.if_missing {
-            Some(crate::config::IfMissing::Error) | None => Err(FnoxError::Config(format!(
+            Some(crate::config::IfMissing::Error) => Err(FnoxError::Config(format!(
                 "Secret '{}' not found and no default provided",
                 key
             ))),
-            Some(crate::config::IfMissing::Warn) => {
+            Some(crate::config::IfMissing::Warn) | None => {
+                // Default to warn when if_missing is not specified
                 eprintln!(
                     "Warning: Secret '{}' not found and no default provided",
                     key

--- a/src/commands/export.rs
+++ b/src/commands/export.rs
@@ -1,8 +1,7 @@
 use crate::commands::Cli;
-use crate::config::{Config, SecretConfig};
-use crate::env;
-use crate::error::{FnoxError, Result};
-use crate::providers::get_provider;
+use crate::config::Config;
+use crate::error::Result;
+use crate::secret_resolver::resolve_secret;
 use clap::{Args, ValueEnum};
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
@@ -55,14 +54,19 @@ impl ExportCommand {
         tracing::debug!("Exporting secrets from profile '{}'", profile);
 
         let profile_secrets = config.get_secrets(&profile)?;
-        let providers = config.get_providers(&profile);
 
         let mut secrets = IndexMap::new();
 
         for (key, secret_config) in profile_secrets {
-            let value = self
-                .resolve_secret_value(key, secret_config, &providers)
-                .await?;
+            // Use centralized secret resolver for consistent priority order
+            let value = resolve_secret(
+                &config,
+                &profile,
+                key,
+                secret_config,
+                cli.age_key_file.as_deref(),
+            )
+            .await?;
             if let Some(value) = value {
                 secrets.insert(key.clone(), value);
             }
@@ -96,69 +100,6 @@ impl ExportCommand {
         }
 
         Ok(())
-    }
-
-    async fn resolve_secret_value(
-        &self,
-        key: &str,
-        secret_config: &SecretConfig,
-        providers: &IndexMap<String, crate::config::ProviderConfig>,
-    ) -> Result<Option<String>> {
-        // Check provider first
-        if let Some(ref provider_name) = secret_config.provider {
-            let provider_config = providers.get(provider_name).ok_or_else(|| {
-                miette::miette!(
-                    "Provider '{}' not found for secret '{}'",
-                    provider_name,
-                    key
-                )
-            })?;
-
-            if let Some(provider_value) = &secret_config.value {
-                let provider = get_provider(provider_config)?;
-                let value = provider.get_secret(provider_value, None).await?;
-                return Ok(Some(value));
-            } else {
-                tracing::warn!(
-                    "Provider '{}' specified for secret '{}' but no value provided",
-                    provider_name,
-                    key
-                );
-                return Ok(None);
-            }
-        }
-
-        // Check direct value
-        if let Some(value) = &secret_config.value {
-            return Ok(Some(value.clone()));
-        }
-
-        // Check current environment variable
-        if let Ok(env_value) = env::var(key) {
-            return Ok(Some(env_value));
-        }
-
-        // Use default value
-        if let Some(default) = &secret_config.default {
-            return Ok(Some(default.clone()));
-        }
-
-        // Handle missing secrets
-        match secret_config.if_missing {
-            Some(crate::config::IfMissing::Error) => Err(FnoxError::Config(format!(
-                "Secret '{}' not found and no default provided",
-                key
-            ))),
-            Some(crate::config::IfMissing::Warn) | None => {
-                // Default to warn when if_missing is not specified
-                eprintln!(
-                    "Warning: Secret '{}' not found and no default provided",
-                    key
-                );
-                Ok(None)
-            }
-            Some(crate::config::IfMissing::Ignore) => Ok(None),
-        }
     }
 
     fn export_as_env(&self, data: &ExportData) -> Result<String> {

--- a/src/secret_resolver.rs
+++ b/src/secret_resolver.rs
@@ -81,11 +81,12 @@ async fn try_resolve_from_provider(
 
 fn handle_missing_secret(key: &str, secret_config: &SecretConfig) -> Result<Option<String>> {
     match secret_config.if_missing {
-        Some(IfMissing::Error) | None => Err(FnoxError::Config(format!(
+        Some(IfMissing::Error) => Err(FnoxError::Config(format!(
             "Secret '{}' not found and no default provided",
             key
         ))),
-        Some(IfMissing::Warn) => {
+        Some(IfMissing::Warn) | None => {
+            // Default to warn when if_missing is not specified
             eprintln!(
                 "Warning: Secret '{}' not found and no default provided",
                 key

--- a/test/default_provider.bats
+++ b/test/default_provider.bats
@@ -220,6 +220,7 @@ EOF
 
 @test "profile with no providers (and no global providers) returns error" {
     # Create config with profile that has no providers
+    # Set if_missing = "error" to require the secret
     cat > fnox.toml << 'EOF'
 root = true
 
@@ -228,7 +229,7 @@ root = true
 [profiles.test]
 
 [profiles.test.secrets]
-MY_SECRET = { description = "test secret" }
+MY_SECRET = { description = "test secret", if_missing = "error" }
 EOF
 
     # Should fail because profile has no providers and secret has no value

--- a/test/exec_if_missing.bats
+++ b/test/exec_if_missing.bats
@@ -1,0 +1,93 @@
+#!/usr/bin/env bats
+
+load 'test_helper/common_setup'
+
+setup() {
+    _common_setup
+}
+
+@test "fnox exec with if_missing=error fails on missing secret" {
+    cat > fnox.toml << 'TOML'
+root = true
+
+[providers.age]
+type = "age"
+recipients = ["age1cdk0klj88zzhg0ncfhe4ul9ja5k58w2st3fpkhmy0f46vlsuh5wq0s0gr9"]
+
+[secrets.MY_SECRET]
+provider = "age"
+value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaaTFhczNBYnN3S1c0NjZwZnlDN2NUMTVaSTFXd2k1OWhnWUJvckVxYmh3CjNRSmhxSWJiYXU3eHoyNlcyOVVLRWNnUlFJeFBjL2N0YlA5K2hUaU04VDQKLS0tIGN6UVYzMHZJUUhKNmlkQjFOaXRXYUpjbzBOaHRMZkFFVVRPa3FaQUs2dHcKf3AcueEBLdl8lzRwKXik+OvDVg48g44QoPZu0j0NLV4lPLDqoq0="
+if_missing = "error"
+TOML
+
+    # Set invalid age key to trigger error
+    export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
+
+    run "$FNOX_BIN" exec -- echo "should not run"
+    assert_failure
+}
+
+@test "fnox exec with if_missing=warn continues on missing secret" {
+    cat > fnox.toml << 'TOML'
+root = true
+
+[providers.age]
+type = "age"
+recipients = ["age1cdk0klj88zzhg0ncfhe4ul9ja5k58w2st3fpkhmy0f46vlsuh5wq0s0gr9"]
+
+[secrets.MY_SECRET]
+provider = "age"
+value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaaTFhczNBYnN3S1c0NjZwZnlDN2NUMTVaSTFXd2k1OWhnWUJvckVxYmh3CjNRSmhxSWJiYXU3eHoyNlcyOVVLRWNnUlFJeFBjL2N0YlA5K2hUaU04VDQKLS0tIGN6UVYzMHZJUUhKNmlkQjFOaXRXYUpjbzBOaHRMZkFFVVRPa3FaQUs2dHcKf3AcueEBLdl8lzRwKXik+OvDVg48g44QoPZu0j0NLV4lPLDqoq0="
+if_missing = "warn"
+TOML
+
+    # Set invalid age key to trigger error
+    export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
+
+    run "$FNOX_BIN" exec -- echo "command succeeded"
+    assert_success
+    assert_output --partial "command succeeded"
+}
+
+@test "fnox exec with default if_missing (warn) continues on missing secret" {
+    cat > fnox.toml << 'TOML'
+root = true
+
+[providers.age]
+type = "age"
+recipients = ["age1cdk0klj88zzhg0ncfhe4ul9ja5k58w2st3fpkhmy0f46vlsuh5wq0s0gr9"]
+
+[secrets.MY_SECRET]
+provider = "age"
+value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaaTFhczNBYnN3S1c0NjZwZnlDN2NUMTVaSTFXd2k1OWhnWUJvckVxYmh3CjNRSmhxSWJiYXU3eHoyNlcyOVVLRWNnUlFJeFBjL2N0YlA5K2hUaU04VDQKLS0tIGN6UVYzMHZJUUhKNmlkQjFOaXRXYUpjbzBOaHRMZkFFVVRPa3FaQUs2dHcKf3AcueEBLdl8lzRwKXik+OvDVg48g44QoPZu0j0NLV4lPLDqoq0="
+TOML
+
+    # Set invalid age key to trigger error
+    export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
+
+    run "$FNOX_BIN" exec -- echo "command succeeded"
+    assert_success
+    assert_output --partial "command succeeded"
+}
+
+@test "fnox exec with if_missing=ignore silently continues on missing secret" {
+    cat > fnox.toml << 'TOML'
+root = true
+
+[providers.age]
+type = "age"
+recipients = ["age1cdk0klj88zzhg0ncfhe4ul9ja5k58w2st3fpkhmy0f46vlsuh5wq0s0gr9"]
+
+[secrets.MY_SECRET]
+provider = "age"
+value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaaTFhczNBYnN3S1c0NjZwZnlDN2NUMTVaSTFXd2k1OWhnWUJvckVxYmh3CjNRSmhxSWJiYXU3eHoyNlcyOVVLRWNnUlFJeFBjL2N0YlA5K2hUaU04VDQKLS0tIGN6UVYzMHZJUUhKNmlkQjFOaXRXYUpjbzBOaHRMZkFFVVRPa3FaQUs2dHcKf3AcueEBLdl8lzRwKXik+OvDVg48g44QoPZu0j0NLV4lPLDqoq0="
+if_missing = "ignore"
+TOML
+
+    # Set invalid age key to trigger error
+    export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
+
+    run "$FNOX_BIN" exec -- echo "command succeeded"
+    assert_success
+    assert_output --partial "command succeeded"
+}

--- a/test/export_if_missing.bats
+++ b/test/export_if_missing.bats
@@ -1,0 +1,96 @@
+#!/usr/bin/env bats
+
+load 'test_helper/common_setup'
+
+setup() {
+    _common_setup
+}
+
+@test "fnox export with if_missing=error fails on missing secret" {
+    cat > fnox.toml << 'TOML'
+root = true
+
+[providers.age]
+type = "age"
+recipients = ["age1cdk0klj88zzhg0ncfhe4ul9ja5k58w2st3fpkhmy0f46vlsuh5wq0s0gr9"]
+
+[secrets.MY_SECRET]
+provider = "age"
+value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaaTFhczNBYnN3S1c0NjZwZnlDN2NUMTVaSTFXd2k1OWhnWUJvckVxYmh3CjNRSmhxSWJiYXU3eHoyNlcyOVVLRWNnUlFJeFBjL2N0YlA5K2hUaU04VDQKLS0tIGN6UVYzMHZJUUhKNmlkQjFOaXRXYUpjbzBOaHRMZkFFVVRPa3FaQUs2dHcKf3AcueEBLdl8lzRwKXik+OvDVg48g44QoPZu0j0NLV4lPLDqoq0="
+if_missing = "error"
+TOML
+
+    # Set invalid age key to trigger error
+    export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
+
+    run "$FNOX_BIN" export
+    assert_failure
+}
+
+@test "fnox export with if_missing=warn continues on missing secret" {
+    cat > fnox.toml << 'TOML'
+root = true
+
+[providers.age]
+type = "age"
+recipients = ["age1cdk0klj88zzhg0ncfhe4ul9ja5k58w2st3fpkhmy0f46vlsuh5wq0s0gr9"]
+
+[secrets.MY_SECRET]
+provider = "age"
+value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaaTFhczNBYnN3S1c0NjZwZnlDN2NUMTVaSTFXd2k1OWhnWUJvckVxYmh3CjNRSmhxSWJiYXU3eHoyNlcyOVVLRWNnUlFJeFBjL2N0YlA5K2hUaU04VDQKLS0tIGN6UVYzMHZJUUhKNmlkQjFOaXRXYUpjbzBOaHRMZkFFVVRPa3FaQUs2dHcKf3AcueEBLdl8lzRwKXik+OvDVg48g44QoPZu0j0NLV4lPLDqoq0="
+if_missing = "warn"
+TOML
+
+    # Set invalid age key to trigger error
+    export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
+
+    run "$FNOX_BIN" export
+    assert_success
+    # Should output env format even though secret failed to resolve
+    assert_output --partial "# Exported from profile: default"
+}
+
+@test "fnox export with default if_missing (warn) continues on missing secret" {
+    cat > fnox.toml << 'TOML'
+root = true
+
+[providers.age]
+type = "age"
+recipients = ["age1cdk0klj88zzhg0ncfhe4ul9ja5k58w2st3fpkhmy0f46vlsuh5wq0s0gr9"]
+
+[secrets.MY_SECRET]
+provider = "age"
+value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaaTFhczNBYnN3S1c0NjZwZnlDN2NUMTVaSTFXd2k1OWhnWUJvckVxYmh3CjNRSmhxSWJiYXU3eHoyNlcyOVVLRWNnUlFJeFBjL2N0YlA5K2hUaU04VDQKLS0tIGN6UVYzMHZJUUhKNmlkQjFOaXRXYUpjbzBOaHRMZkFFVVRPa3FaQUs2dHcKf3AcueEBLdl8lzRwKXik+OvDVg48g44QoPZu0j0NLV4lPLDqoq0="
+TOML
+
+    # Set invalid age key to trigger error
+    export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
+
+    run "$FNOX_BIN" export
+    assert_success
+    # Should output env format even though secret failed to resolve
+    assert_output --partial "# Exported from profile: default"
+}
+
+@test "fnox export with if_missing=ignore silently continues on missing secret" {
+    cat > fnox.toml << 'TOML'
+root = true
+
+[providers.age]
+type = "age"
+recipients = ["age1cdk0klj88zzhg0ncfhe4ul9ja5k58w2st3fpkhmy0f46vlsuh5wq0s0gr9"]
+
+[secrets.MY_SECRET]
+provider = "age"
+value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaaTFhczNBYnN3S1c0NjZwZnlDN2NUMTVaSTFXd2k1OWhnWUJvckVxYmh3CjNRSmhxSWJiYXU3eHoyNlcyOVVLRWNnUlFJeFBjL2N0YlA5K2hUaU04VDQKLS0tIGN6UVYzMHZJUUhKNmlkQjFOaXRXYUpjbzBOaHRMZkFFVVRPa3FaQUs2dHcKf3AcueEBLdl8lzRwKXik+OvDVg48g44QoPZu0j0NLV4lPLDqoq0="
+if_missing = "ignore"
+TOML
+
+    # Set invalid age key to trigger error
+    export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
+
+    run "$FNOX_BIN" export
+    assert_success
+    # Should output env format even though secret failed to resolve
+    assert_output --partial "# Exported from profile: default"
+}

--- a/test/secret_resolution_priority.bats
+++ b/test/secret_resolution_priority.bats
@@ -122,6 +122,7 @@ EOF
 
 @test "error when secret not found and no fallback" {
     # Create config with no provider, no default, no env var
+    # Set if_missing = "error" to require the secret
     cat > fnox.toml << 'EOF'
 root = true
 
@@ -129,6 +130,7 @@ root = true
 type = "plain"
 
 [secrets.MY_SECRET]
+if_missing = "error"
 EOF
 
     # Don't set env var - should error


### PR DESCRIPTION
When secrets cannot be resolved, fnox now defaults to warning instead of
failing. This is more suitable for CI environments (especially forked PRs)
where some secrets may not be available.

Changes:
- secret_resolver.rs: Default to Warn when if_missing is not specified
- exec.rs: Only fail on Error, not on missing if_missing field
- export.rs: Match the new default behavior
- CLAUDE.md: Document the new default behavior and available options
- Tests: Update tests that relied on default error behavior to explicitly set if_missing = "error"

Related: #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Defaults missing-secret handling to warn (continue) and unifies secret resolution in exec/export with full if_missing support, plus docs, tooling, and tests.
> 
> - **Core secret resolution**:
>   - Default `if_missing` (unset) now treated as `"warn"` in `src/secret_resolver.rs`.
>   - `src/commands/exec.rs` and `src/commands/export.rs` respect `if_missing` (`error`/`warn`/`ignore`) and route through `resolve_secret`.
> - **CLI behavior**:
>   - `export` uses centralized resolver; removed custom `resolve_secret_value`.
> - **Docs**:
>   - Add Secret Configuration docs in `CRUSH.md` detailing `if_missing` options and default.
> - **Tooling**:
>   - Add mise task `tasks."test:bats:fork"` to simulate forked PRs with no age key.
> - **Tests**:
>   - New: `test/exec_if_missing.bats`, `test/export_if_missing.bats`.
>   - Updates: adjust tests to set `if_missing = "error"` where failure is required.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ffae0f17946d2328376ab61300a4c8ba75741409. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->