### PR TITLE
fix(import): require --provider flag to prevent plaintext storage

### DIFF
--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -37,6 +37,10 @@ pub struct ImportCommand {
     #[arg(short = 'i', long)]
     input: Option<PathBuf>,
 
+    /// Provider to use for encrypting/storing imported secrets (required)
+    #[arg(short = 'P', long)]
+    provider: String,
+
     /// Only import matching secrets (regex pattern)
     #[arg(long)]
     filter: Option<String>,
@@ -44,10 +48,6 @@ pub struct ImportCommand {
     /// Prefix to add to imported secret names
     #[arg(long)]
     prefix: Option<String>,
-
-    /// Provider to use for encrypting/storing imported secrets (required)
-    #[arg(short = 'P', long)]
-    provider: String,
 }
 
 impl ImportCommand {

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -44,6 +44,10 @@ pub struct ImportCommand {
     /// Prefix to add to imported secret names
     #[arg(long)]
     prefix: Option<String>,
+
+    /// Provider to use for encrypting/storing imported secrets (required)
+    #[arg(short = 'P', long)]
+    provider: String,
 }
 
 impl ImportCommand {
@@ -119,20 +123,89 @@ impl ImportCommand {
             }
         }
 
-        // Load config and add secrets
+        // Verify provider exists
+        let providers = config.get_providers(&profile);
+        let provider_config = providers.get(&self.provider).ok_or_else(|| {
+            miette::miette!(
+                "Provider '{}' not found in profile '{}'. Available providers: {}",
+                self.provider,
+                profile,
+                providers
+                    .keys()
+                    .map(|k| k.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )
+        })?;
+
+        // Get provider and check its capabilities
+        let provider = crate::providers::get_provider(provider_config)?;
+        let capabilities = provider.capabilities();
+
+        if capabilities.is_empty() {
+            return Err(miette::miette!(
+                "Provider '{}' has no capabilities defined",
+                self.provider
+            )
+            .into());
+        }
+
+        let is_encryption_provider =
+            capabilities.contains(&crate::providers::ProviderCapability::Encryption);
+        let is_remote_storage_provider =
+            capabilities.contains(&crate::providers::ProviderCapability::RemoteStorage);
+
+        // Process and encrypt/store each secret
         {
             let profile_secrets = config.get_secrets_mut(&profile);
-            let imported_count = secrets.len();
+            let total_secrets = secrets.len();
 
             for (key, value) in secrets {
                 let secret_config = profile_secrets.entry(key.clone()).or_default();
-                // Import as plain default values (not encrypted)
-                secret_config.default = Some(value);
+
+                // Set the provider
+                secret_config.provider = Some(self.provider.clone());
+
+                // Handle encryption or remote storage based on provider capabilities
+                if is_encryption_provider {
+                    // Encrypt the value
+                    match provider
+                        .encrypt(
+                            &value,
+                            cli.age_key_file.as_ref().map(PathBuf::from).as_deref(),
+                        )
+                        .await
+                    {
+                        Ok(encrypted) => {
+                            secret_config.value = Some(encrypted);
+                        }
+                        Err(e) => {
+                            return Err(miette::miette!(
+                                "Failed to encrypt secret '{}' with provider '{}': {}",
+                                key,
+                                self.provider,
+                                e
+                            )
+                            .into());
+                        }
+                    }
+                } else if is_remote_storage_provider {
+                    return Err(miette::miette!(
+                        "Remote storage providers are not yet supported for import. Use an encryption provider like 'age' instead."
+                    )
+                    .into());
+                } else {
+                    return Err(miette::miette!(
+                        "Provider '{}' does not support encryption or remote storage",
+                        self.provider
+                    )
+                    .into());
+                }
             }
 
             println!(
-                "✓ Imported {} secrets into profile '{}'",
-                imported_count, profile
+                "✓ Imported {} secrets into profile '{}' using provider '{}'",
+                total_secrets, profile, self.provider
             );
         }
 

--- a/test/import.bats
+++ b/test/import.bats
@@ -9,9 +9,36 @@ teardown() {
     _common_teardown
 }
 
-@test "fnox import reads from .env file with -i flag" {
-    # Initialize config
+# Helper function to setup age provider
+setup_age_provider() {
+    if ! command -v age-keygen >/dev/null 2>&1; then
+        skip "age-keygen not installed"
+    fi
+
     assert_fnox_success init
+    local keygen_output
+    keygen_output=$(age-keygen -o key.txt 2>&1)
+    local public_key
+    public_key=$(echo "$keygen_output" | grep "^Public key:" | cut -d' ' -f3)
+    assert_fnox_success provider add age age --recipients "$public_key"
+}
+
+@test "fnox import requires --provider flag" {
+    setup_age_provider
+
+    # Create a .env file
+    cat > .env << EOF
+TEST_SECRET=value123
+EOF
+
+    # Import without --provider should fail
+    assert_fnox_failure import -i .env --force
+    assert_output --partial "required arguments were not provided"
+    assert_output --partial "--provider"
+}
+
+@test "fnox import reads from .env file with -i flag" {
+    setup_age_provider
 
     # Create a .env file with test secrets
     cat > .env << EOF
@@ -20,22 +47,26 @@ API_KEY=secret-key-123
 DEBUG_MODE=true
 EOF
 
-    # Import from .env file
-    assert_fnox_success import -i .env --force
+    # Import from .env file with age provider
+    assert_fnox_success import -i .env --provider age --force
 
-    # Verify secrets were imported
-    assert_fnox_success get DATABASE_URL
+    # Verify secrets were imported and encrypted (not plaintext)
+    assert_config_not_contains "postgresql://localhost:5432/mydb"
+    assert_config_not_contains "secret-key-123"
+
+    # Verify secrets can be retrieved with age key
+    assert_fnox_success get DATABASE_URL --age-key-file key.txt
     assert_output "postgresql://localhost:5432/mydb"
 
-    assert_fnox_success get API_KEY
+    assert_fnox_success get API_KEY --age-key-file key.txt
     assert_output "secret-key-123"
 
-    assert_fnox_success get DEBUG_MODE
+    assert_fnox_success get DEBUG_MODE --age-key-file key.txt
     assert_output "true"
 }
 
 @test "fnox import handles quoted values in .env file" {
-    assert_fnox_success init
+    setup_age_provider
 
     # Create a .env file with quoted values
     cat > .env << EOF
@@ -44,20 +75,20 @@ DOUBLE_QUOTED="another value with spaces"
 UNQUOTED=no_spaces
 EOF
 
-    assert_fnox_success import -i .env --force
+    assert_fnox_success import -i .env --provider age --force
 
-    assert_fnox_success get SINGLE_QUOTED
+    assert_fnox_success get SINGLE_QUOTED --age-key-file key.txt
     assert_output "value with spaces"
 
-    assert_fnox_success get DOUBLE_QUOTED
+    assert_fnox_success get DOUBLE_QUOTED --age-key-file key.txt
     assert_output "another value with spaces"
 
-    assert_fnox_success get UNQUOTED
+    assert_fnox_success get UNQUOTED --age-key-file key.txt
     assert_output "no_spaces"
 }
 
 @test "fnox import handles export statements in .env file" {
-    assert_fnox_success init
+    setup_age_provider
 
     # Create a .env file with export statements
     cat > .env << EOF
@@ -66,20 +97,20 @@ export API_KEY=secret-key-456
 REGULAR_VAR=regular-value
 EOF
 
-    assert_fnox_success import -i .env --force
+    assert_fnox_success import -i .env --provider age --force
 
-    assert_fnox_success get DATABASE_URL
+    assert_fnox_success get DATABASE_URL --age-key-file key.txt
     assert_output "postgresql://localhost:5432/mydb"
 
-    assert_fnox_success get API_KEY
+    assert_fnox_success get API_KEY --age-key-file key.txt
     assert_output "secret-key-456"
 
-    assert_fnox_success get REGULAR_VAR
+    assert_fnox_success get REGULAR_VAR --age-key-file key.txt
     assert_output "regular-value"
 }
 
 @test "fnox import skips comments and empty lines" {
-    assert_fnox_success init
+    setup_age_provider
 
     # Create a .env file with comments and empty lines
     cat > .env << EOF
@@ -91,7 +122,7 @@ API_KEY=secret-key-789
 
 EOF
 
-    assert_fnox_success import -i .env --force
+    assert_fnox_success import -i .env --provider age --force
 
     # Should only import the two actual variables
     assert_fnox_success list
@@ -101,7 +132,7 @@ EOF
 }
 
 @test "fnox import with --filter flag filters secrets by regex" {
-    assert_fnox_success init
+    setup_age_provider
 
     # Create a .env file
     cat > .env << EOF
@@ -113,13 +144,13 @@ DEBUG_MODE=true
 EOF
 
     # Import only DATABASE_* secrets
-    assert_fnox_success import -i .env --filter "^DATABASE_" --force
+    assert_fnox_success import -i .env --filter "^DATABASE_" --provider age --force
 
     # Should have DATABASE_* secrets
-    assert_fnox_success get DATABASE_URL
+    assert_fnox_success get DATABASE_URL --age-key-file key.txt
     assert_output "postgresql://localhost:5432/mydb"
 
-    assert_fnox_success get DATABASE_PASSWORD
+    assert_fnox_success get DATABASE_PASSWORD --age-key-file key.txt
     assert_output "secret123"
 
     # Should not have API_* or DEBUG_MODE
@@ -128,7 +159,7 @@ EOF
 }
 
 @test "fnox import with --prefix flag adds prefix to secret names" {
-    assert_fnox_success init
+    setup_age_provider
 
     # Create a .env file
     cat > .env << EOF
@@ -137,13 +168,13 @@ API_KEY=secret-key-xyz
 EOF
 
     # Import with prefix
-    assert_fnox_success import -i .env --prefix "MYAPP_" --force
+    assert_fnox_success import -i .env --prefix "MYAPP_" --provider age --force
 
     # Should be accessible with prefix
-    assert_fnox_success get MYAPP_DATABASE_URL
+    assert_fnox_success get MYAPP_DATABASE_URL --age-key-file key.txt
     assert_output "postgresql://localhost:5432/mydb"
 
-    assert_fnox_success get MYAPP_API_KEY
+    assert_fnox_success get MYAPP_API_KEY --age-key-file key.txt
     assert_output "secret-key-xyz"
 
     # Should not be accessible without prefix
@@ -152,7 +183,7 @@ EOF
 }
 
 @test "fnox import requires confirmation by default" {
-    assert_fnox_success init
+    setup_age_provider
 
     # Create a .env file
     cat > .env << EOF
@@ -160,7 +191,7 @@ DATABASE_URL=postgresql://localhost:5432/mydb
 EOF
 
     # Import without --force should prompt for confirmation
-    run bash -c "echo 'n' | $FNOX_BIN import -i .env"
+    run bash -c "echo 'n' | $FNOX_BIN import -i .env --provider age"
     assert_output --partial "Continue? [y/N]"
     assert_output --partial "Import cancelled"
 
@@ -169,22 +200,22 @@ EOF
 }
 
 @test "fnox import reads from stdin when -i is not specified" {
-    assert_fnox_success init
+    setup_age_provider
 
     # Import from stdin
-    run bash -c "echo -e 'DATABASE_URL=postgresql://localhost:5432/mydb\nAPI_KEY=secret-key' | $FNOX_BIN import --force"
+    run bash -c "echo -e 'DATABASE_URL=postgresql://localhost:5432/mydb\nAPI_KEY=secret-key' | $FNOX_BIN import --provider age --force"
     assert_success
 
     # Verify secrets were imported
-    assert_fnox_success get DATABASE_URL
+    assert_fnox_success get DATABASE_URL --age-key-file key.txt
     assert_output "postgresql://localhost:5432/mydb"
 
-    assert_fnox_success get API_KEY
+    assert_fnox_success get API_KEY --age-key-file key.txt
     assert_output "secret-key"
 }
 
 @test "fnox import from stdin requires --force flag" {
-    assert_fnox_success init
+    setup_age_provider
 
     # FIXED: stdin imports now require --force to avoid double-stdin consumption bug
     # Without --force, importing from stdin would consume stdin twice:
@@ -192,7 +223,7 @@ EOF
     #   2. Then to read confirmation (stdin.read_line)
     # This would cause the import to fail because stdin is at EOF after reading data
 
-    # Try to import from stdin without --force - should fail with helpful error
+    # Try to import from stdin without --force but without --provider - should fail asking for provider
     run bash -c "echo -e 'TEST_VAR=test123' | $FNOX_BIN import"
     assert_failure
     assert_output --partial "the --force flag"
@@ -201,17 +232,17 @@ EOF
     # Verify secret was NOT imported
     assert_fnox_failure get TEST_VAR
 
-    # Now try with --force - should succeed
-    run bash -c "echo -e 'TEST_VAR=test123' | $FNOX_BIN import --force"
+    # Now try with --force and --provider - should succeed
+    run bash -c "echo -e 'TEST_VAR=test123' | $FNOX_BIN import --provider age --force"
     assert_success
 
     # Verify secret WAS imported
-    assert_fnox_success get TEST_VAR
+    assert_fnox_success get TEST_VAR --age-key-file key.txt
     assert_output "test123"
 }
 
 @test "fnox import supports json format" {
-    assert_fnox_success init
+    setup_age_provider
 
     # Create a JSON file
     cat > secrets.json << EOF
@@ -221,19 +252,33 @@ EOF
 }
 EOF
 
-    assert_fnox_success import -i secrets.json json --force
+    assert_fnox_success import -i secrets.json json --provider age --force
 
-    assert_fnox_success get DATABASE_URL
+    assert_fnox_success get DATABASE_URL --age-key-file key.txt
     assert_output "postgresql://localhost:5432/mydb"
 
-    assert_fnox_success get API_KEY
+    assert_fnox_success get API_KEY --age-key-file key.txt
     assert_output "secret-key-json"
 }
 
 @test "fnox import shows helpful error when file does not exist" {
-    assert_fnox_success init
+    setup_age_provider
 
     # Try to import from non-existent file
-    assert_fnox_failure import -i nonexistent.env --force
+    assert_fnox_failure import -i nonexistent.env --provider age --force
     assert_output --partial "Failed to read input file"
+}
+
+@test "fnox import fails with non-existent provider" {
+    setup_age_provider
+
+    # Create a .env file
+    cat > .env << EOF
+SECRET=value
+EOF
+
+    # Try to import with non-existent provider
+    assert_fnox_failure import -i .env --provider nonexistent --force
+    assert_output --partial "Provider 'nonexistent' not found"
+    assert_output --partial "Available providers: age"
 }


### PR DESCRIPTION
## Summary
Fixes #33 

The import command previously saved all imported secrets in plaintext by setting the `default` field. This created a security risk where secrets could be accidentally committed to version control.

This PR makes the `--provider` flag required for the import command, ensuring that imported secrets are always encrypted using a specified provider.

## Changes
- Made `--provider` flag required for import command
- Added provider validation and capability checks
- Import now encrypts values using the specified provider
- Removed automatic plaintext storage in `default` field
- Added helpful error messages for unsupported provider types
- Updated all import.bats tests to use age provider and verify encryption

## Example Usage

**Before (unsafe - stores plaintext):**
```bash
fnox import < .env  # Would store secrets in plaintext
```

**After (secure - requires encryption):**
```bash
fnox import --provider age < .env  # Encrypts secrets with age provider
```

## Testing
- [x] All existing tests updated to use --provider flag with age encryption
- [x] Added new test to verify --provider is required
- [x] Added test to verify non-existent provider shows helpful error
- [x] Verified secrets are encrypted (not stored in plaintext)
- [x] Code passes pre-commit hooks (cargo-fmt, cargo-check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Import now requires a provider and encrypts values via provider capabilities; tests updated to use age and verify encryption and errors.
> 
> - **CLI/Import (`src/commands/import.rs`)**
>   - Require `--provider` (`-P`) flag and validate provider exists in profile (`config.get_providers`).
>   - Resolve provider, check capabilities, and encrypt values when `Encryption` is supported; disallow `RemoteStorage` for import with clear errors.
>   - Store encrypted data in `secret_config.value` and set `secret_config.provider`; remove plaintext `default` usage.
>   - Improve messages and errors (missing provider, empty capabilities, unsupported provider types).
>   - Preserve existing behaviors: stdin requires `--force`; filtering/prefixing maintained.
> - **Tests (`test/import.bats`)**
>   - Add `setup_age_provider` helper (generates key, configures `age`).
>   - Update all import tests to pass `--provider age` and use `--age-key-file` for retrieval.
>   - Verify secrets are not stored in plaintext and can be decrypted.
>   - Add tests for required `--provider`, non-existent provider error, and stdin `--force` interaction.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f995a6fb7e9a1a98d4a80ef5744363815ae9d7f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->