### PR TITLE
ci: add autofix.ci workflow for automatic linting fixes

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -1,0 +1,32 @@
+name: autofix.ci
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  autofix:
+    if: github.actor != 'renovate[bot]' && github.actor != 'mend[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: autofix
+      - uses: jdx/mise-action@v3
+      - run: "mise run render ::: lint-fix"
+      - uses: autofix-ci/action@v1.3.2

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -269,7 +269,7 @@
       },
       "import": {
         "full_cmd": ["import"],
-        "usage": "import [FLAGS] [FORMAT]",
+        "usage": "import <FLAGS> [FORMAT]",
         "subcommands": {},
         "args": [
           {
@@ -309,6 +309,24 @@
             "arg": {
               "name": "INPUT",
               "usage": "<INPUT>",
+              "required": true,
+              "double_dash": "Optional",
+              "hide": false
+            }
+          },
+          {
+            "name": "provider",
+            "usage": "-p --provider <PROVIDER>",
+            "help": "Provider to use for encrypting/storing imported secrets (required)",
+            "help_first_line": "Provider to use for encrypting/storing imported secrets (required)",
+            "short": ["p"],
+            "long": ["provider"],
+            "required": true,
+            "hide": false,
+            "global": false,
+            "arg": {
+              "name": "PROVIDER",
+              "usage": "<PROVIDER>",
               "required": true,
               "double_dash": "Optional",
               "hide": false
@@ -751,10 +769,10 @@
           },
           {
             "name": "provider",
-            "usage": "-P --provider <PROVIDER>",
+            "usage": "-p --provider <PROVIDER>",
             "help": "Provider to fetch from",
             "help_first_line": "Provider to fetch from",
-            "short": ["P"],
+            "short": ["p"],
             "long": ["provider"],
             "hide": false,
             "global": false,
@@ -862,10 +880,10 @@
       },
       {
         "name": "profile",
-        "usage": "-p --profile <PROFILE>",
+        "usage": "-P --profile <PROFILE>",
         "help": "Profile to use (default: default, or FNOX_PROFILE env var)",
         "help_first_line": "Profile to use (default: default, or FNOX_PROFILE env var)",
-        "short": ["p"],
+        "short": ["P"],
         "long": ["profile"],
         "hide": false,
         "global": true,
@@ -942,7 +960,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.1.0",
+  "version": "1.2.1",
   "usage": "Usage: fnox [OPTIONS] <COMMAND>",
   "complete": {
     "key": {

--- a/docs/cli/import.md
+++ b/docs/cli/import.md
@@ -2,7 +2,7 @@
 
 # `fnox import`
 
-- **Usage**: `fnox import [FLAGS] [FORMAT]`
+- **Usage**: `fnox import <FLAGS> [FORMAT]`
 - **Aliases**: `im`
 
 Import secrets from various sources
@@ -31,6 +31,10 @@ Skip confirmation prompts
 ### `-i --input <INPUT>`
 
 Source file or path to import from (default: stdin)
+
+### `-p --provider <PROVIDER>`
+
+Provider to use for encrypting/storing imported secrets (required)
 
 ### `--filter <FILTER>`
 

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -4,7 +4,7 @@
 
 **Usage**: `fnox [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.1.0
+**Version**: 1.2.1
 
 - **Usage**: `fnox [FLAGS] <SUBCOMMAND>`
 
@@ -45,7 +45,7 @@ Disable colored output
 - [`fnox exec [COMMAND]…`](/cli/exec.md)
 - [`fnox export [-f --format <FORMAT>] [-o --output <OUTPUT>]`](/cli/export.md)
 - [`fnox get <KEY>`](/cli/get.md)
-- [`fnox import [FLAGS] [FORMAT]`](/cli/import.md)
+- [`fnox import <FLAGS> [FORMAT]`](/cli/import.md)
 - [`fnox init [--force] [--skip-wizard]`](/cli/init.md)
 - [`fnox list [FLAGS]`](/cli/list.md)
 - [`fnox profiles`](/cli/profiles.md)

--- a/docs/cli/set.md
+++ b/docs/cli/set.md
@@ -27,7 +27,7 @@ Description of the secret
 
 Key name in the provider (if different from env var name)
 
-### `-P --provider <PROVIDER>`
+### `-p --provider <PROVIDER>`
 
 Provider to fetch from
 

--- a/fnox.usage.kdl
+++ b/fnox.usage.kdl
@@ -1,13 +1,13 @@
 min_usage_version "1.3"
 name fnox
 bin fnox
-version "1.1.0"
+version "1.2.1"
 about "A flexible secret management tool by @jdx"
 usage "Usage: fnox [OPTIONS] <COMMAND>"
 flag "-c --config" help="Path to the configuration file (default: fnox.toml, searches parent directories)" global=#true {
     arg <CONFIG>
 }
-flag "-p --profile" help="Profile to use (default: default, or FNOX_PROFILE env var)" global=#true {
+flag "-P --profile" help="Profile to use (default: default, or FNOX_PROFILE env var)" global=#true {
     arg <PROFILE>
 }
 flag "-v --verbose" help="Enable verbose logging" global=#true
@@ -64,6 +64,9 @@ cmd import help="Import secrets from various sources" {
     flag "-f --force" help="Skip confirmation prompts"
     flag "-i --input" help="Source file or path to import from (default: stdin)" {
         arg <INPUT>
+    }
+    flag "-p --provider" help="Provider to use for encrypting/storing imported secrets (required)" required=#true {
+        arg <PROVIDER>
     }
     flag --filter help="Only import matching secrets (regex pattern)" {
         arg <FILTER>
@@ -133,7 +136,7 @@ cmd set help="Set a secret value" {
     flag "-k --key-name" help="Key name in the provider (if different from env var name)" {
         arg <KEY_NAME>
     }
-    flag "-P --provider" help="Provider to fetch from" {
+    flag "-p --provider" help="Provider to fetch from" {
         arg <PROVIDER>
     }
     flag --default help="Default value to use if secret is not found" {

--- a/mise-tasks/release-plz
+++ b/mise-tasks/release-plz
@@ -37,10 +37,13 @@ cargo set-version --package fnox "${version#v}"
 git config user.name mise-en-dev
 git config user.email 123107610+mise-en-dev@users.noreply.github.com
 cargo update
+mise run render ::: lint-fix
 
 git add \
   Cargo.* \
-  CHANGELOG.md
+  CHANGELOG.md \
+  docs \
+  fnox.usage.kdl
 
 git checkout -B release
 git commit -m "chore: release $version"


### PR DESCRIPTION
## Summary
Add autofix.ci integration to automatically apply lint fixes to pull requests.
The workflow runs on PRs to main and executes both render and lint-fix tasks.

## Changes
- Add `.github/workflows/autofix.yml` with autofix.ci integration
- Workflow runs on pull requests to main
- Excludes renovate and mend bot PRs
- Uses Rust cache for faster builds
- Runs `mise run render ::: lint-fix` to apply fixes

## Test plan
- [ ] Workflow should run on new PRs
- [ ] Autofix bot should commit fixes automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an autofix.ci workflow to auto-apply lint/render fixes on PRs and updates the release script to run these fixes and include additional files in release PRs.
> 
> - **CI**:
>   - Add `/.github/workflows/autofix.yml` to auto-apply fixes on `pull_request` to `main` using `mise run render ::: lint-fix` and `autofix-ci/action`.
>   - Uses Rust cache, checks out submodules, sets concurrency/env, and skips `renovate[bot]`/`mend[bot]`.
> - **Release tooling**:
>   - Update `mise-tasks/release-plz` to run `mise run render ::: lint-fix` before committing.
>   - Expand `git add` to include `docs` and `fnox.usage.kdl` (alongside `Cargo.*` and `CHANGELOG.md`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 86cf123ee60eb22c3b4d88a614ee60ebcdecf1d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->