### PR TITLE
refactor: change profile flag from -p to -P

### DIFF
--- a/CRUSH.md
+++ b/CRUSH.md
@@ -198,7 +198,7 @@ if_missing = "warn"  # Options: "error", "warn", "ignore"
 ### CLI Flags
 
 - `-P, --profile` for profile selection
-- `-P, --provider` for provider specification
+- `-p, --provider` for provider specification
 - `-d, --description` for secret descriptions
 - `-k, --key-name` for provider key names
 

--- a/CRUSH.md
+++ b/CRUSH.md
@@ -197,7 +197,7 @@ if_missing = "warn"  # Options: "error", "warn", "ignore"
 
 ### CLI Flags
 
-- `-p, --profile` for profile selection
+- `-P, --profile` for profile selection
 - `-P, --provider` for provider specification
 - `-d, --description` for secret descriptions
 - `-k, --key-name` for provider key names

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -14,7 +14,7 @@
 
 Path to the configuration file (default: fnox.toml, searches parent directories)
 
-### `-p --profile <PROFILE>`
+### `-P --profile <PROFILE>`
 
 Profile to use (default: default, or FNOX_PROFILE env var)
 

--- a/mise.toml
+++ b/mise.toml
@@ -16,6 +16,7 @@ actionlint = "latest"
 1password = "latest"
 bitwarden = "latest"
 vault = "latest"
+usage = "latest"
 
 [tasks.test]
 description = "Run both cargo and bats tests"

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -38,7 +38,7 @@ pub struct ImportCommand {
     input: Option<PathBuf>,
 
     /// Provider to use for encrypting/storing imported secrets (required)
-    #[arg(short = 'P', long)]
+    #[arg(short = 'p', long)]
     provider: String,
 
     /// Only import matching secrets (regex pattern)

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -38,7 +38,7 @@ pub struct Cli {
     pub config: PathBuf,
 
     /// Profile to use (default: default, or FNOX_PROFILE env var)
-    #[arg(short, long, global = true)]
+    #[arg(short = 'P', long, global = true)]
     pub profile: Option<String>,
 
     /// Enable verbose logging

--- a/src/commands/set.rs
+++ b/src/commands/set.rs
@@ -23,7 +23,7 @@ pub struct SetCommand {
     pub key_name: Option<String>,
 
     /// Provider to fetch from
-    #[arg(short = 'P', long)]
+    #[arg(short = 'p', long)]
     pub provider: Option<String>,
 
     /// Default value to use if secret is not found

--- a/src/error.rs
+++ b/src/error.rs
@@ -80,7 +80,7 @@ pub enum FnoxError {
     #[diagnostic(
         code(fnox::profile::not_found),
         help(
-            "Available profiles: {available_profiles}\n\nTo create this profile, add to your fnox.toml:\n  [profiles.{profile}]\n  # Add provider and secret configuration here\n\nOr use 'fnox set <KEY> <VALUE> -p {profile}' to create it automatically",
+            "Available profiles: {available_profiles}\n\nTo create this profile, add to your fnox.toml:\n  [profiles.{profile}]\n  # Add provider and secret configuration here\n\nOr use 'fnox set <KEY> <VALUE> -P {profile}' to create it automatically",
             available_profiles = if available_profiles.is_empty() {
                 "none (only 'default' is available)".to_string()
             } else {
@@ -112,7 +112,7 @@ pub enum FnoxError {
     #[diagnostic(
         code(fnox::secret::not_found),
         help(
-            "{init_help}Available actions:\n  • View defined secrets: fnox list -p {profile} --sources\n  • Add this secret: fnox set {key} <value> -p {profile}{suggest}",
+            "{init_help}Available actions:\n  • View defined secrets: fnox list -P {profile} --sources\n  • Add this secret: fnox set {key} <value> -P {profile}{suggest}",
             init_help = if config_path.is_none() {
                 "No configuration file found. Create one with:\n  • fnox init\n\n"
             } else {
@@ -138,7 +138,7 @@ pub enum FnoxError {
     #[diagnostic(
         code(fnox::secret::already_exists),
         help(
-            "To update this secret:\n  • Overwrite: fnox set {key} <value> --force -p {profile}{edit}",
+            "To update this secret:\n  • Overwrite: fnox set {key} <value> --force -P {profile}{edit}",
             edit = config_path.as_ref()
                 .map(|p| format!("\n  • Edit directly: {}", p.display()))
                 .unwrap_or_default()

--- a/test/ci_redact.bats
+++ b/test/ci_redact.bats
@@ -118,7 +118,7 @@ EOF
     refute_output --partial "staging-value"
 
     # Test staging profile - inherits top-level secrets
-    run "$FNOX_BIN" -p staging ci-redact
+    run "$FNOX_BIN" -P staging ci-redact
     assert_success
     assert_output --partial "::add-mask::staging-value"
     assert_output --partial "::add-mask::default-value"  # Inherited from top level


### PR DESCRIPTION
## Summary

Update flag short options for clarity and consistency:
- **Profile flag**: Changed from `-p` to `-P` (uppercase)
- **Provider flag**: Changed from `-P` to `-p` (lowercase)

This makes it clear which is which: `-P` for Profile, `-p` for provider.

## Changes

- Updated global CLI argument definition for profile to use `-P` 
- Updated command-specific provider flags (import, set) to use `-p`
- Updated documentation (CRUSH.md, docs/cli/index.md)
- Updated error messages to reference `-P` for profile
- Updated tests to use `-P` flag for profile

## Examples

```bash
# Global profile flag (uppercase P)
fnox -P production get MY_SECRET

# Command-specific provider flag (lowercase p)
fnox set MY_SECRET "value" -p age
fnox import -i .env -p age --force
```

## Test Plan

- ✅ Build succeeds
- ✅ `fnox --help` shows `-P, --profile <PROFILE>`
- ✅ `fnox set --help` shows both `-P` (profile) and `-p` (provider)
- ✅ `fnox import --help` shows both `-P` (profile) and `-p` (provider)
- ✅ All existing tests should continue to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>