### PR TITLE
perf: parallelize CI tests across GHA workers using tranches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,76 +16,15 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
-  ci-macos:
-    runs-on: macos-latest
-    timeout-minutes: 20
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - uses: jdx/mise-action@v3
-      - uses: Swatinem/rust-cache@v2
-      - name: Install parallel on macOS
-        run: brew install parallel
-      - name: Install Rust components
-        run: rustup component add rustfmt clippy
-      - name: Build
-        run: cargo build
-      - name: Setup age key for fnox
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-        run: mkdir -p ~/.config/fnox && echo "${{ secrets.AGE_SECRET }}" > ~/.config/fnox/age.txt
-      - name: Redact secrets in CI output
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-        run: |
-          fnox ci-redact
-          # shellcheck disable=SC2016
-          fnox run -- sh -c 'echo MY_UNIMPORTANT_SECRET: $MY_UNIMPORTANT_SECRET'
-      - name: Run tests
-        run: cargo test
-      - name: Check formatting
-        run: mise run lint
-      - name: Run clippy
-        run: cargo clippy -- -D warnings
-      - name: Run integration tests
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 10
-          max_attempts: 3
-          command: mise run test:bats
-  ci-ubuntu:
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    services:
-      # Vaultwarden for Bitwarden provider tests
-      vaultwarden:
-        image: vaultwarden/server:latest
-        ports:
-          - 8080:80
-        env:
-          DOMAIN: http://localhost:8080
-          SIGNUPS_ALLOWED: "true"
-          DISABLE_ADMIN_TOKEN: "true"
-          I_REALLY_WANT_VOLATILE_STORAGE: "true"
-        options: >-
-          --health-cmd "curl -f http://localhost || exit 1"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-      # HashiCorp Vault for Vault provider tests
-      vault:
-        image: hashicorp/vault:latest
-        ports:
-          - 8200:8200
-        env:
-          VAULT_DEV_ROOT_TOKEN_ID: fnox-test-token
-          VAULT_DEV_LISTEN_ADDRESS: 0.0.0.0:8200
-          VAULT_ADDR: http://127.0.0.1:8200
-        options: >-
-          --cap-add=IPC_LOCK
-          --health-cmd "vault status"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
         with:
@@ -96,38 +35,122 @@ jobs:
         run: rustup component add rustfmt clippy
       - name: Build
         run: cargo build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: fnox-${{ matrix.os }}
+          path: target/debug/fnox
+
+  ci-bats:
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+        tranche: [0, 1, 2]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    steps:
+      - run: brew install parallel vault
+        if: ${{ matrix.os == 'macos-latest' }}
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: jdx/mise-action@v3
+      - uses: actions/download-artifact@v4
+        with:
+          name: fnox-${{ matrix.os }}
+          path: target/debug
+      - run: chmod +x target/debug/fnox
       - name: Setup age key for fnox
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         run: mkdir -p ~/.config/fnox && echo "${{ secrets.AGE_SECRET }}" > ~/.config/fnox/age.txt
-      - name: Redact secrets in CI output
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+      - name: Setup services (Ubuntu)
+        if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
-          fnox ci-redact
-          # shellcheck disable=SC2016
-          fnox run -- sh -c 'echo MY_UNIMPORTANT_SECRET: $MY_UNIMPORTANT_SECRET'
-      - name: Run tests
-        run: cargo test
-      - name: Check formatting
-        run: mise run lint
-      - name: Run clippy
-        run: cargo clippy -- -D warnings
-      - name: Setup Bitwarden for tests
-        run: |
-          # Configure bw CLI for vaultwarden and create test account
-          source ./test/setup-bitwarden-ci.sh
-          # Export BW_SESSION to GITHUB_ENV so it's available in next steps
-          echo "BW_SESSION=$BW_SESSION" >> "$GITHUB_ENV"
-      - name: Setup Vault for tests
-        run: |
-          # Export Vault environment variables for tests
+          # Start Vaultwarden
+          docker run -d --name vaultwarden \
+            -p 8080:80 \
+            -e DOMAIN=http://localhost:8080 \
+            -e SIGNUPS_ALLOWED=true \
+            -e DISABLE_ADMIN_TOKEN=true \
+            -e I_REALLY_WANT_VOLATILE_STORAGE=true \
+            vaultwarden/server:latest
+          # Start Vault
+          docker run -d --name vault --cap-add=IPC_LOCK \
+            -p 8200:8200 \
+            -e VAULT_DEV_ROOT_TOKEN_ID=fnox-test-token \
+            -e VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:8200 \
+            -e VAULT_ADDR=http://127.0.0.1:8200 \
+            hashicorp/vault:latest
+          # Wait for services to be ready
+          sleep 5
           echo "VAULT_ADDR=http://localhost:8200" >> "$GITHUB_ENV"
           echo "VAULT_TOKEN=fnox-test-token" >> "$GITHUB_ENV"
-      - name: Run integration tests
+      - name: Setup Bitwarden for tests
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: |
+          source ./test/setup-bitwarden-ci.sh
+          echo "BW_SESSION=$BW_SESSION" >> "$GITHUB_ENV"
+      - name: Setup services (macOS)
+        if: ${{ matrix.os == 'macos-latest' }}
+        run: |
+          # Start Vault in dev mode in background
+          vault server -dev -dev-root-token-id=fnox-test-token -dev-listen-address=127.0.0.1:8200 &
+          echo "VAULT_ADDR=http://127.0.0.1:8200" >> "$GITHUB_ENV"
+          echo "VAULT_TOKEN=fnox-test-token" >> "$GITHUB_ENV"
+          # Wait for Vault to be ready
+          sleep 2
+      - name: Run bats tests - tranche ${{ matrix.tranche }}
         uses: nick-fields/retry@v3
+        env:
+          TRANCHE: ${{ matrix.tranche }}
+          TRANCHE_COUNT: 3
         with:
           timeout_minutes: 10
           max_attempts: 3
           command: mise run test:bats
+
+  ci-other:
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: jdx/mise-action@v3
+      - uses: Swatinem/rust-cache@v2
+      - name: Install Rust components
+        run: rustup component add rustfmt clippy
+      - uses: actions/download-artifact@v4
+        with:
+          name: fnox-${{ matrix.os }}
+          path: target/debug
+      - run: chmod +x target/debug/fnox
+      - name: Setup age key for fnox
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        run: mkdir -p ~/.config/fnox && echo "${{ secrets.AGE_SECRET }}" > ~/.config/fnox/age.txt
+      - name: Redact secrets in CI output
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        run: |
+          fnox ci-redact
+          # shellcheck disable=SC2016
+          fnox run -- sh -c 'echo MY_UNIMPORTANT_SECRET: $MY_UNIMPORTANT_SECRET'
+      - name: Run tests
+        run: cargo test
+      - name: Check formatting
+        run: mise run lint
+      - name: Run clippy
+        run: cargo clippy -- -D warnings
+
   msrv:
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -138,3 +161,13 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - uses: jdx/mise-action@v3
       - run: cargo msrv verify
+
+  final:
+    needs:
+      - ci-bats
+      - ci-other
+      - msrv
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - run: echo "All CI jobs completed successfully"

--- a/mise.toml
+++ b/mise.toml
@@ -28,7 +28,6 @@ run = "cargo test"
 
 [tasks."test:bats"]
 description = "Run bats tests only"
-depends = ["build"]
 run = '''
 if [ -n "$TRANCHE" ] && [ -n "$TRANCHE_COUNT" ]; then
   tests=$(ls -1 test/*.bats | sort | awk -v t=$TRANCHE -v n=$TRANCHE_COUNT 'NR % n == t')
@@ -40,7 +39,6 @@ fi
 
 [tasks."test:bats:fork"]
 description = "Run bats tests simulating forked PR (no age key access)"
-depends = ["build"]
 env = { FNOX_AGE_KEY = "/tmp/nonexistent-age-key.txt" }
 run = "fnox exec -- bats --jobs 16 {{arg(name='test', var=true, default='test')}}"
 

--- a/mise.toml
+++ b/mise.toml
@@ -29,13 +29,20 @@ run = "cargo test"
 [tasks."test:bats"]
 description = "Run bats tests only"
 depends = ["build"]
-run = "fnox exec -- bats --jobs 4 --no-parallelize-within-files {{arg(name='test', var=true, default='test')}}"
+run = '''
+if [ -n "$TRANCHE" ] && [ -n "$TRANCHE_COUNT" ]; then
+  tests=$(ls -1 test/*.bats | sort | awk -v t=$TRANCHE -v n=$TRANCHE_COUNT 'NR % n == t')
+  fnox exec -- bats --jobs 16 $tests
+else
+  fnox exec -- bats --jobs 16 {{arg(name='test', var=true, default='test')}}
+fi
+'''
 
 [tasks."test:bats:fork"]
 description = "Run bats tests simulating forked PR (no age key access)"
 depends = ["build"]
 env = { FNOX_AGE_KEY = "/tmp/nonexistent-age-key.txt" }
-run = "fnox exec -- bats --jobs 4 --no-parallelize-within-files {{arg(name='test', var=true, default='test')}}"
+run = "fnox exec -- bats --jobs 16 {{arg(name='test', var=true, default='test')}}"
 
 [tasks.cargo-test]
 description = "Run cargo tests only"


### PR DESCRIPTION
## Summary

Implement test parallelization using GitHub Actions matrix strategy with modulo-based test splitting, inspired by hk's approach. This significantly speeds up CI runs by distributing tests across multiple workers running in parallel.

## Architecture

### 1. Build Job (2 workers)
- Builds fnox once per OS (macOS, Ubuntu)
- Uploads artifacts to avoid rebuilding in test jobs
- Saves significant compilation time

### 2. Test Tranches (6 workers: 2 OS × 3 tranches)
- Tests split into 3 tranches using **modulo arithmetic via environment variables**
- `test:bats` task accepts `TRANCHE` and `TRANCHE_COUNT` env vars
- When set: dynamically filters tests using `NR % TRANCHE_COUNT == TRANCHE`
- When unset: runs normally with test file arguments
- Each tranche runs ~11-12 tests (automatically balanced)
- No new mise tasks needed - single task handles both modes

**Tranche Distribution:**
```bash
# Tranche 0: 11 tests (index % 3 == 0)
# Tranche 1: 12 tests (index % 3 == 1)
# Tranche 2: 12 tests (index % 3 == 2)
```

**Usage:**
```bash
# Run all tests normally
mise run test:bats

# Run specific test file
mise run test:bats -- test/init.bats

# Run tranche 0 (CI mode)
TRANCHE=0 TRANCHE_COUNT=3 mise run test:bats

# Run tranche 1 (CI mode)
TRANCHE=1 TRANCHE_COUNT=3 mise run test:bats
```

### 3. CI-Other Job (2 workers)
- Runs cargo tests, linting, clippy on both OS
- Independent of test tranches

### 4. MSRV Job (1 worker)
- Verifies minimum supported Rust version

### 5. Final Job (1 status check)
- Depends on all test jobs
- Provides single status check for PR merging
- Ensures all parallel jobs succeeded

## Total Parallelization

**Up to 10 workers running concurrently:**
- 2 build workers (macos + ubuntu)
- 6 test tranche workers (2 OS × 3 tranches)
- 2 ci-other workers (macos + ubuntu)
- 1 msrv worker
- 1 final status check

## Changes

### mise.toml
- Updated `test:bats` task to accept `TRANCHE` and `TRANCHE_COUNT` env vars
- When env vars present: uses modulo arithmetic to select test subset
  ```bash
  tests=$(ls -1 test/*.bats | sort | awk -v t=$TRANCHE -v n=$TRANCHE_COUNT 'NR % n == t')
  ```
- When env vars absent: runs normally with test arguments
- Increased bats `--jobs` from 4 to 16 for within-tranche parallelization
- No new tasks added - single flexible task

### .github/workflows/ci.yml
- Restructured into 5 jobs: build, ci-bats, ci-other, msrv, final
- `ci-bats` uses matrix strategy: `matrix.tranche: [0, 1, 2]` × `matrix.os: [macos-latest, ubuntu-latest]`
- Sets `TRANCHE` and `TRANCHE_COUNT` env vars when running `mise run test:bats`
- Build artifacts shared across test jobs
- Services (vaultwarden, vault) conditionally enabled on Ubuntu

## Performance Benefits

**Before:**
- Sequential execution: build → tests → lint on each OS
- 2 workers total (1 per OS)

**After:**
- Parallel execution across multiple workers
- Up to 10 concurrent workers
- Build once, test in parallel
- Estimated **3-5x faster CI runs**

## Testing

- ✅ Verified modulo split with env vars (11 + 12 + 12 = 35 tests)
- ✅ Tested `TRANCHE=0 TRANCHE_COUNT=3 mise run test:bats` (125 test cases passed)
- ✅ Tested normal mode `mise run test:bats -- test/init.bats` (5 test cases passed)
- ✅ Confirmed env var approach doesn't require new tasks
- ✅ Services (vaultwarden, vault) correctly configured for Ubuntu only

## Inspiration

This approach mirrors [hk's CI parallelization strategy](https://github.com/jdx/hk/blob/main/.github/workflows/ci.yml):
- Build artifact sharing
- Matrix-based test distribution  
- Final job for status aggregation
- Modulo-based dynamic test splitting
- Environment variable configuration (no hardcoded test lists or extra tasks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restructures CI into build, parallelized bats test tranches, other checks, MSRV, and a final aggregator, while updating mise to split bats tests via env-based modulo and run with higher parallelism.
> 
> - **CI workflow (`.github/workflows/ci.yml`)**:
>   - **Build artifacts**: Matrix build on `macos-latest` and `ubuntu-latest`; upload `fnox` binary for reuse.
>   - **Parallel bats tests**: New `ci-bats` job with matrix `{os × tranche[0..2]}`; downloads artifact; sets `TRANCHE`/`TRANCHE_COUNT`; retries via `nick-fields/retry`.
>   - **Service setup per OS**:
>     - Ubuntu: start `vaultwarden` and `vault` via `docker`; export `VAULT_*`; setup Bitwarden session.
>     - macOS: install `parallel`/`vault`; run `vault` in dev mode.
>   - **Other checks**: `ci-other` runs cargo tests, lint, clippy on both OS using downloaded artifact and secret redaction.
>   - **MSRV**: separate `cargo msrv verify` job.
>   - **Final**: aggregator job depends on `ci-bats`, `ci-other`, and `msrv`.
> - **Mise config (`mise.toml`)**:
>   - `test:bats`: supports `TRANCHE`/`TRANCHE_COUNT` to select test subsets; increases `bats` parallelism to `--jobs 16`.
>   - `test:bats:fork`: aligns to `--jobs 16`; removes build dependency.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f18979a694b2db6ac2cc40e0b13eefbb458217de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->