### PR TITLE
chore: release v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [1.3.0](https://github.com/jdx/fnox/compare/v1.2.3..v1.3.0) - 2025-11-01
+
+### 🚀 Features
+
+- add support for fnox.$FNOX_PROFILE.toml config files by [@jdx](https://github.com/jdx) in [#64](https://github.com/jdx/fnox/pull/64)
+- add Infisical provider with CLI integration and self-hosted CI by [@jdx](https://github.com/jdx) in [#67](https://github.com/jdx/fnox/pull/67)
+
+### 🐛 Bug Fixes
+
+- **(tests)** skip keychain tests in CI when gnome-keyring-daemon unavailable by [@jdx](https://github.com/jdx) in [#72](https://github.com/jdx/fnox/pull/72)
+- **(tests)** let gnome-keyring-daemon create its own control directory by [@jdx](https://github.com/jdx) in [#73](https://github.com/jdx/fnox/pull/73)
+- add unique namespacing to parallel provider tests by [@jdx](https://github.com/jdx) in [#68](https://github.com/jdx/fnox/pull/68)
+
+### 🚜 Refactor
+
+- remove unused env_diff module and \_\_FNOX_DIFF by [@jdx](https://github.com/jdx) in [#70](https://github.com/jdx/fnox/pull/70)
+
+### ⚡ Performance
+
+- parallelize CI tests across GHA workers using tranches by [@jdx](https://github.com/jdx) in [#65](https://github.com/jdx/fnox/pull/65)
+
+### 🛡️ Security
+
+- **(security)** store only hashes in \_\_FNOX_SESSION instead of plaintext secrets by [@jdx](https://github.com/jdx) in [#71](https://github.com/jdx/fnox/pull/71)
+
 ## [1.2.3](https://github.com/jdx/fnox/compare/v1.2.2..v1.2.3) - 2025-11-01
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1147,9 +1147,9 @@ dependencies = [
 
 [[package]]
 name = "ci_info"
-version = "0.14.14"
+version = "0.14.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "840dbb7bdd1f2c4d434d6b08420ef204e0bfad0ab31a07a80a1248d24cc6e38b"
+checksum = "7d502ead02cc105c33a87aa76817cdca915a7576b59caba5eeb4e7abdd633f23"
 dependencies = [
  "envmnt",
 ]
@@ -1727,7 +1727,7 @@ dependencies = [
 
 [[package]]
 name = "fnox"
-version = "1.2.3"
+version = "1.3.0"
 dependencies = [
  "age",
  "anyhow",
@@ -2615,7 +2615,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
- "webpki-roots 1.0.3",
+ "webpki-roots 1.0.4",
 ]
 
 [[package]]
@@ -3317,11 +3317,10 @@ dependencies = [
 
 [[package]]
 name = "num-bigint-dig"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
+checksum = "82c79c15c05d4bf82b6f5ef163104cc81a760d8e874d38ac50ab67c8877b647b"
 dependencies = [
- "byteorder",
  "lazy_static",
  "libm",
  "num-integer",
@@ -4187,7 +4186,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 1.0.3",
+ "webpki-roots 1.0.4",
 ]
 
 [[package]]
@@ -5844,14 +5843,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.3",
+ "webpki-roots 1.0.4",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b130c0d2d49f8b6889abc456e795e82525204f27c42cf767cf0d7734e089b8"
+checksum = "b2878ef029c47c6e8cf779119f20fcf52bde7ad42a731b2a304bc221df17571e"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fnox"
-version = "1.2.3"
+version = "1.3.0"
 edition = "2024"
 authors = ["@jdx"]
 description = "A flexible secret management tool supporting multiple providers and encryption methods"

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -972,7 +972,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.2.3",
+  "version": "1.3.0",
   "usage": "Usage: fnox [OPTIONS] <COMMAND>",
   "complete": {
     "key": {

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -4,7 +4,7 @@
 
 **Usage**: `fnox [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.2.3
+**Version**: 1.3.0
 
 - **Usage**: `fnox [FLAGS] <SUBCOMMAND>`
 

--- a/fnox.usage.kdl
+++ b/fnox.usage.kdl
@@ -1,7 +1,7 @@
 min_usage_version "1.3"
 name fnox
 bin fnox
-version "1.2.3"
+version "1.3.0"
 about "A flexible secret management tool by @jdx"
 usage "Usage: fnox [OPTIONS] <COMMAND>"
 flag "-c --config" help="Path to the configuration file (default: fnox.toml, searches parent directories)" global=#true {


### PR DESCRIPTION
## [1.3.0](https://github.com/jdx/fnox/compare/v1.2.3..v1.3.0) - 2025-11-01

### 🚀 Features

- add support for fnox.$FNOX_PROFILE.toml config files by [@jdx](https://github.com/jdx) in [#64](https://github.com/jdx/fnox/pull/64)
- add Infisical provider with CLI integration and self-hosted CI by [@jdx](https://github.com/jdx) in [#67](https://github.com/jdx/fnox/pull/67)

### 🐛 Bug Fixes

- **(tests)** skip keychain tests in CI when gnome-keyring-daemon unavailable by [@jdx](https://github.com/jdx) in [#72](https://github.com/jdx/fnox/pull/72)
- **(tests)** let gnome-keyring-daemon create its own control directory by [@jdx](https://github.com/jdx) in [#73](https://github.com/jdx/fnox/pull/73)
- add unique namespacing to parallel provider tests by [@jdx](https://github.com/jdx) in [#68](https://github.com/jdx/fnox/pull/68)

### 🚜 Refactor

- remove unused env_diff module and __FNOX_DIFF by [@jdx](https://github.com/jdx) in [#70](https://github.com/jdx/fnox/pull/70)

### ⚡ Performance

- parallelize CI tests across GHA workers using tranches by [@jdx](https://github.com/jdx) in [#65](https://github.com/jdx/fnox/pull/65)

### 🛡️ Security

- **(security)** store only hashes in __FNOX_SESSION instead of plaintext secrets by [@jdx](https://github.com/jdx) in [#71](https://github.com/jdx/fnox/pull/71)