### PR TITLE
fix(security): store only hashes in __FNOX_SESSION instead of plaintext secrets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,6 +204,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -912,6 +918,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
+name = "blake3"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1245,6 +1264,12 @@ name = "const_fn"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f8a2ca5ac02d09563609681103aada9e1777d54fc57a5acd7a41404f9c93b6e"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "cookie-factory"
@@ -1716,6 +1741,7 @@ dependencies = [
  "azure_identity",
  "azure_security_keyvault",
  "base64 0.22.1",
+ "blake3",
  "chrono",
  "ci_info",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ arc-swap = "1"
 async-trait = "0.1"
 atty = "0.2"
 base64 = "0.22"
+blake3 = "1"
 chrono = "0.4"
 ci_info = "0.14"
 clap = { version = "4", features = ["derive", "env"] }

--- a/src/commands/deactivate.rs
+++ b/src/commands/deactivate.rs
@@ -48,7 +48,7 @@ fn clear_old_env(shell: &dyn shell::Shell) -> String {
 
     // Unset all loaded secrets from the previous session
     let mut output = String::new();
-    for key in prev_session.loaded_secrets.keys() {
+    for key in prev_session.secret_hashes.keys() {
         output.push_str(&shell.unset_env(key));
     }
 


### PR DESCRIPTION
Previously, __FNOX_SESSION stored the full plaintext values of all secrets,
which could leak through process listings, environment dumps, logs, etc.

This commit improves security by:
- Storing only BLAKE3 keyed hashes of secret values in the session
- Storing a list of loaded keys (for deactivation) instead of full key-value pairs
- Using a unique random hash key per session to prevent:
  * Offline dictionary attacks against low-entropy secrets
  * Correlation of secret values across different sessions
- Comparing hashes to detect changes rather than plaintext values

The session's hash_key is generated from:
- Current timestamp (nanoseconds)
- Process ID
- BLAKE3 hash for randomness

Change detection still works correctly by:
1. Computing hash of new secret value using previous session's key
2. Comparing with stored hash from previous session
3. Only exporting secrets that changed (new, modified, or removed)

All 27 cargo tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces plaintext secrets in `__FNOX_SESSION` with per-session BLAKE3-keyed hashes and updates change detection/deactivation to use these hashes.
> 
> - **Session storage (`hook_env.rs`)**:
>   - Replace `loaded_secrets` with `secret_hashes: IndexMap<String, String>` and add per-session `hash_key: [u8; 32]`.
>   - Generate random `hash_key` and store only BLAKE3-keyed hashes of secret values.
>   - Add helpers `hash_secret_with_key` and `hash_secret_value_with_session`.
> - **Hook-env behavior (`commands/hook_env.rs`)**:
>   - Compute added/removed by hashing new values with previous session’s key and comparing to `secret_hashes`.
>   - Create new `HookEnvSession` from plaintext secrets but persist only hashes.
> - **Deactivate (`commands/deactivate.rs`)**:
>   - Unset env vars using keys from `secret_hashes` (no plaintext required).
> - **Dependencies**:
>   - Add `blake3` (and related transitive crates).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1895ad52021177ff595914596458070a0fd82fd0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->