### PR TITLE
docs: use single-line TOML syntax with section headers

### DIFF
--- a/CRUSH.md
+++ b/CRUSH.md
@@ -175,10 +175,8 @@ mise run test:bats -- test/bitwarden.bats
 Secrets support an `if_missing` field to control behavior when a secret cannot be resolved:
 
 ```toml
-[secrets.MY_SECRET]
-provider = "age"
-value = "..."
-if_missing = "warn"  # Options: "error", "warn", "ignore"
+[secrets]
+MY_SECRET = { provider = "age", value = "...", if_missing = "warn" }  # Options: "error", "warn", "ignore"
 ```
 
 **Default behavior**: When `if_missing` is not specified, fnox defaults to `"warn"`. This means:
@@ -226,18 +224,18 @@ The 1Password provider integrates with the 1Password CLI (`op`) to retrieve secr
 **Configuration:**
 
 ```toml
-[providers.onepass]
-type = "1password"
-vault = "my-vault"
-account = "my.1password.com"  # Optional
+[providers]
+onepass = { type = "1password", vault = "my-vault", account = "my.1password.com" }  # account is optional
 
-[secrets.MY_SECRET]
-provider = "onepass"
-value = "item-name"           # Retrieves password field
-# OR
-value = "item-name/username"  # Retrieves specific field
-# OR
-value = "op://vault/item/field"  # Full op:// reference
+[secrets]
+# Retrieves password field
+MY_SECRET = { provider = "onepass", value = "item-name" }
+
+# OR retrieves specific field
+MY_SECRET = { provider = "onepass", value = "item-name/username" }
+
+# OR full op:// reference
+MY_SECRET = { provider = "onepass", value = "op://vault/item/field" }
 ```
 
 **Requirements:**
@@ -276,16 +274,15 @@ The Bitwarden provider integrates with the Bitwarden CLI (`bw`) to retrieve secr
 **Configuration:**
 
 ```toml
-[providers.bitwarden]
-type = "bitwarden"
-collection = "my-collection-id"     # Optional
-organization_id = "my-org-id"       # Optional
+[providers]
+bitwarden = { type = "bitwarden", collection = "my-collection-id", organization_id = "my-org-id" }  # collection and organization_id are optional
 
-[secrets.MY_SECRET]
-provider = "bitwarden"
-value = "item-name"                 # Retrieves password field
-# OR
-value = "item-name/username"        # Retrieves specific field
+[secrets]
+# Retrieves password field
+MY_SECRET = { provider = "bitwarden", value = "item-name" }
+
+# OR retrieves specific field
+MY_SECRET = { provider = "bitwarden", value = "item-name/username" }
 ```
 
 **Requirements:**
@@ -345,14 +342,11 @@ The AWS KMS provider uses AWS Key Management Service to encrypt and decrypt secr
 **Configuration:**
 
 ```toml
-[providers.kms]
-type = "aws-kms"
-key_id = "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012"
-region = "us-east-1"
+[providers]
+kms = { type = "aws-kms", key_id = "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012", region = "us-east-1" }
 
-[secrets.MY_SECRET]
-provider = "kms"
-value = "base64-encoded-ciphertext"  # Encrypted value stored in config
+[secrets]
+MY_SECRET = { provider = "kms", value = "base64-encoded-ciphertext" }  # Encrypted value stored in config
 ```
 
 **Requirements:**
@@ -409,14 +403,11 @@ The AWS Secrets Manager provider retrieves secrets stored remotely in AWS Secret
 **Configuration:**
 
 ```toml
-[providers.sm]
-type = "aws-sm"
-region = "us-east-1"
-prefix = "fnox/"  # Optional prefix prepended to secret names
+[providers]
+sm = { type = "aws-sm", region = "us-east-1", prefix = "fnox/" }  # prefix is optional
 
-[secrets.MY_SECRET]
-provider = "sm"
-value = "my-secret-name"  # Name of secret in AWS Secrets Manager
+[secrets]
+MY_SECRET = { provider = "sm", value = "my-secret-name" }  # Name of secret in AWS Secrets Manager
 ```
 
 **Requirements:**
@@ -470,9 +461,8 @@ fnox provider add sm --type aws-sm \
 
 # Add secret reference (fnox just stores the reference, not the value)
 cat >> fnox.toml << EOF
-[secrets.MY_SECRET]
-provider = "sm"
-value = "my-secret-name"
+[secrets]
+MY_SECRET = { provider = "sm", value = "my-secret-name" }
 EOF
 
 # Retrieve secret from AWS Secrets Manager
@@ -506,14 +496,11 @@ The Keychain provider stores secrets in the operating system's native secure sto
 **Configuration:**
 
 ```toml
-[providers.keychain]
-type = "keychain"
-service = "fnox"
-prefix = "myapp/"  # Optional
+[providers]
+keychain = { type = "keychain", service = "fnox", prefix = "myapp/" }  # prefix is optional
 
-[secrets.MY_SECRET]
-provider = "keychain"
-value = "my-secret-name"  # Key name in keychain, not the actual value
+[secrets]
+MY_SECRET = { provider = "keychain", value = "my-secret-name" }  # Key name in keychain, not the actual value
 ```
 
 **Requirements:**
@@ -528,10 +515,8 @@ value = "my-secret-name"  # Key name in keychain, not the actual value
 ```bash
 # Set up provider in fnox.toml
 cat >> fnox.toml << EOF
-[providers.keychain]
-type = "keychain"
-service = "fnox"
-prefix = "myapp/"
+[providers]
+keychain = { type = "keychain", service = "fnox", prefix = "myapp/" }
 EOF
 
 # Store a secret in OS keychain (encrypts and stores in keychain)

--- a/CRUSH.md
+++ b/CRUSH.md
@@ -342,8 +342,10 @@ The AWS KMS provider uses AWS Key Management Service to encrypt and decrypt secr
 **Configuration:**
 
 ```toml
-[providers]
-kms = { type = "aws-kms", key_id = "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012", region = "us-east-1" }
+[providers.kms]
+type = "aws-kms"
+key_id = "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012"
+region = "us-east-1"
 
 [secrets]
 MY_SECRET = { provider = "kms", value = "base64-encoded-ciphertext" }  # Encrypted value stored in config

--- a/README.md
+++ b/README.md
@@ -97,28 +97,19 @@ Your `fnox.toml` config file either contains encrypted secrets or references to 
 ```toml
 # fnox.toml
 
-# Provider configuration
-[providers.age]
-type = "age"
-recipients = ["age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"]
+[providers]
+age = { type = "age", recipients = ["age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"] }
 
+[secrets]
 # Development secrets (encrypted in git)
-[secrets.DATABASE_URL]
-provider = "age"
-value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHNjcnlwdC..."  # ← encrypted, safe to commit
+DATABASE_URL = { provider = "age", value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHNjcnlwdC..." }  # ← encrypted, safe to commit
+API_KEY = { default = "dev-key-12345" }  # ← plain default for local dev
 
-[secrets.API_KEY]
-default = "dev-key-12345"  # ← plain default for local dev
+[profiles.production.providers]
+aws = { type = "aws-sm", region = "us-east-1", prefix = "myapp/" }
 
-# Production profile (AWS Secrets Manager)
-[profiles.production.providers.aws]
-type = "aws-sm"
-region = "us-east-1"
-prefix = "myapp/"
-
-[profiles.production.secrets.DATABASE_URL]
-provider = "aws"
-value = "database-url"  # ← reference to AWS secret
+[profiles.production.secrets]
+DATABASE_URL = { provider = "aws", value = "database-url" }  # ← reference to AWS secret
 ```
 
 ```bash

--- a/docs/guide/hierarchical-config.md
+++ b/docs/guide/hierarchical-config.md
@@ -35,21 +35,13 @@ Each level merges both the main config and local overrides, with child configs t
 ```toml
 # project/fnox.toml
 
-# Shared age provider
-[providers.age]
-type = "age"
-recipients = ["age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"]
+[providers]
+age = { type = "age", recipients = ["age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"] }
 
-# Shared secrets
-[secrets.LOG_LEVEL]
-default = "info"
-
-[secrets.ENVIRONMENT]
-default = "development"
-
-[secrets.JWT_SECRET]
-provider = "age"
-value = "encrypted-shared-jwt..."
+[secrets]
+LOG_LEVEL = { default = "info" }
+ENVIRONMENT = { default = "development" }
+JWT_SECRET = { provider = "age", value = "encrypted-shared-jwt..." }
 ```
 
 ### API Service Config
@@ -57,17 +49,10 @@ value = "encrypted-shared-jwt..."
 ```toml
 # project/services/api/fnox.toml
 
-# API-specific secrets
-[secrets.API_PORT]
-default = "3000"
-
-[secrets.DATABASE_URL]
-provider = "age"
-value = "encrypted-api-db..."
-
-# Override shared secret for API
-[secrets.LOG_LEVEL]
-default = "debug"  # More verbose for API during dev
+[secrets]
+API_PORT = { default = "3000" }
+DATABASE_URL = { provider = "age", value = "encrypted-api-db..." }
+LOG_LEVEL = { default = "debug" }  # Override shared secret - more verbose for API during dev
 ```
 
 ### Worker Service Config
@@ -75,13 +60,9 @@ default = "debug"  # More verbose for API during dev
 ```toml
 # project/services/worker/fnox.toml
 
-# Worker-specific secrets
-[secrets.QUEUE_URL]
-provider = "age"
-value = "encrypted-queue-url..."
-
-[secrets.WORKER_CONCURRENCY]
-default = "4"
+[secrets]
+QUEUE_URL = { provider = "age", value = "encrypted-queue-url..." }
+WORKER_CONCURRENCY = { default = "4" }
 ```
 
 ## Resulting Secrets

--- a/docs/guide/how-it-works.md
+++ b/docs/guide/how-it-works.md
@@ -11,13 +11,11 @@ Secrets can be stored in two ways:
 The encrypted ciphertext lives directly in the config file:
 
 ```toml
-[providers.age]
-type = "age"
-recipients = ["age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"]
+[providers]
+age = { type = "age", recipients = ["age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"] }
 
-[secrets.DATABASE_URL]
-provider = "age"
-value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHNjcnlwdC4uLg=="  # ← encrypted, safe to commit
+[secrets]
+DATABASE_URL = { provider = "age", value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHNjcnlwdC4uLg==" }  # ← encrypted, safe to commit
 ```
 
 **Providers:** age, aws-kms, azure-kms, gcp-kms
@@ -38,14 +36,11 @@ value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHNjcnlwdC4uLg=="  # ← encrypted, saf
 The config contains only a reference to a secret stored remotely:
 
 ```toml
-[providers.aws]
-type = "aws-sm"
-region = "us-east-1"
-prefix = "myapp/"
+[providers]
+aws = { type = "aws-sm", region = "us-east-1", prefix = "myapp/" }
 
-[secrets.DATABASE_URL]
-provider = "aws"
-value = "database-url"  # ← Just a reference, actual secret in AWS
+[secrets]
+DATABASE_URL = { provider = "aws", value = "database-url" }  # ← Just a reference, actual secret in AWS
 ```
 
 **Providers:** aws-sm, azure-sm, gcp-sm, vault, 1password, bitwarden, keychain
@@ -78,27 +73,14 @@ First match wins!
 
 ```toml
 # Provider definitions
-[providers.age]
-type = "age"
-recipients = ["age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"]
+[providers]
+age = { type = "age", recipients = ["age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"] }
+aws = { type = "aws-sm", region = "us-east-1" }
 
-[providers.aws]
-type = "aws-sm"
-region = "us-east-1"
-
-# Encrypted secret (in git)
-[secrets.JWT_SECRET]
-provider = "age"
-value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHNjcnlwdC4uLg=="
-
-# Remote secret (in AWS)
-[secrets.DATABASE_URL]
-provider = "aws"
-value = "prod-database-url"
-
-# Default value (fallback)
-[secrets.NODE_ENV]
-default = "development"
+[secrets]
+JWT_SECRET = { provider = "age", value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHNjcnlwdC4uLg==" }  # Encrypted secret (in git)
+DATABASE_URL = { provider = "aws", value = "prod-database-url" }  # Remote secret (in AWS)
+NODE_ENV = { default = "development" }  # Default value (fallback)
 ```
 
 ## Execution Flow

--- a/docs/guide/missing-secrets.md
+++ b/docs/guide/missing-secrets.md
@@ -24,23 +24,15 @@ You can set `if_missing` at multiple levels. fnox uses the first match:
 Set different behaviors for different secrets:
 
 ```toml
+[secrets]
 # Critical secrets must exist
-[secrets.DATABASE_URL]
-provider = "aws"
-value = "database-url"
-if_missing = "error"  # Fail if missing
+DATABASE_URL = { provider = "aws", value = "database-url", if_missing = "error" }  # Fail if missing
 
 # Optional secrets
-[secrets.ANALYTICS_KEY]
-provider = "aws"
-value = "analytics-key"
-if_missing = "ignore"  # Continue silently if missing
+ANALYTICS_KEY = { provider = "aws", value = "analytics-key", if_missing = "ignore" }  # Continue silently if missing
 
 # Warn about missing secrets (default)
-[secrets.CACHE_URL]
-provider = "aws"
-value = "cache-url"
-if_missing = "warn"  # Print warning if missing
+CACHE_URL = { provider = "aws", value = "cache-url", if_missing = "warn" }  # Print warning if missing
 ```
 
 ## Top-Level Default
@@ -51,20 +43,10 @@ Set a default for all secrets:
 # Make all secrets strict by default
 if_missing = "error"
 
-[secrets.DATABASE_URL]
-provider = "age"
-value = "encrypted..."
-# ↑ Inherits if_missing = "error"
-
-[secrets.API_KEY]
-provider = "age"
-value = "encrypted..."
-# ↑ Inherits if_missing = "error"
-
-# Override for specific secret
-[secrets.OPTIONAL_FEATURE_FLAG]
-default = "false"
-if_missing = "ignore"  # This one can be missing
+[secrets]
+DATABASE_URL = { provider = "age", value = "encrypted..." }  # Inherits if_missing = "error"
+API_KEY = { provider = "age", value = "encrypted..." }  # Inherits if_missing = "error"
+OPTIONAL_FEATURE_FLAG = { default = "false", if_missing = "ignore" }  # Override - this one can be missing
 ```
 
 ## Runtime Override with CLI
@@ -185,35 +167,24 @@ jobs:
 ### Optional Analytics/Monitoring
 
 ```toml
+[secrets]
 # Won't break the app if missing
-[secrets.SENTRY_DSN]
-provider = "aws"
-value = "sentry-dsn"
-if_missing = "ignore"
-
-[secrets.DATADOG_API_KEY]
-provider = "aws"
-value = "datadog-key"
-if_missing = "ignore"
+SENTRY_DSN = { provider = "aws", value = "sentry-dsn", if_missing = "ignore" }
+DATADOG_API_KEY = { provider = "aws", value = "datadog-key", if_missing = "ignore" }
 ```
 
 ### Required Database
 
 ```toml
-# Must exist or fail
-[secrets.DATABASE_URL]
-provider = "aws"
-value = "database-url"
-if_missing = "error"
+[secrets]
+DATABASE_URL = { provider = "aws", value = "database-url", if_missing = "error" }  # Must exist or fail
 ```
 
 ### Development Defaults
 
 ```toml
-# Warn if missing, but provide a default
-[secrets.REDIS_URL]
-default = "redis://localhost:6379"
-if_missing = "warn"
+[secrets]
+REDIS_URL = { default = "redis://localhost:6379", if_missing = "warn" }  # Warn if missing, but provide a default
 ```
 
 ## Behavior Summary

--- a/docs/guide/profiles.md
+++ b/docs/guide/profiles.md
@@ -8,28 +8,19 @@ Define environment-specific secrets using profiles:
 
 ```toml
 # Default profile (development)
-[secrets.API_URL]
-default = "http://localhost:3000"
-
-[secrets.DATABASE_URL]
-provider = "age"
-value = "encrypted-dev-db..."
+[secrets]
+API_URL = { default = "http://localhost:3000" }
+DATABASE_URL = { provider = "age", value = "encrypted-dev-db..." }
 
 # Staging profile
-[profiles.staging.secrets.API_URL]
-default = "https://staging.example.com"
-
-[profiles.staging.secrets.DATABASE_URL]
-provider = "age"
-value = "encrypted-staging-db..."
+[profiles.staging.secrets]
+API_URL = { default = "https://staging.example.com" }
+DATABASE_URL = { provider = "age", value = "encrypted-staging-db..." }
 
 # Production profile
-[profiles.production.secrets.API_URL]
-default = "https://api.example.com"
-
-[profiles.production.secrets.DATABASE_URL]
-provider = "aws"
-value = "prod-database-url"  # Stored in AWS Secrets Manager
+[profiles.production.secrets]
+API_URL = { default = "https://api.example.com" }
+DATABASE_URL = { provider = "aws", value = "prod-database-url" }  # Stored in AWS Secrets Manager
 ```
 
 ## Using Profiles
@@ -76,27 +67,19 @@ Profiles automatically inherit secrets from the top level:
 
 ```toml
 # Define once - all profiles inherit
-[secrets.LOG_LEVEL]
-default = "info"
-
-[secrets.API_TIMEOUT]
-default = "30"
-
-[secrets.DATABASE_URL]
-provider = "age"
-value = "encrypted-dev-db..."
+[secrets]
+LOG_LEVEL = { default = "info" }
+API_TIMEOUT = { default = "30" }
+DATABASE_URL = { provider = "age", value = "encrypted-dev-db..." }
 
 # Staging inherits all top-level secrets
 [profiles.staging]
 # Automatically gets: LOG_LEVEL, API_TIMEOUT, DATABASE_URL
 
 # Production overrides specific secrets, inherits the rest
-[profiles.production.secrets.DATABASE_URL]
-provider = "aws"
-value = "prod-db"  # Overrides DATABASE_URL
-
-[profiles.production.secrets.LOG_LEVEL]
-default = "warn"   # Overrides LOG_LEVEL
+[profiles.production.secrets]
+DATABASE_URL = { provider = "aws", value = "prod-db" }  # Overrides DATABASE_URL
+LOG_LEVEL = { default = "warn" }  # Overrides LOG_LEVEL
 # Still inherits API_TIMEOUT="30" from top level
 ```
 
@@ -108,21 +91,17 @@ Each profile can have its own providers:
 
 ```toml
 # Default providers (for development)
-[providers.age]
-type = "age"
-recipients = ["age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"]
+[providers]
+age = { type = "age", recipients = ["age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"] }
 
 # Production profile with AWS providers
 [profiles.production]
 
-[profiles.production.providers.aws]
-type = "aws-sm"
-region = "us-east-1"
-prefix = "myapp/"
+[profiles.production.providers]
+aws = { type = "aws-sm", region = "us-east-1", prefix = "myapp/" }
 
-[profiles.production.secrets.DATABASE_URL]
-provider = "aws"
-value = "database-url"
+[profiles.production.secrets]
+DATABASE_URL = { provider = "aws", value = "database-url" }
 ```
 
 ## List Profiles
@@ -147,46 +126,42 @@ production
 
 ```toml
 # Development (default): encrypted in git
-[providers.age]
-type = "age"
-recipients = ["age1..."]
+[providers]
+age = { type = "age", recipients = ["age1..."] }
 
-[secrets.DATABASE_URL]
-provider = "age"
-value = "encrypted..."
+[secrets]
+DATABASE_URL = { provider = "age", value = "encrypted..." }
 
 # Production: AWS Secrets Manager
-[profiles.production.providers.aws]
-type = "aws-sm"
-region = "us-east-1"
+[profiles.production.providers]
+aws = { type = "aws-sm", region = "us-east-1" }
 
-[profiles.production.secrets.DATABASE_URL]
-provider = "aws"
-value = "database-url"
+[profiles.production.secrets]
+DATABASE_URL = { provider = "aws", value = "database-url" }
 ```
 
 ### Multi-Region Production
 
 ```toml
-[profiles.production-us.providers.aws]
-type = "aws-sm"
-region = "us-east-1"
+[profiles.production-us.providers]
+aws = { type = "aws-sm", region = "us-east-1" }
 
-[profiles.production-eu.providers.aws]
-type = "aws-sm"
-region = "eu-west-1"
+[profiles.production-eu.providers]
+aws = { type = "aws-sm", region = "eu-west-1" }
 ```
 
 ### Per-Developer Profiles
 
 ```toml
 [profiles.alice]
-[profiles.alice.secrets.DATABASE_URL]
-default = "postgresql://localhost/alice_db"
+
+[profiles.alice.secrets]
+DATABASE_URL = { default = "postgresql://localhost/alice_db" }
 
 [profiles.bob]
-[profiles.bob.secrets.DATABASE_URL]
-default = "postgresql://localhost/bob_db"
+
+[profiles.bob.secrets]
+DATABASE_URL = { default = "postgresql://localhost/bob_db" }
 ```
 
 ```bash

--- a/docs/guide/real-world-example.md
+++ b/docs/guide/real-world-example.md
@@ -42,13 +42,12 @@ Add to `fnox.toml`:
 
 ```toml
 # Shared age provider for dev and staging
-[providers.age]
-type = "age"
-recipients = [
+[providers]
+age = { type = "age", recipients = [
   "age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p",  # alice
   "age1pr3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqabc123",  # bob
-  "age1zr3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqdxf456",  # ci
-]
+  "age1zr3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqdxf456"   # ci
+] }
 ```
 
 Set decryption key:
@@ -71,25 +70,14 @@ fnox set SENDGRID_KEY "SG.test123" --provider age
 Your `fnox.toml` now contains encrypted secrets:
 
 ```toml
-[providers.age]
-type = "age"
-recipients = ["age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"]
+[providers]
+age = { type = "age", recipients = ["age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"] }
 
-[secrets.DATABASE_URL]
-provider = "age"
-value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHNjcnlwdC..."
-
-[secrets.JWT_SECRET]
-provider = "age"
-value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHNjcnlwdC..."
-
-[secrets.STRIPE_KEY]
-provider = "age"
-value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHNjcnlwdC..."
-
-[secrets.SENDGRID_KEY]
-provider = "age"
-value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHNjcnlwdC..."
+[secrets]
+DATABASE_URL = { provider = "age", value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHNjcnlwdC..." }
+JWT_SECRET = { provider = "age", value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHNjcnlwdC..." }
+STRIPE_KEY = { provider = "age", value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHNjcnlwdC..." }
+SENDGRID_KEY = { provider = "age", value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHNjcnlwdC..." }
 ```
 
 **Commit this!** It's encrypted and safe.
@@ -125,30 +113,19 @@ fnox set SENDGRID_KEY "SG.staging456" \
 Your `fnox.toml` now has a staging profile:
 
 ```toml
-[providers.age]
-type = "age"
-recipients = ["age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"]
+[providers]
+age = { type = "age", recipients = ["age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"] }
 
 # Development (default profile)
-[secrets.DATABASE_URL]
-provider = "age"
-value = "..."
-
-[secrets.JWT_SECRET]
-provider = "age"
-value = "..."
-
+[secrets]
+DATABASE_URL = { provider = "age", value = "..." }
+JWT_SECRET = { provider = "age", value = "..." }
 # ... other dev secrets ...
 
 # Staging profile
-[profiles.staging.secrets.DATABASE_URL]
-provider = "age"
-value = "..."
-
-[profiles.staging.secrets.JWT_SECRET]
-provider = "age"
-value = "..."
-
+[profiles.staging.secrets]
+DATABASE_URL = { provider = "age", value = "..." }
+JWT_SECRET = { provider = "age", value = "..." }
 # ... other staging secrets ...
 ```
 
@@ -159,30 +136,14 @@ Add production configuration (secrets stored in AWS):
 ```toml
 # Add to fnox.toml
 
-[profiles.production.providers.aws]
-type = "aws-sm"
-region = "us-east-1"
-prefix = "myapi/"
+[profiles.production.providers]
+aws = { type = "aws-sm", region = "us-east-1", prefix = "myapi/" }
 
-[profiles.production.secrets.DATABASE_URL]
-provider = "aws"
-value = "database-url"
-if_missing = "error"  # Critical secret
-
-[profiles.production.secrets.JWT_SECRET]
-provider = "aws"
-value = "jwt-secret"
-if_missing = "error"
-
-[profiles.production.secrets.STRIPE_KEY]
-provider = "aws"
-value = "stripe-key"
-if_missing = "error"
-
-[profiles.production.secrets.SENDGRID_KEY]
-provider = "aws"
-value = "sendgrid-key"
-if_missing = "error"
+[profiles.production.secrets]
+DATABASE_URL = { provider = "aws", value = "database-url", if_missing = "error" }  # Critical secret
+JWT_SECRET = { provider = "aws", value = "jwt-secret", if_missing = "error" }
+STRIPE_KEY = { provider = "aws", value = "stripe-key", if_missing = "error" }
+SENDGRID_KEY = { provider = "aws", value = "sendgrid-key", if_missing = "error" }
 ```
 
 Create secrets in AWS:
@@ -228,11 +189,9 @@ Each developer can create personal overrides:
 ```toml
 # fnox.local.toml (not committed)
 
-[secrets.DATABASE_URL]
-default = "postgresql://localhost/alice_db"  # Personal DB
-
-[secrets.DEBUG_MODE]
-default = "true"  # Enable debugging
+[secrets]
+DATABASE_URL = { default = "postgresql://localhost/alice_db" }  # Personal DB
+DEBUG_MODE = { default = "true" }  # Enable debugging
 ```
 
 ## Step 7: Use It

--- a/docs/guide/real-world-example.md
+++ b/docs/guide/real-world-example.md
@@ -42,12 +42,13 @@ Add to `fnox.toml`:
 
 ```toml
 # Shared age provider for dev and staging
-[providers]
-age = { type = "age", recipients = [
+[providers.age]
+type = "age"
+recipients = [
   "age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p",  # alice
   "age1pr3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqabc123",  # bob
   "age1zr3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqdxf456"   # ci
-] }
+]
 ```
 
 Set decryption key:

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,16 +67,12 @@ You configure providers (encryption methods or cloud services), then assign each
 
 ```toml
 # fnox.toml
-[providers.age]
-type = "age"
-recipients = ["age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"]
+[providers]
+age = { type = "age", recipients = ["age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"] }
 
-[secrets.DATABASE_URL]
-provider = "age"
-value = "YWdlLWVuY3J5cHRpb24uLi4="  # ← encrypted ciphertext, safe to commit
-
-[secrets.API_KEY]
-default = "dev-key-12345"  # ← plain default value for local dev
+[secrets]
+DATABASE_URL = { provider = "age", value = "YWdlLWVuY3J5cHRpb24uLi4=" }  # ← encrypted ciphertext, safe to commit
+API_KEY = { default = "dev-key-12345" }  # ← plain default value for local dev
 ```
 
 ## Supported Providers

--- a/docs/providers/1password.md
+++ b/docs/providers/1password.md
@@ -16,9 +16,8 @@ fnox set OP_SERVICE_ACCOUNT_TOKEN "ops_YOUR_TOKEN" --provider age
 
 # 4. Configure 1Password provider
 cat >> fnox.toml << 'EOF'
-[providers.onepass]
-type = "1password"
-vault = "Development"
+[providers]
+onepass = { type = "1password", vault = "Development" }
 EOF
 
 # 5. Add secrets to 1Password (via app or CLI)
@@ -29,9 +28,8 @@ op item create --category=login \
 
 # 6. Reference in fnox
 cat >> fnox.toml << 'EOF'
-[secrets.DATABASE_PASSWORD]
-provider = "onepass"
-value = "Database"
+[secrets]
+DATABASE_PASSWORD = { provider = "onepass", value = "Database" }
 EOF
 
 # 7. Use it
@@ -79,9 +77,8 @@ Use age encryption to store the token:
 ```bash
 # First, set up age provider (if not already done)
 cat >> fnox.toml << 'EOF'
-[providers.age]
-type = "age"
-recipients = ["age1..."]
+[providers]
+age = { type = "age", recipients = ["age1..."] }
 EOF
 
 # Store the 1Password token encrypted in fnox
@@ -97,10 +94,8 @@ export OP_SERVICE_ACCOUNT_TOKEN=$(fnox get OP_SERVICE_ACCOUNT_TOKEN)
 ### 3. Configure 1Password Provider
 
 ```toml
-[providers.onepass]
-type = "1password"
-vault = "Development"  # Your vault name
-account = "my.1password.com"  # Optional
+[providers]
+onepass = { type = "1password", vault = "Development", account = "my.1password.com" }  # account is optional
 ```
 
 ## Adding Secrets to 1Password
@@ -146,17 +141,10 @@ op item create --category=login \
 Add references to `fnox.toml`:
 
 ```toml
-[secrets.DATABASE_PASSWORD]
-provider = "onepass"
-value = "Database"  # Item name (fetches 'password' field)
-
-[secrets.DB_USERNAME]
-provider = "onepass"
-value = "Database/username"  # Specific field
-
-[secrets.API_KEY]
-provider = "onepass"
-value = "op://Development/API Keys/credential"  # Full op:// URI
+[secrets]
+DATABASE_PASSWORD = { provider = "onepass", value = "Database" }  # Item name (fetches 'password' field)
+DB_USERNAME = { provider = "onepass", value = "Database/username" }  # Specific field
+API_KEY = { provider = "onepass", value = "op://Development/API Keys/credential" }  # Full op:// URI
 ```
 
 ## Reference Formats
@@ -166,21 +154,16 @@ fnox supports multiple ways to reference 1Password items:
 ### 1. Item Name (Gets Password Field)
 
 ```toml
-[secrets.MY_SECRET]
-provider = "onepass"
-value = "My Item"  # → Gets the 'password' field
+[secrets]
+MY_SECRET = { provider = "onepass", value = "My Item" }  # → Gets the 'password' field
 ```
 
 ### 2. Item Name + Field
 
 ```toml
-[secrets.USERNAME]
-provider = "onepass"
-value = "Database/username"  # → Gets 'username' field
-
-[secrets.PASSWORD]
-provider = "onepass"
-value = "Database/password"  # → Gets 'password' field
+[secrets]
+USERNAME = { provider = "onepass", value = "Database/username" }  # → Gets 'username' field
+PASSWORD = { provider = "onepass", value = "Database/password" }  # → Gets 'password' field
 ```
 
 Common fields: `username`, `password`, `url`, `notes`
@@ -188,9 +171,8 @@ Common fields: `username`, `password`, `url`, `notes`
 ### 3. Full op:// URI
 
 ```toml
-[secrets.API_KEY]
-provider = "onepass"
-value = "op://Development/API Keys/credential"
+[secrets]
+API_KEY = { provider = "onepass", value = "op://Development/API Keys/credential" }
 ```
 
 Format: `op://VAULT/ITEM/FIELD`
@@ -213,31 +195,20 @@ fnox exec -- npm start
 
 ```toml
 # Bootstrap token (encrypted in git)
-[providers.age]
-type = "age"
-recipients = ["age1..."]
+[providers]
+age = { type = "age", recipients = ["age1..."] }
+onepass = { type = "1password", vault = "Development" }
 
-[secrets.OP_SERVICE_ACCOUNT_TOKEN]
-provider = "age"
-value = "encrypted-token..."
-
-# Development: 1Password
-[providers.onepass]
-type = "1password"
-vault = "Development"
-
-[secrets.DATABASE_URL]
-provider = "onepass"
-value = "Dev Database"
+[secrets]
+OP_SERVICE_ACCOUNT_TOKEN = { provider = "age", value = "encrypted-token..." }
+DATABASE_URL = { provider = "onepass", value = "Dev Database" }
 
 # Production: Different 1Password vault
-[profiles.production.providers.onepass]
-type = "1password"
-vault = "Production"
+[profiles.production.providers]
+onepass = { type = "1password", vault = "Production" }
 
-[profiles.production.secrets.DATABASE_URL]
-provider = "onepass"
-value = "Prod Database"
+[profiles.production.secrets]
+DATABASE_URL = { provider = "onepass", value = "Prod Database" }
 ```
 
 ## CI/CD Example
@@ -280,9 +251,8 @@ jobs:
 3. **Admin creates items** in 1Password vault
 4. **Admin adds references** to fnox.toml:
    ```toml
-   [secrets.DATABASE_URL]
-   provider = "onepass"
-   value = "Database"
+   [secrets]
+   DATABASE_URL = { provider = "onepass", value = "Database" }
    ```
 5. **Team members pull and use**:
    ```bash

--- a/docs/providers/age.md
+++ b/docs/providers/age.md
@@ -14,9 +14,8 @@ grep "public key:" ~/.config/fnox/age.txt
 
 # 3. Configure fnox
 cat >> fnox.toml << 'EOF'
-[providers.age]
-type = "age"
-recipients = ["age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"]
+[providers]
+age = { type = "age", recipients = ["age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"] }
 EOF
 
 # 4. Set private key
@@ -77,17 +76,15 @@ Age has first-class SSH key support! Use your existing SSH keys:
 Add age provider to `fnox.toml`:
 
 ```toml
-[providers.age]
-type = "age"
-recipients = ["age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"]
+[providers]
+age = { type = "age", recipients = ["age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"] }
 ```
 
 Or with SSH key:
 
 ```toml
-[providers.age]
-type = "age"
-recipients = ["ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGQs8..."]
+[providers]
+age = { type = "age", recipients = ["ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGQs8..."] }
 ```
 
 ### Set Decryption Key
@@ -123,9 +120,8 @@ fnox set DATABASE_URL "postgresql://localhost/mydb" --provider age
 The resulting `fnox.toml`:
 
 ```toml
-[secrets.DATABASE_URL]
-provider = "age"
-value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHNjcnlwdC..."  # ← Encrypted, safe to commit!
+[secrets]
+DATABASE_URL = { provider = "age", value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHNjcnlwdC..." }  # ← Encrypted, safe to commit!
 ```
 
 ### Decrypt and Get a Secret
@@ -152,12 +148,11 @@ Age natively supports SSH keys—no conversion needed!
 ### Using SSH Keys
 
 ```toml
-[providers.age]
-type = "age"
-recipients = [
+[providers]
+age = { type = "age", recipients = [
   "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGQs8YqSC... alice@example.com",
   "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC5... bob@example.com"
-]
+] }
 ```
 
 Set decryption key:
@@ -198,13 +193,12 @@ cat ~/.ssh/id_ed25519.pub
 ### 2. Add All Recipients
 
 ```toml
-[providers.age]
-type = "age"
-recipients = [
+[providers]
+age = { type = "age", recipients = [
   "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGQs... # alice",
   "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBws... # bob",
   "age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2el... # ci-bot"
-]
+] }
 ```
 
 ### 3. Encrypt Secrets
@@ -254,13 +248,12 @@ fnox get DATABASE_URL  # Works for all recipients!
 2. **Admin adds to recipients**:
 
    ```toml
-   [providers.age]
-   type = "age"
-   recipients = [
+   [providers]
+   age = { type = "age", recipients = [
      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGQs... # alice",
      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBws... # bob",
      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIXyz... # charlie (NEW)"
-   ]
+   ] }
    ```
 
 3. **Re-encrypt all secrets** (necessary for new recipient):

--- a/docs/providers/age.md
+++ b/docs/providers/age.md
@@ -148,11 +148,12 @@ Age natively supports SSH keys—no conversion needed!
 ### Using SSH Keys
 
 ```toml
-[providers]
-age = { type = "age", recipients = [
+[providers.age]
+type = "age"
+recipients = [
   "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGQs8YqSC... alice@example.com",
   "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC5... bob@example.com"
-] }
+]
 ```
 
 Set decryption key:
@@ -193,12 +194,13 @@ cat ~/.ssh/id_ed25519.pub
 ### 2. Add All Recipients
 
 ```toml
-[providers]
-age = { type = "age", recipients = [
-  "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGQs... # alice",
-  "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBws... # bob",
-  "age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2el... # ci-bot"
-] }
+[providers.age]
+type = "age"
+recipients = [
+  "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGQs...",  # alice
+  "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBws...",  # bob
+  "age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2el..."   # ci-bot
+]
 ```
 
 ### 3. Encrypt Secrets
@@ -248,12 +250,13 @@ fnox get DATABASE_URL  # Works for all recipients!
 2. **Admin adds to recipients**:
 
    ```toml
-   [providers]
-   age = { type = "age", recipients = [
-     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGQs... # alice",
-     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBws... # bob",
-     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIXyz... # charlie (NEW)"
-   ] }
+   [providers.age]
+   type = "age"
+   recipients = [
+     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGQs...",  # alice
+     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBws...",  # bob
+     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIXyz..."   # charlie (NEW)
+   ]
    ```
 
 3. **Re-encrypt all secrets** (necessary for new recipient):

--- a/docs/providers/aws-kms.md
+++ b/docs/providers/aws-kms.md
@@ -25,10 +25,8 @@ aws kms create-key --description "fnox secrets encryption"
 
 # 2. Configure provider
 cat >> fnox.toml << 'EOF'
-[providers.kms]
-type = "aws-kms"
-key_id = "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012"
-region = "us-east-1"
+[providers]
+kms = { type = "aws-kms", key_id = "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012", region = "us-east-1" }
 EOF
 
 # 3. Encrypt a secret
@@ -83,10 +81,8 @@ Same as [AWS Secrets Manager](/providers/aws-sm#configure-aws-credentials).
 ### 3. Configure fnox Provider
 
 ```toml
-[providers.kms]
-type = "aws-kms"
-key_id = "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012"
-region = "us-east-1"
+[providers]
+kms = { type = "aws-kms", key_id = "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012", region = "us-east-1" }
 ```
 
 The `key_id` can be:
@@ -106,9 +102,8 @@ fnox set DATABASE_URL "postgresql://prod.example.com/db" --provider kms
 Result in `fnox.toml`:
 
 ```toml
-[secrets.DATABASE_URL]
-provider = "kms"
-value = "AQICAHhw...base64...ciphertext..."  # ← Encrypted, safe to commit!
+[secrets]
+DATABASE_URL = { provider = "kms", value = "AQICAHhw...base64...ciphertext..." }  # ← Encrypted, safe to commit!
 ```
 
 ### Decrypt and Get
@@ -131,23 +126,18 @@ fnox get DATABASE_URL
 
 ```toml
 # Development: age encryption (free)
-[providers.age]
-type = "age"
-recipients = ["age1..."]
+[providers]
+age = { type = "age", recipients = ["age1..."] }
 
-[secrets.DATABASE_URL]
-provider = "age"
-value = "encrypted-dev..."
+[secrets]
+DATABASE_URL = { provider = "age", value = "encrypted-dev..." }
 
 # Production: AWS KMS
-[profiles.production.providers.kms]
-type = "aws-kms"
-key_id = "arn:aws:kms:us-east-1:123456789012:key/..."
-region = "us-east-1"
+[profiles.production.providers]
+kms = { type = "aws-kms", key_id = "arn:aws:kms:us-east-1:123456789012:key/...", region = "us-east-1" }
 
-[profiles.production.secrets.DATABASE_URL]
-provider = "kms"
-value = "AQICAHhw..."  # ← KMS encrypted ciphertext
+[profiles.production.secrets]
+DATABASE_URL = { provider = "kms", value = "AQICAHhw..." }  # ← KMS encrypted ciphertext
 ```
 
 ## Key Rotation

--- a/docs/providers/aws-kms.md
+++ b/docs/providers/aws-kms.md
@@ -25,8 +25,10 @@ aws kms create-key --description "fnox secrets encryption"
 
 # 2. Configure provider
 cat >> fnox.toml << 'EOF'
-[providers]
-kms = { type = "aws-kms", key_id = "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012", region = "us-east-1" }
+[providers.kms]
+type = "aws-kms"
+key_id = "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012"
+region = "us-east-1"
 EOF
 
 # 3. Encrypt a secret
@@ -81,8 +83,10 @@ Same as [AWS Secrets Manager](/providers/aws-sm#configure-aws-credentials).
 ### 3. Configure fnox Provider
 
 ```toml
-[providers]
-kms = { type = "aws-kms", key_id = "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012", region = "us-east-1" }
+[providers.kms]
+type = "aws-kms"
+key_id = "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012"
+region = "us-east-1"
 ```
 
 The `key_id` can be:

--- a/docs/providers/aws-sm.md
+++ b/docs/providers/aws-sm.md
@@ -7,10 +7,8 @@ AWS Secrets Manager provides centralized secret management with IAM access contr
 ```bash
 # 1. Configure provider in fnox.toml
 cat >> fnox.toml << 'EOF'
-[providers.aws]
-type = "aws-sm"
-region = "us-east-1"
-prefix = "myapp/"
+[providers]
+aws = { type = "aws-sm", region = "us-east-1", prefix = "myapp/" }
 EOF
 
 # 2. Create secret in AWS
@@ -20,9 +18,8 @@ aws secretsmanager create-secret \
 
 # 3. Reference in fnox.toml
 cat >> fnox.toml << 'EOF'
-[secrets.DATABASE_URL]
-provider = "aws"
-value = "database-url"  # With prefix, fetches "myapp/database-url"
+[secrets]
+DATABASE_URL = { provider = "aws", value = "database-url" }  # With prefix, fetches "myapp/database-url"
 EOF
 
 # 4. Fetch secret
@@ -130,10 +127,8 @@ If running on EC2, ECS, Lambda, or other AWS services:
 ### Configure fnox Provider
 
 ```toml
-[providers.aws]
-type = "aws-sm"
-region = "us-east-1"
-prefix = "myapp/"  # Optional: prepended to all secret names
+[providers]
+aws = { type = "aws-sm", region = "us-east-1", prefix = "myapp/" }  # prefix is optional
 ```
 
 ## Creating Secrets
@@ -173,16 +168,10 @@ aws secretsmanager create-secret \
 Add references to `fnox.toml`:
 
 ```toml
-[secrets.DATABASE_URL]
-provider = "aws"
-value = "database-url"  # → Fetches "myapp/database-url"
-
-[secrets.API_KEY]
-provider = "aws"
-value = "api-key"  # → Fetches "myapp/api-key"
-
-# Without prefix in provider, use full name:
-# value = "myapp/api-key"
+[secrets]
+DATABASE_URL = { provider = "aws", value = "database-url" }  # → Fetches "myapp/database-url"
+API_KEY = { provider = "aws", value = "api-key" }  # → Fetches "myapp/api-key"
+# Without prefix in provider, use full name like: value = "myapp/api-key"
 ```
 
 ## Usage
@@ -212,60 +201,47 @@ fnox exec --profile production -- ./deploy.sh
 The `prefix` is prepended to the `value`:
 
 ```toml
-[providers.aws]
-prefix = "myapp/"
+[providers]
+aws = { prefix = "myapp/" }
 
-[secrets.DATABASE_URL]
-provider = "aws"
-value = "database-url"  # → Fetches "myapp/database-url"
-
-[secrets.API_KEY]
-provider = "aws"
-value = "api-key"  # → Fetches "myapp/api-key"
+[secrets]
+DATABASE_URL = { provider = "aws", value = "database-url" }  # → Fetches "myapp/database-url"
+API_KEY = { provider = "aws", value = "api-key" }  # → Fetches "myapp/api-key"
 ```
 
 Without prefix:
 
 ```toml
-[providers.aws]
-# No prefix
+[providers]
+aws = { }  # No prefix
 
-[secrets.DATABASE_URL]
-provider = "aws"
-value = "myapp/database-url"  # → Fetches "myapp/database-url"
+[secrets]
+DATABASE_URL = { provider = "aws", value = "myapp/database-url" }  # → Fetches "myapp/database-url"
 ```
 
 ## Multi-Environment Example
 
 ```toml
 # Development: age encryption
-[providers.age]
-type = "age"
-recipients = ["age1..."]
+[providers]
+age = { type = "age", recipients = ["age1..."] }
 
-[secrets.DATABASE_URL]
-provider = "age"
-value = "encrypted-dev-db..."
+[secrets]
+DATABASE_URL = { provider = "age", value = "encrypted-dev-db..." }
 
 # Staging: AWS Secrets Manager (us-east-1)
-[profiles.staging.providers.aws]
-type = "aws-sm"
-region = "us-east-1"
-prefix = "myapp-staging/"
+[profiles.staging.providers]
+aws = { type = "aws-sm", region = "us-east-1", prefix = "myapp-staging/" }
 
-[profiles.staging.secrets.DATABASE_URL]
-provider = "aws"
-value = "database-url"  # → myapp-staging/database-url
+[profiles.staging.secrets]
+DATABASE_URL = { provider = "aws", value = "database-url" }  # → myapp-staging/database-url
 
 # Production: AWS Secrets Manager (us-west-2)
-[profiles.production.providers.aws]
-type = "aws-sm"
-region = "us-west-2"
-prefix = "myapp-prod/"
+[profiles.production.providers]
+aws = { type = "aws-sm", region = "us-west-2", prefix = "myapp-prod/" }
 
-[profiles.production.secrets.DATABASE_URL]
-provider = "aws"
-value = "database-url"  # → myapp-prod/database-url
+[profiles.production.secrets]
+DATABASE_URL = { provider = "aws", value = "database-url" }  # → myapp-prod/database-url
 ```
 
 ```bash

--- a/docs/providers/azure-kms.md
+++ b/docs/providers/azure-kms.md
@@ -10,10 +10,8 @@ az keyvault key create --vault-name "myapp-vault" --name "encryption-key" --prot
 
 # 2. Configure provider
 cat >> fnox.toml << 'EOF'
-[providers.azurekms]
-type = "azure-kms"
-vault_url = "https://myapp-vault.vault.azure.net/"
-key_name = "encryption-key"
+[providers]
+azurekms = { type = "azure-kms", vault_url = "https://myapp-vault.vault.azure.net/", key_name = "encryption-key" }
 EOF
 
 # 3. Encrypt a secret
@@ -37,10 +35,8 @@ az role assignment create \
 ## Configuration
 
 ```toml
-[providers.azurekms]
-type = "azure-kms"
-vault_url = "https://myapp-vault.vault.azure.net/"
-key_name = "encryption-key"
+[providers]
+azurekms = { type = "azure-kms", vault_url = "https://myapp-vault.vault.azure.net/", key_name = "encryption-key" }
 ```
 
 ## How It Works

--- a/docs/providers/azure-sm.md
+++ b/docs/providers/azure-sm.md
@@ -10,10 +10,8 @@ az keyvault create --name "myapp-vault" --resource-group "myapp-rg"
 
 # 2. Configure provider
 cat >> fnox.toml << 'EOF'
-[providers.azure]
-type = "azure-sm"
-vault_url = "https://myapp-vault.vault.azure.net/"
-prefix = "myapp/"
+[providers]
+azure = { type = "azure-sm", vault_url = "https://myapp-vault.vault.azure.net/", prefix = "myapp/" }
 EOF
 
 # 3. Create secret
@@ -21,9 +19,8 @@ az keyvault secret set --vault-name "myapp-vault" --name "myapp-database-url" --
 
 # 4. Reference in fnox
 cat >> fnox.toml << 'EOF'
-[secrets.DATABASE_URL]
-provider = "azure"
-value = "database-url"
+[secrets]
+DATABASE_URL = { provider = "azure", value = "database-url" }
 EOF
 
 # 5. Get secret
@@ -61,10 +58,8 @@ az role assignment create \
 ## Configuration
 
 ```toml
-[providers.azure]
-type = "azure-sm"
-vault_url = "https://myapp-vault.vault.azure.net/"
-prefix = "myapp/"  # Optional
+[providers]
+azure = { type = "azure-sm", vault_url = "https://myapp-vault.vault.azure.net/", prefix = "myapp/" }  # prefix is optional
 ```
 
 ## Pros

--- a/docs/providers/bitwarden.md
+++ b/docs/providers/bitwarden.md
@@ -19,8 +19,8 @@ fnox set BW_SESSION "$(bw unlock --raw)" --provider age
 
 # 5. Configure Bitwarden provider
 cat >> fnox.toml << 'EOF'
-[providers.bitwarden]
-type = "bitwarden"
+[providers]
+bitwarden = { type = "bitwarden" }
 EOF
 
 # 6. Add secrets to Bitwarden
@@ -30,9 +30,8 @@ bw create item --name "Database" \
 
 # 7. Reference in fnox
 cat >> fnox.toml << 'EOF'
-[secrets.DATABASE_PASSWORD]
-provider = "bitwarden"
-value = "Database"
+[secrets]
+DATABASE_PASSWORD = { provider = "bitwarden", value = "Database" }
 EOF
 
 # 8. Use it
@@ -98,10 +97,8 @@ export BW_SESSION=$(fnox get BW_SESSION)
 ### 4. Configure Bitwarden Provider
 
 ```toml
-[providers.bitwarden]
-type = "bitwarden"
-collection = "my-collection-id"     # Optional
-organization_id = "my-org-id"       # Optional
+[providers]
+bitwarden = { type = "bitwarden", collection = "my-collection-id", organization_id = "my-org-id" }  # both optional
 ```
 
 ## Adding Secrets to Bitwarden
@@ -145,17 +142,10 @@ bw list items
 Add references to `fnox.toml`:
 
 ```toml
-[secrets.DATABASE_PASSWORD]
-provider = "bitwarden"
-value = "Database"  # Item name (fetches 'password' field)
-
-[secrets.DB_USERNAME]
-provider = "bitwarden"
-value = "Database/username"  # Specific field
-
-[secrets.API_KEY]
-provider = "bitwarden"
-value = "API Key"
+[secrets]
+DATABASE_PASSWORD = { provider = "bitwarden", value = "Database" }  # Item name (fetches 'password' field)
+DB_USERNAME = { provider = "bitwarden", value = "Database/username" }  # Specific field
+API_KEY = { provider = "bitwarden", value = "API Key" }
 ```
 
 ## Reference Formats
@@ -163,25 +153,17 @@ value = "API Key"
 ### 1. Item Name (Gets Password Field)
 
 ```toml
-[secrets.MY_SECRET]
-provider = "bitwarden"
-value = "My Item"  # → Gets the 'password' field
+[secrets]
+MY_SECRET = { provider = "bitwarden", value = "My Item" }  # → Gets the 'password' field
 ```
 
 ### 2. Item Name + Field
 
 ```toml
-[secrets.USERNAME]
-provider = "bitwarden"
-value = "Database/username"
-
-[secrets.PASSWORD]
-provider = "bitwarden"
-value = "Database/password"
-
-[secrets.TOTP]
-provider = "bitwarden"
-value = "Database/totp"
+[secrets]
+USERNAME = { provider = "bitwarden", value = "Database/username" }
+PASSWORD = { provider = "bitwarden", value = "Database/password" }
+TOTP = { provider = "bitwarden", value = "Database/totp" }
 ```
 
 Supported fields: `username`, `password`, `notes`, `uri`, `totp`
@@ -208,30 +190,20 @@ fnox exec -- npm start
 
 ```toml
 # Bootstrap session token (encrypted in git)
-[providers.age]
-type = "age"
-recipients = ["age1..."]
+[providers]
+age = { type = "age", recipients = ["age1..."] }
+bitwarden = { type = "bitwarden" }
 
-[secrets.BW_SESSION]
-provider = "age"
-value = "encrypted-session..."
-
-# Development: Bitwarden
-[providers.bitwarden]
-type = "bitwarden"
-
-[secrets.DATABASE_URL]
-provider = "bitwarden"
-value = "Dev Database"
+[secrets]
+BW_SESSION = { provider = "age", value = "encrypted-session..." }
+DATABASE_URL = { provider = "bitwarden", value = "Dev Database" }
 
 # Production: Different Bitwarden organization
-[profiles.production.providers.bitwarden]
-type = "bitwarden"
-organization_id = "prod-org-id"
+[profiles.production.providers]
+bitwarden = { type = "bitwarden", organization_id = "prod-org-id" }
 
-[profiles.production.secrets.DATABASE_URL]
-provider = "bitwarden"
-value = "Prod Database"
+[profiles.production.secrets]
+DATABASE_URL = { provider = "bitwarden", value = "Prod Database" }
 ```
 
 ## Self-Hosted Vaultwarden
@@ -318,10 +290,8 @@ export BW_SESSION=$(bw unlock --raw)
 Filter secrets by collection or organization:
 
 ```toml
-[providers.bitwarden]
-type = "bitwarden"
-collection = "abc123-collection-id"
-organization_id = "org-id"
+[providers]
+bitwarden = { type = "bitwarden", collection = "abc123-collection-id", organization_id = "org-id" }
 ```
 
 Get collection ID:

--- a/docs/providers/gcp-kms.md
+++ b/docs/providers/gcp-kms.md
@@ -12,12 +12,8 @@ gcloud kms keys create "fnox-key" --keyring="fnox-keyring" --location="us-centra
 
 # 2. Configure provider
 cat >> fnox.toml << 'EOF'
-[providers.gcpkms]
-type = "gcp-kms"
-project = "my-project-id"
-location = "us-central1"
-keyring = "fnox-keyring"
-key = "fnox-key"
+[providers]
+gcpkms = { type = "gcp-kms", project = "my-project-id", location = "us-central1", keyring = "fnox-keyring", key = "fnox-key" }
 EOF
 
 # 3. Encrypt a secret
@@ -42,12 +38,8 @@ gcloud kms keys add-iam-policy-binding "fnox-key" \
 ## Configuration
 
 ```toml
-[providers.gcpkms]
-type = "gcp-kms"
-project = "my-project-id"
-location = "us-central1"
-keyring = "fnox-keyring"
-key = "fnox-key"
+[providers]
+gcpkms = { type = "gcp-kms", project = "my-project-id", location = "us-central1", keyring = "fnox-keyring", key = "fnox-key" }
 ```
 
 ## How It Works

--- a/docs/providers/gcp-kms.md
+++ b/docs/providers/gcp-kms.md
@@ -12,8 +12,12 @@ gcloud kms keys create "fnox-key" --keyring="fnox-keyring" --location="us-centra
 
 # 2. Configure provider
 cat >> fnox.toml << 'EOF'
-[providers]
-gcpkms = { type = "gcp-kms", project = "my-project-id", location = "us-central1", keyring = "fnox-keyring", key = "fnox-key" }
+[providers.gcpkms]
+type = "gcp-kms"
+project = "my-project-id"
+location = "us-central1"
+keyring = "fnox-keyring"
+key = "fnox-key"
 EOF
 
 # 3. Encrypt a secret
@@ -38,8 +42,12 @@ gcloud kms keys add-iam-policy-binding "fnox-key" \
 ## Configuration
 
 ```toml
-[providers]
-gcpkms = { type = "gcp-kms", project = "my-project-id", location = "us-central1", keyring = "fnox-keyring", key = "fnox-key" }
+[providers.gcpkms]
+type = "gcp-kms"
+project = "my-project-id"
+location = "us-central1"
+keyring = "fnox-keyring"
+key = "fnox-key"
 ```
 
 ## How It Works

--- a/docs/providers/gcp-sm.md
+++ b/docs/providers/gcp-sm.md
@@ -10,10 +10,8 @@ gcloud services enable secretmanager.googleapis.com
 
 # 2. Configure provider
 cat >> fnox.toml << 'EOF'
-[providers.gcp]
-type = "gcp-sm"
-project = "my-project-id"
-prefix = "myapp/"
+[providers]
+gcp = { type = "gcp-sm", project = "my-project-id", prefix = "myapp/" }
 EOF
 
 # 3. Create secret
@@ -21,9 +19,8 @@ echo -n "postgresql://..." | gcloud secrets create myapp-database-url --data-fil
 
 # 4. Reference in fnox
 cat >> fnox.toml << 'EOF'
-[secrets.DATABASE_URL]
-provider = "gcp"
-value = "database-url"
+[secrets]
+DATABASE_URL = { provider = "gcp", value = "database-url" }
 EOF
 
 # 5. Get secret
@@ -58,10 +55,8 @@ gcloud projects add-iam-policy-binding PROJECT-ID \
 ## Configuration
 
 ```toml
-[providers.gcp]
-type = "gcp-sm"
-project = "my-project-id"
-prefix = "myapp/"  # Optional
+[providers]
+gcp = { type = "gcp-sm", project = "my-project-id", prefix = "myapp/" }  # prefix is optional
 ```
 
 ## Pros

--- a/docs/providers/keychain.md
+++ b/docs/providers/keychain.md
@@ -16,9 +16,8 @@ sudo apt-get install libsecret-1-0 libsecret-1-dev  # Ubuntu/Debian
 
 # 2. Configure provider
 cat >> fnox.toml << 'EOF'
-[providers.keychain]
-type = "keychain"
-service = "fnox"
+[providers]
+keychain = { type = "keychain", service = "fnox" }
 EOF
 
 # 3. Store a secret in OS keychain
@@ -53,10 +52,8 @@ macOS and Windows have built-in support—no installation needed.
 ## Configuration
 
 ```toml
-[providers.keychain]
-type = "keychain"
-service = "fnox"        # Namespace for fnox secrets
-prefix = "myapp/"       # Optional prefix for secret names
+[providers]
+keychain = { type = "keychain", service = "fnox", prefix = "myapp/" }  # Prefix is optional
 ```
 
 ### Service Name
@@ -64,11 +61,11 @@ prefix = "myapp/"       # Optional prefix for secret names
 The `service` acts as a namespace to isolate fnox secrets from other applications:
 
 ```toml
-[providers.keychain]
-service = "fnox"         # All fnox secrets under "fnox" service
+[providers]
+keychain = { service = "fnox" }  # All fnox secrets under "fnox" service
 
 # Or use project-specific service
-service = "myapp"        # All secrets under "myapp" service
+keychain = { service = "myapp" }  # All secrets under "myapp" service
 ```
 
 ### Prefix
@@ -76,9 +73,8 @@ service = "myapp"        # All secrets under "myapp" service
 Optional prefix prepended to secret names:
 
 ```toml
-[providers.keychain]
-service = "fnox"
-prefix = "myapp/"        # "database-url" becomes "myapp/database-url"
+[providers]
+keychain = { service = "fnox", prefix = "myapp/" }  # "database-url" becomes "myapp/database-url"
 ```
 
 ## How It Works
@@ -100,9 +96,8 @@ fnox set DATABASE_URL "postgresql://localhost/mydb" --provider keychain
 Your `fnox.toml`:
 
 ```toml
-[secrets.DATABASE_URL]
-provider = "keychain"
-value = "database-url"  # ← Keychain entry name, not the actual secret
+[secrets]
+DATABASE_URL = { provider = "keychain", value = "database-url" }  # ← Keychain entry name, not the actual secret
 ```
 
 The actual secret is stored in the OS keychain, encrypted.
@@ -124,23 +119,13 @@ fnox exec -- npm run dev
 A common pattern is to store provider tokens in the keychain:
 
 ```toml
-[providers.keychain]
-type = "keychain"
-service = "fnox"
+[providers]
+keychain = { type = "keychain", service = "fnox" }
+age = { type = "age", recipients = ["age1..."] }
 
-[providers.age]
-type = "age"
-recipients = ["age1..."]
-
-# Store 1Password token in keychain
-[secrets.OP_SERVICE_ACCOUNT_TOKEN]
-provider = "keychain"
-value = "op-token"
-
-# Other secrets encrypted with age
-[secrets.DATABASE_URL]
-provider = "age"
-value = "encrypted..."
+[secrets]
+OP_SERVICE_ACCOUNT_TOKEN = { provider = "keychain", value = "op-token" }  # Store 1Password token in keychain
+DATABASE_URL = { provider = "age", value = "encrypted..." }  # Other secrets encrypted with age
 ```
 
 Then bootstrap:
@@ -156,46 +141,34 @@ fnox exec -- ./start.sh
 ### Personal Project
 
 ```toml
-[providers.keychain]
-type = "keychain"
-service = "myapp"
+[providers]
+keychain = { type = "keychain", service = "myapp" }
 
-[secrets.DATABASE_URL]
-provider = "keychain"
-value = "database-url"
-
-[secrets.API_KEY]
-provider = "keychain"
-value = "api-key"
+[secrets]
+DATABASE_URL = { provider = "keychain", value = "database-url" }
+API_KEY = { provider = "keychain", value = "api-key" }
 ```
 
 ### Bootstrap Tokens
 
 ```toml
-[providers.keychain]
-type = "keychain"
-service = "fnox-tokens"
+[providers]
+keychain = { type = "keychain", service = "fnox-tokens" }
 
-[secrets.GITHUB_TOKEN]
-provider = "keychain"
-value = "github"
-
-[secrets.NPM_TOKEN]
-provider = "keychain"
-value = "npm"
+[secrets]
+GITHUB_TOKEN = { provider = "keychain", value = "github" }
+NPM_TOKEN = { provider = "keychain", value = "npm" }
 ```
 
 ### Machine-Specific Secrets
 
 ```toml
 # fnox.local.toml (gitignored)
-[providers.keychain]
-type = "keychain"
-service = "fnox-local"
+[providers]
+keychain = { type = "keychain", service = "fnox-local" }
 
-[secrets.LAPTOP_DB_URL]
-provider = "keychain"
-value = "laptop-db"
+[secrets]
+LAPTOP_DB_URL = { provider = "keychain", value = "laptop-db" }
 ```
 
 ## Platform Details

--- a/docs/providers/overview.md
+++ b/docs/providers/overview.md
@@ -164,24 +164,17 @@ You can use multiple providers in the same project:
 
 ```toml
 # Age for development
-[providers.age]
-type = "age"
-recipients = ["age1..."]
-
-# AWS for production
-[providers.aws]
-type = "aws-sm"
-region = "us-east-1"
+[providers]
+age = { type = "age", recipients = ["age1..."] }
+aws = { type = "aws-sm", region = "us-east-1" }
 
 # Development secrets (encrypted in git)
-[secrets.DATABASE_URL]
-provider = "age"
-value = "encrypted..."
+[secrets]
+DATABASE_URL = { provider = "age", value = "encrypted..." }
 
 # Production secrets (in AWS)
-[profiles.production.secrets.DATABASE_URL]
-provider = "aws"
-value = "database-url"
+[profiles.production.secrets]
+DATABASE_URL = { provider = "aws", value = "database-url" }
 ```
 
 ## Feature Comparison

--- a/docs/providers/plain.md
+++ b/docs/providers/plain.md
@@ -7,14 +7,10 @@ Store secrets as plain text (for default values only!).
 Plain text is the default when no provider is specified:
 
 ```toml
-[secrets.NODE_ENV]
-default = "development"  # ← Plain text, safe for non-sensitive defaults
-
-[secrets.LOG_LEVEL]
-default = "info"  # ← Plain text
-
-[secrets.API_TIMEOUT]
-default = "30"  # ← Plain text
+[secrets]
+NODE_ENV = { default = "development" }  # ← Plain text, safe for non-sensitive defaults
+LOG_LEVEL = { default = "info" }  # ← Plain text
+API_TIMEOUT = { default = "30" }  # ← Plain text
 ```
 
 ## When Plain Text is Appropriate
@@ -22,36 +18,26 @@ default = "30"  # ← Plain text
 ### 1. Non-Sensitive Defaults
 
 ```toml
-[secrets.PORT]
-default = "3000"
-
-[secrets.HOST]
-default = "localhost"
-
-[secrets.NODE_ENV]
-default = "development"
-
-[secrets.LOG_LEVEL]
-default = "info"
+[secrets]
+PORT = { default = "3000" }
+HOST = { default = "localhost" }
+NODE_ENV = { default = "development" }
+LOG_LEVEL = { default = "info" }
 ```
 
 ### 2. Public Configuration
 
 ```toml
-[secrets.PUBLIC_API_URL]
-default = "https://api.example.com"
-
-[secrets.CDN_URL]
-default = "https://cdn.example.com"
+[secrets]
+PUBLIC_API_URL = { default = "https://api.example.com" }
+CDN_URL = { default = "https://cdn.example.com" }
 ```
 
 ### 3. Development Fallbacks
 
 ```toml
-[secrets.DATABASE_URL]
-provider = "age"
-value = "encrypted-production-db..."
-default = "postgresql://localhost/dev_db"  # ← Fallback for local dev
+[secrets]
+DATABASE_URL = { provider = "age", value = "encrypted-production-db...", default = "postgresql://localhost/dev_db" }  # ← Fallback for local dev
 ```
 
 If the encrypted value can't be decrypted (e.g., missing key), falls back to the plaintext default.
@@ -62,39 +48,36 @@ If the encrypted value can't be decrypted (e.g., missing key), falls back to the
 
 ```toml
 # ❌ BAD - Never do this!
-[secrets.DATABASE_PASSWORD]
-default = "super-secret-password"
+[secrets]
+DATABASE_PASSWORD = { default = "super-secret-password" }
 
 # ✅ GOOD - Use encryption
-[secrets.DATABASE_PASSWORD]
-provider = "age"
-value = "encrypted..."
+[secrets]
+DATABASE_PASSWORD = { provider = "age", value = "encrypted..." }
 ```
 
 ### Never for API Keys
 
 ```toml
 # ❌ BAD
-[secrets.STRIPE_KEY]
-default = "sk_live_abc123xyz789"
+[secrets]
+STRIPE_KEY = { default = "sk_live_abc123xyz789" }
 
 # ✅ GOOD
-[secrets.STRIPE_KEY]
-provider = "age"
-value = "encrypted..."
+[secrets]
+STRIPE_KEY = { provider = "age", value = "encrypted..." }
 ```
 
 ### Never for Tokens
 
 ```toml
 # ❌ BAD
-[secrets.JWT_SECRET]
-default = "my-secret-key"
+[secrets]
+JWT_SECRET = { default = "my-secret-key" }
 
 # ✅ GOOD
-[secrets.JWT_SECRET]
-provider = "age"
-value = "encrypted..."
+[secrets]
+JWT_SECRET = { provider = "age", value = "encrypted..." }
 ```
 
 ## Mixing Plain and Encrypted
@@ -102,25 +85,14 @@ value = "encrypted..."
 It's common to mix plain text defaults with encrypted values:
 
 ```toml
-# Encrypted sensitive values
-[providers.age]
-type = "age"
-recipients = ["age1..."]
+[providers]
+age = { type = "age", recipients = ["age1..."] }
 
-[secrets.DATABASE_PASSWORD]
-provider = "age"
-value = "encrypted..."
-default = "dev-password"  # ← Fallback for local dev (non-production)
-
-# Plain text non-sensitive defaults
-[secrets.DATABASE_HOST]
-default = "localhost"
-
-[secrets.DATABASE_PORT]
-default = "5432"
-
-[secrets.LOG_LEVEL]
-default = "info"
+[secrets]
+DATABASE_PASSWORD = { provider = "age", value = "encrypted...", default = "dev-password" }  # Encrypted sensitive values, fallback for local dev
+DATABASE_HOST = { default = "localhost" }  # Plain text non-sensitive defaults
+DATABASE_PORT = { default = "5432" }
+LOG_LEVEL = { default = "info" }
 ```
 
 ## Security Best Practices
@@ -152,54 +124,31 @@ fnox scan --fix
 
 ```toml
 # Application settings (non-sensitive)
-[secrets.APP_NAME]
-default = "My Application"
-
-[secrets.APP_VERSION]
-default = "1.0.0"
-
-[secrets.ENVIRONMENT]
-default = "development"
-
-[secrets.DEBUG_MODE]
-default = "true"
-
-[secrets.TIMEOUT_MS]
-default = "5000"
-
-# Public URLs
-[secrets.PUBLIC_SITE_URL]
-default = "https://example.com"
-
-[secrets.DOCS_URL]
-default = "https://docs.example.com"
+[secrets]
+APP_NAME = { default = "My Application" }
+APP_VERSION = { default = "1.0.0" }
+ENVIRONMENT = { default = "development" }
+DEBUG_MODE = { default = "true" }
+TIMEOUT_MS = { default = "5000" }
+PUBLIC_SITE_URL = { default = "https://example.com" }  # Public URLs
+DOCS_URL = { default = "https://docs.example.com" }
 ```
 
 ### Mixed Usage (Plain + Encrypted)
 
 ```toml
-[providers.age]
-type = "age"
-recipients = ["age1..."]
+[providers]
+age = { type = "age", recipients = ["age1..."] }
 
+[secrets]
 # Sensitive (encrypted)
-[secrets.DATABASE_URL]
-provider = "age"
-value = "encrypted-connection-string..."
-
-[secrets.API_KEY]
-provider = "age"
-value = "encrypted-key..."
+DATABASE_URL = { provider = "age", value = "encrypted-connection-string..." }
+API_KEY = { provider = "age", value = "encrypted-key..." }
 
 # Non-sensitive (plain)
-[secrets.DATABASE_POOL_SIZE]
-default = "10"
-
-[secrets.CACHE_TTL_SECONDS]
-default = "3600"
-
-[secrets.FEATURE_FLAG_NEW_UI]
-default = "false"
+DATABASE_POOL_SIZE = { default = "10" }
+CACHE_TTL_SECONDS = { default = "3600" }
+FEATURE_FLAG_NEW_UI = { default = "false" }
 ```
 
 ## Remember

--- a/docs/providers/vault.md
+++ b/docs/providers/vault.md
@@ -23,11 +23,8 @@ sudo apt update && sudo apt install vault
 ## Configuration
 
 ```toml
-[providers.vault]
-type = "vault"
-address = "https://vault.example.com:8200"
-path = "secret/myapp"  # KV v2 mount path
-# token = "hvs.CAESIJ..."  # Optional, can use VAULT_TOKEN env var
+[providers]
+vault = { type = "vault", address = "https://vault.example.com:8200", path = "secret/myapp" }  # token optional, can use VAULT_TOKEN env var
 ```
 
 ## Setup
@@ -73,13 +70,9 @@ vault kv put secret/myapp/api-key value="sk_live_abc123"
 ### 4. Reference in fnox
 
 ```toml
-[secrets.DATABASE_URL]
-provider = "vault"
-value = "database/url"  # → secret/myapp/database/url
-
-[secrets.API_KEY]
-provider = "vault"
-value = "api-key/value"  # → secret/myapp/api-key/value
+[secrets]
+DATABASE_URL = { provider = "vault", value = "database/url" }  # → secret/myapp/database/url
+API_KEY = { provider = "vault", value = "api-key/value" }  # → secret/myapp/api-key/value
 ```
 
 ## Usage

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -121,8 +121,12 @@ gcp = { type = "gcp-sm", project = "my-project-id", prefix = "myapp/" }  # prefi
 #### GCP Cloud KMS
 
 ```toml
-[providers]
-gcpkms = { type = "gcp-kms", project = "my-project-id", location = "us-central1", keyring = "fnox-keyring", key = "fnox-key" }
+[providers.gcpkms]
+type = "gcp-kms"
+project = "my-project-id"
+location = "us-central1"
+keyring = "fnox-keyring"
+key = "fnox-key"
 ```
 
 #### 1Password

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -19,17 +19,12 @@ if_missing = "warn"  # Global default for missing secrets
 imports = ["./shared/secrets.toml"]  # Import other configs
 
 # Provider definitions
-[providers.PROVIDER_NAME]
-type = "PROVIDER_TYPE"
-# ... provider-specific config ...
+[providers]
+PROVIDER_NAME = { type = "PROVIDER_TYPE" }  # ... provider-specific config ...
 
 # Secret definitions
-[secrets.SECRET_NAME]
-provider = "PROVIDER_NAME"
-value = "..."
-default = "..."
-if_missing = "error"
-description = "..."
+[secrets]
+SECRET_NAME = { provider = "PROVIDER_NAME", value = "...", default = "...", if_missing = "error", description = "..." }
 
 # Profile definitions
 [profiles.PROFILE_NAME]
@@ -81,116 +76,88 @@ type = "PROVIDER_TYPE"
 #### Age Encryption
 
 ```toml
-[providers.age]
-type = "age"
-recipients = [
+[providers]
+age = { type = "age", recipients = [
   "age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p",
   "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGQs..."
-]
+] }
 ```
 
 #### AWS Secrets Manager
 
 ```toml
-[providers.aws]
-type = "aws-sm"
-region = "us-east-1"
-prefix = "myapp/"  # Optional
+[providers]
+aws = { type = "aws-sm", region = "us-east-1", prefix = "myapp/" }  # prefix is optional
 ```
 
 #### AWS KMS
 
 ```toml
-[providers.kms]
-type = "aws-kms"
-key_id = "arn:aws:kms:us-east-1:123456789012:key/..."
-region = "us-east-1"
+[providers]
+kms = { type = "aws-kms", key_id = "arn:aws:kms:us-east-1:123456789012:key/...", region = "us-east-1" }
 ```
 
 #### Azure Key Vault Secrets
 
 ```toml
-[providers.azure]
-type = "azure-sm"
-vault_url = "https://myapp-vault.vault.azure.net/"
-prefix = "myapp/"  # Optional
+[providers]
+azure = { type = "azure-sm", vault_url = "https://myapp-vault.vault.azure.net/", prefix = "myapp/" }  # prefix is optional
 ```
 
 #### Azure Key Vault Keys
 
 ```toml
-[providers.azurekms]
-type = "azure-kms"
-vault_url = "https://myapp-vault.vault.azure.net/"
-key_name = "encryption-key"
+[providers]
+azurekms = { type = "azure-kms", vault_url = "https://myapp-vault.vault.azure.net/", key_name = "encryption-key" }
 ```
 
 #### GCP Secret Manager
 
 ```toml
-[providers.gcp]
-type = "gcp-sm"
-project = "my-project-id"
-prefix = "myapp/"  # Optional
+[providers]
+gcp = { type = "gcp-sm", project = "my-project-id", prefix = "myapp/" }  # prefix is optional
 ```
 
 #### GCP Cloud KMS
 
 ```toml
-[providers.gcpkms]
-type = "gcp-kms"
-project = "my-project-id"
-location = "us-central1"
-keyring = "fnox-keyring"
-key = "fnox-key"
+[providers]
+gcpkms = { type = "gcp-kms", project = "my-project-id", location = "us-central1", keyring = "fnox-keyring", key = "fnox-key" }
 ```
 
 #### 1Password
 
 ```toml
-[providers.onepass]
-type = "1password"
-vault = "Development"
-account = "my.1password.com"  # Optional
+[providers]
+onepass = { type = "1password", vault = "Development", account = "my.1password.com" }  # account is optional
 ```
 
 #### Bitwarden
 
 ```toml
-[providers.bitwarden]
-type = "bitwarden"
-collection = "collection-id"     # Optional
-organization_id = "org-id"       # Optional
+[providers]
+bitwarden = { type = "bitwarden", collection = "collection-id", organization_id = "org-id" }  # both optional
 ```
 
 #### HashiCorp Vault
 
 ```toml
-[providers.vault]
-type = "vault"
-address = "https://vault.example.com:8200"
-path = "secret/myapp"
-token = "hvs.CAESIJ..."  # Optional, can use VAULT_TOKEN env var
+[providers]
+vault = { type = "vault", address = "https://vault.example.com:8200", path = "secret/myapp", token = "hvs.CAESIJ..." }  # token optional, can use VAULT_TOKEN env var
 ```
 
 #### OS Keychain
 
 ```toml
-[providers.keychain]
-type = "keychain"
-service = "fnox"
-prefix = "myapp/"  # Optional
+[providers]
+keychain = { type = "keychain", service = "fnox", prefix = "myapp/" }  # prefix is optional
 ```
 
 ## Secret Configuration
 
 ```toml
-[secrets.SECRET_NAME]
-provider = "PROVIDER_NAME"    # Required (unless using default)
-value = "..."                 # Provider-specific value
-default = "..."               # Fallback value
-if_missing = "error"          # Behavior when missing
-description = "..."           # Human-readable description
+[secrets]
+SECRET_NAME = { provider = "PROVIDER_NAME", value = "...", default = "...", if_missing = "error", description = "..." }
 ```
 
 ### Fields
@@ -200,9 +167,8 @@ description = "..."           # Human-readable description
 Provider to use for this secret.
 
 ```toml
-[secrets.DATABASE_URL]
-provider = "age"
-value = "encrypted..."
+[secrets]
+DATABASE_URL = { provider = "age", value = "encrypted..." }
 ```
 
 **Required:** Unless using only `default` (plain text).
@@ -215,15 +181,12 @@ Provider-specific value:
 - **Remote providers** (aws-sm, 1password, etc.): Secret name/reference
 
 ```toml
+[secrets]
 # Encrypted ciphertext (age)
-[secrets.DATABASE_URL]
-provider = "age"
-value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHNjcnlwdC..."
+DATABASE_URL = { provider = "age", value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHNjcnlwdC..." }
 
 # Remote reference (AWS)
-[secrets.DATABASE_URL]
-provider = "aws"
-value = "database-url"  # Secret name in AWS Secrets Manager
+DATABASE_URL = { provider = "aws", value = "database-url" }  # Secret name in AWS Secrets Manager
 ```
 
 #### `default`
@@ -231,10 +194,8 @@ value = "database-url"  # Secret name in AWS Secrets Manager
 Fallback value if secret cannot be resolved.
 
 ```toml
-[secrets.DATABASE_URL]
-provider = "age"
-value = "encrypted..."
-default = "postgresql://localhost/dev"  # Fallback for local dev
+[secrets]
+DATABASE_URL = { provider = "age", value = "encrypted...", default = "postgresql://localhost/dev" }  # Fallback for local dev
 ```
 
 **Use for:**
@@ -248,15 +209,9 @@ default = "postgresql://localhost/dev"  # Fallback for local dev
 Behavior when secret cannot be resolved.
 
 ```toml
-[secrets.DATABASE_URL]
-provider = "aws"
-value = "database-url"
-if_missing = "error"  # Fail if missing (critical secret)
-
-[secrets.ANALYTICS_KEY]
-provider = "aws"
-value = "analytics-key"
-if_missing = "ignore"  # Silently skip if missing (optional)
+[secrets]
+DATABASE_URL = { provider = "aws", value = "database-url", if_missing = "error" }  # Fail if missing (critical secret)
+ANALYTICS_KEY = { provider = "aws", value = "analytics-key", if_missing = "ignore" }  # Silently skip if missing (optional)
 ```
 
 **Values:** `"error"`, `"warn"`, `"ignore"`
@@ -268,10 +223,8 @@ if_missing = "ignore"  # Silently skip if missing (optional)
 Human-readable description.
 
 ```toml
-[secrets.DATABASE_URL]
-provider = "age"
-value = "encrypted..."
-description = "Production database connection string"
+[secrets]
+DATABASE_URL = { provider = "age", value = "encrypted...", description = "Production database connection string" }
 ```
 
 ## Profile Configuration
@@ -280,20 +233,17 @@ Profiles allow environment-specific configuration:
 
 ```toml
 # Default profile (no prefix)
-[secrets.DATABASE_URL]
-provider = "age"
-value = "encrypted-dev..."
+[secrets]
+DATABASE_URL = { provider = "age", value = "encrypted-dev..." }
 
 # Production profile
 [profiles.production]
 
-[profiles.production.providers.aws]
-type = "aws-sm"
-region = "us-east-1"
+[profiles.production.providers]
+aws = { type = "aws-sm", region = "us-east-1" }
 
-[profiles.production.secrets.DATABASE_URL]
-provider = "aws"
-value = "database-url"
+[profiles.production.secrets]
+DATABASE_URL = { provider = "aws", value = "database-url" }
 ```
 
 ### Profile Structure
@@ -302,14 +252,11 @@ value = "database-url"
 [profiles.PROFILE_NAME]
 if_missing = "error"  # Profile-specific default
 
-[profiles.PROFILE_NAME.providers.PROVIDER_NAME]
-type = "PROVIDER_TYPE"
-# ... provider config ...
+[profiles.PROFILE_NAME.providers]
+PROVIDER_NAME = { type = "PROVIDER_TYPE" }  # ... provider config ...
 
-[profiles.PROFILE_NAME.secrets.SECRET_NAME]
-provider = "PROVIDER_NAME"
-value = "..."
-# ... secret config ...
+[profiles.PROFILE_NAME.secrets]
+SECRET_NAME = { provider = "PROVIDER_NAME", value = "..." }  # ... secret config ...
 ```
 
 ### Profile Inheritance
@@ -318,17 +265,13 @@ Profiles inherit top-level secrets and providers:
 
 ```toml
 # Top-level (inherited by all profiles)
-[secrets.LOG_LEVEL]
-default = "info"
-
-[secrets.DATABASE_URL]
-provider = "age"
-value = "encrypted-dev..."
+[secrets]
+LOG_LEVEL = { default = "info" }
+DATABASE_URL = { provider = "age", value = "encrypted-dev..." }
 
 # Production profile
-[profiles.production.secrets.DATABASE_URL]
-provider = "aws"
-value = "prod-db"  # Overrides top-level DATABASE_URL
+[profiles.production.secrets]
+DATABASE_URL = { provider = "aws", value = "prod-db" }  # Overrides top-level DATABASE_URL
 # Inherits LOG_LEVEL="info" from top-level
 ```
 
@@ -340,48 +283,26 @@ if_missing = "warn"
 imports = ["./shared/common.toml"]
 
 # Providers
-[providers.age]
-type = "age"
-recipients = ["age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"]
-
-[providers.aws]
-type = "aws-sm"
-region = "us-east-1"
-prefix = "myapp/"
+[providers]
+age = { type = "age", recipients = ["age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"] }
+aws = { type = "aws-sm", region = "us-east-1", prefix = "myapp/" }
 
 # Default profile secrets
-[secrets.DATABASE_URL]
-provider = "age"
-value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHNjcnlwdC..."
-default = "postgresql://localhost/dev"
-description = "Database connection string"
-
-[secrets.JWT_SECRET]
-provider = "age"
-value = "encrypted..."
-if_missing = "error"
-
-[secrets.LOG_LEVEL]
-default = "info"
+[secrets]
+DATABASE_URL = { provider = "age", value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHNjcnlwdC...", default = "postgresql://localhost/dev", description = "Database connection string" }
+JWT_SECRET = { provider = "age", value = "encrypted...", if_missing = "error" }
+LOG_LEVEL = { default = "info" }
 
 # Production profile
 [profiles.production]
 if_missing = "error"
 
-[profiles.production.providers.aws]
-type = "aws-sm"
-region = "us-east-1"
-prefix = "myapp-prod/"
+[profiles.production.providers]
+aws = { type = "aws-sm", region = "us-east-1", prefix = "myapp-prod/" }
 
-[profiles.production.secrets.DATABASE_URL]
-provider = "aws"
-value = "database-url"
-description = "Production database"
-
-[profiles.production.secrets.JWT_SECRET]
-provider = "aws"
-value = "jwt-secret"
-
+[profiles.production.secrets]
+DATABASE_URL = { provider = "aws", value = "database-url", description = "Production database" }
+JWT_SECRET = { provider = "aws", value = "jwt-secret" }
 # Inherits LOG_LEVEL from top-level
 ```
 
@@ -392,12 +313,9 @@ Create `fnox.local.toml` alongside `fnox.toml` for local overrides:
 ```toml
 # fnox.local.toml (gitignored)
 
-# Override secrets for local development
-[secrets.DATABASE_URL]
-default = "postgresql://localhost/mylocal"
-
-[secrets.DEBUG_MODE]
-default = "true"
+[secrets]
+DATABASE_URL = { default = "postgresql://localhost/mylocal" }  # Override for local development
+DEBUG_MODE = { default = "true" }
 ```
 
 **Important:** Add to `.gitignore`:

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -76,11 +76,12 @@ type = "PROVIDER_TYPE"
 #### Age Encryption
 
 ```toml
-[providers]
-age = { type = "age", recipients = [
+[providers.age]
+type = "age"
+recipients = [
   "age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p",
   "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGQs..."
-] }
+]
 ```
 
 #### AWS Secrets Manager


### PR DESCRIPTION
## Summary

Update documentation to use single-line TOML syntax for better readability while maintaining proper section headers (`[providers]`, `[secrets]`).

## Changes

- Convert multi-line TOML blocks to single-line inline table syntax
- Add section headers above single-line declarations for clarity
- Update all provider configuration examples in CLAUDE.md:
  - 1Password provider
  - Bitwarden provider
  - AWS KMS provider
  - AWS Secrets Manager provider
  - Keychain provider
  - Secret configuration section
- Update README.md main example to use consistent syntax
- Improve consistency across all documentation

## Example

**Before:**
```toml
[secrets.MY_SECRET]
provider = "age"
value = "..."
```

**After:**
```toml
[secrets]
MY_SECRET = { provider = "age", value = "..." }
```

## Benefits

- More concise and easier to read
- Maintains proper TOML structure with section headers
- Consistent syntax across all documentation
- Matches common TOML best practices for simple configurations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes documentation to single-line TOML inline table syntax with explicit [providers]/[secrets] headers, updating examples across guides, provider pages, README, and references.
> 
> - **Documentation (TOML syntax standardization)**:
>   - Convert multi-line `[secrets.NAME]`/`[providers.NAME]` blocks to single-line inline tables under `[secrets]` and `[providers]`.
>   - Normalize examples, comments, and prefixes; minor formatting fixes (commas, optional fields notes).
> - **Updated Areas**:
>   - **Guides**: `docs/guide/{how-it-works,profiles,hierarchical-config,missing-secrets,real-world-example}` and `docs/index.md`.
>   - **Provider Docs**: `docs/providers/{1password,bitwarden,aws-sm,aws-kms,azure-sm,azure-kms,gcp-sm,keychain,age,plain,vault,overview}.md`.
>   - **Reference**: `docs/reference/configuration.md` (structure and examples aligned to new syntax).
>   - **Repo Docs**: `README.md`, `CRUSH.md` (dev guide examples).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 85f53f8035933bceeddb04ca96976ec105d32006. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->