### PR TITLE
fix(ci): make final job fail if any dependencies fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,11 +199,8 @@ jobs:
     steps:
       - name: Check job results
         if: |
-          needs.ci-bats.result == 'failure' ||
-          needs.ci-other.result == 'failure' ||
-          needs.msrv.result == 'failure' ||
-          needs.ci-bats.result == 'cancelled' ||
-          needs.ci-other.result == 'cancelled' ||
-          needs.msrv.result == 'cancelled'
+          needs.ci-bats.result != 'success' ||
+          needs.ci-other.result != 'success' ||
+          needs.msrv.result != 'success'
         run: exit 1
       - run: echo "All CI jobs completed successfully"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,5 +195,15 @@ jobs:
       - msrv
     runs-on: ubuntu-latest
     timeout-minutes: 1
+    if: always()
     steps:
+      - name: Check job results
+        if: |
+          needs.ci-bats.result == 'failure' ||
+          needs.ci-other.result == 'failure' ||
+          needs.msrv.result == 'failure' ||
+          needs.ci-bats.result == 'cancelled' ||
+          needs.ci-other.result == 'cancelled' ||
+          needs.msrv.result == 'cancelled'
+        run: exit 1
       - run: echo "All CI jobs completed successfully"


### PR DESCRIPTION
## Summary
- Add `if: always()` to the final job so it runs even when dependencies fail
- Add explicit check step that fails if any dependency job failed or was cancelled
- Ensures overall CI workflow status accurately reflects failures in constituent jobs

## Changes
The `final` job now:
1. Always runs regardless of dependency status (`if: always()`)
2. Explicitly checks each dependency's result (ci-bats, ci-other, msrv)
3. Fails with `exit 1` if any dependency failed or was cancelled
4. Only shows success message if all dependencies succeeded

## Why
Previously, if a dependency job failed, the final job would be skipped, making the overall workflow status less clear. With this change, the final job will always run and explicitly fail if any dependency fails, providing a clearer signal in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates CI to always run the `final` job and explicitly fail it if `ci-bats`, `ci-other`, or `msrv` did not succeed.
> 
> - **CI Workflow (`.github/workflows/ci.yml`)**:
>   - **Final job**:
>     - Runs unconditionally via `if: always()`.
>     - Adds check step to `exit 1` if any of `needs.ci-bats`, `needs.ci-other`, or `needs.msrv` are not `success`.
>     - Prints success message only when all dependencies succeed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c8644ab19d81d2fa3f79b5bfdac9feee07f0feec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->