### PR TITLE
chore: release v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## [1.2.0](https://github.com/jdx/fnox/compare/v1.1.0..v1.2.0) - 2025-10-28
+
+### 🚀 Features
+
+- add support for fnox.local.toml local config overrides by [@jdx](https://github.com/jdx) in [#30](https://github.com/jdx/fnox/pull/30)
+- add batch secret resolution to improve performance by [@jdx](https://github.com/jdx) in [#31](https://github.com/jdx/fnox/pull/31)
+
+### 🐛 Bug Fixes
+
+- import command now reads from input file instead of config file by [@jdx](https://github.com/jdx) in [#28](https://github.com/jdx/fnox/pull/28)
+
+### 📚 Documentation
+
+- Add VitePress documentation and GitHub Pages deployment by [@jdx](https://github.com/jdx) in [#32](https://github.com/jdx/fnox/pull/32)
+
+### 🔍 Other Changes
+
+- Update URLs to use custom domain fnox.jdx.dev and remove DOCS_DEPLOYMENT.md by [@jdx](https://github.com/jdx) in [79a2c78](https://github.com/jdx/fnox/commit/79a2c7875e8b74283b71093be74d1e41171e5143)
+- Remove DOCS_DEPLOYMENT.md by [@jdx](https://github.com/jdx) in [dd9cb7b](https://github.com/jdx/fnox/commit/dd9cb7b90c6ffff43074aaba5908cc444bb8f412)
+- Remove ONEPASSWORD.md (content migrated to docs) by [@jdx](https://github.com/jdx) in [622baa3](https://github.com/jdx/fnox/commit/622baa3052abdebce3955d181848770bf9ef1ed6)
+- Add fnox vault logo by [@jdx](https://github.com/jdx) in [95a100f](https://github.com/jdx/fnox/commit/95a100fd22b6c9019a5d8e0d907680a235ec52bd)
+- Add auto-generated CLI reference documentation by [@jdx](https://github.com/jdx) in [582af5b](https://github.com/jdx/fnox/commit/582af5ba07f232f727041934af344bf953d72bab)
+- Show CLI Reference in sidebar on all pages by [@jdx](https://github.com/jdx) in [a19d6d1](https://github.com/jdx/fnox/commit/a19d6d127ae7d462424390147e9d46643dff16a6)
+- Remove 'When to Use' sections from provider docs by [@jdx](https://github.com/jdx) in [9fc9a75](https://github.com/jdx/fnox/commit/9fc9a756b9e85f5277deb46f0e11df61095eb663)
+- Add custom dark theme with Fort Knox styling by [@jdx](https://github.com/jdx) in [9c83a2e](https://github.com/jdx/fnox/commit/9c83a2eb4a4e1e17bd793e6c1a6e56aecc25fac8)
+- Fix dead links to /reference/commands by [@jdx](https://github.com/jdx) in [86762d8](https://github.com/jdx/fnox/commit/86762d8076f084f0fe704519dc4e2974d518dc02)
+
 ## [1.1.0](https://github.com/jdx/fnox/compare/v1.0.1..v1.1.0) - 2025-10-27
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,9 +450,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-secretsmanager"
-version = "1.90.0"
+version = "1.91.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a4341054ab5166fd7737dac0e1e1d2f6ae00b9e34a7bcfc97483fc008f39c8"
+checksum = "b9fd137b238bb8abdec9f36a02d039c11516c2f2612318d53d014df7061a785d"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1701,7 +1701,7 @@ dependencies = [
 
 [[package]]
 name = "fnox"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "age",
  "anyhow",
@@ -3001,9 +3001,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.81"
+version = "0.3.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
+checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -5771,9 +5771,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.104"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
+checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5783,24 +5783,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.104"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-shared",
-]
-
-[[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.54"
+version = "0.4.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e038d41e478cc73bae0ff9b36c60cff1c98b8f38f8d7e8061e79ee63608ac5c"
+checksum = "551f88106c6d5e7ccc7cd9a16f312dd3b5d36ea8b4954304657d5dfba115d4a0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -5811,9 +5797,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.104"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
+checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5821,22 +5807,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.104"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
+checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.104"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
+checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
 dependencies = [
  "unicode-ident",
 ]
@@ -5856,9 +5842,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.81"
+version = "0.3.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9367c417a924a74cae129e6a2ae3b47fabb1f8995595ab474029da749a8be120"
+checksum = "3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fnox"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2024"
 authors = ["@jdx"]
 description = "A flexible secret management tool supporting multiple providers and encryption methods"


### PR DESCRIPTION
## [1.2.0](https://github.com/jdx/fnox/compare/v1.1.0..v1.2.0) - 2025-10-28

### 🚀 Features

- add support for fnox.local.toml local config overrides by [@jdx](https://github.com/jdx) in [#30](https://github.com/jdx/fnox/pull/30)
- add batch secret resolution to improve performance by [@jdx](https://github.com/jdx) in [#31](https://github.com/jdx/fnox/pull/31)

### 🐛 Bug Fixes

- import command now reads from input file instead of config file by [@jdx](https://github.com/jdx) in [#28](https://github.com/jdx/fnox/pull/28)

### 📚 Documentation

- Add VitePress documentation and GitHub Pages deployment by [@jdx](https://github.com/jdx) in [#32](https://github.com/jdx/fnox/pull/32)

### 🔍 Other Changes

- Update URLs to use custom domain fnox.jdx.dev and remove DOCS_DEPLOYMENT.md by [@jdx](https://github.com/jdx) in [79a2c78](https://github.com/jdx/fnox/commit/79a2c7875e8b74283b71093be74d1e41171e5143)
- Remove DOCS_DEPLOYMENT.md by [@jdx](https://github.com/jdx) in [dd9cb7b](https://github.com/jdx/fnox/commit/dd9cb7b90c6ffff43074aaba5908cc444bb8f412)
- Remove ONEPASSWORD.md (content migrated to docs) by [@jdx](https://github.com/jdx) in [622baa3](https://github.com/jdx/fnox/commit/622baa3052abdebce3955d181848770bf9ef1ed6)
- Add fnox vault logo by [@jdx](https://github.com/jdx) in [95a100f](https://github.com/jdx/fnox/commit/95a100fd22b6c9019a5d8e0d907680a235ec52bd)
- Add auto-generated CLI reference documentation by [@jdx](https://github.com/jdx) in [582af5b](https://github.com/jdx/fnox/commit/582af5ba07f232f727041934af344bf953d72bab)
- Show CLI Reference in sidebar on all pages by [@jdx](https://github.com/jdx) in [a19d6d1](https://github.com/jdx/fnox/commit/a19d6d127ae7d462424390147e9d46643dff16a6)
- Remove 'When to Use' sections from provider docs by [@jdx](https://github.com/jdx) in [9fc9a75](https://github.com/jdx/fnox/commit/9fc9a756b9e85f5277deb46f0e11df61095eb663)
- Add custom dark theme with Fort Knox styling by [@jdx](https://github.com/jdx) in [9c83a2e](https://github.com/jdx/fnox/commit/9c83a2eb4a4e1e17bd793e6c1a6e56aecc25fac8)
- Fix dead links to /reference/commands by [@jdx](https://github.com/jdx) in [86762d8](https://github.com/jdx/fnox/commit/86762d8076f084f0fe704519dc4e2974d518dc02)