### PR TITLE
feat: add global if_missing configuration with priority chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1563,6 +1563,101 @@ default = "info"
 if_missing = "warn"  # "error", "warn", or "ignore"
 ```
 
+### Handling Missing Secrets
+
+Control what happens when a secret can't be resolved using the `if_missing` setting. This is especially useful for CI environments or when some secrets are optional.
+
+#### Available Modes
+
+- `error` - Fail the command if a secret cannot be resolved (strictest)
+- `warn` - Print a warning and continue (default)
+- `ignore` - Silently skip missing secrets
+
+#### Priority Chain
+
+You can set `if_missing` at multiple levels. fnox uses the first match:
+
+1. **CLI flag** (highest priority): `--if-missing error`
+2. **Environment variable**: `FNOX_IF_MISSING=warn`
+3. **Secret-level config**: `[secrets.MY_SECRET]` with `if_missing = "error"`
+4. **Top-level config**: Global default for all secrets
+5. **Default**: `warn` (lowest priority)
+
+#### Examples
+
+**Per-secret configuration:**
+
+```toml
+# Critical secrets must exist (fail if missing)
+[secrets.DATABASE_URL]
+provider = "aws"
+value = "database-url"
+if_missing = "error"
+
+# Optional secrets (continue if missing)
+[secrets.ANALYTICS_KEY]
+provider = "aws"
+value = "analytics-key"
+if_missing = "ignore"
+```
+
+**Top-level default for all secrets:**
+
+```toml
+# Make all secrets strict by default
+if_missing = "error"
+
+[secrets.DATABASE_URL]
+provider = "age"
+value = "encrypted..."
+
+[secrets.API_KEY]
+provider = "age"
+value = "encrypted..."
+# ↑ Both inherit if_missing = "error"
+```
+
+**Runtime override with CLI:**
+
+```bash
+# Override config to be lenient (useful in CI with missing secrets)
+fnox exec --if-missing ignore -- npm test
+
+# Override to be strict (ensure all secrets are present)
+fnox exec --if-missing error -- ./deploy.sh
+```
+
+**Runtime override with environment variable:**
+
+```bash
+# Set globally for a session
+export FNOX_IF_MISSING=warn
+fnox exec -- npm start
+
+# Or inline
+FNOX_IF_MISSING=error fnox exec -- ./critical-task.sh
+```
+
+**CI/CD example:**
+
+```yaml
+# .github/workflows/test.yml
+name: Test
+on: [push]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run tests (some secrets may be missing in forks)
+        env:
+          FNOX_IF_MISSING: ignore # Don't fail on missing secrets in CI
+        run: |
+          fnox exec -- npm test
+```
+
 ### Import/Export
 
 Migrate from `.env` files:
@@ -1619,4 +1714,5 @@ fnox export --format toml > secrets.toml
 - `FNOX_CONFIG_DIR` - Config directory (default: `~/.config/fnox`)
 - `FNOX_AGE_KEY` - Age encryption key (alternative to file)
 - `FNOX_AGE_KEY_FILE` - Path to age key file
+- `FNOX_IF_MISSING` - Default behavior for missing secrets (`error`, `warn`, `ignore`)
 - `FNOX_SHELL_OUTPUT` - Shell integration output (`none`, `normal`, `debug`)

--- a/README.md
+++ b/README.md
@@ -1581,7 +1581,8 @@ You can set `if_missing` at multiple levels. fnox uses the first match:
 2. **Environment variable**: `FNOX_IF_MISSING=warn`
 3. **Secret-level config**: `[secrets.MY_SECRET]` with `if_missing = "error"`
 4. **Top-level config**: Global default for all secrets
-5. **Default**: `warn` (lowest priority)
+5. **Base default environment variable**: `FNOX_IF_MISSING_DEFAULT=error`
+6. **Default**: `warn` (lowest priority)
 
 #### Examples
 
@@ -1636,6 +1637,18 @@ fnox exec -- npm start
 
 # Or inline
 FNOX_IF_MISSING=error fnox exec -- ./critical-task.sh
+```
+
+**Set a base default behavior (when nothing is configured):**
+
+```bash
+# Change the default behavior when if_missing is not specified in config
+# Useful for setting strict or lenient defaults across all projects
+export FNOX_IF_MISSING_DEFAULT=error  # Strict: fail on missing secrets by default
+
+# This affects only secrets without explicit if_missing configuration
+# Config file settings (top-level or secret-level) will override this
+fnox exec -- ./my-app
 ```
 
 **CI/CD example:**
@@ -1714,5 +1727,6 @@ fnox export --format toml > secrets.toml
 - `FNOX_CONFIG_DIR` - Config directory (default: `~/.config/fnox`)
 - `FNOX_AGE_KEY` - Age encryption key (alternative to file)
 - `FNOX_AGE_KEY_FILE` - Path to age key file
-- `FNOX_IF_MISSING` - Default behavior for missing secrets (`error`, `warn`, `ignore`)
+- `FNOX_IF_MISSING` - Runtime override for missing secrets behavior (`error`, `warn`, `ignore`)
+- `FNOX_IF_MISSING_DEFAULT` - Base default for missing secrets when not configured (`error`, `warn`, `ignore`)
 - `FNOX_SHELL_OUTPUT` - Shell integration output (`none`, `normal`, `debug`)

--- a/settings.toml
+++ b/settings.toml
@@ -81,3 +81,26 @@ examples = [
   "FNOX_SHELL_OUTPUT=debug fnox activate zsh",
 ]
 since = "0.1.0"
+
+[if_missing]
+type = "string"
+default = "\"warn\""
+sources.cli = ["--if-missing"]
+sources.env = ["FNOX_IF_MISSING"]
+docs = """
+Default behavior when a secret cannot be resolved.
+
+Available modes:
+- "error" - Fail the command if a secret cannot be resolved
+- "warn" - Print a warning and continue (default when not specified)
+- "ignore" - Silently skip missing secrets
+
+This can be set at multiple levels with the following priority chain.
+
+Priority (highest to lowest): CLI flag > Environment > Secret level > Top-level config > Default (warn)
+"""
+examples = [
+  "fnox exec --if-missing error -- ./my-app",
+  "FNOX_IF_MISSING=ignore fnox exec -- ./my-app",
+]
+since = "1.1.0"

--- a/settings.toml
+++ b/settings.toml
@@ -83,8 +83,8 @@ examples = [
 since = "0.1.0"
 
 [if_missing]
-type = "string"
-default = "\"warn\""
+type = "option<string>"
+default = "None"
 sources.cli = ["--if-missing"]
 sources.env = ["FNOX_IF_MISSING"]
 docs = """

--- a/settings.toml
+++ b/settings.toml
@@ -88,19 +88,42 @@ default = "None"
 sources.cli = ["--if-missing"]
 sources.env = ["FNOX_IF_MISSING"]
 docs = """
-Default behavior when a secret cannot be resolved.
+Runtime override for if_missing behavior when a secret cannot be resolved.
 
 Available modes:
 - "error" - Fail the command if a secret cannot be resolved
-- "warn" - Print a warning and continue (default when not specified)
+- "warn" - Print a warning and continue
 - "ignore" - Silently skip missing secrets
 
-This can be set at multiple levels with the following priority chain.
+This overrides all config file settings. Use FNOX_IF_MISSING_DEFAULT to set the base default.
 
-Priority (highest to lowest): CLI flag > Environment > Secret level > Top-level config > Default (warn)
+Priority (highest to lowest): CLI flag > Environment > Secret level > Top-level config > FNOX_IF_MISSING_DEFAULT > Default (warn)
 """
 examples = [
   "fnox exec --if-missing error -- ./my-app",
   "FNOX_IF_MISSING=ignore fnox exec -- ./my-app",
+]
+since = "1.1.0"
+
+[if_missing_default]
+type = "option<string>"
+default = "None"
+sources.env = ["FNOX_IF_MISSING_DEFAULT"]
+docs = """
+Base default behavior when a secret cannot be resolved and not specified in config.
+
+Available modes:
+- "error" - Fail the command if a secret cannot be resolved
+- "warn" - Print a warning and continue (default)
+- "ignore" - Silently skip missing secrets
+
+This sets the fallback behavior when nothing is configured in fnox.toml.
+Config file settings (top-level or secret-level) override this.
+
+Priority (highest to lowest): CLI flag > FNOX_IF_MISSING > Secret level > Top-level config > FNOX_IF_MISSING_DEFAULT > Default (warn)
+"""
+examples = [
+  "export FNOX_IF_MISSING_DEFAULT=error  # Strict by default",
+  "export FNOX_IF_MISSING_DEFAULT=ignore  # Lenient by default",
 ]
 since = "1.1.0"

--- a/src/commands/ci_redact.rs
+++ b/src/commands/ci_redact.rs
@@ -84,22 +84,41 @@ impl CiRedactCommand {
                 }
                 Err(e) => {
                     // Provider error - respect if_missing to decide whether to fail or continue
-                    // Priority: CLI flag > Env var > Secret-level > Top-level config > Default
+                    // Priority: CLI flag > Env var > Secret-level > Top-level config > FNOX_IF_MISSING_DEFAULT > Default
                     let if_missing = Settings::try_get()
                         .ok()
                         .and_then(|s| {
                             // If Some(value), CLI or env var was explicitly set (highest priority)
-                            s.if_missing.as_ref().and_then(|value| {
+                            s.if_missing.as_ref().map(|value| {
                                 match value.to_lowercase().as_str() {
-                                    "error" => Some(IfMissing::Error),
-                                    "warn" => Some(IfMissing::Warn),
-                                    "ignore" => Some(IfMissing::Ignore),
-                                    _ => Some(IfMissing::Warn),
+                                    "error" => IfMissing::Error,
+                                    "warn" => IfMissing::Warn,
+                                    "ignore" => IfMissing::Ignore,
+                                    _ => IfMissing::Warn,
                                 }
                             })
                         })
                         .or(secret_config.if_missing)
                         .or(config.if_missing)
+                        .or_else(|| {
+                            // Check FNOX_IF_MISSING_DEFAULT (via Settings) as fallback
+                            Settings::try_get().ok().and_then(|s| {
+                                s.if_missing_default
+                                    .as_ref()
+                                    .map(|value| match value.to_lowercase().as_str() {
+                                        "error" => IfMissing::Error,
+                                        "warn" => IfMissing::Warn,
+                                        "ignore" => IfMissing::Ignore,
+                                        _ => {
+                                            eprintln!(
+                                                "Warning: Invalid FNOX_IF_MISSING_DEFAULT value '{}', using 'warn'",
+                                                value
+                                            );
+                                            IfMissing::Warn
+                                        }
+                                    })
+                            })
+                        })
                         .unwrap_or(IfMissing::Warn);
 
                     match if_missing {

--- a/src/commands/ci_redact.rs
+++ b/src/commands/ci_redact.rs
@@ -88,17 +88,15 @@ impl CiRedactCommand {
                     let if_missing = Settings::try_get()
                         .ok()
                         .and_then(|s| {
-                            if s.if_missing != "warn" {
-                                // User explicitly set it via CLI or env var
-                                match s.if_missing.to_lowercase().as_str() {
+                            // If Some(value), CLI or env var was explicitly set (highest priority)
+                            s.if_missing.as_ref().and_then(|value| {
+                                match value.to_lowercase().as_str() {
                                     "error" => Some(IfMissing::Error),
                                     "warn" => Some(IfMissing::Warn),
                                     "ignore" => Some(IfMissing::Ignore),
                                     _ => Some(IfMissing::Warn),
                                 }
-                            } else {
-                                None // Use config or default
-                            }
+                            })
                         })
                         .or(secret_config.if_missing)
                         .or(config.if_missing)

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -53,22 +53,35 @@ impl ExecCommand {
                 Err(e) => {
                     // Provider error (auth, network, missing secret, etc.)
                     // Respect if_missing to decide whether to fail or continue
-                    // Priority: CLI flag > Env var > Secret-level > Top-level config > Default
+                    // Priority: CLI > Env > Secret > Config > FNOX_IF_MISSING_DEFAULT > Default
                     let if_missing = Settings::try_get()
                         .ok()
                         .and_then(|s| {
                             // If Some(value), CLI or env var was explicitly set (highest priority)
-                            s.if_missing.as_ref().and_then(|value| {
-                                match value.to_lowercase().as_str() {
-                                    "error" => Some(IfMissing::Error),
-                                    "warn" => Some(IfMissing::Warn),
-                                    "ignore" => Some(IfMissing::Ignore),
-                                    _ => Some(IfMissing::Warn),
-                                }
-                            })
+                            s.if_missing
+                                .as_ref()
+                                .map(|value| match value.to_lowercase().as_str() {
+                                    "error" => IfMissing::Error,
+                                    "warn" => IfMissing::Warn,
+                                    "ignore" => IfMissing::Ignore,
+                                    _ => IfMissing::Warn,
+                                })
                         })
                         .or(secret_config.if_missing)
                         .or(config.if_missing)
+                        .or_else(|| {
+                            // Check FNOX_IF_MISSING_DEFAULT (via Settings) as fallback
+                            Settings::try_get().ok().and_then(|s| {
+                                s.if_missing_default.as_ref().map(|value| {
+                                    match value.to_lowercase().as_str() {
+                                        "error" => IfMissing::Error,
+                                        "warn" => IfMissing::Warn,
+                                        "ignore" => IfMissing::Ignore,
+                                        _ => IfMissing::Warn,
+                                    }
+                                })
+                            })
+                        })
                         .unwrap_or(IfMissing::Warn);
 
                     match if_missing {

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -1,6 +1,5 @@
 use crate::error::{FnoxError, Result};
-use crate::secret_resolver::resolve_secret;
-use crate::settings::Settings;
+use crate::secret_resolver::{resolve_if_missing_behavior, resolve_secret};
 use crate::{
     commands::Cli,
     config::{Config, IfMissing},
@@ -53,36 +52,7 @@ impl ExecCommand {
                 Err(e) => {
                     // Provider error (auth, network, missing secret, etc.)
                     // Respect if_missing to decide whether to fail or continue
-                    // Priority: CLI > Env > Secret > Config > FNOX_IF_MISSING_DEFAULT > Default
-                    let if_missing = Settings::try_get()
-                        .ok()
-                        .and_then(|s| {
-                            // If Some(value), CLI or env var was explicitly set (highest priority)
-                            s.if_missing
-                                .as_ref()
-                                .map(|value| match value.to_lowercase().as_str() {
-                                    "error" => IfMissing::Error,
-                                    "warn" => IfMissing::Warn,
-                                    "ignore" => IfMissing::Ignore,
-                                    _ => IfMissing::Warn,
-                                })
-                        })
-                        .or(secret_config.if_missing)
-                        .or(config.if_missing)
-                        .or_else(|| {
-                            // Check FNOX_IF_MISSING_DEFAULT (via Settings) as fallback
-                            Settings::try_get().ok().and_then(|s| {
-                                s.if_missing_default.as_ref().map(|value| {
-                                    match value.to_lowercase().as_str() {
-                                        "error" => IfMissing::Error,
-                                        "warn" => IfMissing::Warn,
-                                        "ignore" => IfMissing::Ignore,
-                                        _ => IfMissing::Warn,
-                                    }
-                                })
-                            })
-                        })
-                        .unwrap_or(IfMissing::Warn);
+                    let if_missing = resolve_if_missing_behavior(secret_config, &config);
 
                     match if_missing {
                         IfMissing::Error => {

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -57,17 +57,15 @@ impl ExecCommand {
                     let if_missing = Settings::try_get()
                         .ok()
                         .and_then(|s| {
-                            if s.if_missing != "warn" {
-                                // User explicitly set it via CLI or env var
-                                match s.if_missing.to_lowercase().as_str() {
+                            // If Some(value), CLI or env var was explicitly set (highest priority)
+                            s.if_missing.as_ref().and_then(|value| {
+                                match value.to_lowercase().as_str() {
                                     "error" => Some(IfMissing::Error),
                                     "warn" => Some(IfMissing::Warn),
                                     "ignore" => Some(IfMissing::Ignore),
                                     _ => Some(IfMissing::Warn),
                                 }
-                            } else {
-                                None // Use config or default
-                            }
+                            })
                         })
                         .or(secret_config.if_missing)
                         .or(config.if_missing)

--- a/src/commands/export.rs
+++ b/src/commands/export.rs
@@ -77,22 +77,41 @@ impl ExportCommand {
                 }
                 Err(e) => {
                     // Provider error - respect if_missing to decide whether to fail or continue
-                    // Priority: CLI flag > Env var > Secret-level > Top-level config > Default
+                    // Priority: CLI flag > Env var > Secret-level > Top-level config > FNOX_IF_MISSING_DEFAULT > Default
                     let if_missing = Settings::try_get()
                         .ok()
                         .and_then(|s| {
                             // If Some(value), CLI or env var was explicitly set (highest priority)
-                            s.if_missing.as_ref().and_then(|value| {
+                            s.if_missing.as_ref().map(|value| {
                                 match value.to_lowercase().as_str() {
-                                    "error" => Some(IfMissing::Error),
-                                    "warn" => Some(IfMissing::Warn),
-                                    "ignore" => Some(IfMissing::Ignore),
-                                    _ => Some(IfMissing::Warn),
+                                    "error" => IfMissing::Error,
+                                    "warn" => IfMissing::Warn,
+                                    "ignore" => IfMissing::Ignore,
+                                    _ => IfMissing::Warn,
                                 }
                             })
                         })
                         .or(secret_config.if_missing)
                         .or(config.if_missing)
+                        .or_else(|| {
+                            // Check FNOX_IF_MISSING_DEFAULT (via Settings) as fallback
+                            Settings::try_get().ok().and_then(|s| {
+                                s.if_missing_default
+                                    .as_ref()
+                                    .map(|value| match value.to_lowercase().as_str() {
+                                        "error" => IfMissing::Error,
+                                        "warn" => IfMissing::Warn,
+                                        "ignore" => IfMissing::Ignore,
+                                        _ => {
+                                            eprintln!(
+                                                "Warning: Invalid FNOX_IF_MISSING_DEFAULT value '{}', using 'warn'",
+                                                value
+                                            );
+                                            IfMissing::Warn
+                                        }
+                                    })
+                            })
+                        })
                         .unwrap_or(IfMissing::Warn);
 
                     match if_missing {

--- a/src/commands/export.rs
+++ b/src/commands/export.rs
@@ -2,6 +2,7 @@ use crate::commands::Cli;
 use crate::config::{Config, IfMissing};
 use crate::error::Result;
 use crate::secret_resolver::resolve_secret;
+use crate::settings::Settings;
 use clap::{Args, ValueEnum};
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
@@ -76,16 +77,35 @@ impl ExportCommand {
                 }
                 Err(e) => {
                     // Provider error - respect if_missing to decide whether to fail or continue
-                    match secret_config.if_missing {
-                        Some(IfMissing::Error) => {
+                    // Priority: CLI flag > Env var > Secret-level > Top-level config > Default
+                    let if_missing = Settings::try_get()
+                        .ok()
+                        .and_then(|s| {
+                            if s.if_missing != "warn" {
+                                // User explicitly set it via CLI or env var
+                                match s.if_missing.to_lowercase().as_str() {
+                                    "error" => Some(IfMissing::Error),
+                                    "warn" => Some(IfMissing::Warn),
+                                    "ignore" => Some(IfMissing::Ignore),
+                                    _ => Some(IfMissing::Warn),
+                                }
+                            } else {
+                                None // Use config or default
+                            }
+                        })
+                        .or(secret_config.if_missing)
+                        .or(config.if_missing)
+                        .unwrap_or(IfMissing::Warn);
+
+                    match if_missing {
+                        IfMissing::Error => {
                             tracing::error!("Error resolving secret '{}': {}", key, e);
                             return Err(e);
                         }
-                        Some(IfMissing::Warn) | None => {
-                            // Default (None) is Warn
+                        IfMissing::Warn => {
                             tracing::warn!("Error resolving secret '{}': {}", key, e);
                         }
-                        Some(IfMissing::Ignore) => {
+                        IfMissing::Ignore => {
                             // Silently skip
                         }
                     }

--- a/src/commands/export.rs
+++ b/src/commands/export.rs
@@ -81,17 +81,15 @@ impl ExportCommand {
                     let if_missing = Settings::try_get()
                         .ok()
                         .and_then(|s| {
-                            if s.if_missing != "warn" {
-                                // User explicitly set it via CLI or env var
-                                match s.if_missing.to_lowercase().as_str() {
+                            // If Some(value), CLI or env var was explicitly set (highest priority)
+                            s.if_missing.as_ref().and_then(|value| {
+                                match value.to_lowercase().as_str() {
                                     "error" => Some(IfMissing::Error),
                                     "warn" => Some(IfMissing::Warn),
                                     "ignore" => Some(IfMissing::Ignore),
                                     _ => Some(IfMissing::Warn),
                                 }
-                            } else {
-                                None // Use config or default
-                            }
+                            })
                         })
                         .or(secret_config.if_missing)
                         .or(config.if_missing)

--- a/src/commands/export.rs
+++ b/src/commands/export.rs
@@ -1,8 +1,7 @@
 use crate::commands::Cli;
 use crate::config::{Config, IfMissing};
 use crate::error::Result;
-use crate::secret_resolver::resolve_secret;
-use crate::settings::Settings;
+use crate::secret_resolver::{resolve_if_missing_behavior, resolve_secret};
 use clap::{Args, ValueEnum};
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
@@ -77,42 +76,7 @@ impl ExportCommand {
                 }
                 Err(e) => {
                     // Provider error - respect if_missing to decide whether to fail or continue
-                    // Priority: CLI flag > Env var > Secret-level > Top-level config > FNOX_IF_MISSING_DEFAULT > Default
-                    let if_missing = Settings::try_get()
-                        .ok()
-                        .and_then(|s| {
-                            // If Some(value), CLI or env var was explicitly set (highest priority)
-                            s.if_missing.as_ref().map(|value| {
-                                match value.to_lowercase().as_str() {
-                                    "error" => IfMissing::Error,
-                                    "warn" => IfMissing::Warn,
-                                    "ignore" => IfMissing::Ignore,
-                                    _ => IfMissing::Warn,
-                                }
-                            })
-                        })
-                        .or(secret_config.if_missing)
-                        .or(config.if_missing)
-                        .or_else(|| {
-                            // Check FNOX_IF_MISSING_DEFAULT (via Settings) as fallback
-                            Settings::try_get().ok().and_then(|s| {
-                                s.if_missing_default
-                                    .as_ref()
-                                    .map(|value| match value.to_lowercase().as_str() {
-                                        "error" => IfMissing::Error,
-                                        "warn" => IfMissing::Warn,
-                                        "ignore" => IfMissing::Ignore,
-                                        _ => {
-                                            eprintln!(
-                                                "Warning: Invalid FNOX_IF_MISSING_DEFAULT value '{}', using 'warn'",
-                                                value
-                                            );
-                                            IfMissing::Warn
-                                        }
-                                    })
-                            })
-                        })
-                        .unwrap_or(IfMissing::Warn);
+                    let if_missing = resolve_if_missing_behavior(secret_config, &config);
 
                     match if_missing {
                         IfMissing::Error => {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -49,6 +49,10 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub age_key_file: Option<PathBuf>,
 
+    /// What to do if a secret is missing (error, warn, ignore)
+    #[arg(long, global = true)]
+    pub if_missing: Option<String>,
+
     /// Disable colored output
     #[arg(long, global = true)]
     pub no_color: bool,

--- a/src/config.rs
+++ b/src/config.rs
@@ -42,6 +42,10 @@ pub struct Config {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub age_key_file: Option<PathBuf>,
 
+    /// Default if_missing behavior for all secrets in this config
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub if_missing: Option<IfMissing>,
+
     /// Track which config file each provider came from (not serialized)
     #[serde(skip)]
     pub provider_sources: HashMap<String, PathBuf>,
@@ -249,6 +253,11 @@ impl Config {
             merged.age_key_file = overlay.age_key_file;
         }
 
+        // Merge if_missing (overlay takes precedence)
+        if overlay.if_missing.is_some() {
+            merged.if_missing = overlay.if_missing;
+        }
+
         // Merge providers (overlay takes precedence)
         for (name, provider) in overlay.providers {
             merged.providers.insert(name, provider);
@@ -322,6 +331,7 @@ impl Config {
             secrets: IndexMap::new(),
             profiles: IndexMap::new(),
             age_key_file: None,
+            if_missing: None,
             provider_sources: HashMap::new(),
             secret_sources: HashMap::new(),
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,7 @@ async fn main() -> miette::Result<()> {
     settings::Settings::set_cli_snapshot(settings::CliSnapshot {
         age_key_file: cli.age_key_file.clone(),
         profile: cli.profile.clone(),
+        if_missing: cli.if_missing.clone(),
     });
 
     // Handle --no-color flag

--- a/src/secret_resolver.rs
+++ b/src/secret_resolver.rs
@@ -94,23 +94,21 @@ fn handle_missing_secret(
     let if_missing = Settings::try_get()
         .ok()
         .and_then(|s| {
-            if s.if_missing != "warn" {
-                // User explicitly set it via CLI or env var
-                match s.if_missing.to_lowercase().as_str() {
+            // If Some(value), CLI or env var was explicitly set (highest priority)
+            s.if_missing
+                .as_ref()
+                .and_then(|value| match value.to_lowercase().as_str() {
                     "error" => Some(IfMissing::Error),
                     "warn" => Some(IfMissing::Warn),
                     "ignore" => Some(IfMissing::Ignore),
                     _ => {
                         eprintln!(
                             "Warning: Invalid if_missing value '{}', using 'warn'",
-                            s.if_missing
+                            value
                         );
                         Some(IfMissing::Warn)
                     }
-                }
-            } else {
-                None // Use config or default
-            }
+                })
         })
         .or(secret_config.if_missing)
         .or(config.if_missing)

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -222,7 +222,7 @@ mod tests {
             age_key_file: None,
             profile: "default".to_string(),
             shell_integration_output: "normal".to_string(),
-            if_missing: "warn".to_string(),
+            if_missing: None,
         };
 
         let mut env = SourceMap::new();
@@ -252,7 +252,7 @@ mod tests {
             age_key_file: None,
             profile: "default".to_string(),
             shell_integration_output: "normal".to_string(),
-            if_missing: "warn".to_string(),
+            if_missing: None,
         };
 
         let mut env = SourceMap::new();

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -43,6 +43,7 @@ static INITIALIZED: LazyLock<Mutex<bool>> = LazyLock::new(|| Mutex::new(false));
 pub struct CliSnapshot {
     pub age_key_file: Option<std::path::PathBuf>,
     pub profile: Option<String>,
+    pub if_missing: Option<String>,
 }
 
 static CLI_SNAPSHOT: LazyLock<Mutex<Option<CliSnapshot>>> = LazyLock::new(|| Mutex::new(None));
@@ -149,6 +150,10 @@ impl Settings {
             if let Some(profile) = snapshot.profile {
                 map.insert("profile", SettingValue::String(profile));
             }
+
+            if let Some(if_missing) = snapshot.if_missing {
+                map.insert("if_missing", SettingValue::OptionString(Some(if_missing)));
+            }
         }
 
         map
@@ -217,6 +222,7 @@ mod tests {
             age_key_file: None,
             profile: "default".to_string(),
             shell_integration_output: "normal".to_string(),
+            if_missing: "warn".to_string(),
         };
 
         let mut env = SourceMap::new();
@@ -246,6 +252,7 @@ mod tests {
             age_key_file: None,
             profile: "default".to_string(),
             shell_integration_output: "normal".to_string(),
+            if_missing: "warn".to_string(),
         };
 
         let mut env = SourceMap::new();

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -223,6 +223,7 @@ mod tests {
             profile: "default".to_string(),
             shell_integration_output: "normal".to_string(),
             if_missing: None,
+            if_missing_default: None,
         };
 
         let mut env = SourceMap::new();
@@ -253,6 +254,7 @@ mod tests {
             profile: "default".to_string(),
             shell_integration_output: "normal".to_string(),
             if_missing: None,
+            if_missing_default: None,
         };
 
         let mut env = SourceMap::new();

--- a/test/if_missing_priority.bats
+++ b/test/if_missing_priority.bats
@@ -209,3 +209,52 @@ TOML
     run "$FNOX_BIN" exec -- echo "should not run"
     assert_failure
 }
+
+@test "fnox exec explicit --if-missing warn overrides config ignore" {
+    cat > fnox.toml << 'TOML'
+root = true
+if_missing = "ignore"
+
+[providers.age]
+type = "age"
+recipients = ["age1cdk0klj88zzhg0ncfhe4ul9ja5k58w2st3fpkhmy0f46vlsuh5wq0s0gr9"]
+
+[secrets.MY_SECRET]
+provider = "age"
+value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaaTFhczNBYnN3S1c0NjZwZnlDN2NUMTVaSTFXd2k1OWhnWUJvckVxYmh3CjNRSmhxSWJiYXU3eHoyNlcyOVVLRWNnUlFJeFBjL2N0YlA5K2hUaU04VDQKLS0tIGN6UVYzMHZJUUhKNmlkQjFOaXRXYUpjbzBOaHRMZkFFVVRPa3FaQUs2dHcKf3AcueEBLdl8lzRwKXik+OvDVg48g44QoPZu0j0NLV4lPLDqoq0="
+TOML
+
+    # Set invalid age key to trigger error
+    export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
+
+    # Should show warning because explicit --if-missing warn overrides config if_missing=ignore
+    run "$FNOX_BIN" exec --if-missing warn -- echo "command succeeded"
+    assert_success
+    assert_output --partial "command succeeded"
+    assert_output --partial "WARN"
+}
+
+@test "fnox exec explicit FNOX_IF_MISSING=warn overrides config ignore" {
+    cat > fnox.toml << 'TOML'
+root = true
+if_missing = "ignore"
+
+[providers.age]
+type = "age"
+recipients = ["age1cdk0klj88zzhg0ncfhe4ul9ja5k58w2st3fpkhmy0f46vlsuh5wq0s0gr9"]
+
+[secrets.MY_SECRET]
+provider = "age"
+value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaaTFhczNBYnN3S1c0NjZwZnlDN2NUMTVaSTFXd2k1OWhnWUJvckVxYmh3CjNRSmhxSWJiYXU3eHoyNlcyOVVLRWNnUlFJeFBjL2N0YlA5K2hUaU04VDQKLS0tIGN6UVYzMHZJUUhKNmlkQjFOaXRXYUpjbzBOaHRMZkFFVVRPa3FaQUs2dHcKf3AcueEBLdl8lzRwKXik+OvDVg48g44QoPZu0j0NLV4lPLDqoq0="
+TOML
+
+    # Set invalid age key to trigger error
+    export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
+    export FNOX_IF_MISSING="warn"
+
+    # Should show warning because explicit FNOX_IF_MISSING=warn overrides config if_missing=ignore
+    run "$FNOX_BIN" exec -- echo "command succeeded"
+    assert_success
+    assert_output --partial "command succeeded"
+    assert_output --partial "WARN"
+}

--- a/test/if_missing_priority.bats
+++ b/test/if_missing_priority.bats
@@ -258,3 +258,72 @@ TOML
     assert_output --partial "command succeeded"
     assert_output --partial "WARN"
 }
+
+@test "fnox exec with FNOX_IF_MISSING_DEFAULT=error fails on missing secret" {
+    cat > fnox.toml << 'TOML'
+root = true
+
+[providers.age]
+type = "age"
+recipients = ["age1cdk0klj88zzhg0ncfhe4ul9ja5k58w2st3fpkhmy0f46vlsuh5wq0s0gr9"]
+
+[secrets.MY_SECRET]
+provider = "age"
+value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaaTFhczNBYnN3S1c0NjZwZnlDN2NUMTVaSTFXd2k1OWhnWUJvckVxYmh3CjNRSmhxSWJiYXU3eHoyNlcyOVVLRWNnUlFJeFBjL2N0YlA5K2hUaU04VDQKLS0tIGN6UVYzMHZJUUhKNmlkQjFOaXRXYUpjbzBOaHRMZkFFVVRPa3FaQUs2dHcKf3AcueEBLdl8lzRwKXik+OvDVg48g44QoPZu0j0NLV4lPLDqoq0="
+TOML
+
+    # Set invalid age key to trigger error
+    export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
+    export FNOX_IF_MISSING_DEFAULT="error"
+
+    run "$FNOX_BIN" exec -- echo "should not run"
+    assert_failure
+}
+
+@test "fnox exec top-level config overrides FNOX_IF_MISSING_DEFAULT" {
+    cat > fnox.toml << 'TOML'
+root = true
+if_missing = "ignore"
+
+[providers.age]
+type = "age"
+recipients = ["age1cdk0klj88zzhg0ncfhe4ul9ja5k58w2st3fpkhmy0f46vlsuh5wq0s0gr9"]
+
+[secrets.MY_SECRET]
+provider = "age"
+value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaaTFhczNBYnN3S1c0NjZwZnlDN2NUMTVaSTFXd2k1OWhnWUJvckVxYmh3CjNRSmhxSWJiYXU3eHoyNlcyOVVLRWNnUlFJeFBjL2N0YlA5K2hUaU04VDQKLS0tIGN6UVYzMHZJUUhKNmlkQjFOaXRXYUpjbzBOaHRMZkFFVVRPa3FaQUs2dHcKf3AcueEBLdl8lzRwKXik+OvDVg48g44QoPZu0j0NLV4lPLDqoq0="
+TOML
+
+    # Set invalid age key to trigger error
+    export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
+    export FNOX_IF_MISSING_DEFAULT="error"
+
+    # Should succeed because config if_missing=ignore overrides FNOX_IF_MISSING_DEFAULT=error
+    run "$FNOX_BIN" exec -- echo "command succeeded"
+    assert_success
+    assert_output --partial "command succeeded"
+}
+
+@test "fnox exec FNOX_IF_MISSING overrides FNOX_IF_MISSING_DEFAULT" {
+    cat > fnox.toml << 'TOML'
+root = true
+
+[providers.age]
+type = "age"
+recipients = ["age1cdk0klj88zzhg0ncfhe4ul9ja5k58w2st3fpkhmy0f46vlsuh5wq0s0gr9"]
+
+[secrets.MY_SECRET]
+provider = "age"
+value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaaTFhczNBYnN3S1c0NjZwZnlDN2NUMTVaSTFXd2k1OWhnWUJvckVxYmh3CjNRSmhxSWJiYXU3eHoyNlcyOVVLRWNnUlFJeFBjL2N0YlA5K2hUaU04VDQKLS0tIGN6UVYzMHZJUUhKNmlkQjFOaXRXYUpjbzBOaHRMZkFFVVRPa3FaQUs2dHcKf3AcueEBLdl8lzRwKXik+OvDVg48g44QoPZu0j0NLV4lPLDqoq0="
+TOML
+
+    # Set invalid age key to trigger error
+    export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
+    export FNOX_IF_MISSING_DEFAULT="error"
+    export FNOX_IF_MISSING="ignore"
+
+    # Should succeed because FNOX_IF_MISSING=ignore overrides FNOX_IF_MISSING_DEFAULT=error
+    run "$FNOX_BIN" exec -- echo "command succeeded"
+    assert_success
+    assert_output --partial "command succeeded"
+}

--- a/test/if_missing_priority.bats
+++ b/test/if_missing_priority.bats
@@ -1,0 +1,211 @@
+#!/usr/bin/env bats
+
+load 'test_helper/common_setup'
+
+setup() {
+    _common_setup
+}
+
+@test "fnox exec with top-level if_missing=error fails on missing secret" {
+    cat > fnox.toml << 'TOML'
+root = true
+if_missing = "error"
+
+[providers.age]
+type = "age"
+recipients = ["age1cdk0klj88zzhg0ncfhe4ul9ja5k58w2st3fpkhmy0f46vlsuh5wq0s0gr9"]
+
+[secrets.MY_SECRET]
+provider = "age"
+value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaaTFhczNBYnN3S1c0NjZwZnlDN2NUMTVaSTFXd2k1OWhnWUJvckVxYmh3CjNRSmhxSWJiYXU3eHoyNlcyOVVLRWNnUlFJeFBjL2N0YlA5K2hUaU04VDQKLS0tIGN6UVYzMHZJUUhKNmlkQjFOaXRXYUpjbzBOaHRMZkFFVVRPa3FaQUs2dHcKf3AcueEBLdl8lzRwKXik+OvDVg48g44QoPZu0j0NLV4lPLDqoq0="
+TOML
+
+    # Set invalid age key to trigger error
+    export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
+
+    run "$FNOX_BIN" exec -- echo "should not run"
+    assert_failure
+}
+
+@test "fnox exec with top-level if_missing=warn continues on missing secret" {
+    cat > fnox.toml << 'TOML'
+root = true
+if_missing = "warn"
+
+[providers.age]
+type = "age"
+recipients = ["age1cdk0klj88zzhg0ncfhe4ul9ja5k58w2st3fpkhmy0f46vlsuh5wq0s0gr9"]
+
+[secrets.MY_SECRET]
+provider = "age"
+value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaaTFhczNBYnN3S1c0NjZwZnlDN2NUMTVaSTFXd2k1OWhnWUJvckVxYmh3CjNRSmhxSWJiYXU3eHoyNlcyOVVLRWNnUlFJeFBjL2N0YlA5K2hUaU04VDQKLS0tIGN6UVYzMHZJUUhKNmlkQjFOaXRXYUpjbzBOaHRMZkFFVVRPa3FaQUs2dHcKf3AcueEBLdl8lzRwKXik+OvDVg48g44QoPZu0j0NLV4lPLDqoq0="
+TOML
+
+    # Set invalid age key to trigger error
+    export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
+
+    run "$FNOX_BIN" exec -- echo "command succeeded"
+    assert_success
+    assert_output --partial "command succeeded"
+}
+
+@test "fnox exec with top-level if_missing=ignore silently continues on missing secret" {
+    cat > fnox.toml << 'TOML'
+root = true
+if_missing = "ignore"
+
+[providers.age]
+type = "age"
+recipients = ["age1cdk0klj88zzhg0ncfhe4ul9ja5k58w2st3fpkhmy0f46vlsuh5wq0s0gr9"]
+
+[secrets.MY_SECRET]
+provider = "age"
+value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaaTFhczNBYnN3S1c0NjZwZnlDN2NUMTVaSTFXd2k1OWhnWUJvckVxYmh3CjNRSmhxSWJiYXU3eHoyNlcyOVVLRWNnUlFJeFBjL2N0YlA5K2hUaU04VDQKLS0tIGN6UVYzMHZJUUhKNmlkQjFOaXRXYUpjbzBOaHRMZkFFVVRPa3FaQUs2dHcKf3AcueEBLdl8lzRwKXik+OvDVg48g44QoPZu0j0NLV4lPLDqoq0="
+TOML
+
+    # Set invalid age key to trigger error
+    export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
+
+    run "$FNOX_BIN" exec -- echo "command succeeded"
+    assert_success
+    assert_output --partial "command succeeded"
+    # Should not have warning message
+    refute_output --partial "Warning:"
+}
+
+@test "fnox exec with FNOX_IF_MISSING=error fails on missing secret" {
+    cat > fnox.toml << 'TOML'
+root = true
+
+[providers.age]
+type = "age"
+recipients = ["age1cdk0klj88zzhg0ncfhe4ul9ja5k58w2st3fpkhmy0f46vlsuh5wq0s0gr9"]
+
+[secrets.MY_SECRET]
+provider = "age"
+value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaaTFhczNBYnN3S1c0NjZwZnlDN2NUMTVaSTFXd2k1OWhnWUJvckVxYmh3CjNRSmhxSWJiYXU3eHoyNlcyOVVLRWNnUlFJeFBjL2N0YlA5K2hUaU04VDQKLS0tIGN6UVYzMHZJUUhKNmlkQjFOaXRXYUpjbzBOaHRMZkFFVVRPa3FaQUs2dHcKf3AcueEBLdl8lzRwKXik+OvDVg48g44QoPZu0j0NLV4lPLDqoq0="
+TOML
+
+    # Set invalid age key to trigger error
+    export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
+    export FNOX_IF_MISSING="error"
+
+    run "$FNOX_BIN" exec -- echo "should not run"
+    assert_failure
+}
+
+@test "fnox exec with FNOX_IF_MISSING=ignore silently continues on missing secret" {
+    cat > fnox.toml << 'TOML'
+root = true
+
+[providers.age]
+type = "age"
+recipients = ["age1cdk0klj88zzhg0ncfhe4ul9ja5k58w2st3fpkhmy0f46vlsuh5wq0s0gr9"]
+
+[secrets.MY_SECRET]
+provider = "age"
+value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaaTFhczNBYnN3S1c0NjZwZnlDN2NUMTVaSTFXd2k1OWhnWUJvckVxYmh3CjNRSmhxSWJiYXU3eHoyNlcyOVVLRWNnUlFJeFBjL2N0YlA5K2hUaU04VDQKLS0tIGN6UVYzMHZJUUhKNmlkQjFOaXRXYUpjbzBOaHRMZkFFVVRPa3FaQUs2dHcKf3AcueEBLdl8lzRwKXik+OvDVg48g44QoPZu0j0NLV4lPLDqoq0="
+TOML
+
+    # Set invalid age key to trigger error
+    export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
+    export FNOX_IF_MISSING="ignore"
+
+    run "$FNOX_BIN" exec -- echo "command succeeded"
+    assert_success
+    assert_output --partial "command succeeded"
+    # Should not have warning message
+    refute_output --partial "Warning:"
+}
+
+@test "fnox exec CLI flag --if-missing overrides secret-level config" {
+    cat > fnox.toml << 'TOML'
+root = true
+
+[providers.age]
+type = "age"
+recipients = ["age1cdk0klj88zzhg0ncfhe4ul9ja5k58w2st3fpkhmy0f46vlsuh5wq0s0gr9"]
+
+[secrets.MY_SECRET]
+provider = "age"
+value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaaTFhczNBYnN3S1c0NjZwZnlDN2NUMTVaSTFXd2k1OWhnWUJvckVxYmh3CjNRSmhxSWJiYXU3eHoyNlcyOVVLRWNnUlFJeFBjL2N0YlA5K2hUaU04VDQKLS0tIGN6UVYzMHZJUUhKNmlkQjFOaXRXYUpjbzBOaHRMZkFFVVRPa3FaQUs2dHcKf3AcueEBLdl8lzRwKXik+OvDVg48g44QoPZu0j0NLV4lPLDqoq0="
+if_missing = "ignore"
+TOML
+
+    # Set invalid age key to trigger error
+    export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
+
+    # Should fail because --if-missing error overrides secret-level if_missing=ignore
+    run "$FNOX_BIN" exec --if-missing error -- echo "should not run"
+    assert_failure
+}
+
+@test "fnox exec secret-level if_missing overrides top-level config" {
+    cat > fnox.toml << 'TOML'
+root = true
+if_missing = "error"
+
+[providers.age]
+type = "age"
+recipients = ["age1cdk0klj88zzhg0ncfhe4ul9ja5k58w2st3fpkhmy0f46vlsuh5wq0s0gr9"]
+
+[secrets.MY_SECRET]
+provider = "age"
+value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaaTFhczNBYnN3S1c0NjZwZnlDN2NUMTVaSTFXd2k1OWhnWUJvckVxYmh3CjNRSmhxSWJiYXU3eHoyNlcyOVVLRWNnUlFJeFBjL2N0YlA5K2hUaU04VDQKLS0tIGN6UVYzMHZJUUhKNmlkQjFOaXRXYUpjbzBOaHRMZkFFVVRPa3FaQUs2dHcKf3AcueEBLdl8lzRwKXik+OvDVg48g44QoPZu0j0NLV4lPLDqoq0="
+if_missing = "ignore"
+TOML
+
+    # Set invalid age key to trigger error
+    export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
+
+    # Should succeed because secret-level if_missing=ignore overrides top-level if_missing=error
+    run "$FNOX_BIN" exec -- echo "command succeeded"
+    assert_success
+    assert_output --partial "command succeeded"
+}
+
+@test "fnox exec FNOX_IF_MISSING env var overrides secret-level config" {
+    cat > fnox.toml << 'TOML'
+root = true
+
+[providers.age]
+type = "age"
+recipients = ["age1cdk0klj88zzhg0ncfhe4ul9ja5k58w2st3fpkhmy0f46vlsuh5wq0s0gr9"]
+
+[secrets.MY_SECRET]
+provider = "age"
+value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaaTFhczNBYnN3S1c0NjZwZnlDN2NUMTVaSTFXd2k1OWhnWUJvckVxYmh3CjNRSmhxSWJiYXU3eHoyNlcyOVVLRWNnUlFJeFBjL2N0YlA5K2hUaU04VDQKLS0tIGN6UVYzMHZJUUhKNmlkQjFOaXRXYUpjbzBOaHRMZkFFVVRPa3FaQUs2dHcKf3AcueEBLdl8lzRwKXik+OvDVg48g44QoPZu0j0NLV4lPLDqoq0="
+if_missing = "ignore"
+TOML
+
+    # Set invalid age key to trigger error
+    export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
+    export FNOX_IF_MISSING="error"
+
+    # Should fail because FNOX_IF_MISSING=error overrides secret-level if_missing=ignore
+    run "$FNOX_BIN" exec -- echo "should not run"
+    assert_failure
+}
+
+@test "fnox exec FNOX_IF_MISSING env var overrides top-level config" {
+    cat > fnox.toml << 'TOML'
+root = true
+if_missing = "ignore"
+
+[providers.age]
+type = "age"
+recipients = ["age1cdk0klj88zzhg0ncfhe4ul9ja5k58w2st3fpkhmy0f46vlsuh5wq0s0gr9"]
+
+[secrets.MY_SECRET]
+provider = "age"
+value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaaTFhczNBYnN3S1c0NjZwZnlDN2NUMTVaSTFXd2k1OWhnWUJvckVxYmh3CjNRSmhxSWJiYXU3eHoyNlcyOVVLRWNnUlFJeFBjL2N0YlA5K2hUaU04VDQKLS0tIGN6UVYzMHZJUUhKNmlkQjFOaXRXYUpjbzBOaHRMZkFFVVRPa3FaQUs2dHcKf3AcueEBLdl8lzRwKXik+OvDVg48g44QoPZu0j0NLV4lPLDqoq0="
+TOML
+
+    # Set invalid age key to trigger error
+    export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
+    export FNOX_IF_MISSING="error"
+
+    # Should fail because FNOX_IF_MISSING=error overrides top-level if_missing=ignore
+    run "$FNOX_BIN" exec -- echo "should not run"
+    assert_failure
+}


### PR DESCRIPTION
## Summary
Adds the ability to define `if_missing` at multiple levels with a clear priority chain. This allows for flexible control over missing secret behavior at runtime via CLI flags and environment variables, while also supporting project-level defaults in fnox.toml.

## Changes
- **Config**: Added `if_missing` field to top-level `Config` struct
- **Settings**: Added `if_missing` setting to settings.toml with CLI (`--if-missing`) and environment (`FNOX_IF_MISSING`) support
- **Priority Chain**: Implemented consistent priority resolution across all commands:
  1. CLI flag (`--if-missing`)
  2. Environment variable (`FNOX_IF_MISSING`)
  3. Secret-level config in fnox.toml
  4. Top-level config in fnox.toml
  5. Default (warn)
- **Commands**: Updated `exec`, `export`, and `ci_redact` commands to use the full priority chain
- **Tests**: Added comprehensive test suite (`test/if_missing_priority.bats`) to verify priority chain behavior

## Usage Examples

```bash
# CLI flag (highest priority)
fnox exec --if-missing error -- ./my-app

# Environment variable
FNOX_IF_MISSING=ignore fnox exec -- ./my-app

# Top-level config (applies to all secrets)
# fnox.toml
if_missing = "warn"

# Per-secret config
[secrets.MY_SECRET]
if_missing = "error"
```

## Test Plan
- ✅ All existing tests pass
- ✅ New test suite covers all priority chain scenarios
- ✅ Verified CLI flag overrides all other settings
- ✅ Verified env var overrides config file settings
- ✅ Verified secret-level overrides top-level config
- ✅ Verified top-level config works as default for all secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce a unified `if_missing` priority chain (CLI > env > secret-level > top-level > base env default > warn) and apply it across secret resolution and commands.
> 
> - **Core/Resolution**:
>   - Add centralized `resolve_if_missing_behavior` and `handle_provider_error` in `src/secret_resolver.rs`; integrate into `resolve_secret` missing-path handling.
>   - Extend `Config` with top-level `if_missing` and merge logic in `src/config.rs`.
> - **CLI/Settings**:
>   - Add `--if-missing` global flag to `commands::Cli` and plumb via `src/main.rs` into `settings::CliSnapshot`.
>   - Define settings in `settings.toml` for `if_missing` and `if_missing_default`; wire through `src/settings.rs` generated settings pipeline.
>   - Support env vars `FNOX_IF_MISSING` and `FNOX_IF_MISSING_DEFAULT`.
> - **Commands**:
>   - Update `exec`, `export`, and `ci_redact` to use centralized `if_missing` resolution and provider error handling.
> - **Docs**:
>   - Add README section “Handling Missing Secrets” with modes, priority chain, and examples; list new env vars.
> - **Tests**:
>   - Add `test/if_missing_priority.bats` covering overrides for CLI, env, secret-level, top-level, and base default.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a11ed4fc2c67ea6a47a953c297f95992aced869b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->