### PR TITLE
feat: add support for fnox.local.toml local config overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ test/tmp/
 *.key
 *.pem
 age.txt
+
+# Local configuration overrides (user-specific, should not be committed)
+fnox.local.toml

--- a/CRUSH.md
+++ b/CRUSH.md
@@ -166,6 +166,9 @@ mise run test:bats -- test/bitwarden.bats
 - Named profiles in `[profiles.name]` sections
 - Each profile can have its own providers and encryption
 - Environment variable: `FNOX_PROFILE`
+- Local overrides: `fnox.local.toml` (gitignored) is loaded alongside `fnox.toml` and takes precedence
+- Config recursion: searches parent directories for `fnox.toml` files
+- Local config works with config recursion: both files are merged in each directory before recursing upward
 
 ### Secret Configuration
 

--- a/README.md
+++ b/README.md
@@ -1533,6 +1533,69 @@ project/
 
 Child configs override parent values. Great for monorepos!
 
+### Local Configuration Overrides
+
+Use `fnox.local.toml` for user-specific or machine-specific overrides without committing them to version control:
+
+```
+project/
+├── fnox.toml              # Committed config (team secrets)
+├── fnox.local.toml        # Local overrides (gitignored)
+└── .gitignore             # Contains: fnox.local.toml
+```
+
+**How it works:**
+
+- `fnox.local.toml` is loaded automatically alongside `fnox.toml` in the same directory
+- Local config takes precedence over `fnox.toml` values
+- Perfect for personal development settings, machine-specific credentials, or testing
+- Works with profiles and config recursion
+
+**Example use case:**
+
+```toml
+# fnox.toml (committed to git)
+[providers.age]
+type = "age"
+recipients = ["age1team..."]
+
+[secrets.DATABASE_URL]
+provider = "age"
+value = "encrypted-team-db..."
+
+[secrets.API_KEY]
+provider = "age"
+value = "encrypted-shared-key..."
+```
+
+```toml
+# fnox.local.toml (gitignored, personal overrides)
+[secrets.DATABASE_URL]
+default = "postgresql://localhost/mylocal"  # Override with local DB
+
+[secrets.DEBUG_MODE]
+default = "true"  # Personal debugging flag
+```
+
+**Common use cases:**
+
+- **Personal development databases:** Override team DB URLs with local instances
+- **Developer-specific tokens:** Store personal API keys without sharing
+- **Testing configurations:** Try different provider settings without affecting the team
+- **Machine-specific secrets:** Different values per machine (laptop vs desktop)
+
+**Important:** To use explicit config paths (bypassing local overrides), use a path prefix:
+
+```bash
+# Uses both fnox.toml and fnox.local.toml
+fnox get DATABASE_URL
+
+# Only uses fnox.toml (skips fnox.local.toml)
+fnox -c ./fnox.toml get DATABASE_URL
+```
+
+Remember to add `fnox.local.toml` to your `.gitignore`!
+
 ### Configuration Imports
 
 Split configs across files:

--- a/mise.toml
+++ b/mise.toml
@@ -19,7 +19,7 @@ vault = "latest"
 
 [tasks.test]
 description = "Run both cargo and bats tests"
-depends = ["test:*"]
+depends = ["test:cargo", "test:bats"]
 
 [tasks."test:cargo"]
 description = "Run cargo tests only"

--- a/test/local_config.bats
+++ b/test/local_config.bats
@@ -1,0 +1,389 @@
+#!/usr/bin/env bats
+
+setup() {
+    load 'test_helper/common_setup'
+    _common_setup
+}
+
+teardown() {
+    _common_teardown
+}
+
+@test "fnox.local.toml overrides fnox.toml secrets" {
+    # Create main config
+    cat > fnox.toml <<EOF
+root = true
+
+[providers.test]
+type = "age"
+recipients = ["age1test"]
+
+[secrets]
+SHARED_SECRET = { description = "Main config secret", default = "main-value" }
+MAIN_ONLY_SECRET = { description = "Main only secret", default = "main-only-value" }
+EOF
+
+    # Create local config that overrides SHARED_SECRET
+    cat > fnox.local.toml <<EOF
+[secrets]
+SHARED_SECRET = { description = "Local override", default = "local-value" }
+LOCAL_ONLY_SECRET = { description = "Local only secret", default = "local-only-value" }
+EOF
+
+    # Test that local config overrides shared secret
+    run "$FNOX_BIN" get SHARED_SECRET
+    assert_success
+    assert_output --partial "local-value"
+
+    # Test that main-only secret is still accessible
+    run "$FNOX_BIN" get MAIN_ONLY_SECRET
+    assert_success
+    assert_output --partial "main-only-value"
+
+    # Test that local-only secret is accessible
+    run "$FNOX_BIN" get LOCAL_ONLY_SECRET
+    assert_success
+    assert_output --partial "local-only-value"
+}
+
+@test "fnox.local.toml can add new providers" {
+    # Create main config with one provider
+    cat > fnox.toml <<EOF
+root = true
+
+[providers.main_provider]
+type = "age"
+recipients = ["age1test"]
+
+[secrets]
+MAIN_SECRET = { provider = "main_provider", default = "main-value" }
+EOF
+
+    # Create local config with additional provider
+    cat > fnox.local.toml <<EOF
+[providers.local_provider]
+type = "age"
+recipients = ["age1localtest"]
+
+[secrets]
+LOCAL_SECRET = { provider = "local_provider", default = "local-value" }
+EOF
+
+    # Test that both secrets work
+    run "$FNOX_BIN" get MAIN_SECRET
+    assert_success
+    assert_output --partial "main-value"
+
+    run "$FNOX_BIN" get LOCAL_SECRET
+    assert_success
+    assert_output --partial "local-value"
+}
+
+@test "fnox.local.toml works with profile-specific secrets" {
+    # Create main config
+    cat > fnox.toml <<EOF
+root = true
+
+[providers.test]
+type = "age"
+recipients = ["age1test"]
+
+[profiles.production.secrets]
+PROD_SECRET = { description = "Production secret", default = "prod-value" }
+EOF
+
+    # Create local config with production profile override
+    cat > fnox.local.toml <<EOF
+[profiles.production.secrets]
+PROD_SECRET = { description = "Local prod override", default = "local-prod-value" }
+LOCAL_PROD_SECRET = { description = "Local prod secret", default = "local-prod-only" }
+EOF
+
+    # Test that local overrides production secret
+    run "$FNOX_BIN" get PROD_SECRET --profile production
+    assert_success
+    assert_output --partial "local-prod-value"
+
+    # Test that local-only production secret is accessible
+    run "$FNOX_BIN" get LOCAL_PROD_SECRET --profile production
+    assert_success
+    assert_output --partial "local-prod-only"
+}
+
+@test "fnox.local.toml works with config recursion" {
+    # Create directory structure
+    mkdir -p parent/child
+
+    # Create parent config
+    cat > parent/fnox.toml <<EOF
+[providers.test]
+type = "age"
+recipients = ["age1test"]
+
+[secrets]
+PARENT_SECRET = { description = "Parent secret", default = "parent-value" }
+EOF
+
+    # Create parent local config
+    cat > parent/fnox.local.toml <<EOF
+[secrets]
+PARENT_SECRET = { description = "Parent local override", default = "parent-local-value" }
+PARENT_LOCAL_SECRET = { description = "Parent local secret", default = "parent-local-only" }
+EOF
+
+    # Create child config
+    cat > parent/child/fnox.toml <<EOF
+[secrets]
+CHILD_SECRET = { description = "Child secret", default = "child-value" }
+EOF
+
+    # Create child local config
+    cat > parent/child/fnox.local.toml <<EOF
+[secrets]
+CHILD_SECRET = { description = "Child local override", default = "child-local-value" }
+CHILD_LOCAL_SECRET = { description = "Child local secret", default = "child-local-only" }
+EOF
+
+    # Change to child directory
+    cd parent/child
+
+    # Test that child local overrides child config
+    run "$FNOX_BIN" get CHILD_SECRET
+    assert_success
+    assert_output --partial "child-local-value"
+
+    # Test that child local secrets are accessible
+    run "$FNOX_BIN" get CHILD_LOCAL_SECRET
+    assert_success
+    assert_output --partial "child-local-only"
+
+    # Test that parent local overrides parent config
+    run "$FNOX_BIN" get PARENT_SECRET
+    assert_success
+    assert_output --partial "parent-local-value"
+
+    # Test that parent local secrets are accessible
+    run "$FNOX_BIN" get PARENT_LOCAL_SECRET
+    assert_success
+    assert_output --partial "parent-local-only"
+}
+
+@test "fnox.local.toml alone without fnox.toml works" {
+    # Create only local config (no main config)
+    cat > fnox.local.toml <<EOF
+root = true
+
+[providers.test]
+type = "age"
+recipients = ["age1test"]
+
+[secrets]
+LOCAL_ONLY = { description = "Local only secret", default = "local-only-value" }
+EOF
+
+    # Test that local config works on its own
+    run "$FNOX_BIN" get LOCAL_ONLY
+    assert_success
+    assert_output --partial "local-only-value"
+}
+
+@test "fnox.local.toml can override default_provider" {
+    # Create main config with default provider
+    cat > fnox.toml <<EOF
+root = true
+default_provider = "main_provider"
+
+[providers.main_provider]
+type = "age"
+recipients = ["age1maintest"]
+
+[providers.alt_provider]
+type = "age"
+recipients = ["age1alttest"]
+EOF
+
+    # Create local config that changes default provider
+    cat > fnox.local.toml <<EOF
+default_provider = "alt_provider"
+EOF
+
+    # Set a secret without specifying provider (should use default)
+    run "$FNOX_BIN" set TEST_SECRET "test-value"
+    assert_success
+
+    # Check that it used the local default provider
+    # The config should show the secret was set with alt_provider
+    run cat fnox.toml
+    assert_success
+    assert_output --partial 'TEST_SECRET'
+}
+
+@test "fnox.local.toml can set if_missing default" {
+    # Create main config
+    cat > fnox.toml <<EOF
+root = true
+
+[providers.test]
+type = "age"
+recipients = ["age1test"]
+
+[secrets]
+NO_VALUE_SECRET = { description = "Secret without value" }
+EOF
+
+    # Create local config with if_missing = ignore
+    cat > fnox.local.toml <<EOF
+if_missing = "ignore"
+EOF
+
+    # Test that missing secret is ignored (no error)
+    run "$FNOX_BIN" exec -- env
+    assert_success
+    # Should not fail even though NO_VALUE_SECRET has no value
+}
+
+@test "fnox list shows secrets from both fnox.toml and fnox.local.toml" {
+    # Create main config
+    cat > fnox.toml <<EOF
+root = true
+
+[providers.test]
+type = "age"
+recipients = ["age1test"]
+
+[secrets]
+MAIN_SECRET = { description = "Main config secret", default = "main-value" }
+SHARED_SECRET = { description = "Shared secret", default = "main-value" }
+EOF
+
+    # Create local config
+    cat > fnox.local.toml <<EOF
+[secrets]
+LOCAL_SECRET = { description = "Local config secret", default = "local-value" }
+SHARED_SECRET = { description = "Local override", default = "local-value" }
+EOF
+
+    # Test that list shows all secrets
+    run "$FNOX_BIN" list --complete
+    assert_success
+
+    # Should show MAIN_SECRET, LOCAL_SECRET, and SHARED_SECRET (merged)
+    assert_output --partial "MAIN_SECRET"
+    assert_output --partial "LOCAL_SECRET"
+    assert_output --partial "SHARED_SECRET"
+}
+
+@test "fnox.local.toml respects root flag" {
+    # Create parent config
+    cat > fnox.toml <<EOF
+[providers.test]
+type = "age"
+recipients = ["age1test"]
+
+[secrets]
+PARENT_SECRET = { description = "Parent secret", default = "parent-value" }
+EOF
+
+    # Create local config with root=true to stop recursion
+    cat > fnox.local.toml <<EOF
+root = true
+
+[providers.test]
+type = "age"
+recipients = ["age1test"]
+
+[secrets]
+LOCAL_SECRET = { description = "Local secret", default = "local-value" }
+EOF
+
+    # Test that local config's root flag is respected
+    run "$FNOX_BIN" get LOCAL_SECRET
+    assert_success
+    assert_output --partial "local-value"
+
+    # Parent secret should still be accessible because it's in the same directory
+    # (Both fnox.toml and fnox.local.toml are loaded before checking root)
+    run "$FNOX_BIN" get PARENT_SECRET
+    assert_success
+    assert_output --partial "parent-value"
+}
+
+@test "explicit config path ignores fnox.local.toml" {
+    # Create main config
+    cat > fnox.toml <<EOF
+root = true
+
+[providers.test]
+type = "age"
+recipients = ["age1test"]
+
+[secrets]
+MAIN_SECRET = { description = "Main secret", default = "main-value" }
+EOF
+
+    # Create local config
+    cat > fnox.local.toml <<EOF
+[secrets]
+LOCAL_SECRET = { description = "Local secret", default = "local-value" }
+MAIN_SECRET = { description = "Local override", default = "local-override" }
+EOF
+
+    # Using explicit path with ./ prefix should only load that specific file
+    # (bypasses recursion and local config merging)
+    run "$FNOX_BIN" -c ./fnox.toml get MAIN_SECRET
+    assert_success
+    assert_output --partial "main-value"
+
+    # Local secret should not be accessible with explicit path
+    run "$FNOX_BIN" -c ./fnox.toml get LOCAL_SECRET
+    assert_failure
+    assert_output --partial "not found"
+}
+
+@test "fnox.local.toml can have imports" {
+    # Create imported config
+    cat > shared.toml <<EOF
+root = true
+
+[providers.test]
+type = "age"
+recipients = ["age1test"]
+
+[secrets]
+SHARED_IMPORT = { description = "Shared import secret", default = "shared-value" }
+EOF
+
+    # Create main config
+    cat > fnox.toml <<EOF
+root = true
+
+[providers.test]
+type = "age"
+recipients = ["age1test"]
+
+[secrets]
+MAIN_SECRET = { description = "Main secret", default = "main-value" }
+EOF
+
+    # Create local config with import
+    cat > fnox.local.toml <<EOF
+import = ["./shared.toml"]
+
+[secrets]
+LOCAL_SECRET = { description = "Local secret", default = "local-value" }
+EOF
+
+    # Test that imported secret is accessible
+    run "$FNOX_BIN" get SHARED_IMPORT
+    assert_success
+    assert_output --partial "shared-value"
+
+    # Test that main and local secrets are still accessible
+    run "$FNOX_BIN" get MAIN_SECRET
+    assert_success
+    assert_output --partial "main-value"
+
+    run "$FNOX_BIN" get LOCAL_SECRET
+    assert_success
+    assert_output --partial "local-value"
+}


### PR DESCRIPTION
## Summary

Adds support for `fnox.local.toml` files that provide local, user-specific overrides without needing to commit them to version control.

## Features

- `fnox.local.toml` is loaded automatically alongside `fnox.toml` in each directory
- Local config takes precedence over `fnox.toml` values
- Works seamlessly with config recursion (searches parent directories)
- Works with profiles and all configuration features
- Automatically gitignored

## Use Cases

- **Personal development databases:** Override team DB URLs with local instances
- **Developer-specific tokens:** Store personal API keys without sharing
- **Testing configurations:** Try different provider settings without affecting the team
- **Machine-specific secrets:** Different values per machine (laptop vs desktop)

## Example

```toml
# fnox.toml (committed to git)
[providers.age]
type = "age"
recipients = ["age1team..."]

[secrets.DATABASE_URL]
provider = "age"
value = "encrypted-team-db..."
```

```toml
# fnox.local.toml (gitignored, personal overrides)
[secrets.DATABASE_URL]
default = "postgresql://localhost/mylocal"  # Override with local DB

[secrets.DEBUG_MODE]
default = "true"  # Personal debugging flag
```

## Changes

1. **Core Implementation** (`src/config.rs`):
   - Modified `load_recursive()` to automatically load and merge `fnox.local.toml`
   - Local config merged with higher precedence than main config
   
2. **Gitignore**:
   - Added `fnox.local.toml` entry to prevent accidental commits

3. **Tests** (`test/local_config.bats`):
   - 11 comprehensive test cases covering all functionality
   - Tests for overrides, profiles, recursion, imports, and edge cases
   - All tests passing ✅

4. **Documentation**:
   - Updated README.md with detailed usage examples and common use cases
   - Updated CLAUDE.md with implementation notes

## Test Results

✅ All 11 new tests passed  
✅ All existing tests still pass  
✅ Linting checks passed  
✅ CI pipeline succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce `fnox.local.toml` local overrides merged with `fnox.toml` (with precedence) in recursive loading; add tests, docs, gitignore entry, and tweak test task deps.
> 
> - **Config/Core**:
>   - Load and merge `fnox.local.toml` alongside `fnox.toml` in `load_recursive`, with local overrides taking precedence and working with imports, profiles, and recursion.
> - **Tests**:
>   - Add `test/local_config.bats` covering overrides, providers, profiles, recursion, imports, root flag, explicit-path bypass, and listing.
> - **Docs**:
>   - Update `README.md` and `CRUSH.md` to document local overrides, precedence, recursion behavior, and explicit-path usage.
> - **Repo hygiene/Tooling**:
>   - Add `fnox.local.toml` to `.gitignore`.
>   - Adjust `mise.toml` `tasks.test` deps to `["test:cargo", "test:bats"]`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5bc47c0d7b752b73f075f67aab8c8137101e9e21. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->