### PR TITLE
docs: clean up local overrides docs

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -54,7 +54,6 @@ export default defineConfig({
           { text: "Shell Integration", link: "/guide/shell-integration" },
           { text: "Profiles", link: "/guide/profiles" },
           { text: "Hierarchical Config", link: "/guide/hierarchical-config" },
-          { text: "Local Overrides", link: "/guide/local-overrides" },
           {
             text: "Handling Missing Secrets",
             link: "/guide/missing-secrets",

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -269,7 +269,7 @@
       },
       "import": {
         "full_cmd": ["import"],
-        "usage": "import [FLAGS] [FORMAT]",
+        "usage": "import <FLAGS> [FORMAT]",
         "subcommands": {},
         "args": [
           {
@@ -309,6 +309,24 @@
             "arg": {
               "name": "INPUT",
               "usage": "<INPUT>",
+              "required": true,
+              "double_dash": "Optional",
+              "hide": false
+            }
+          },
+          {
+            "name": "provider",
+            "usage": "-p --provider <PROVIDER>",
+            "help": "Provider to use for encrypting/storing imported secrets (required)",
+            "help_first_line": "Provider to use for encrypting/storing imported secrets (required)",
+            "short": ["p"],
+            "long": ["provider"],
+            "required": true,
+            "hide": false,
+            "global": false,
+            "arg": {
+              "name": "PROVIDER",
+              "usage": "<PROVIDER>",
               "required": true,
               "double_dash": "Optional",
               "hide": false
@@ -751,10 +769,10 @@
           },
           {
             "name": "provider",
-            "usage": "-P --provider <PROVIDER>",
+            "usage": "-p --provider <PROVIDER>",
             "help": "Provider to fetch from",
             "help_first_line": "Provider to fetch from",
-            "short": ["P"],
+            "short": ["p"],
             "long": ["provider"],
             "hide": false,
             "global": false,
@@ -862,10 +880,10 @@
       },
       {
         "name": "profile",
-        "usage": "-p --profile <PROFILE>",
+        "usage": "-P --profile <PROFILE>",
         "help": "Profile to use (default: default, or FNOX_PROFILE env var)",
         "help_first_line": "Profile to use (default: default, or FNOX_PROFILE env var)",
-        "short": ["p"],
+        "short": ["P"],
         "long": ["profile"],
         "hide": false,
         "global": true,
@@ -942,7 +960,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.1.0",
+  "version": "1.2.1",
   "usage": "Usage: fnox [OPTIONS] <COMMAND>",
   "complete": {
     "key": {

--- a/docs/cli/import.md
+++ b/docs/cli/import.md
@@ -2,7 +2,7 @@
 
 # `fnox import`
 
-- **Usage**: `fnox import [FLAGS] [FORMAT]`
+- **Usage**: `fnox import <FLAGS> [FORMAT]`
 - **Aliases**: `im`
 
 Import secrets from various sources
@@ -31,6 +31,10 @@ Skip confirmation prompts
 ### `-i --input <INPUT>`
 
 Source file or path to import from (default: stdin)
+
+### `-p --provider <PROVIDER>`
+
+Provider to use for encrypting/storing imported secrets (required)
 
 ### `--filter <FILTER>`
 

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -4,7 +4,7 @@
 
 **Usage**: `fnox [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.1.0
+**Version**: 1.2.1
 
 - **Usage**: `fnox [FLAGS] <SUBCOMMAND>`
 
@@ -45,7 +45,7 @@ Disable colored output
 - [`fnox exec [COMMAND]…`](/cli/exec.md)
 - [`fnox export [-f --format <FORMAT>] [-o --output <OUTPUT>]`](/cli/export.md)
 - [`fnox get <KEY>`](/cli/get.md)
-- [`fnox import [FLAGS] [FORMAT]`](/cli/import.md)
+- [`fnox import <FLAGS> [FORMAT]`](/cli/import.md)
 - [`fnox init [--force] [--skip-wizard]`](/cli/init.md)
 - [`fnox list [FLAGS]`](/cli/list.md)
 - [`fnox profiles`](/cli/profiles.md)

--- a/docs/cli/set.md
+++ b/docs/cli/set.md
@@ -27,7 +27,7 @@ Description of the secret
 
 Key name in the provider (if different from env var name)
 
-### `-P --provider <PROVIDER>`
+### `-p --provider <PROVIDER>`
 
 Provider to fetch from
 

--- a/docs/guide/profiles.md
+++ b/docs/guide/profiles.md
@@ -213,6 +213,5 @@ jobs:
 
 ## Next Steps
 
-- [Hierarchical Config](/guide/hierarchical-config) - Organize configs across directories
-- [Local Overrides](/guide/local-overrides) - Per-developer customization
+- [Hierarchical Config](/guide/hierarchical-config) - Organize configs across directories (includes local overrides)
 - [Real-World Example](/guide/real-world-example) - Complete multi-environment setup

--- a/docs/providers/keychain.md
+++ b/docs/providers/keychain.md
@@ -340,5 +340,5 @@ sudo apt-get install kwalletmanager
 ## Next Steps
 
 - [Age Encryption](/providers/age) - Team-friendly alternative
-- [Local Overrides](/guide/local-overrides) - Per-machine configuration
+- [Hierarchical Config](/guide/hierarchical-config) - Per-machine configuration with fnox.local.toml
 - [1Password](/providers/1password) - Team password manager


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Consolidates local overrides into hierarchical config docs and updates CLI docs (import requires provider, provider flag `-p`, profile flag `-P`), with version bumped to 1.2.1.
> 
> - **Docs**:
>   - **Hierarchical Config**: Expanded to include `fnox.local.toml`, explicit merge order, local overrides section, imports vs hierarchy guidance, and tips/examples.
>   - **Navigation/Links**: Removed `Local Overrides` page from sidebar; updated references in `profiles` and `keychain` to point to hierarchical config (covers local overrides).
> - **CLI Reference**:
>   - `import`: Usage updated to `fnox import <FLAGS> [FORMAT]`; adds required `-p --provider <PROVIDER>` flag.
>   - `set`: Changes provider flag to `-p --provider` (from `-P`).
>   - Global: Profile flag standardized to `-P --profile`.
>   - Version strings updated to `1.2.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 63d64084e311ef78d628eb11f29f4925da22ea22. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->