### PR TITLE
chore: shellcheck/shfmt

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,4 @@
+# Suppress info-level messages for bats tests
+# SC2030/SC2031: Variable modifications in subshells (expected in bats)
+# SC2016: Expressions in single quotes (intentional for subshell expansion)
+disable=SC2030,SC2031,SC2016

--- a/hk.pkl
+++ b/hk.pkl
@@ -11,8 +11,12 @@ local linters = new Mapping<String, Step> {
     ["cargo-clippy"] = (Builtins.cargo_clippy) {
         profiles = List("slow")
     }
-    ["shfmt"] = Builtins.shfmt
-    ["shellcheck"] = Builtins.shellcheck
+    ["shfmt"] = (Builtins.shfmt) {
+        glob = List("**/*.bats", "**/*.sh", "**/*.bash")
+    }
+    ["shellcheck"] = (Builtins.shellcheck) {
+        glob = List("**/*.bats", "**/*.sh", "**/*.bash")
+    }
 
     // define a custom linter
     ["pkl"] {

--- a/test/age.bats
+++ b/test/age.bats
@@ -1,29 +1,30 @@
 #!/usr/bin/env bats
 
 setup() {
-    load 'test_helper/common_setup'
-    _common_setup
+	load 'test_helper/common_setup'
+	_common_setup
 }
 
 teardown() {
-    _common_teardown
+	_common_teardown
 }
 
 @test "decrypts using FNOX_AGE_KEY environment variable" {
-    # Skip if age not installed
-    if ! command -v age-keygen >/dev/null 2>&1; then
-        skip "age-keygen not installed"
-    fi
+	# Skip if age not installed
+	if ! command -v age-keygen >/dev/null 2>&1; then
+		skip "age-keygen not installed"
+	fi
 
-    # Generate age key
-    local keygen_output
-    keygen_output=$(age-keygen -o key.txt 2>&1)
-    local public_key
-    public_key=$(echo "$keygen_output" | grep "^Public key:" | cut -d' ' -f3)
-    local private_key=$(grep "^AGE-SECRET-KEY" key.txt)
+	# Generate age key
+	local keygen_output
+	keygen_output=$(age-keygen -o key.txt 2>&1)
+	local public_key
+	public_key=$(echo "$keygen_output" | grep "^Public key:" | cut -d' ' -f3)
+	local private_key
+	private_key=$(grep "^AGE-SECRET-KEY" key.txt)
 
-    # Create config with single provider
-    cat > fnox.toml << EOF
+	# Create config with single provider
+	cat >fnox.toml <<EOF
 root = true
 
 [providers.age]
@@ -33,17 +34,17 @@ recipients = ["$public_key"]
 [secrets]
 EOF
 
-    # Set a secret without specifying provider - should use the only one available
-    run "$FNOX_BIN" set MY_SECRET "secret-value"
-    assert_success
+	# Set a secret without specifying provider - should use the only one available
+	run "$FNOX_BIN" set MY_SECRET "secret-value"
+	assert_success
 
-    # Verify the secret was encrypted with the age provider
-    assert_config_contains "MY_SECRET"
-    assert_config_not_contains "secret-value"
+	# Verify the secret was encrypted with the age provider
+	assert_config_contains "MY_SECRET"
+	assert_config_not_contains "secret-value"
 
-    # Should be able to get it back
-    export FNOX_AGE_KEY=$private_key
-    run "$FNOX_BIN" get MY_SECRET
-    assert_success
-    assert_output "secret-value"
+	# Should be able to get it back
+	export FNOX_AGE_KEY=$private_key
+	run "$FNOX_BIN" get MY_SECRET
+	assert_success
+	assert_output "secret-value"
 }

--- a/test/aws_kms.bats
+++ b/test/aws_kms.bats
@@ -15,39 +15,39 @@
 #
 
 setup() {
-    load 'test_helper/common_setup'
-    _common_setup
+	load 'test_helper/common_setup'
+	_common_setup
 
-    # Check if AWS credentials are available
-    # (mise run test:bats automatically loads secrets via fnox exec)
-    if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
-        skip "AWS credentials not available. Ensure AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are configured."
-    fi
+	# Check if AWS credentials are available
+	# (mise run test:bats automatically loads secrets via fnox exec)
+	if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
+		skip "AWS credentials not available. Ensure AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are configured."
+	fi
 
-    # Check if aws CLI is installed
-    if ! command -v aws >/dev/null 2>&1; then
-        skip "AWS CLI not installed. Install with: brew install awscli"
-    fi
+	# Check if aws CLI is installed
+	if ! command -v aws >/dev/null 2>&1; then
+		skip "AWS CLI not installed. Install with: brew install awscli"
+	fi
 
-    # Set the KMS key ID and region
-    export KMS_KEY_ID="alias/fnox-testing"
-    export KMS_REGION="us-east-1"
+	# Set the KMS key ID and region
+	export KMS_KEY_ID="alias/fnox-testing"
+	export KMS_REGION="us-east-1"
 
-    # Verify we can access the KMS key
-    if ! aws kms describe-key --key-id "$KMS_KEY_ID" --region "$KMS_REGION" >/dev/null 2>&1; then
-        skip "Cannot access KMS key '$KMS_KEY_ID'. Key may not exist or permissions may be insufficient."
-    fi
+	# Verify we can access the KMS key
+	if ! aws kms describe-key --key-id "$KMS_KEY_ID" --region "$KMS_REGION" >/dev/null 2>&1; then
+		skip "Cannot access KMS key '$KMS_KEY_ID'. Key may not exist or permissions may be insufficient."
+	fi
 }
 
 teardown() {
-    _common_teardown
+	_common_teardown
 }
 
 # Helper function to create an AWS KMS test config
 create_kms_config() {
-    local key_id="${1:-alias/fnox-testing}"
-    local region="${2:-us-east-1}"
-    cat > "${FNOX_CONFIG_FILE:-fnox.toml}" << EOF
+	local key_id="${1:-alias/fnox-testing}"
+	local region="${2:-us-east-1}"
+	cat >"${FNOX_CONFIG_FILE:-fnox.toml}" <<EOF
 root = true
 
 [providers.kms]
@@ -60,93 +60,93 @@ EOF
 }
 
 @test "fnox set encrypts secret with AWS KMS" {
-    create_kms_config
+	create_kms_config
 
-    # Set a secret with KMS encryption
-    run "$FNOX_BIN" set KMS_TEST_SECRET "my-secret-value" --provider kms
-    assert_success
-    assert_output --partial "✓ Set secret KMS_TEST_SECRET"
+	# Set a secret with KMS encryption
+	run "$FNOX_BIN" set KMS_TEST_SECRET "my-secret-value" --provider kms
+	assert_success
+	assert_output --partial "✓ Set secret KMS_TEST_SECRET"
 
-    # Verify the config contains encrypted value (base64)
-    run grep "value =" "${FNOX_CONFIG_FILE}"
-    assert_success
-    assert_output --regexp 'value = "[A-Za-z0-9+/=]{50,}"'
+	# Verify the config contains encrypted value (base64)
+	run grep "value =" "${FNOX_CONFIG_FILE}"
+	assert_success
+	assert_output --regexp 'value = "[A-Za-z0-9+/=]{50,}"'
 }
 
 @test "fnox get decrypts secret from AWS KMS" {
-    create_kms_config
+	create_kms_config
 
-    # Set a secret
-    run "$FNOX_BIN" set KMS_DECRYPT_TEST "test-plaintext-value" --provider kms
-    assert_success
+	# Set a secret
+	run "$FNOX_BIN" set KMS_DECRYPT_TEST "test-plaintext-value" --provider kms
+	assert_success
 
-    # Get the secret back
-    run "$FNOX_BIN" get KMS_DECRYPT_TEST
-    assert_success
-    assert_output "test-plaintext-value"
+	# Get the secret back
+	run "$FNOX_BIN" get KMS_DECRYPT_TEST
+	assert_success
+	assert_output "test-plaintext-value"
 }
 
 @test "fnox set and get with special characters" {
-    create_kms_config
+	create_kms_config
 
-    # Set a secret with special characters
-    local special_value='{"password":"p@ssw0rd!","key":"abc=123&xyz"}'
-    run "$FNOX_BIN" set KMS_SPECIAL_CHARS "$special_value" --provider kms
-    assert_success
+	# Set a secret with special characters
+	local special_value='{"password":"p@ssw0rd!","key":"abc=123&xyz"}'
+	run "$FNOX_BIN" set KMS_SPECIAL_CHARS "$special_value" --provider kms
+	assert_success
 
-    # Get the secret back
-    run "$FNOX_BIN" get KMS_SPECIAL_CHARS
-    assert_success
-    assert_output "$special_value"
+	# Get the secret back
+	run "$FNOX_BIN" get KMS_SPECIAL_CHARS
+	assert_success
+	assert_output "$special_value"
 }
 
 @test "fnox set with multiline secret" {
-    create_kms_config
+	create_kms_config
 
-    # Set a multiline secret
-    local multiline_value="line1
+	# Set a multiline secret
+	local multiline_value="line1
 line2
 line3"
-    run "$FNOX_BIN" set KMS_MULTILINE "$multiline_value" --provider kms
-    assert_success
+	run "$FNOX_BIN" set KMS_MULTILINE "$multiline_value" --provider kms
+	assert_success
 
-    # Get the secret back
-    run "$FNOX_BIN" get KMS_MULTILINE
-    assert_success
-    assert_output "$multiline_value"
+	# Get the secret back
+	run "$FNOX_BIN" get KMS_MULTILINE
+	assert_success
+	assert_output "$multiline_value"
 }
 
 @test "fnox get fails with invalid ciphertext" {
-    create_kms_config
+	create_kms_config
 
-    # Manually create config with invalid base64 ciphertext
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	# Manually create config with invalid base64 ciphertext
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.INVALID_CIPHERTEXT]
 provider = "kms"
 value = "invalid-base64-!@#$%"
 EOF
 
-    run "$FNOX_BIN" get INVALID_CIPHERTEXT
-    assert_failure
-    assert_output --partial "Failed to decode base64 ciphertext"
+	run "$FNOX_BIN" get INVALID_CIPHERTEXT
+	assert_failure
+	assert_output --partial "Failed to decode base64 ciphertext"
 }
 
 @test "fnox set warns and stores plaintext with wrong KMS key" {
-    # Create config with non-existent key
-    create_kms_config "arn:aws:kms:us-east-1:123456789012:key/00000000-0000-0000-0000-000000000000"
+	# Create config with non-existent key
+	create_kms_config "arn:aws:kms:us-east-1:123456789012:key/00000000-0000-0000-0000-000000000000"
 
-    # When encryption fails, fnox currently warns and stores plaintext
-    run "$FNOX_BIN" set KMS_WRONG_KEY "test" --provider kms
-    assert_success
-    assert_output --partial "Encryption not supported for provider 'kms'"
-    assert_output --partial "Storing plaintext"
+	# When encryption fails, fnox currently warns and stores plaintext
+	run "$FNOX_BIN" set KMS_WRONG_KEY "test" --provider kms
+	assert_success
+	assert_output --partial "Encryption not supported for provider 'kms'"
+	assert_output --partial "Storing plaintext"
 }
 
 @test "fnox list shows KMS secrets" {
-    create_kms_config
+	create_kms_config
 
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.KMS_SECRET_1]
 description = "First KMS secret"
@@ -159,111 +159,113 @@ provider = "kms"
 value = "AQICAHiy8nEpehKbN0gxZ6AQfrlCEWWoKMLw5eogFUZ3c5gd1QEA1/K/EPEgXnmoj0rHIELGAAAAjDCBiQYJKoZIhvcNAQcGoHwwegIBADB1BgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDNaM0QctJeav8gwCMgIBEIBIbZFODxF3kivTBXDBZ+NenrryPEJz10X6XxeZtT32HjgMtUwravXPF0O4xpoaRlcHVYssmhq2RmOYGJxtlayDC0YsNwfb7kgX"
 EOF
 
-    run "$FNOX_BIN" list
-    assert_success
-    assert_output --partial "KMS_SECRET_1"
-    assert_output --partial "KMS_SECRET_2"
-    assert_output --partial "First KMS secret"
+	run "$FNOX_BIN" list
+	assert_success
+	assert_output --partial "KMS_SECRET_1"
+	assert_output --partial "KMS_SECRET_2"
+	assert_output --partial "First KMS secret"
 }
 
 @test "fnox set with description" {
-    create_kms_config
+	create_kms_config
 
-    run "$FNOX_BIN" set KMS_WITH_DESC "test-value" --provider kms --description "My KMS secret"
-    assert_success
+	run "$FNOX_BIN" set KMS_WITH_DESC "test-value" --provider kms --description "My KMS secret"
+	assert_success
 
-    # Verify description is in config
-    run grep "description" "${FNOX_CONFIG_FILE}"
-    assert_success
-    assert_output --partial "My KMS secret"
+	# Verify description is in config
+	run grep "description" "${FNOX_CONFIG_FILE}"
+	assert_success
+	assert_output --partial "My KMS secret"
 }
 
 @test "AWS KMS provider works with full key ARN" {
-    # Get the full ARN of the test key
-    local key_arn=$(aws kms describe-key --key-id "alias/fnox-testing" --region us-east-1 --query 'KeyMetadata.Arn' --output text)
+	# Get the full ARN of the test key
+	local key_arn
+	key_arn=$(aws kms describe-key --key-id "alias/fnox-testing" --region us-east-1 --query 'KeyMetadata.Arn' --output text)
 
-    create_kms_config "$key_arn" "us-east-1"
+	create_kms_config "$key_arn" "us-east-1"
 
-    run "$FNOX_BIN" set KMS_ARN_TEST "test-with-arn" --provider kms
-    assert_success
+	run "$FNOX_BIN" set KMS_ARN_TEST "test-with-arn" --provider kms
+	assert_success
 
-    run "$FNOX_BIN" get KMS_ARN_TEST
-    assert_success
-    assert_output "test-with-arn"
+	run "$FNOX_BIN" get KMS_ARN_TEST
+	assert_success
+	assert_output "test-with-arn"
 }
 
 @test "fnox exec sets KMS environment variables" {
-    create_kms_config
+	create_kms_config
 
-    # Set a secret
-    run "$FNOX_BIN" set MY_KMS_VAR "kms-env-value" --provider kms
-    assert_success
+	# Set a secret
+	run "$FNOX_BIN" set MY_KMS_VAR "kms-env-value" --provider kms
+	assert_success
 
-    # Use exec to run a command with the secret as env var
-    # Explicitly set FNOX_CONFIG_FILE to avoid inheriting parent config
-    run env FNOX_CONFIG_FILE="$FNOX_CONFIG_FILE" "$FNOX_BIN" exec -- sh -c 'echo $MY_KMS_VAR'
-    assert_success
-    assert_output "kms-env-value"
+	# Use exec to run a command with the secret as env var
+	# Explicitly set FNOX_CONFIG_FILE to avoid inheriting parent config
+	# shellcheck disable=SC2016 # Single quotes intentional - variable should expand in subshell
+	run env FNOX_CONFIG_FILE="$FNOX_CONFIG_FILE" "$FNOX_BIN" exec -- sh -c 'echo $MY_KMS_VAR'
+	assert_success
+	assert_output "kms-env-value"
 }
 
 @test "KMS encryption produces different ciphertext each time" {
-    create_kms_config
+	create_kms_config
 
-    # Set a secret twice with the same value
-    run "$FNOX_BIN" set KMS_UNIQUE_1 "same-value" --provider kms
-    assert_success
+	# Set a secret twice with the same value
+	run "$FNOX_BIN" set KMS_UNIQUE_1 "same-value" --provider kms
+	assert_success
 
-    # Set again with same value
-    run "$FNOX_BIN" set KMS_UNIQUE_2 "same-value" --provider kms
-    assert_success
+	# Set again with same value
+	run "$FNOX_BIN" set KMS_UNIQUE_2 "same-value" --provider kms
+	assert_success
 
-    # Get the encrypted values from config (inline table format)
-    # Secrets are now stored as: KMS_UNIQUE_1 = { provider = "kms", value = "..." }
-    cipher1=$(grep "^KMS_UNIQUE_1\s*=" "${FNOX_CONFIG_FILE}" | sed 's/.*value = "\([^"]*\)".*/\1/')
-    cipher2=$(grep "^KMS_UNIQUE_2\s*=" "${FNOX_CONFIG_FILE}" | sed 's/.*value = "\([^"]*\)".*/\1/')
+	# Get the encrypted values from config (inline table format)
+	# Secrets are now stored as: KMS_UNIQUE_1 = { provider = "kms", value = "..." }
+	cipher1=$(grep "^KMS_UNIQUE_1\s*=" "${FNOX_CONFIG_FILE}" | sed 's/.*value = "\([^"]*\)".*/\1/')
+	cipher2=$(grep "^KMS_UNIQUE_2\s*=" "${FNOX_CONFIG_FILE}" | sed 's/.*value = "\([^"]*\)".*/\1/')
 
-    # Verify ciphertexts were extracted
-    [ -n "$cipher1" ]
-    [ -n "$cipher2" ]
+	# Verify ciphertexts were extracted
+	[ -n "$cipher1" ]
+	[ -n "$cipher2" ]
 
-    # Ciphertexts should be different (KMS adds randomness)
-    [ "$cipher1" != "$cipher2" ]
+	# Ciphertexts should be different (KMS adds randomness)
+	[ "$cipher1" != "$cipher2" ]
 
-    # But both should decrypt to the same value
-    run "$FNOX_BIN" get KMS_UNIQUE_1
-    assert_success
-    assert_output "same-value"
+	# But both should decrypt to the same value
+	run "$FNOX_BIN" get KMS_UNIQUE_1
+	assert_success
+	assert_output "same-value"
 
-    run "$FNOX_BIN" get KMS_UNIQUE_2
-    assert_success
-    assert_output "same-value"
+	run "$FNOX_BIN" get KMS_UNIQUE_2
+	assert_success
+	assert_output "same-value"
 }
 
 @test "fnox set updates existing KMS secret" {
-    create_kms_config
+	create_kms_config
 
-    # Set initial value
-    run "$FNOX_BIN" set KMS_UPDATE_TEST "initial-value" --provider kms
-    assert_success
+	# Set initial value
+	run "$FNOX_BIN" set KMS_UPDATE_TEST "initial-value" --provider kms
+	assert_success
 
-    # Update with new value
-    run "$FNOX_BIN" set KMS_UPDATE_TEST "updated-value" --provider kms
-    assert_success
+	# Update with new value
+	run "$FNOX_BIN" set KMS_UPDATE_TEST "updated-value" --provider kms
+	assert_success
 
-    # Verify new value is retrieved
-    run "$FNOX_BIN" get KMS_UPDATE_TEST
-    assert_success
-    assert_output "updated-value"
+	# Verify new value is retrieved
+	run "$FNOX_BIN" get KMS_UPDATE_TEST
+	assert_success
+	assert_output "updated-value"
 }
 
 @test "KMS provider respects region configuration" {
-    # Test that we're using the correct region
-    create_kms_config "alias/fnox-testing" "us-east-1"
+	# Test that we're using the correct region
+	create_kms_config "alias/fnox-testing" "us-east-1"
 
-    run "$FNOX_BIN" set KMS_REGION_TEST "region-specific" --provider kms
-    assert_success
+	run "$FNOX_BIN" set KMS_REGION_TEST "region-specific" --provider kms
+	assert_success
 
-    run "$FNOX_BIN" get KMS_REGION_TEST
-    assert_success
-    assert_output "region-specific"
+	run "$FNOX_BIN" get KMS_REGION_TEST
+	assert_success
+	assert_output "region-specific"
 }

--- a/test/aws_secrets_manager.bats
+++ b/test/aws_secrets_manager.bats
@@ -16,51 +16,51 @@
 #
 
 setup() {
-    load 'test_helper/common_setup'
-    _common_setup
+	load 'test_helper/common_setup'
+	_common_setup
 
-    # Check if AWS credentials are available
-    if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
-        skip "AWS credentials not available. Ensure AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are configured."
-    fi
+	# Check if AWS credentials are available
+	if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
+		skip "AWS credentials not available. Ensure AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are configured."
+	fi
 
-    # Check if aws CLI is installed
-    if ! command -v aws >/dev/null 2>&1; then
-        skip "AWS CLI not installed. Install with: brew install awscli"
-    fi
+	# Check if aws CLI is installed
+	if ! command -v aws >/dev/null 2>&1; then
+		skip "AWS CLI not installed. Install with: brew install awscli"
+	fi
 
-    # Set the region
-    export SM_REGION="us-east-1"
+	# Set the region
+	export SM_REGION="us-east-1"
 
-    # Verify we can access Secrets Manager
-    if ! aws secretsmanager list-secrets --region "$SM_REGION" --max-results 1 >/dev/null 2>&1; then
-        skip "Cannot access AWS Secrets Manager. Permissions may be insufficient."
-    fi
+	# Verify we can access Secrets Manager
+	if ! aws secretsmanager list-secrets --region "$SM_REGION" --max-results 1 >/dev/null 2>&1; then
+		skip "Cannot access AWS Secrets Manager. Permissions may be insufficient."
+	fi
 }
 
 teardown() {
-    # Clean up any test secrets created during tests
-    if [ -n "$TEST_SECRET_NAME" ]; then
-        aws secretsmanager delete-secret \
-            --secret-id "$TEST_SECRET_NAME" \
-            --force-delete-without-recovery \
-            --region "$SM_REGION" >/dev/null 2>&1 || true
-    fi
+	# Clean up any test secrets created during tests
+	if [ -n "$TEST_SECRET_NAME" ]; then
+		aws secretsmanager delete-secret \
+			--secret-id "$TEST_SECRET_NAME" \
+			--force-delete-without-recovery \
+			--region "$SM_REGION" >/dev/null 2>&1 || true
+	fi
 
-    _common_teardown
+	_common_teardown
 }
 
 # Helper function to create an AWS Secrets Manager test config
 create_sm_config() {
-    local region="${1:-us-east-1}"
-    local prefix="${2}"
-    if [ -z "$prefix" ] && [ "$#" -lt 2 ]; then
-        prefix="fnox-test/"
-    fi
+	local region="${1:-us-east-1}"
+	local prefix="${2}"
+	if [ -z "$prefix" ] && [ "$#" -lt 2 ]; then
+		prefix="fnox-test/"
+	fi
 
-    if [ -z "$prefix" ]; then
-        # Omit prefix line entirely when empty
-        cat > "${FNOX_CONFIG_FILE:-fnox.toml}" << EOF
+	if [ -z "$prefix" ]; then
+		# Omit prefix line entirely when empty
+		cat >"${FNOX_CONFIG_FILE:-fnox.toml}" <<EOF
 root = true
 
 [providers.sm]
@@ -69,8 +69,8 @@ region = "$region"
 
 [secrets]
 EOF
-    else
-        cat > "${FNOX_CONFIG_FILE:-fnox.toml}" << EOF
+	else
+		cat >"${FNOX_CONFIG_FILE:-fnox.toml}" <<EOF
 root = true
 
 [providers.sm]
@@ -80,160 +80,165 @@ prefix = "$prefix"
 
 [secrets]
 EOF
-    fi
+	fi
 }
 
 # Helper function to create a test secret in AWS Secrets Manager
 create_test_secret() {
-    local secret_name="$1"
-    local secret_value="$2"
-    
-    aws secretsmanager create-secret \
-        --name "$secret_name" \
-        --secret-string "$secret_value" \
-        --region "$SM_REGION" >/dev/null 2>&1
+	local secret_name="$1"
+	local secret_value="$2"
 
-    # Give AWS Secrets Manager time to propagate the secret (eventual consistency)
-    sleep 2
+	aws secretsmanager create-secret \
+		--name "$secret_name" \
+		--secret-string "$secret_value" \
+		--region "$SM_REGION" >/dev/null 2>&1
 
-    export TEST_SECRET_NAME="$secret_name"
+	# Give AWS Secrets Manager time to propagate the secret (eventual consistency)
+	sleep 2
+
+	export TEST_SECRET_NAME="$secret_name"
 }
 
 @test "fnox get retrieves secret from AWS Secrets Manager" {
-    create_sm_config
+	create_sm_config
 
-    # Create a test secret
-    local timestamp="$(date +%s)-$$-${BATS_TEST_NUMBER:-0}"
-    local secret_name="fnox-test/test-secret-${timestamp}"
-    local secret_value="my-test-secret-value"
-    create_test_secret "$secret_name" "$secret_value"
+	# Create a test secret
+	local timestamp
+	timestamp="$(date +%s)-$$-${BATS_TEST_NUMBER:-0}"
+	local secret_name="fnox-test/test-secret-${timestamp}"
+	local secret_value="my-test-secret-value"
+	create_test_secret "$secret_name" "$secret_value"
 
-    # Add secret reference to config (using just the name without prefix)
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	# Add secret reference to config (using just the name without prefix)
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.SM_TEST]
 provider = "sm"
 value = "test-secret-${timestamp}"
 EOF
 
-    # Get the secret
-    run "$FNOX_BIN" get SM_TEST
-    assert_success
-    assert_output "$secret_value"
+	# Get the secret
+	run "$FNOX_BIN" get SM_TEST
+	assert_success
+	assert_output "$secret_value"
 }
 
 @test "fnox get with prefix prepends prefix to secret name" {
-    create_sm_config "us-east-1" "fnox-test/"
+	create_sm_config "us-east-1" "fnox-test/"
 
-    # Create a test secret with full path
-    local timestamp="$(date +%s)-$$-${BATS_TEST_NUMBER:-0}"
-    local secret_name="fnox-test/prefixed-${timestamp}"
-    local secret_value="value-with-prefix"
-    create_test_secret "$secret_name" "$secret_value"
+	# Create a test secret with full path
+	local timestamp
+	timestamp="$(date +%s)-$$-${BATS_TEST_NUMBER:-0}"
+	local secret_name="fnox-test/prefixed-${timestamp}"
+	local secret_value="value-with-prefix"
+	create_test_secret "$secret_name" "$secret_value"
 
-    # Add secret reference using just the suffix
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	# Add secret reference using just the suffix
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.PREFIXED_SECRET]
 provider = "sm"
 value = "prefixed-${timestamp}"
 EOF
 
-    # Get the secret
-    run "$FNOX_BIN" get PREFIXED_SECRET
-    assert_success
-    assert_output "$secret_value"
+	# Get the secret
+	run "$FNOX_BIN" get PREFIXED_SECRET
+	assert_success
+	assert_output "$secret_value"
 }
 
 @test "fnox get without prefix uses full secret name" {
-    create_sm_config "us-east-1" ""
+	create_sm_config "us-east-1" ""
 
-    # Create a test secret without prefix
-    local timestamp="$(date +%s)-$$-${BATS_TEST_NUMBER:-0}"
-    local secret_name="fnox-full-name-${timestamp}"
-    local secret_value="value-no-prefix"
-    create_test_secret "$secret_name" "$secret_value"
+	# Create a test secret without prefix
+	local timestamp
+	timestamp="$(date +%s)-$$-${BATS_TEST_NUMBER:-0}"
+	local secret_name="fnox-full-name-${timestamp}"
+	local secret_value="value-no-prefix"
+	create_test_secret "$secret_name" "$secret_value"
 
-    # Add secret reference
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	# Add secret reference
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.FULL_NAME_SECRET]
 provider = "sm"
 value = "$secret_name"
 EOF
 
-    # Get the secret
-    run "$FNOX_BIN" get FULL_NAME_SECRET
-    assert_success
-    assert_output "$secret_value"
+	# Get the secret
+	run "$FNOX_BIN" get FULL_NAME_SECRET
+	assert_success
+	assert_output "$secret_value"
 }
 
 @test "fnox get fails with non-existent secret" {
-    create_sm_config
+	create_sm_config
 
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.NONEXISTENT]
 provider = "sm"
 value = "does-not-exist-$(date +%s)"
 EOF
 
-    # Try to get non-existent secret
-    run "$FNOX_BIN" get NONEXISTENT
-    assert_failure
-    assert_output --partial "Failed to get secret"
+	# Try to get non-existent secret
+	run "$FNOX_BIN" get NONEXISTENT
+	assert_failure
+	assert_output --partial "Failed to get secret"
 }
 
 @test "fnox get with JSON secret value" {
-    create_sm_config
+	create_sm_config
 
-    # Create a JSON secret
-    local timestamp="$(date +%s)-$$-${BATS_TEST_NUMBER:-0}"
-    local secret_name="fnox-test/json-secret-${timestamp}"
-    local secret_value='{"api_key":"test123","endpoint":"https://api.example.com"}'
-    create_test_secret "$secret_name" "$secret_value"
+	# Create a JSON secret
+	local timestamp
+	timestamp="$(date +%s)-$$-${BATS_TEST_NUMBER:-0}"
+	local secret_name="fnox-test/json-secret-${timestamp}"
+	local secret_value='{"api_key":"test123","endpoint":"https://api.example.com"}'
+	create_test_secret "$secret_name" "$secret_value"
 
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.JSON_SECRET]
 provider = "sm"
 value = "json-secret-${timestamp}"
 EOF
 
-    # Get the secret
-    run "$FNOX_BIN" get JSON_SECRET
-    assert_success
-    assert_output "$secret_value"
+	# Get the secret
+	run "$FNOX_BIN" get JSON_SECRET
+	assert_success
+	assert_output "$secret_value"
 }
 
 @test "fnox get with multiline secret" {
-    create_sm_config
+	create_sm_config
 
-    # Create a multiline secret
-    local timestamp="$(date +%s)-$$-${BATS_TEST_NUMBER:-0}"
-    local secret_name="fnox-test/multiline-${timestamp}"
-    local secret_value="line1
+	# Create a multiline secret
+	local timestamp
+	timestamp="$(date +%s)-$$-${BATS_TEST_NUMBER:-0}"
+	local secret_name="fnox-test/multiline-${timestamp}"
+	local secret_value="line1
 line2
 line3"
-    create_test_secret "$secret_name" "$secret_value"
+	create_test_secret "$secret_name" "$secret_value"
 
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.MULTILINE_SECRET]
 provider = "sm"
 value = "multiline-${timestamp}"
 EOF
 
-    # Get the secret
-    run "$FNOX_BIN" get MULTILINE_SECRET
-    assert_success
-    assert_output "$secret_value"
+	# Get the secret
+	run "$FNOX_BIN" get MULTILINE_SECRET
+	assert_success
+	assert_output "$secret_value"
 }
 
 @test "fnox list shows Secrets Manager secrets" {
-    create_sm_config
+	create_sm_config
 
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.SM_SECRET_1]
 description = "First Secrets Manager secret"
@@ -246,78 +251,80 @@ provider = "sm"
 value = "secret2"
 EOF
 
-    run "$FNOX_BIN" list
-    assert_success
-    assert_output --partial "SM_SECRET_1"
-    assert_output --partial "SM_SECRET_2"
-    assert_output --partial "First Secrets Manager secret"
+	run "$FNOX_BIN" list
+	assert_success
+	assert_output --partial "SM_SECRET_1"
+	assert_output --partial "SM_SECRET_2"
+	assert_output --partial "First Secrets Manager secret"
 }
 
 @test "fnox get respects region configuration" {
-    create_sm_config "us-east-1"
+	create_sm_config "us-east-1"
 
-    # Create a secret in the specified region
-    local timestamp="$(date +%s)-$$-${BATS_TEST_NUMBER:-0}"
-    local secret_name="fnox-test/regional-${timestamp}"
-    local secret_value="region-specific-value"
-    create_test_secret "$secret_name" "$secret_value"
+	# Create a secret in the specified region
+	local timestamp
+	timestamp="$(date +%s)-$$-${BATS_TEST_NUMBER:-0}"
+	local secret_name="fnox-test/regional-${timestamp}"
+	local secret_value="region-specific-value"
+	create_test_secret "$secret_name" "$secret_value"
 
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.REGIONAL_SECRET]
 provider = "sm"
 value = "regional-${timestamp}"
 EOF
 
-    # Get the secret
-    run "$FNOX_BIN" get REGIONAL_SECRET
-    assert_success
-    assert_output "$secret_value"
+	# Get the secret
+	run "$FNOX_BIN" get REGIONAL_SECRET
+	assert_success
+	assert_output "$secret_value"
 }
 
 @test "fnox get with special characters in secret value" {
-    create_sm_config
+	create_sm_config
 
-    # Create a secret with special characters
-    local timestamp="$(date +%s)-$$-${BATS_TEST_NUMBER:-0}"
-    local secret_name="fnox-test/special-${timestamp}"
-    local secret_value='p@ssw0rd!#$%^&*()_+-={}[]|\:";'\''<>?,./~`'
-    create_test_secret "$secret_name" "$secret_value"
+	# Create a secret with special characters
+	local timestamp
+	timestamp="$(date +%s)-$$-${BATS_TEST_NUMBER:-0}"
+	local secret_name="fnox-test/special-${timestamp}"
+	local secret_value='p@ssw0rd!#$%^&*()_+-={}[]|\:";'\''<>?,./~`'
+	create_test_secret "$secret_name" "$secret_value"
 
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.SPECIAL_CHARS]
 provider = "sm"
 value = "special-${timestamp}"
 EOF
 
-    # Get the secret
-    run "$FNOX_BIN" get SPECIAL_CHARS
-    assert_success
-    assert_output "$secret_value"
+	# Get the secret
+	run "$FNOX_BIN" get SPECIAL_CHARS
+	assert_success
+	assert_output "$secret_value"
 }
 
 @test "AWS Secrets Manager works with existing fnox/test-secret" {
-    # Test with the pre-created secret from setup
-    create_sm_config "us-east-1" "fnox/"
+	# Test with the pre-created secret from setup
+	create_sm_config "us-east-1" "fnox/"
 
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.EXISTING_SECRET]
 provider = "sm"
 value = "test-secret"
 EOF
 
-    # Get the secret
-    run "$FNOX_BIN" get EXISTING_SECRET
-    assert_success
-    assert_output "This is a test secret in AWS Secrets Manager!"
+	# Get the secret
+	run "$FNOX_BIN" get EXISTING_SECRET
+	assert_success
+	assert_output "This is a test secret in AWS Secrets Manager!"
 }
 
 @test "fnox get with description" {
-    create_sm_config
+	create_sm_config
 
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.DESCRIBED_SECRET]
 description = "A secret with a description"
@@ -325,9 +332,9 @@ provider = "sm"
 value = "some-secret"
 EOF
 
-    # List to verify description
-    run "$FNOX_BIN" list
-    assert_success
-    assert_output --partial "DESCRIBED_SECRET"
-    assert_output --partial "A secret with a description"
+	# List to verify description
+	run "$FNOX_BIN" list
+	assert_success
+	assert_output --partial "DESCRIBED_SECRET"
+	assert_output --partial "A secret with a description"
 }

--- a/test/azure_kms.bats
+++ b/test/azure_kms.bats
@@ -15,47 +15,47 @@
 #
 
 setup() {
-    load 'test_helper/common_setup'
-    _common_setup
+	load 'test_helper/common_setup'
+	_common_setup
 
-    # Check if Azure credentials are available
-    if [ -z "$AZURE_CLIENT_ID" ] || [ -z "$AZURE_CLIENT_SECRET" ] || [ -z "$AZURE_TENANT_ID" ]; then
-        skip "Azure credentials not available. Ensure AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, and AZURE_TENANT_ID are configured."
-    fi
+	# Check if Azure credentials are available
+	if [ -z "$AZURE_CLIENT_ID" ] || [ -z "$AZURE_CLIENT_SECRET" ] || [ -z "$AZURE_TENANT_ID" ]; then
+		skip "Azure credentials not available. Ensure AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, and AZURE_TENANT_ID are configured."
+	fi
 
-    # Check if az CLI is installed
-    if ! command -v az >/dev/null 2>&1; then
-        skip "Azure CLI not installed. Install with: brew install azure-cli"
-    fi
+	# Check if az CLI is installed
+	if ! command -v az >/dev/null 2>&1; then
+		skip "Azure CLI not installed. Install with: brew install azure-cli"
+	fi
 
-    # Set the Key Vault URL and key name
-    export VAULT_URL="https://fnox-testing-kv.vault.azure.net/"
-    export KEY_NAME="fnox-test-key"
+	# Set the Key Vault URL and key name
+	export VAULT_URL="https://fnox-testing-kv.vault.azure.net/"
+	export KEY_NAME="fnox-test-key"
 
-    # Authenticate Azure CLI with service principal if not already logged in
-    if ! az account show >/dev/null 2>&1; then
-        az login --service-principal \
-            -u "$AZURE_CLIENT_ID" \
-            -p "$AZURE_CLIENT_SECRET" \
-            --tenant "$AZURE_TENANT_ID" >/dev/null 2>&1 || \
-            skip "Failed to authenticate Azure CLI with service principal"
-    fi
+	# Authenticate Azure CLI with service principal if not already logged in
+	if ! az account show >/dev/null 2>&1; then
+		az login --service-principal \
+			-u "$AZURE_CLIENT_ID" \
+			-p "$AZURE_CLIENT_SECRET" \
+			--tenant "$AZURE_TENANT_ID" >/dev/null 2>&1 ||
+			skip "Failed to authenticate Azure CLI with service principal"
+	fi
 
-    # Verify we can access the Key Vault key
-    if ! az keyvault key show --vault-name fnox-testing-kv --name "$KEY_NAME" >/dev/null 2>&1; then
-        skip "Cannot access Azure Key Vault key '$KEY_NAME'. Key may not exist or permissions may be insufficient."
-    fi
+	# Verify we can access the Key Vault key
+	if ! az keyvault key show --vault-name fnox-testing-kv --name "$KEY_NAME" >/dev/null 2>&1; then
+		skip "Cannot access Azure Key Vault key '$KEY_NAME'. Key may not exist or permissions may be insufficient."
+	fi
 }
 
 teardown() {
-    _common_teardown
+	_common_teardown
 }
 
 # Helper function to create an Azure KMS test config
 create_azure_kms_config() {
-    local vault_url="${1:-https://fnox-testing-kv.vault.azure.net/}"
-    local key_name="${2:-fnox-test-key}"
-    cat > "${FNOX_CONFIG_FILE:-fnox.toml}" << EOF
+	local vault_url="${1:-https://fnox-testing-kv.vault.azure.net/}"
+	local key_name="${2:-fnox-test-key}"
+	cat >"${FNOX_CONFIG_FILE:-fnox.toml}" <<EOF
 root = true
 
 [providers.azure-kms]
@@ -68,93 +68,93 @@ EOF
 }
 
 @test "fnox set encrypts secret with Azure KMS" {
-    create_azure_kms_config
+	create_azure_kms_config
 
-    # Set a secret with Azure KMS encryption
-    run "$FNOX_BIN" set AZURE_KMS_TEST_SECRET "my-secret-value" --provider azure-kms
-    assert_success
-    assert_output --partial "✓ Set secret AZURE_KMS_TEST_SECRET"
+	# Set a secret with Azure KMS encryption
+	run "$FNOX_BIN" set AZURE_KMS_TEST_SECRET "my-secret-value" --provider azure-kms
+	assert_success
+	assert_output --partial "✓ Set secret AZURE_KMS_TEST_SECRET"
 
-    # Verify the config contains encrypted value (base64)
-    run grep "value =" "${FNOX_CONFIG_FILE}"
-    assert_success
-    assert_output --regexp 'value = "[A-Za-z0-9+/=]{50,}"'
+	# Verify the config contains encrypted value (base64)
+	run grep "value =" "${FNOX_CONFIG_FILE}"
+	assert_success
+	assert_output --regexp 'value = "[A-Za-z0-9+/=]{50,}"'
 }
 
 @test "fnox get decrypts secret from Azure KMS" {
-    create_azure_kms_config
+	create_azure_kms_config
 
-    # Set a secret
-    run "$FNOX_BIN" set AZURE_KMS_DECRYPT_TEST "test-plaintext-value" --provider azure-kms
-    assert_success
+	# Set a secret
+	run "$FNOX_BIN" set AZURE_KMS_DECRYPT_TEST "test-plaintext-value" --provider azure-kms
+	assert_success
 
-    # Get the secret back
-    run "$FNOX_BIN" get AZURE_KMS_DECRYPT_TEST
-    assert_success
-    assert_output "test-plaintext-value"
+	# Get the secret back
+	run "$FNOX_BIN" get AZURE_KMS_DECRYPT_TEST
+	assert_success
+	assert_output "test-plaintext-value"
 }
 
 @test "fnox set and get with special characters" {
-    create_azure_kms_config
+	create_azure_kms_config
 
-    # Set a secret with special characters
-    local special_value='{"password":"p@ssw0rd!","key":"abc=123&xyz"}'
-    run "$FNOX_BIN" set AZURE_KMS_SPECIAL_CHARS "$special_value" --provider azure-kms
-    assert_success
+	# Set a secret with special characters
+	local special_value='{"password":"p@ssw0rd!","key":"abc=123&xyz"}'
+	run "$FNOX_BIN" set AZURE_KMS_SPECIAL_CHARS "$special_value" --provider azure-kms
+	assert_success
 
-    # Get the secret back
-    run "$FNOX_BIN" get AZURE_KMS_SPECIAL_CHARS
-    assert_success
-    assert_output "$special_value"
+	# Get the secret back
+	run "$FNOX_BIN" get AZURE_KMS_SPECIAL_CHARS
+	assert_success
+	assert_output "$special_value"
 }
 
 @test "fnox set with multiline secret" {
-    create_azure_kms_config
+	create_azure_kms_config
 
-    # Set a multiline secret
-    local multiline_value="line1
+	# Set a multiline secret
+	local multiline_value="line1
 line2
 line3"
-    run "$FNOX_BIN" set AZURE_KMS_MULTILINE "$multiline_value" --provider azure-kms
-    assert_success
+	run "$FNOX_BIN" set AZURE_KMS_MULTILINE "$multiline_value" --provider azure-kms
+	assert_success
 
-    # Get the secret back
-    run "$FNOX_BIN" get AZURE_KMS_MULTILINE
-    assert_success
-    assert_output "$multiline_value"
+	# Get the secret back
+	run "$FNOX_BIN" get AZURE_KMS_MULTILINE
+	assert_success
+	assert_output "$multiline_value"
 }
 
 @test "fnox get fails with invalid ciphertext" {
-    create_azure_kms_config
+	create_azure_kms_config
 
-    # Manually create config with invalid base64 ciphertext
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	# Manually create config with invalid base64 ciphertext
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.INVALID_CIPHERTEXT]
 provider = "azure-kms"
 value = "invalid-base64-!@#$%"
 EOF
 
-    run "$FNOX_BIN" get INVALID_CIPHERTEXT
-    assert_failure
-    assert_output --partial "Failed to decode base64 ciphertext"
+	run "$FNOX_BIN" get INVALID_CIPHERTEXT
+	assert_failure
+	assert_output --partial "Failed to decode base64 ciphertext"
 }
 
 @test "fnox set warns and stores plaintext with wrong key" {
-    # Create config with non-existent key
-    create_azure_kms_config "https://fnox-testing-kv.vault.azure.net/" "non-existent-key"
+	# Create config with non-existent key
+	create_azure_kms_config "https://fnox-testing-kv.vault.azure.net/" "non-existent-key"
 
-    # When encryption fails, fnox currently warns and stores plaintext
-    run "$FNOX_BIN" set AZURE_KMS_WRONG_KEY "test" --provider azure-kms
-    assert_success
-    assert_output --partial "Encryption not supported for provider 'azure-kms'"
-    assert_output --partial "Storing plaintext"
+	# When encryption fails, fnox currently warns and stores plaintext
+	run "$FNOX_BIN" set AZURE_KMS_WRONG_KEY "test" --provider azure-kms
+	assert_success
+	assert_output --partial "Encryption not supported for provider 'azure-kms'"
+	assert_output --partial "Storing plaintext"
 }
 
 @test "fnox list shows Azure KMS secrets" {
-    create_azure_kms_config
+	create_azure_kms_config
 
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.AZURE_KMS_SECRET_1]
 description = "First Azure KMS secret"
@@ -167,85 +167,85 @@ provider = "azure-kms"
 value = "AQICAHiy8nEpehKbN0gxZ6AQfrlCEWWoKMLw5eogFUZ3c5gd1QEA1/K/EPEgXnmoj0rHIELGAAAAjDCBiQYJKoZIhvcNAQcGoHwwegIBADB1BgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDNaM0QctJeav8gwCMgIBEIBIbZFODxF3kivTBXDBZ+NenrryPEJz10X6XxeZtT32HjgMtUwravXPF0O4xpoaRlcHVYssmhq2RmOYGJxtlayDC0YsNwfb7kgX"
 EOF
 
-    run "$FNOX_BIN" list
-    assert_success
-    assert_output --partial "AZURE_KMS_SECRET_1"
-    assert_output --partial "AZURE_KMS_SECRET_2"
-    assert_output --partial "First Azure KMS secret"
+	run "$FNOX_BIN" list
+	assert_success
+	assert_output --partial "AZURE_KMS_SECRET_1"
+	assert_output --partial "AZURE_KMS_SECRET_2"
+	assert_output --partial "First Azure KMS secret"
 }
 
 @test "fnox set with description" {
-    create_azure_kms_config
+	create_azure_kms_config
 
-    run "$FNOX_BIN" set AZURE_KMS_WITH_DESC "test-value" --provider azure-kms --description "My Azure KMS secret"
-    assert_success
+	run "$FNOX_BIN" set AZURE_KMS_WITH_DESC "test-value" --provider azure-kms --description "My Azure KMS secret"
+	assert_success
 
-    # Verify description is in config
-    run grep "description" "${FNOX_CONFIG_FILE}"
-    assert_success
-    assert_output --partial "My Azure KMS secret"
+	# Verify description is in config
+	run grep "description" "${FNOX_CONFIG_FILE}"
+	assert_success
+	assert_output --partial "My Azure KMS secret"
 }
 
 @test "Azure KMS encryption produces different ciphertext each time" {
-    create_azure_kms_config
+	create_azure_kms_config
 
-    # Set a secret twice with the same value
-    run "$FNOX_BIN" set AZURE_KMS_UNIQUE_1 "same-value" --provider azure-kms
-    assert_success
+	# Set a secret twice with the same value
+	run "$FNOX_BIN" set AZURE_KMS_UNIQUE_1 "same-value" --provider azure-kms
+	assert_success
 
-    # Set again with same value
-    run "$FNOX_BIN" set AZURE_KMS_UNIQUE_2 "same-value" --provider azure-kms
-    assert_success
+	# Set again with same value
+	run "$FNOX_BIN" set AZURE_KMS_UNIQUE_2 "same-value" --provider azure-kms
+	assert_success
 
-    # Get the encrypted values from config (inline table format)
-    # Secrets are now stored as: AZURE_KMS_UNIQUE_1 = { provider = "azure-kms", value = "..." }
-    cipher1=$(grep "^AZURE_KMS_UNIQUE_1\s*=" "${FNOX_CONFIG_FILE}" | sed 's/.*value = "\([^"]*\)".*/\1/')
-    cipher2=$(grep "^AZURE_KMS_UNIQUE_2\s*=" "${FNOX_CONFIG_FILE}" | sed 's/.*value = "\([^"]*\)".*/\1/')
+	# Get the encrypted values from config (inline table format)
+	# Secrets are now stored as: AZURE_KMS_UNIQUE_1 = { provider = "azure-kms", value = "..." }
+	cipher1=$(grep "^AZURE_KMS_UNIQUE_1\s*=" "${FNOX_CONFIG_FILE}" | sed 's/.*value = "\([^"]*\)".*/\1/')
+	cipher2=$(grep "^AZURE_KMS_UNIQUE_2\s*=" "${FNOX_CONFIG_FILE}" | sed 's/.*value = "\([^"]*\)".*/\1/')
 
-    # Verify ciphertexts were extracted
-    [ -n "$cipher1" ]
-    [ -n "$cipher2" ]
+	# Verify ciphertexts were extracted
+	[ -n "$cipher1" ]
+	[ -n "$cipher2" ]
 
-    # Ciphertexts should be different (Azure KMS adds randomness)
-    [ "$cipher1" != "$cipher2" ]
+	# Ciphertexts should be different (Azure KMS adds randomness)
+	[ "$cipher1" != "$cipher2" ]
 
-    # But both should decrypt to the same value
-    run "$FNOX_BIN" get AZURE_KMS_UNIQUE_1
-    assert_success
-    assert_output "same-value"
+	# But both should decrypt to the same value
+	run "$FNOX_BIN" get AZURE_KMS_UNIQUE_1
+	assert_success
+	assert_output "same-value"
 
-    run "$FNOX_BIN" get AZURE_KMS_UNIQUE_2
-    assert_success
-    assert_output "same-value"
+	run "$FNOX_BIN" get AZURE_KMS_UNIQUE_2
+	assert_success
+	assert_output "same-value"
 }
 
 @test "fnox set updates existing Azure KMS secret" {
-    create_azure_kms_config
+	create_azure_kms_config
 
-    # Set initial value
-    run "$FNOX_BIN" set AZURE_KMS_UPDATE_TEST "initial-value" --provider azure-kms
-    assert_success
+	# Set initial value
+	run "$FNOX_BIN" set AZURE_KMS_UPDATE_TEST "initial-value" --provider azure-kms
+	assert_success
 
-    # Update with new value
-    run "$FNOX_BIN" set AZURE_KMS_UPDATE_TEST "updated-value" --provider azure-kms
-    assert_success
+	# Update with new value
+	run "$FNOX_BIN" set AZURE_KMS_UPDATE_TEST "updated-value" --provider azure-kms
+	assert_success
 
-    # Verify new value is retrieved
-    run "$FNOX_BIN" get AZURE_KMS_UPDATE_TEST
-    assert_success
-    assert_output "updated-value"
+	# Verify new value is retrieved
+	run "$FNOX_BIN" get AZURE_KMS_UPDATE_TEST
+	assert_success
+	assert_output "updated-value"
 }
 
 @test "fnox exec sets Azure KMS environment variables" {
-    create_azure_kms_config
+	create_azure_kms_config
 
-    # Set a secret
-    run "$FNOX_BIN" set MY_AZURE_KMS_VAR "azure-kms-env-value" --provider azure-kms
-    assert_success
+	# Set a secret
+	run "$FNOX_BIN" set MY_AZURE_KMS_VAR "azure-kms-env-value" --provider azure-kms
+	assert_success
 
-    # Use exec to run a command with the secret as env var
-    # Explicitly set FNOX_CONFIG_FILE to avoid inheriting parent config
-    run env FNOX_CONFIG_FILE="$FNOX_CONFIG_FILE" "$FNOX_BIN" exec -- sh -c 'echo $MY_AZURE_KMS_VAR'
-    assert_success
-    assert_output "azure-kms-env-value"
+	# Use exec to run a command with the secret as env var
+	# Explicitly set FNOX_CONFIG_FILE to avoid inheriting parent config
+	run env FNOX_CONFIG_FILE="$FNOX_CONFIG_FILE" "$FNOX_BIN" exec -- sh -c 'echo $MY_AZURE_KMS_VAR'
+	assert_success
+	assert_output "azure-kms-env-value"
 }

--- a/test/azure_secrets_manager.bats
+++ b/test/azure_secrets_manager.bats
@@ -14,68 +14,68 @@
 #
 
 setup() {
-    load 'test_helper/common_setup'
-    _common_setup
+	load 'test_helper/common_setup'
+	_common_setup
 
-    # Check if Azure credentials are available
-    if [ -z "$AZURE_CLIENT_ID" ] || [ -z "$AZURE_CLIENT_SECRET" ] || [ -z "$AZURE_TENANT_ID" ]; then
-        skip "Azure credentials not available. Ensure AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, and AZURE_TENANT_ID are configured."
-    fi
+	# Check if Azure credentials are available
+	if [ -z "$AZURE_CLIENT_ID" ] || [ -z "$AZURE_CLIENT_SECRET" ] || [ -z "$AZURE_TENANT_ID" ]; then
+		skip "Azure credentials not available. Ensure AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, and AZURE_TENANT_ID are configured."
+	fi
 
-    # Check if az CLI is installed
-    if ! command -v az >/dev/null 2>&1; then
-        skip "Azure CLI not installed. Install with: brew install azure-cli"
-    fi
+	# Check if az CLI is installed
+	if ! command -v az >/dev/null 2>&1; then
+		skip "Azure CLI not installed. Install with: brew install azure-cli"
+	fi
 
-    # Set the Key Vault URL (from fnox.toml secrets)
-    export VAULT_URL="https://fnox-testing-kv.vault.azure.net/"
+	# Set the Key Vault URL (from fnox.toml secrets)
+	export VAULT_URL="https://fnox-testing-kv.vault.azure.net/"
 
-    # Authenticate Azure CLI with service principal if not already logged in
-    if ! az account show >/dev/null 2>&1; then
-        az login --service-principal \
-            -u "$AZURE_CLIENT_ID" \
-            -p "$AZURE_CLIENT_SECRET" \
-            --tenant "$AZURE_TENANT_ID" >/dev/null 2>&1 || \
-            skip "Failed to authenticate Azure CLI with service principal"
-    fi
+	# Authenticate Azure CLI with service principal if not already logged in
+	if ! az account show >/dev/null 2>&1; then
+		az login --service-principal \
+			-u "$AZURE_CLIENT_ID" \
+			-p "$AZURE_CLIENT_SECRET" \
+			--tenant "$AZURE_TENANT_ID" >/dev/null 2>&1 ||
+			skip "Failed to authenticate Azure CLI with service principal"
+	fi
 
-    # Verify we can access Key Vault secrets
-    if ! az keyvault secret list --vault-name fnox-testing-kv >/dev/null 2>&1; then
-        skip "Cannot access Azure Key Vault. Permissions may be insufficient."
-    fi
+	# Verify we can access Key Vault secrets
+	if ! az keyvault secret list --vault-name fnox-testing-kv >/dev/null 2>&1; then
+		skip "Cannot access Azure Key Vault. Permissions may be insufficient."
+	fi
 }
 
 teardown() {
-    # Clean up any test secrets created during tests
-    if [ -n "$TEST_SECRET_NAME" ]; then
-        az keyvault secret delete \
-            --vault-name fnox-testing-kv \
-            --name "$TEST_SECRET_NAME" >/dev/null 2>&1 || true
-        # Purge the deleted secret (Key Vault has soft-delete by default)
-        az keyvault secret purge \
-            --vault-name fnox-testing-kv \
-            --name "$TEST_SECRET_NAME" >/dev/null 2>&1 || true
-    fi
+	# Clean up any test secrets created during tests
+	if [ -n "$TEST_SECRET_NAME" ]; then
+		az keyvault secret delete \
+			--vault-name fnox-testing-kv \
+			--name "$TEST_SECRET_NAME" >/dev/null 2>&1 || true
+		# Purge the deleted secret (Key Vault has soft-delete by default)
+		az keyvault secret purge \
+			--vault-name fnox-testing-kv \
+			--name "$TEST_SECRET_NAME" >/dev/null 2>&1 || true
+	fi
 
-    # Clean up Azure CLI cache/config directory created during tests
-    if [ -d "$TEST_TEMP_DIR/.azure" ]; then
-        rm -rf "$TEST_TEMP_DIR/.azure" || true
-    fi
+	# Clean up Azure CLI cache/config directory created during tests
+	if [ -d "$TEST_TEMP_DIR/.azure" ]; then
+		rm -rf "$TEST_TEMP_DIR/.azure" || true
+	fi
 
-    _common_teardown
+	_common_teardown
 }
 
 # Helper function to create an Azure Secrets Manager test config
 create_azure_sm_config() {
-    local vault_url="${1:-https://fnox-testing-kv.vault.azure.net/}"
-    local prefix="${2}"
-    if [ -z "$prefix" ] && [ "$#" -lt 2 ]; then
-        prefix="fnox-test-"
-    fi
+	local vault_url="${1:-https://fnox-testing-kv.vault.azure.net/}"
+	local prefix="${2}"
+	if [ -z "$prefix" ] && [ "$#" -lt 2 ]; then
+		prefix="fnox-test-"
+	fi
 
-    if [ -z "$prefix" ]; then
-        # Omit prefix line entirely when empty
-        cat > "${FNOX_CONFIG_FILE:-fnox.toml}" << EOF
+	if [ -z "$prefix" ]; then
+		# Omit prefix line entirely when empty
+		cat >"${FNOX_CONFIG_FILE:-fnox.toml}" <<EOF
 root = true
 
 [providers.azure-sm]
@@ -84,8 +84,8 @@ vault_url = "$vault_url"
 
 [secrets]
 EOF
-    else
-        cat > "${FNOX_CONFIG_FILE:-fnox.toml}" << EOF
+	else
+		cat >"${FNOX_CONFIG_FILE:-fnox.toml}" <<EOF
 root = true
 
 [providers.azure-sm]
@@ -95,157 +95,162 @@ prefix = "$prefix"
 
 [secrets]
 EOF
-    fi
+	fi
 }
 
 # Helper function to create a test secret in Azure Key Vault
 create_test_secret() {
-    local secret_name="$1"
-    local secret_value="$2"
+	local secret_name="$1"
+	local secret_value="$2"
 
-    az keyvault secret set \
-        --vault-name fnox-testing-kv \
-        --name "$secret_name" \
-        --value "$secret_value" >/dev/null 2>&1
+	az keyvault secret set \
+		--vault-name fnox-testing-kv \
+		--name "$secret_name" \
+		--value "$secret_value" >/dev/null 2>&1
 
-    export TEST_SECRET_NAME="$secret_name"
+	export TEST_SECRET_NAME="$secret_name"
 }
 
 @test "fnox get retrieves secret from Azure Key Vault" {
-    create_azure_sm_config
+	create_azure_sm_config
 
-    # Create a test secret
-    local timestamp="$(date +%s)-$$-${BATS_TEST_NUMBER:-0}"
-    local secret_name="fnox-test-secret-${timestamp}"
-    local secret_value="my-test-secret-value"
-    create_test_secret "$secret_name" "$secret_value"
+	# Create a test secret
+	local timestamp
+	timestamp="$(date +%s)-$$-${BATS_TEST_NUMBER:-0}"
+	local secret_name="fnox-test-secret-${timestamp}"
+	local secret_value="my-test-secret-value"
+	create_test_secret "$secret_name" "$secret_value"
 
-    # Add secret reference to config (using just the name without prefix)
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	# Add secret reference to config (using just the name without prefix)
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.AZURE_TEST]
 provider = "azure-sm"
 value = "secret-${timestamp}"
 EOF
 
-    # Get the secret
-    run "$FNOX_BIN" get AZURE_TEST
-    assert_success
-    assert_output "$secret_value"
+	# Get the secret
+	run "$FNOX_BIN" get AZURE_TEST
+	assert_success
+	assert_output "$secret_value"
 }
 
 @test "fnox get with prefix prepends prefix to secret name" {
-    create_azure_sm_config "https://fnox-testing-kv.vault.azure.net/" "fnox-test-"
+	create_azure_sm_config "https://fnox-testing-kv.vault.azure.net/" "fnox-test-"
 
-    # Create a test secret with full path
-    local timestamp="$(date +%s)-$$-${BATS_TEST_NUMBER:-0}"
-    local secret_name="fnox-test-prefixed-${timestamp}"
-    local secret_value="value-with-prefix"
-    create_test_secret "$secret_name" "$secret_value"
+	# Create a test secret with full path
+	local timestamp
+	timestamp="$(date +%s)-$$-${BATS_TEST_NUMBER:-0}"
+	local secret_name="fnox-test-prefixed-${timestamp}"
+	local secret_value="value-with-prefix"
+	create_test_secret "$secret_name" "$secret_value"
 
-    # Add secret reference using just the suffix
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	# Add secret reference using just the suffix
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.PREFIXED_SECRET]
 provider = "azure-sm"
 value = "prefixed-${timestamp}"
 EOF
 
-    # Get the secret
-    run "$FNOX_BIN" get PREFIXED_SECRET
-    assert_success
-    assert_output "$secret_value"
+	# Get the secret
+	run "$FNOX_BIN" get PREFIXED_SECRET
+	assert_success
+	assert_output "$secret_value"
 }
 
 @test "fnox get without prefix uses full secret name" {
-    create_azure_sm_config "https://fnox-testing-kv.vault.azure.net/" ""
+	create_azure_sm_config "https://fnox-testing-kv.vault.azure.net/" ""
 
-    # Create a test secret without prefix
-    local timestamp="$(date +%s)-$$-${BATS_TEST_NUMBER:-0}"
-    local secret_name="fnox-full-name-${timestamp}"
-    local secret_value="value-no-prefix"
-    create_test_secret "$secret_name" "$secret_value"
+	# Create a test secret without prefix
+	local timestamp
+	timestamp="$(date +%s)-$$-${BATS_TEST_NUMBER:-0}"
+	local secret_name="fnox-full-name-${timestamp}"
+	local secret_value="value-no-prefix"
+	create_test_secret "$secret_name" "$secret_value"
 
-    # Add secret reference
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	# Add secret reference
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.FULL_NAME_SECRET]
 provider = "azure-sm"
 value = "$secret_name"
 EOF
 
-    # Get the secret
-    run "$FNOX_BIN" get FULL_NAME_SECRET
-    assert_success
-    assert_output "$secret_value"
+	# Get the secret
+	run "$FNOX_BIN" get FULL_NAME_SECRET
+	assert_success
+	assert_output "$secret_value"
 }
 
 @test "fnox get fails with non-existent secret" {
-    create_azure_sm_config
+	create_azure_sm_config
 
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.NONEXISTENT]
 provider = "azure-sm"
 value = "does-not-exist-$(date +%s)"
 EOF
 
-    # Try to get non-existent secret
-    run "$FNOX_BIN" get NONEXISTENT
-    assert_failure
-    assert_output --partial "Failed to get secret"
+	# Try to get non-existent secret
+	run "$FNOX_BIN" get NONEXISTENT
+	assert_failure
+	assert_output --partial "Failed to get secret"
 }
 
 @test "fnox get with JSON secret value" {
-    create_azure_sm_config
+	create_azure_sm_config
 
-    # Create a JSON secret
-    local timestamp="$(date +%s)-$$-${BATS_TEST_NUMBER:-0}"
-    local secret_name="fnox-test-json-secret-${timestamp}"
-    local secret_value='{"api_key":"test123","endpoint":"https://api.example.com"}'
-    create_test_secret "$secret_name" "$secret_value"
+	# Create a JSON secret
+	local timestamp
+	timestamp="$(date +%s)-$$-${BATS_TEST_NUMBER:-0}"
+	local secret_name="fnox-test-json-secret-${timestamp}"
+	local secret_value='{"api_key":"test123","endpoint":"https://api.example.com"}'
+	create_test_secret "$secret_name" "$secret_value"
 
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.JSON_SECRET]
 provider = "azure-sm"
 value = "json-secret-${timestamp}"
 EOF
 
-    # Get the secret
-    run "$FNOX_BIN" get JSON_SECRET
-    assert_success
-    assert_output "$secret_value"
+	# Get the secret
+	run "$FNOX_BIN" get JSON_SECRET
+	assert_success
+	assert_output "$secret_value"
 }
 
 @test "fnox get with multiline secret" {
-    create_azure_sm_config
+	create_azure_sm_config
 
-    # Create a multiline secret
-    local timestamp="$(date +%s)-$$-${BATS_TEST_NUMBER:-0}"
-    local secret_name="fnox-test-multiline-${timestamp}"
-    local secret_value="line1
+	# Create a multiline secret
+	local timestamp
+	timestamp="$(date +%s)-$$-${BATS_TEST_NUMBER:-0}"
+	local secret_name="fnox-test-multiline-${timestamp}"
+	local secret_value="line1
 line2
 line3"
-    create_test_secret "$secret_name" "$secret_value"
+	create_test_secret "$secret_name" "$secret_value"
 
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.MULTILINE_SECRET]
 provider = "azure-sm"
 value = "multiline-${timestamp}"
 EOF
 
-    # Get the secret
-    run "$FNOX_BIN" get MULTILINE_SECRET
-    assert_success
-    assert_output "$secret_value"
+	# Get the secret
+	run "$FNOX_BIN" get MULTILINE_SECRET
+	assert_success
+	assert_output "$secret_value"
 }
 
 @test "fnox list shows Azure Secrets Manager secrets" {
-    create_azure_sm_config
+	create_azure_sm_config
 
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.AZURE_SECRET_1]
 description = "First Azure secret"
@@ -258,56 +263,57 @@ provider = "azure-sm"
 value = "secret2"
 EOF
 
-    run "$FNOX_BIN" list
-    assert_success
-    assert_output --partial "AZURE_SECRET_1"
-    assert_output --partial "AZURE_SECRET_2"
-    assert_output --partial "First Azure secret"
+	run "$FNOX_BIN" list
+	assert_success
+	assert_output --partial "AZURE_SECRET_1"
+	assert_output --partial "AZURE_SECRET_2"
+	assert_output --partial "First Azure secret"
 }
 
 @test "fnox get with special characters in secret value" {
-    create_azure_sm_config
+	create_azure_sm_config
 
-    # Create a secret with special characters
-    local timestamp="$(date +%s)-$$-${BATS_TEST_NUMBER:-0}"
-    local secret_name="fnox-test-special-${timestamp}"
-    local secret_value='p@ssw0rd!#$%^&*()_+-={}[]|\:";'\''<>?,./~`'
-    create_test_secret "$secret_name" "$secret_value"
+	# Create a secret with special characters
+	local timestamp
+	timestamp="$(date +%s)-$$-${BATS_TEST_NUMBER:-0}"
+	local secret_name="fnox-test-special-${timestamp}"
+	local secret_value='p@ssw0rd!#$%^&*()_+-={}[]|\:";'\''<>?,./~`'
+	create_test_secret "$secret_name" "$secret_value"
 
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.SPECIAL_CHARS]
 provider = "azure-sm"
 value = "special-${timestamp}"
 EOF
 
-    # Get the secret
-    run "$FNOX_BIN" get SPECIAL_CHARS
-    assert_success
-    assert_output "$secret_value"
+	# Get the secret
+	run "$FNOX_BIN" get SPECIAL_CHARS
+	assert_success
+	assert_output "$secret_value"
 }
 
 @test "Azure Secrets Manager works with existing fnox-test-secret" {
-    # Test with the pre-created secret from setup
-    create_azure_sm_config "https://fnox-testing-kv.vault.azure.net/" ""
+	# Test with the pre-created secret from setup
+	create_azure_sm_config "https://fnox-testing-kv.vault.azure.net/" ""
 
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.EXISTING_SECRET]
 provider = "azure-sm"
 value = "fnox-test-secret"
 EOF
 
-    # Get the secret
-    run "$FNOX_BIN" get EXISTING_SECRET
-    assert_success
-    assert_output "test-secret-value-123"
+	# Get the secret
+	run "$FNOX_BIN" get EXISTING_SECRET
+	assert_success
+	assert_output "test-secret-value-123"
 }
 
 @test "fnox get with description" {
-    create_azure_sm_config
+	create_azure_sm_config
 
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.DESCRIBED_SECRET]
 description = "A secret with a description"
@@ -315,32 +321,33 @@ provider = "azure-sm"
 value = "some-secret"
 EOF
 
-    # List to verify description
-    run "$FNOX_BIN" list
-    assert_success
-    assert_output --partial "DESCRIBED_SECRET"
-    assert_output --partial "A secret with a description"
+	# List to verify description
+	run "$FNOX_BIN" list
+	assert_success
+	assert_output --partial "DESCRIBED_SECRET"
+	assert_output --partial "A secret with a description"
 }
 
 @test "fnox set creates secret in Azure Key Vault" {
-    create_azure_sm_config
+	create_azure_sm_config
 
-    # Create a unique secret value
-    local timestamp="$(date +%s)-$$-${BATS_TEST_NUMBER:-0}"
-    local secret_value="my-test-secret-value-${timestamp}"
+	# Create a unique secret value
+	local timestamp
+	timestamp="$(date +%s)-$$-${BATS_TEST_NUMBER:-0}"
+	local secret_value="my-test-secret-value-${timestamp}"
 
-    # Set the secret name for teardown cleanup
-    # Note: Azure Key Vault secret names can only contain alphanumeric characters and hyphens
-    export TEST_SECRET_NAME="fnox-test-AZURE-SM-CREATE-TEST-${timestamp}"
+	# Set the secret name for teardown cleanup
+	# Note: Azure Key Vault secret names can only contain alphanumeric characters and hyphens
+	export TEST_SECRET_NAME="fnox-test-AZURE-SM-CREATE-TEST-${timestamp}"
 
-    # Create secret using fnox set (will create it in Azure Key Vault)
-    run "$FNOX_BIN" set "AZURE-SM-CREATE-TEST-${timestamp}" "$secret_value" --provider azure-sm
-    assert_success
+	# Create secret using fnox set (will create it in Azure Key Vault)
+	run "$FNOX_BIN" set "AZURE-SM-CREATE-TEST-${timestamp}" "$secret_value" --provider azure-sm
+	assert_success
 
-    # Get secret back to verify it was created correctly
-    run "$FNOX_BIN" get "AZURE-SM-CREATE-TEST-${timestamp}"
-    assert_success
-    assert_output "$secret_value"
+	# Get secret back to verify it was created correctly
+	run "$FNOX_BIN" get "AZURE-SM-CREATE-TEST-${timestamp}"
+	assert_success
+	assert_output "$secret_value"
 
-    # Cleanup will be handled by teardown function
+	# Cleanup will be handled by teardown function
 }

--- a/test/bitwarden.bats
+++ b/test/bitwarden.bats
@@ -16,36 +16,36 @@
 #
 
 setup() {
-    load 'test_helper/common_setup'
-    _common_setup
+	load 'test_helper/common_setup'
+	_common_setup
 
-    # Check if bw CLI is installed
-    if ! command -v bw >/dev/null 2>&1; then
-        skip "Bitwarden CLI (bw) not installed. Install with: npm install -g @bitwarden/cli"
-    fi
+	# Check if bw CLI is installed
+	if ! command -v bw >/dev/null 2>&1; then
+		skip "Bitwarden CLI (bw) not installed. Install with: npm install -g @bitwarden/cli"
+	fi
 
-    # Some tests don't need BW_SESSION (like 'fnox list')
-    # Only skip if this test actually needs authentication
-    if [[ "$BATS_TEST_DESCRIPTION" != *"list"* ]]; then
-        # Check if BW_SESSION is available
-        if [ -z "$BW_SESSION" ]; then
-            skip "BW_SESSION not available. Run: export BW_SESSION=\$(bw unlock --raw)"
-        fi
+	# Some tests don't need BW_SESSION (like 'fnox list')
+	# Only skip if this test actually needs authentication
+	if [[ $BATS_TEST_DESCRIPTION != *"list"* ]]; then
+		# Check if BW_SESSION is available
+		if [ -z "$BW_SESSION" ]; then
+			skip 'BW_SESSION not available. Run: export BW_SESSION=$(bw unlock --raw)'
+		fi
 
-        # Verify we can authenticate with Bitwarden by checking status
-        if ! bw status --session "$BW_SESSION" >/dev/null 2>&1; then
-            skip "Cannot authenticate with Bitwarden. Session may be invalid or expired."
-        fi
-    fi
+		# Verify we can authenticate with Bitwarden by checking status
+		if ! bw status --session "$BW_SESSION" >/dev/null 2>&1; then
+			skip "Cannot authenticate with Bitwarden. Session may be invalid or expired."
+		fi
+	fi
 }
 
 teardown() {
-    _common_teardown
+	_common_teardown
 }
 
 # Helper function to create a Bitwarden test config
 create_bitwarden_config() {
-    cat > "${FNOX_CONFIG_FILE:-fnox.toml}" << EOF
+	cat >"${FNOX_CONFIG_FILE:-fnox.toml}" <<EOF
 [providers.bitwarden]
 type = "bitwarden"
 
@@ -56,13 +56,17 @@ EOF
 # Helper function to create a test item in Bitwarden
 # Returns the item ID
 create_test_bw_item() {
-    local item_name="fnox-test-$(date +%s)-$$-${BATS_TEST_NUMBER:-0}"
-    local password="test-secret-value-$(date +%s)-$$-${BATS_TEST_NUMBER:-0}"
-    local username="testuser"
+	local item_name
+	item_name="fnox-test-$(date +%s)-$$-${BATS_TEST_NUMBER:-0}"
+	local password
+	password="test-secret-value-$(date +%s)-$$-${BATS_TEST_NUMBER:-0}"
+	local username="testuser"
 
-    # Create item with bw CLI
-    # Note: This is a simplified version - real implementation would need proper JSON encoding
-    local template=$(cat <<EOF
+	# Create item with bw CLI
+	# Note: This is a simplified version - real implementation would need proper JSON encoding
+	local template
+	template=$(
+		cat <<EOF
 {
   "organizationId": null,
   "folderId": null,
@@ -77,129 +81,130 @@ create_test_bw_item() {
   }
 }
 EOF
-)
+	)
 
-    local item_id=$(echo "$template" | bw encode | bw create item --session "$BW_SESSION" | bw get item - --session "$BW_SESSION" | jq -r '.id')
-    echo "$item_id|$item_name"
+	local item_id
+	item_id=$(echo "$template" | bw encode | bw create item --session "$BW_SESSION" | bw get item - --session "$BW_SESSION" | jq -r '.id')
+	echo "$item_id|$item_name"
 }
 
 # Helper function to delete a test item from Bitwarden
 delete_test_bw_item() {
-    local item_id="${1}"
-    bw delete item "$item_id" --session "$BW_SESSION" >/dev/null 2>&1 || true
+	local item_id="${1}"
+	bw delete item "$item_id" --session "$BW_SESSION" >/dev/null 2>&1 || true
 }
 
 @test "fnox get retrieves secret from Bitwarden" {
-    create_bitwarden_config
+	create_bitwarden_config
 
-    # Create a test item
-    item_info=$(create_test_bw_item)
-    item_id=$(echo "$item_info" | cut -d'|' -f1)
-    item_name=$(echo "$item_info" | cut -d'|' -f2)
+	# Create a test item
+	item_info=$(create_test_bw_item)
+	item_id=$(echo "$item_info" | cut -d'|' -f1)
+	item_name=$(echo "$item_info" | cut -d'|' -f2)
 
-    # Add secret reference to config
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	# Add secret reference to config
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.TEST_BW_SECRET]
 provider = "bitwarden"
 value = "$item_name"
 EOF
 
-    # Get the secret
-    run "$FNOX_BIN" get TEST_BW_SECRET
-    assert_success
-    assert_output --partial "test-secret-value-"
+	# Get the secret
+	run "$FNOX_BIN" get TEST_BW_SECRET
+	assert_success
+	assert_output --partial "test-secret-value-"
 
-    # Cleanup
-    delete_test_bw_item "$item_id"
+	# Cleanup
+	delete_test_bw_item "$item_id"
 }
 
 @test "fnox get retrieves specific field from Bitwarden item" {
-    create_bitwarden_config
+	create_bitwarden_config
 
-    # Create a test item
-    item_info=$(create_test_bw_item)
-    item_id=$(echo "$item_info" | cut -d'|' -f1)
-    item_name=$(echo "$item_info" | cut -d'|' -f2)
+	# Create a test item
+	item_info=$(create_test_bw_item)
+	item_id=$(echo "$item_info" | cut -d'|' -f1)
+	item_name=$(echo "$item_info" | cut -d'|' -f2)
 
-    # Add secret reference to config (fetch username field)
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	# Add secret reference to config (fetch username field)
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.TEST_USERNAME]
 provider = "bitwarden"
 value = "$item_name/username"
 EOF
 
-    # Get the secret
-    run "$FNOX_BIN" get TEST_USERNAME
-    assert_success
-    assert_output "testuser"
+	# Get the secret
+	run "$FNOX_BIN" get TEST_USERNAME
+	assert_success
+	assert_output "testuser"
 
-    # Cleanup
-    delete_test_bw_item "$item_id"
+	# Cleanup
+	delete_test_bw_item "$item_id"
 }
 
 @test "fnox get retrieves password field from Bitwarden item" {
-    create_bitwarden_config
+	create_bitwarden_config
 
-    # Create a test item
-    item_info=$(create_test_bw_item)
-    item_id=$(echo "$item_info" | cut -d'|' -f1)
-    item_name=$(echo "$item_info" | cut -d'|' -f2)
+	# Create a test item
+	item_info=$(create_test_bw_item)
+	item_id=$(echo "$item_info" | cut -d'|' -f1)
+	item_name=$(echo "$item_info" | cut -d'|' -f2)
 
-    # Add secret reference to config (explicit password field)
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	# Add secret reference to config (explicit password field)
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.TEST_PASSWORD]
 provider = "bitwarden"
 value = "$item_name/password"
 EOF
 
-    # Get the secret
-    run "$FNOX_BIN" get TEST_PASSWORD
-    assert_success
-    assert_output --partial "test-secret-value-"
+	# Get the secret
+	run "$FNOX_BIN" get TEST_PASSWORD
+	assert_success
+	assert_output --partial "test-secret-value-"
 
-    # Cleanup
-    delete_test_bw_item "$item_id"
+	# Cleanup
+	delete_test_bw_item "$item_id"
 }
 
 @test "fnox get fails with invalid item name" {
-    create_bitwarden_config
+	create_bitwarden_config
 
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.INVALID_ITEM]
 provider = "bitwarden"
 value = "nonexistent-item-$(date +%s)"
 EOF
 
-    # Try to get non-existent secret
-    run "$FNOX_BIN" get INVALID_ITEM
-    assert_failure
-    assert_output --partial "Bitwarden CLI command failed"
+	# Try to get non-existent secret
+	run "$FNOX_BIN" get INVALID_ITEM
+	assert_failure
+	assert_output --partial "Bitwarden CLI command failed"
 }
 
 @test "fnox get handles invalid secret reference format" {
-    create_bitwarden_config
+	create_bitwarden_config
 
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.INVALID_FORMAT]
 provider = "bitwarden"
 value = "invalid/format/with/too/many/slashes"
 EOF
 
-    run "$FNOX_BIN" get INVALID_FORMAT
-    assert_failure
-    assert_output --partial "Invalid secret reference format"
+	run "$FNOX_BIN" get INVALID_FORMAT
+	assert_failure
+	assert_output --partial "Invalid secret reference format"
 }
 
 @test "fnox list shows Bitwarden secrets" {
-    # This test doesn't need BW_SESSION since list just reads the config file
-    create_bitwarden_config
+	# This test doesn't need BW_SESSION since list just reads the config file
+	create_bitwarden_config
 
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.BW_SECRET_1]
 description = "First Bitwarden secret"
@@ -212,44 +217,44 @@ provider = "bitwarden"
 value = "item2/username"
 EOF
 
-    run "$FNOX_BIN" list
-    assert_success
-    assert_output --partial "BW_SECRET_1"
-    assert_output --partial "BW_SECRET_2"
-    assert_output --partial "First Bitwarden secret"
+	run "$FNOX_BIN" list
+	assert_success
+	assert_output --partial "BW_SECRET_1"
+	assert_output --partial "BW_SECRET_2"
+	assert_output --partial "First Bitwarden secret"
 }
 
 @test "Bitwarden provider works with session token from environment" {
-    # This test verifies that bw CLI uses BW_SESSION from environment
-    # The token should be set by setup() from fnox config or environment
+	# This test verifies that bw CLI uses BW_SESSION from environment
+	# The token should be set by setup() from fnox config or environment
 
-    create_bitwarden_config
+	create_bitwarden_config
 
-    item_info=$(create_test_bw_item)
-    item_id=$(echo "$item_info" | cut -d'|' -f1)
-    item_name=$(echo "$item_info" | cut -d'|' -f2)
+	item_info=$(create_test_bw_item)
+	item_id=$(echo "$item_info" | cut -d'|' -f1)
+	item_name=$(echo "$item_info" | cut -d'|' -f2)
 
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.TEST_WITH_ENV_TOKEN]
 provider = "bitwarden"
 value = "$item_name"
 EOF
 
-    # The BW_SESSION should be set by setup()
-    run "$FNOX_BIN" get TEST_WITH_ENV_TOKEN
-    assert_success
-    assert_output --partial "test-secret-value-"
+	# The BW_SESSION should be set by setup()
+	run "$FNOX_BIN" get TEST_WITH_ENV_TOKEN
+	assert_success
+	assert_output --partial "test-secret-value-"
 
-    # Cleanup
-    delete_test_bw_item "$item_id"
+	# Cleanup
+	delete_test_bw_item "$item_id"
 }
 
 @test "Bitwarden provider with collection filter" {
-    skip "Bitwarden provider collection filtering not yet implemented"
+	skip "Bitwarden provider collection filtering not yet implemented"
 
-    # Create config with collection parameter
-    cat > "${FNOX_CONFIG_FILE:-fnox.toml}" << EOF
+	# Create config with collection parameter
+	cat >"${FNOX_CONFIG_FILE:-fnox.toml}" <<EOF
 [providers.bitwarden]
 type = "bitwarden"
 collection = "my-collection-id"
@@ -259,17 +264,17 @@ provider = "bitwarden"
 value = "test-item"
 EOF
 
-    # This should pass collection filter to bw CLI
-    run "$FNOX_BIN" get TEST_SECRET
-    # Will fail if collection doesn't exist, but that's expected
-    assert_failure
+	# This should pass collection filter to bw CLI
+	run "$FNOX_BIN" get TEST_SECRET
+	# Will fail if collection doesn't exist, but that's expected
+	assert_failure
 }
 
 @test "Bitwarden provider with organization filter" {
-    skip "Bitwarden provider organization filtering not yet implemented"
+	skip "Bitwarden provider organization filtering not yet implemented"
 
-    # Create config with organization parameter
-    cat > "${FNOX_CONFIG_FILE:-fnox.toml}" << EOF
+	# Create config with organization parameter
+	cat >"${FNOX_CONFIG_FILE:-fnox.toml}" <<EOF
 [providers.bitwarden]
 type = "bitwarden"
 organization_id = "my-org-id"
@@ -279,8 +284,8 @@ provider = "bitwarden"
 value = "test-item"
 EOF
 
-    # This should pass organization filter to bw CLI
-    run "$FNOX_BIN" get TEST_SECRET
-    # Will fail if organization doesn't exist, but that's expected
-    assert_failure
+	# This should pass organization filter to bw CLI
+	run "$FNOX_BIN" get TEST_SECRET
+	# Will fail if organization doesn't exist, but that's expected
+	assert_failure
 }

--- a/test/check.bats
+++ b/test/check.bats
@@ -1,80 +1,80 @@
 #!/usr/bin/env bats
 
 setup() {
-    load 'test_helper/common_setup'
-    _common_setup
+	load 'test_helper/common_setup'
+	_common_setup
 }
 
 teardown() {
-    _common_teardown
+	_common_teardown
 }
 
 @test "fnox check passes with valid config" {
-    create_test_config
-    assert_fnox_success check
+	create_test_config
+	assert_fnox_success check
 }
 
 @test "fnox check fails with missing required secret" {
-    create_test_config
-    
-    # Add a required secret without value
-    cat >> "${FNOX_CONFIG_FILE:-fnox.toml}" << EOF
+	create_test_config
+
+	# Add a required secret without value
+	cat >>"${FNOX_CONFIG_FILE:-fnox.toml}" <<EOF
 
 [secrets.required_secret]
 if_missing = "error"
 EOF
-    
-    assert_fnox_failure check
-    assert_output --partial "required_secret"
+
+	assert_fnox_failure check
+	assert_output --partial "required_secret"
 }
 
 @test "fnox check warns about missing optional secret" {
-    create_test_config
-    
-    # Add an optional secret without value
-    cat >> "${FNOX_CONFIG_FILE:-fnox.toml}" << EOF
+	create_test_config
+
+	# Add an optional secret without value
+	cat >>"${FNOX_CONFIG_FILE:-fnox.toml}" <<EOF
 
 [secrets.optional_secret]
 if_missing = "warn"
 EOF
-    
-    assert_fnox_success check
-    assert_output --partial "optional_secret"
+
+	assert_fnox_success check
+	assert_output --partial "optional_secret"
 }
 
 @test "fnox check with profile" {
-    create_test_config
-    assert_fnox_success check --profile test
+	create_test_config
+	assert_fnox_success check --profile test
 }
 
 @test "fnox check works with unknown profile (profile-specific config file support)" {
-    create_test_config
-    # With fnox.$FNOX_PROFILE.toml support, unknown profiles are allowed
-    # They just use top-level secrets (same as default profile)
-    assert_fnox_success check --profile unknown
-    # Should show it's checking the profile
-    assert_output --partial "unknown"
+	create_test_config
+	# With fnox.$FNOX_PROFILE.toml support, unknown profiles are allowed
+	# They just use top-level secrets (same as default profile)
+	assert_fnox_success check --profile unknown
+	# Should show it's checking the profile
+	assert_output --partial "unknown"
 }
 
 @test "fnox check warns about unknown provider" {
-    create_test_config
-    
-    # Add a secret with unknown provider
-    cat >> "${FNOX_CONFIG_FILE:-fnox.toml}" << EOF
+	create_test_config
+
+	# Add a secret with unknown provider
+	cat >>"${FNOX_CONFIG_FILE:-fnox.toml}" <<EOF
 
 [secrets.bad_secret]
 provider = "unknown"
 value = "test"
 EOF
-    
-    assert_fnox_success check
-    assert_output --partial "unknown"
+
+	assert_fnox_success check
+	assert_output --partial "unknown"
 }
 
 @test "fnox check with empty config" {
-    # Create empty config with root=true to prevent recursion
-    echo "root = true" > "${FNOX_CONFIG_FILE:-fnox.toml}"
+	# Create empty config with root=true to prevent recursion
+	echo "root = true" >"${FNOX_CONFIG_FILE:-fnox.toml}"
 
-    assert_fnox_success check
-    assert_output --partial "No secrets"
+	assert_fnox_success check
+	assert_output --partial "No secrets"
 }

--- a/test/ci_redact.bats
+++ b/test/ci_redact.bats
@@ -6,12 +6,12 @@
 #
 
 setup() {
-    load 'test_helper/common_setup'
-    _common_setup
+	load 'test_helper/common_setup'
+	_common_setup
 
-    # Create a test config with secrets
-    # Use root = true to prevent loading parent configs
-    cat > "$FNOX_CONFIG_FILE" << EOF
+	# Create a test config with secrets
+	# Use root = true to prevent loading parent configs
+	cat >"$FNOX_CONFIG_FILE" <<EOF
 root = true
 
 [secrets]
@@ -22,83 +22,83 @@ EOF
 }
 
 teardown() {
-    _common_teardown
+	_common_teardown
 }
 
 @test "ci-redact fails when not in CI environment" {
-    # Ensure CI env vars are not set
-    unset CI
-    unset GITHUB_ACTIONS
-    unset GITLAB_CI
-    unset CIRCLECI
+	# Ensure CI env vars are not set
+	unset CI
+	unset GITHUB_ACTIONS
+	unset GITLAB_CI
+	unset CIRCLECI
 
-    run "$FNOX_BIN" ci-redact
-    assert_failure
-    assert_output --partial "Not running in a CI environment"
+	run "$FNOX_BIN" ci-redact
+	assert_failure
+	assert_output --partial "Not running in a CI environment"
 }
 
 @test "ci-redact works in GitHub Actions" {
-    # Simulate GitHub Actions environment
-    export CI=true
-    export GITHUB_ACTIONS=true
+	# Simulate GitHub Actions environment
+	export CI=true
+	export GITHUB_ACTIONS=true
 
-    run "$FNOX_BIN" ci-redact
-    assert_success
-    assert_output --partial "::add-mask::secret-value-1"
-    assert_output --partial "::add-mask::secret-value-2"
-    assert_output --partial "::add-mask::super-secret-password"
+	run "$FNOX_BIN" ci-redact
+	assert_success
+	assert_output --partial "::add-mask::secret-value-1"
+	assert_output --partial "::add-mask::secret-value-2"
+	assert_output --partial "::add-mask::super-secret-password"
 }
 
 @test "ci-redact outputs correct number of mask commands" {
-    export CI=true
-    export GITHUB_ACTIONS=true
+	export CI=true
+	export GITHUB_ACTIONS=true
 
-    run "$FNOX_BIN" ci-redact
-    assert_success
+	run "$FNOX_BIN" ci-redact
+	assert_success
 
-    # Count the number of mask commands (should be 3 for our 3 secrets)
-    mask_count=$(echo "$output" | grep -c "::add-mask::" || true)
-    [ "$mask_count" -eq 3 ]
+	# Count the number of mask commands (should be 3 for our 3 secrets)
+	mask_count=$(echo "$output" | grep -c "::add-mask::" || true)
+	[ "$mask_count" -eq 3 ]
 }
 
 @test "ci-redact fails on GitLab CI" {
-    export CI=true
-    export GITLAB_CI=true
-    unset GITHUB_ACTIONS
+	export CI=true
+	export GITLAB_CI=true
+	unset GITHUB_ACTIONS
 
-    run "$FNOX_BIN" ci-redact
-    assert_failure
-    assert_output --partial "GitLab CI does not support runtime secret masking"
+	run "$FNOX_BIN" ci-redact
+	assert_failure
+	assert_output --partial "GitLab CI does not support runtime secret masking"
 }
 
 @test "ci-redact fails on CircleCI" {
-    export CI=true
-    export CIRCLECI=true
-    unset GITHUB_ACTIONS
+	export CI=true
+	export CIRCLECI=true
+	unset GITHUB_ACTIONS
 
-    run "$FNOX_BIN" ci-redact
-    assert_failure
-    assert_output --partial "CircleCI does not support runtime secret masking"
+	run "$FNOX_BIN" ci-redact
+	assert_failure
+	assert_output --partial "CircleCI does not support runtime secret masking"
 }
 
 @test "ci-redact handles empty secrets gracefully" {
-    cat > "$FNOX_CONFIG_FILE" << EOF
+	cat >"$FNOX_CONFIG_FILE" <<EOF
 root = true
 
 [secrets]
 EOF
 
-    export CI=true
-    export GITHUB_ACTIONS=true
+	export CI=true
+	export GITHUB_ACTIONS=true
 
-    run "$FNOX_BIN" ci-redact
-    assert_success
-    # Should have no output for empty secrets
-    [ -z "$output" ]
+	run "$FNOX_BIN" ci-redact
+	assert_success
+	# Should have no output for empty secrets
+	[ -z "$output" ]
 }
 
 @test "ci-redact with profile" {
-    cat > "$FNOX_CONFIG_FILE" << EOF
+	cat >"$FNOX_CONFIG_FILE" <<EOF
 root = true
 
 [secrets]
@@ -108,24 +108,24 @@ DEFAULT_SECRET = { default = "default-value" }
 STAGING_SECRET = { default = "staging-value" }
 EOF
 
-    export CI=true
-    export GITHUB_ACTIONS=true
+	export CI=true
+	export GITHUB_ACTIONS=true
 
-    # Test default profile
-    run "$FNOX_BIN" ci-redact
-    assert_success
-    assert_output --partial "::add-mask::default-value"
-    refute_output --partial "staging-value"
+	# Test default profile
+	run "$FNOX_BIN" ci-redact
+	assert_success
+	assert_output --partial "::add-mask::default-value"
+	refute_output --partial "staging-value"
 
-    # Test staging profile - inherits top-level secrets
-    run "$FNOX_BIN" -P staging ci-redact
-    assert_success
-    assert_output --partial "::add-mask::staging-value"
-    assert_output --partial "::add-mask::default-value"  # Inherited from top level
+	# Test staging profile - inherits top-level secrets
+	run "$FNOX_BIN" -P staging ci-redact
+	assert_success
+	assert_output --partial "::add-mask::staging-value"
+	assert_output --partial "::add-mask::default-value" # Inherited from top level
 }
 
 @test "ci-redact handles missing secrets with if_missing=ignore" {
-    cat > "$FNOX_CONFIG_FILE" << EOF
+	cat >"$FNOX_CONFIG_FILE" <<EOF
 root = true
 
 [secrets]
@@ -133,19 +133,19 @@ REQUIRED = { default = "required-value" }
 OPTIONAL = { if_missing = "ignore" }
 EOF
 
-    export CI=true
-    export GITHUB_ACTIONS=true
+	export CI=true
+	export GITHUB_ACTIONS=true
 
-    run "$FNOX_BIN" ci-redact
-    assert_success
-    assert_output --partial "::add-mask::required-value"
-    # Should only output one mask command
-    mask_count=$(echo "$output" | grep -c "::add-mask::" || true)
-    [ "$mask_count" -eq 1 ]
+	run "$FNOX_BIN" ci-redact
+	assert_success
+	assert_output --partial "::add-mask::required-value"
+	# Should only output one mask command
+	mask_count=$(echo "$output" | grep -c "::add-mask::" || true)
+	[ "$mask_count" -eq 1 ]
 }
 
 @test "ci-redact handles missing secrets with if_missing=warn" {
-    cat > "$FNOX_CONFIG_FILE" << EOF
+	cat >"$FNOX_CONFIG_FILE" <<EOF
 root = true
 
 [secrets]
@@ -153,33 +153,33 @@ REQUIRED = { default = "required-value" }
 OPTIONAL = { if_missing = "warn" }
 EOF
 
-    export CI=true
-    export GITHUB_ACTIONS=true
+	export CI=true
+	export GITHUB_ACTIONS=true
 
-    run "$FNOX_BIN" ci-redact
-    assert_success
-    assert_output --partial "::add-mask::required-value"
-    assert_output --partial "Warning: Secret 'OPTIONAL' not found"
+	run "$FNOX_BIN" ci-redact
+	assert_success
+	assert_output --partial "::add-mask::required-value"
+	assert_output --partial "Warning: Secret 'OPTIONAL' not found"
 }
 
 @test "ci-redact fails with missing required secrets" {
-    cat > "$FNOX_CONFIG_FILE" << EOF
+	cat >"$FNOX_CONFIG_FILE" <<EOF
 root = true
 
 [secrets]
 REQUIRED = { if_missing = "error" }
 EOF
 
-    export CI=true
-    export GITHUB_ACTIONS=true
+	export CI=true
+	export GITHUB_ACTIONS=true
 
-    run "$FNOX_BIN" ci-redact
-    assert_failure
-    assert_output --partial "Secret 'REQUIRED' not found"
+	run "$FNOX_BIN" ci-redact
+	assert_failure
+	assert_output --partial "Secret 'REQUIRED' not found"
 }
 
 @test "ci-redact with environment variable values" {
-    cat > "$FNOX_CONFIG_FILE" << EOF
+	cat >"$FNOX_CONFIG_FILE" <<EOF
 root = true
 
 [secrets]
@@ -187,31 +187,31 @@ FROM_ENV = {}
 FROM_DEFAULT = { default = "default-value" }
 EOF
 
-    export FROM_ENV="env-value"
-    export CI=true
-    export GITHUB_ACTIONS=true
+	export FROM_ENV="env-value"
+	export CI=true
+	export GITHUB_ACTIONS=true
 
-    run "$FNOX_BIN" ci-redact
-    assert_success
-    assert_output --partial "::add-mask::env-value"
-    assert_output --partial "::add-mask::default-value"
+	run "$FNOX_BIN" ci-redact
+	assert_success
+	assert_output --partial "::add-mask::env-value"
+	assert_output --partial "::add-mask::default-value"
 }
 
 @test "ci-redact is hidden from main help" {
-    run "$FNOX_BIN" --help
-    assert_success
-    refute_output --partial "ci-redact"
+	run "$FNOX_BIN" --help
+	assert_success
+	refute_output --partial "ci-redact"
 }
 
 @test "ci-redact has its own help" {
-    run "$FNOX_BIN" ci-redact --help
-    assert_success
-    assert_output --partial "Redact secrets in CI/CD output"
+	run "$FNOX_BIN" ci-redact --help
+	assert_success
+	assert_output --partial "Redact secrets in CI/CD output"
 }
 
 @test "ci-redact warns about multiline secrets" {
-    # Create a multiline secret (like a JSON file or private key)
-    cat > "$FNOX_CONFIG_FILE" << 'EOF'
+	# Create a multiline secret (like a JSON file or private key)
+	cat >"$FNOX_CONFIG_FILE" <<'EOF'
 root = true
 
 [secrets]
@@ -221,26 +221,26 @@ line3""" }
 SINGLE_LINE = { default = "single" }
 EOF
 
-    export CI=true
-    export GITHUB_ACTIONS=true
+	export CI=true
+	export GITHUB_ACTIONS=true
 
-    run "$FNOX_BIN" ci-redact
-    assert_success
+	run "$FNOX_BIN" ci-redact
+	assert_success
 
-    # Should warn about the multiline secret
-    assert_output --partial "Secret 'MULTILINE_SECRET' contains newlines and cannot be fully redacted"
+	# Should warn about the multiline secret
+	assert_output --partial "Secret 'MULTILINE_SECRET' contains newlines and cannot be fully redacted"
 
-    # Should still mask the single-line secret
-    assert_output --partial "::add-mask::single"
+	# Should still mask the single-line secret
+	assert_output --partial "::add-mask::single"
 
-    # Only 1 mask command for single-line secret
-    mask_count=$(echo "$output" | grep -c "::add-mask::" || true)
-    [ "$mask_count" -eq 1 ]
+	# Only 1 mask command for single-line secret
+	mask_count=$(echo "$output" | grep -c "::add-mask::" || true)
+	[ "$mask_count" -eq 1 ]
 }
 
 @test "ci-redact warns about JSON secrets" {
-    # Simulate a GCP service account key or similar JSON secret
-    cat > "$FNOX_CONFIG_FILE" << 'EOF'
+	# Simulate a GCP service account key or similar JSON secret
+	cat >"$FNOX_CONFIG_FILE" <<'EOF'
 root = true
 
 [secrets]
@@ -252,16 +252,16 @@ GCP_KEY = { default = """{
 SAFE_SECRET = { default = "safe-value" }
 EOF
 
-    export CI=true
-    export GITHUB_ACTIONS=true
+	export CI=true
+	export GITHUB_ACTIONS=true
 
-    run "$FNOX_BIN" ci-redact
-    assert_success
+	run "$FNOX_BIN" ci-redact
+	assert_success
 
-    # Should warn about the multiline JSON secret
-    assert_output --partial "Secret 'GCP_KEY' contains newlines and cannot be fully redacted"
-    assert_output --partial "Consider using a secret manager"
+	# Should warn about the multiline JSON secret
+	assert_output --partial "Secret 'GCP_KEY' contains newlines and cannot be fully redacted"
+	assert_output --partial "Consider using a secret manager"
 
-    # Should still mask single-line secrets
-    assert_output --partial "::add-mask::safe-value"
+	# Should still mask single-line secrets
+	assert_output --partial "::add-mask::safe-value"
 }

--- a/test/config_recursion.bats
+++ b/test/config_recursion.bats
@@ -1,20 +1,20 @@
 #!/usr/bin/env bats
 
 setup() {
-    load 'test_helper/common_setup'
-    _common_setup
+	load 'test_helper/common_setup'
+	_common_setup
 }
 
 teardown() {
-    _common_teardown
+	_common_teardown
 }
 
 @test "config recursion finds parent configs" {
-    # Create directory structure
-    mkdir -p parent/child/grandchild
+	# Create directory structure
+	mkdir -p parent/child/grandchild
 
-    # Create parent config (allows recursion to child)
-    cat > parent/fnox.toml <<EOF
+	# Create parent config (allows recursion to child)
+	cat >parent/fnox.toml <<EOF
 [providers.test]
 type = "age"
 recipients = ["age1test"]
@@ -26,36 +26,36 @@ PARENT_SECRET = { description = "Parent secret", default = "parent-value" }
 PARENT_PROD_SECRET = { description = "Parent prod secret", default = "parent-prod-value" }
 EOF
 
-    # Create child config 
-    cat > parent/child/fnox.toml <<EOF
+	# Create child config
+	cat >parent/child/fnox.toml <<EOF
 [secrets]
 CHILD_SECRET = { description = "Child secret", default = "child-value" }
 PARENT_SECRET = { description = "Override parent secret", default = "child-override-value" }
 EOF
 
-    # Change to grandchild directory
-    cd parent/child/grandchild
+	# Change to grandchild directory
+	cd parent/child/grandchild
 
-    # Test that we can access merged secrets
-    run "$FNOX_BIN" get PARENT_SECRET
-    assert_success
-    assert_output --partial "child-override-value"  # Child overrides parent
+	# Test that we can access merged secrets
+	run "$FNOX_BIN" get PARENT_SECRET
+	assert_success
+	assert_output --partial "child-override-value" # Child overrides parent
 
-    run "$FNOX_BIN" get CHILD_SECRET
-    assert_success
-    assert_output --partial "child-value"
+	run "$FNOX_BIN" get CHILD_SECRET
+	assert_success
+	assert_output --partial "child-value"
 
-    run "$FNOX_BIN" get PARENT_PROD_SECRET --profile production
-    assert_success
-    assert_output --partial "parent-prod-value"
+	run "$FNOX_BIN" get PARENT_PROD_SECRET --profile production
+	assert_success
+	assert_output --partial "parent-prod-value"
 }
 
 @test "config root stops recursion" {
-    # Create directory structure
-    mkdir -p root/child/grandchild
-    
-    # Create root config with root = true
-    cat > root/fnox.toml <<EOF
+	# Create directory structure
+	mkdir -p root/child/grandchild
+
+	# Create root config with root = true
+	cat >root/fnox.toml <<EOF
 root = true
 
 [providers.test]
@@ -66,31 +66,31 @@ recipients = ["age1test"]
 ROOT_SECRET = { description = "Root secret", default = "root-value" }
 EOF
 
-    # Create grandparent config above root (should be ignored)
-    cat > fnox.toml <<EOF
+	# Create grandparent config above root (should be ignored)
+	cat >fnox.toml <<EOF
 root = true
 
 [secrets]
 GRANDPARENT_SECRET = { description = "Should be ignored", default = "grandparent-value" }
 EOF
 
-    # Change to child directory
-    cd root/child
+	# Change to child directory
+	cd root/child
 
-    # Test that we can access root secrets
-    run "$FNOX_BIN" get ROOT_SECRET
-    assert_success
-    assert_output --partial "root-value"
+	# Test that we can access root secrets
+	run "$FNOX_BIN" get ROOT_SECRET
+	assert_success
+	assert_output --partial "root-value"
 
-    # Test that grandparent secrets are not accessible
-    run "$FNOX_BIN" get GRANDPARENT_SECRET
-    assert_failure
-    assert_output --partial "not found"
+	# Test that grandparent secrets are not accessible
+	run "$FNOX_BIN" get GRANDPARENT_SECRET
+	assert_failure
+	assert_output --partial "not found"
 }
 
 @test "config imports work correctly" {
-    # Create imported config
-    cat > imported.toml <<EOF
+	# Create imported config
+	cat >imported.toml <<EOF
 root = true
 
 [providers.test]
@@ -104,8 +104,8 @@ IMPORTED_SECRET = { description = "Imported secret", default = "imported-value" 
 IMPORTED_PROFILE_SECRET = { description = "Imported profile secret", default = "imported-profile-value" }
 EOF
 
-    # Create main config that imports
-    cat > fnox.toml <<EOF
+	# Create main config that imports
+	cat >fnox.toml <<EOF
 root = true
 import = ["./imported.toml"]
 
@@ -118,23 +118,23 @@ MAIN_SECRET = { description = "Main secret", default = "main-value" }
 IMPORTED_SECRET = { description = "Override imported secret", default = "main-override-value" }
 EOF
 
-    # Test that we can access imported secrets
-    run "$FNOX_BIN" get IMPORTED_SECRET
-    assert_success
-    assert_output --partial "main-override-value"  # Main overrides imported
+	# Test that we can access imported secrets
+	run "$FNOX_BIN" get IMPORTED_SECRET
+	assert_success
+	assert_output --partial "main-override-value" # Main overrides imported
 
-    run "$FNOX_BIN" get MAIN_SECRET
-    assert_success
-    assert_output --partial "main-value"
+	run "$FNOX_BIN" get MAIN_SECRET
+	assert_success
+	assert_output --partial "main-value"
 
-    run "$FNOX_BIN" get IMPORTED_PROFILE_SECRET --profile imported
-    assert_success
-    assert_output --partial "imported-profile-value"
+	run "$FNOX_BIN" get IMPORTED_PROFILE_SECRET --profile imported
+	assert_success
+	assert_output --partial "imported-profile-value"
 }
 
 @test "config imports with absolute paths work" {
-    # Create imported config
-    cat > imported.toml <<EOF
+	# Create imported config
+	cat >imported.toml <<EOF
 root = true
 
 [providers.test]
@@ -145,11 +145,11 @@ recipients = ["age1test"]
 ABS_IMPORT_SECRET = { description = "Absolute import secret", default = "abs-import-value" }
 EOF
 
-    # Get absolute path
-    abs_path="$(pwd)/imported.toml"
+	# Get absolute path
+	abs_path="$(pwd)/imported.toml"
 
-    # Create main config with absolute import
-    cat > fnox.toml <<EOF
+	# Create main config with absolute import
+	cat >fnox.toml <<EOF
 root = true
 import = ["${abs_path}"]
 
@@ -161,15 +161,15 @@ recipients = ["age1test"]
 MAIN_SECRET = { description = "Main secret", default = "main-value" }
 EOF
 
-    # Test that absolute import works
-    run "$FNOX_BIN" get ABS_IMPORT_SECRET
-    assert_success
-    assert_output --partial "abs-import-value"
+	# Test that absolute import works
+	run "$FNOX_BIN" get ABS_IMPORT_SECRET
+	assert_success
+	assert_output --partial "abs-import-value"
 }
 
 @test "config import errors are handled gracefully" {
-    # Create main config with non-existent import
-    cat > fnox.toml <<EOF
+	# Create main config with non-existent import
+	cat >fnox.toml <<EOF
 root = true
 import = ["./nonexistent.toml"]
 
@@ -177,18 +177,18 @@ import = ["./nonexistent.toml"]
 MAIN_SECRET = { description = "Main secret", default = "main-value" }
 EOF
 
-    # Test that import error is reported
-    run "$FNOX_BIN" get MAIN_SECRET
-    assert_failure
-    assert_output --partial "Import file not found"
+	# Test that import error is reported
+	run "$FNOX_BIN" get MAIN_SECRET
+	assert_failure
+	assert_output --partial "Import file not found"
 }
 
 @test "config recursion with imports works together" {
-    # Create directory structure
-    mkdir -p parent/child
-    
-    # Create imported config
-    cat > imported.toml <<EOF
+	# Create directory structure
+	mkdir -p parent/child
+
+	# Create imported config
+	cat >imported.toml <<EOF
 root = true
 
 [providers.test]
@@ -199,8 +199,8 @@ recipients = ["age1test"]
 IMPORTED_SECRET = { description = "Imported secret", default = "imported-value" }
 EOF
 
-    # Create parent config with import
-    cat > parent/fnox.toml <<EOF
+	# Create parent config with import
+	cat >parent/fnox.toml <<EOF
 import = ["../imported.toml"]
 
 [providers.test]
@@ -211,35 +211,35 @@ recipients = ["age1test"]
 PARENT_SECRET = { description = "Parent secret", default = "parent-value" }
 EOF
 
-    # Create child config
-    cat > parent/child/fnox.toml <<EOF
+	# Create child config
+	cat >parent/child/fnox.toml <<EOF
 [secrets]
 CHILD_SECRET = { description = "Child secret", default = "child-value" }
 EOF
 
-    # Change to child directory
-    cd parent/child
+	# Change to child directory
+	cd parent/child
 
-    # Test that we can access all secrets
-    run "$FNOX_BIN" get IMPORTED_SECRET
-    assert_success
-    assert_output --partial "imported-value"
+	# Test that we can access all secrets
+	run "$FNOX_BIN" get IMPORTED_SECRET
+	assert_success
+	assert_output --partial "imported-value"
 
-    run "$FNOX_BIN" get PARENT_SECRET
-    assert_success
-    assert_output --partial "parent-value"
+	run "$FNOX_BIN" get PARENT_SECRET
+	assert_success
+	assert_output --partial "parent-value"
 
-    run "$FNOX_BIN" get CHILD_SECRET
-    assert_success
-    assert_output --partial "child-value"
+	run "$FNOX_BIN" get CHILD_SECRET
+	assert_success
+	assert_output --partial "child-value"
 }
 
 @test "explicit config path bypasses recursion" {
-    # Create directory structure
-    mkdir -p parent/child
-    
-    # Create parent config
-    cat > parent/fnox.toml <<EOF
+	# Create directory structure
+	mkdir -p parent/child
+
+	# Create parent config
+	cat >parent/fnox.toml <<EOF
 [providers.test]
 type = "age"
 recipients = ["age1test"]
@@ -248,24 +248,24 @@ recipients = ["age1test"]
 PARENT_SECRET = { description = "Parent secret", default = "parent-value" }
 EOF
 
-    # Create child config
-    cat > parent/child/fnox.toml <<EOF
+	# Create child config
+	cat >parent/child/fnox.toml <<EOF
 root = true
 
 [secrets]
 CHILD_SECRET = { description = "Child secret", default = "child-value" }
 EOF
 
-    # Change to child directory and test explicit path
-    cd parent/child
-    
-    # Use explicit path - should only load that file
-    run "$FNOX_BIN" -c ../fnox.toml get PARENT_SECRET
-    assert_success
-    assert_output --partial "parent-value"
+	# Change to child directory and test explicit path
+	cd parent/child
 
-    # Should not find child secret when using parent config
-    run "$FNOX_BIN" -c ../fnox.toml get CHILD_SECRET
-    assert_failure
-    assert_output --partial "not found"
+	# Use explicit path - should only load that file
+	run "$FNOX_BIN" -c ../fnox.toml get PARENT_SECRET
+	assert_success
+	assert_output --partial "parent-value"
+
+	# Should not find child secret when using parent config
+	run "$FNOX_BIN" -c ../fnox.toml get CHILD_SECRET
+	assert_failure
+	assert_output --partial "not found"
 }

--- a/test/default_provider.bats
+++ b/test/default_provider.bats
@@ -1,43 +1,43 @@
 #!/usr/bin/env bats
 
 setup() {
-    load 'test_helper/common_setup'
-    _common_setup
+	load 'test_helper/common_setup'
+	_common_setup
 }
 
 teardown() {
-    _common_teardown
+	_common_teardown
 }
 
 @test "config with no providers returns error" {
-    # Create config with no providers
-    cat > fnox.toml << 'EOF'
+	# Create config with no providers
+	cat >fnox.toml <<'EOF'
 root = true
 
 [secrets]
 MY_SECRET = { value = "test" }
 EOF
 
-    # Any command that loads the config should fail
-    run "$FNOX_BIN" get MY_SECRET
-    assert_failure
-    assert_output --partial "No providers configured"
+	# Any command that loads the config should fail
+	run "$FNOX_BIN" get MY_SECRET
+	assert_failure
+	assert_output --partial "No providers configured"
 }
 
 @test "single provider is auto-selected as default" {
-    # Skip if age not installed
-    if ! command -v age-keygen >/dev/null 2>&1; then
-        skip "age-keygen not installed"
-    fi
+	# Skip if age not installed
+	if ! command -v age-keygen >/dev/null 2>&1; then
+		skip "age-keygen not installed"
+	fi
 
-    # Generate age key
-    local keygen_output
-    keygen_output=$(age-keygen -o key.txt 2>&1)
-    local public_key
-    public_key=$(echo "$keygen_output" | grep "^Public key:" | cut -d' ' -f3)
+	# Generate age key
+	local keygen_output
+	keygen_output=$(age-keygen -o key.txt 2>&1)
+	local public_key
+	public_key=$(echo "$keygen_output" | grep "^Public key:" | cut -d' ' -f3)
 
-    # Create config with single provider
-    cat > fnox.toml << EOF
+	# Create config with single provider
+	cat >fnox.toml <<EOF
 root = true
 
 [providers.age]
@@ -47,34 +47,34 @@ recipients = ["$public_key"]
 [secrets]
 EOF
 
-    # Set a secret without specifying provider - should use the only one available
-    run "$FNOX_BIN" set MY_SECRET "secret-value"
-    assert_success
+	# Set a secret without specifying provider - should use the only one available
+	run "$FNOX_BIN" set MY_SECRET "secret-value"
+	assert_success
 
-    # Verify the secret was encrypted with the age provider
-    assert_config_contains "MY_SECRET"
-    assert_config_not_contains "secret-value"
+	# Verify the secret was encrypted with the age provider
+	assert_config_contains "MY_SECRET"
+	assert_config_not_contains "secret-value"
 
-    # Should be able to get it back
-    run "$FNOX_BIN" get MY_SECRET --age-key-file key.txt
-    assert_success
-    assert_output "secret-value"
+	# Should be able to get it back
+	run "$FNOX_BIN" get MY_SECRET --age-key-file key.txt
+	assert_success
+	assert_output "secret-value"
 }
 
 @test "explicit default_provider is used when set" {
-    # Skip if age not installed
-    if ! command -v age-keygen >/dev/null 2>&1; then
-        skip "age-keygen not installed"
-    fi
+	# Skip if age not installed
+	if ! command -v age-keygen >/dev/null 2>&1; then
+		skip "age-keygen not installed"
+	fi
 
-    # Generate age key
-    local keygen_output
-    keygen_output=$(age-keygen -o key.txt 2>&1)
-    local public_key
-    public_key=$(echo "$keygen_output" | grep "^Public key:" | cut -d' ' -f3)
+	# Generate age key
+	local keygen_output
+	keygen_output=$(age-keygen -o key.txt 2>&1)
+	local public_key
+	public_key=$(echo "$keygen_output" | grep "^Public key:" | cut -d' ' -f3)
 
-    # Create config with multiple providers and explicit default
-    cat > fnox.toml << EOF
+	# Create config with multiple providers and explicit default
+	cat >fnox.toml <<EOF
 root = true
 default_provider = "age"
 
@@ -89,39 +89,39 @@ address = "https://vault.example.com"
 [secrets]
 EOF
 
-    # Set a secret without specifying provider - should use default_provider
-    run "$FNOX_BIN" set MY_SECRET "secret-value"
-    assert_success
+	# Set a secret without specifying provider - should use default_provider
+	run "$FNOX_BIN" set MY_SECRET "secret-value"
+	assert_success
 
-    # Verify the secret was encrypted with the age provider
-    assert_config_contains "MY_SECRET"
-    assert_config_not_contains "secret-value"
+	# Verify the secret was encrypted with the age provider
+	assert_config_contains "MY_SECRET"
+	assert_config_not_contains "secret-value"
 
-    # Should be able to get it back
-    run "$FNOX_BIN" get MY_SECRET --age-key-file key.txt
-    assert_success
-    assert_output "secret-value"
+	# Should be able to get it back
+	run "$FNOX_BIN" get MY_SECRET --age-key-file key.txt
+	assert_success
+	assert_output "secret-value"
 }
 
 @test "profile default_provider overrides global default_provider" {
-    # Skip if age not installed
-    if ! command -v age-keygen >/dev/null 2>&1; then
-        skip "age-keygen not installed"
-    fi
+	# Skip if age not installed
+	if ! command -v age-keygen >/dev/null 2>&1; then
+		skip "age-keygen not installed"
+	fi
 
-    # Generate two age keys
-    local keygen_output1
-    keygen_output1=$(age-keygen -o key1.txt 2>&1)
-    local public_key1
-    public_key1=$(echo "$keygen_output1" | grep "^Public key:" | cut -d' ' -f3)
+	# Generate two age keys
+	local keygen_output1
+	keygen_output1=$(age-keygen -o key1.txt 2>&1)
+	local public_key1
+	public_key1=$(echo "$keygen_output1" | grep "^Public key:" | cut -d' ' -f3)
 
-    local keygen_output2
-    keygen_output2=$(age-keygen -o key2.txt 2>&1)
-    local public_key2
-    public_key2=$(echo "$keygen_output2" | grep "^Public key:" | cut -d' ' -f3)
+	local keygen_output2
+	keygen_output2=$(age-keygen -o key2.txt 2>&1)
+	local public_key2
+	public_key2=$(echo "$keygen_output2" | grep "^Public key:" | cut -d' ' -f3)
 
-    # Create config with global default and profile override
-    cat > fnox.toml << EOF
+	# Create config with global default and profile override
+	cat >fnox.toml <<EOF
 root = true
 default_provider = "age1"
 
@@ -141,38 +141,38 @@ default_provider = "age2"
 [profiles.prod.secrets]
 EOF
 
-    # Set a secret in default profile - should use age1
-    run "$FNOX_BIN" set DEFAULT_SECRET "default-value"
-    assert_success
+	# Set a secret in default profile - should use age1
+	run "$FNOX_BIN" set DEFAULT_SECRET "default-value"
+	assert_success
 
-    # Set a secret in prod profile - should use age2
-    run "$FNOX_BIN" set --profile prod PROD_SECRET "prod-value"
-    assert_success
+	# Set a secret in prod profile - should use age2
+	run "$FNOX_BIN" set --profile prod PROD_SECRET "prod-value"
+	assert_success
 
-    # Verify we can get them back with the right keys
-    run "$FNOX_BIN" get DEFAULT_SECRET --age-key-file key1.txt
-    assert_success
-    assert_output "default-value"
+	# Verify we can get them back with the right keys
+	run "$FNOX_BIN" get DEFAULT_SECRET --age-key-file key1.txt
+	assert_success
+	assert_output "default-value"
 
-    run "$FNOX_BIN" get --profile prod PROD_SECRET --age-key-file key2.txt
-    assert_success
-    assert_output "prod-value"
+	run "$FNOX_BIN" get --profile prod PROD_SECRET --age-key-file key2.txt
+	assert_success
+	assert_output "prod-value"
 }
 
 @test "multiple providers without default_provider requires explicit provider" {
-    # Skip if age not installed
-    if ! command -v age-keygen >/dev/null 2>&1; then
-        skip "age-keygen not installed"
-    fi
+	# Skip if age not installed
+	if ! command -v age-keygen >/dev/null 2>&1; then
+		skip "age-keygen not installed"
+	fi
 
-    # Generate age key
-    local keygen_output
-    keygen_output=$(age-keygen -o key.txt 2>&1)
-    local public_key
-    public_key=$(echo "$keygen_output" | grep "^Public key:" | cut -d' ' -f3)
+	# Generate age key
+	local keygen_output
+	keygen_output=$(age-keygen -o key.txt 2>&1)
+	local public_key
+	public_key=$(echo "$keygen_output" | grep "^Public key:" | cut -d' ' -f3)
 
-    # Create config with multiple providers and NO default
-    cat > fnox.toml << EOF
+	# Create config with multiple providers and NO default
+	cat >fnox.toml <<EOF
 root = true
 
 [providers.age]
@@ -186,22 +186,22 @@ address = "https://vault.example.com"
 [secrets]
 EOF
 
-    # Set a secret without specifying provider - should store as plaintext since no default
-    run "$FNOX_BIN" set MY_SECRET "secret-value"
-    assert_success
+	# Set a secret without specifying provider - should store as plaintext since no default
+	run "$FNOX_BIN" set MY_SECRET "secret-value"
+	assert_success
 
-    # Verify the secret was stored as plaintext (not encrypted)
-    assert_config_contains "secret-value"
+	# Verify the secret was stored as plaintext (not encrypted)
+	assert_config_contains "secret-value"
 
-    # Get should work
-    run "$FNOX_BIN" get MY_SECRET
-    assert_success
-    assert_output "secret-value"
+	# Get should work
+	run "$FNOX_BIN" get MY_SECRET
+	assert_success
+	assert_output "secret-value"
 }
 
 @test "invalid default_provider returns error" {
-    # Create config with invalid default_provider
-    cat > fnox.toml << 'EOF'
+	# Create config with invalid default_provider
+	cat >fnox.toml <<'EOF'
 root = true
 default_provider = "nonexistent"
 
@@ -212,16 +212,16 @@ recipients = ["age1test"]
 [secrets]
 EOF
 
-    # Should fail to validate
-    run "$FNOX_BIN" get MY_SECRET 2>&1 || true
-    assert_failure
-    assert_output --partial "Default provider 'nonexistent' not found"
+	# Should fail to validate
+	run "$FNOX_BIN" get MY_SECRET 2>&1 || true
+	assert_failure
+	assert_output --partial "Default provider 'nonexistent' not found"
 }
 
 @test "profile with no providers (and no global providers) returns error" {
-    # Create config with profile that has no providers
-    # Set if_missing = "error" to require the secret
-    cat > fnox.toml << 'EOF'
+	# Create config with profile that has no providers
+	# Set if_missing = "error" to require the secret
+	cat >fnox.toml <<'EOF'
 root = true
 
 [secrets]
@@ -232,25 +232,25 @@ root = true
 MY_SECRET = { description = "test secret", if_missing = "error" }
 EOF
 
-    # Should fail because profile has no providers and secret has no value
-    run "$FNOX_BIN" get --profile test MY_SECRET
-    assert_failure
+	# Should fail because profile has no providers and secret has no value
+	run "$FNOX_BIN" get --profile test MY_SECRET
+	assert_failure
 }
 
 @test "profile inherits global providers" {
-    # Skip if age not installed
-    if ! command -v age-keygen >/dev/null 2>&1; then
-        skip "age-keygen not installed"
-    fi
+	# Skip if age not installed
+	if ! command -v age-keygen >/dev/null 2>&1; then
+		skip "age-keygen not installed"
+	fi
 
-    # Generate age key
-    local keygen_output
-    keygen_output=$(age-keygen -o key.txt 2>&1)
-    local public_key
-    public_key=$(echo "$keygen_output" | grep "^Public key:" | cut -d' ' -f3)
+	# Generate age key
+	local keygen_output
+	keygen_output=$(age-keygen -o key.txt 2>&1)
+	local public_key
+	public_key=$(echo "$keygen_output" | grep "^Public key:" | cut -d' ' -f3)
 
-    # Create config with global provider only
-    cat > fnox.toml << EOF
+	# Create config with global provider only
+	cat >fnox.toml <<EOF
 root = true
 
 [providers.age]
@@ -264,38 +264,38 @@ recipients = ["$public_key"]
 [profiles.test.secrets]
 EOF
 
-    # Set a secret in test profile - should use inherited provider
-    run "$FNOX_BIN" set --profile test TEST_SECRET "test-value"
-    assert_success
+	# Set a secret in test profile - should use inherited provider
+	run "$FNOX_BIN" set --profile test TEST_SECRET "test-value"
+	assert_success
 
-    # Verify it was encrypted
-    assert_config_not_contains "test-value"
+	# Verify it was encrypted
+	assert_config_not_contains "test-value"
 
-    # Should be able to get it back
-    run "$FNOX_BIN" get --profile test TEST_SECRET --age-key-file key.txt
-    assert_success
-    assert_output "test-value"
+	# Should be able to get it back
+	run "$FNOX_BIN" get --profile test TEST_SECRET --age-key-file key.txt
+	assert_success
+	assert_output "test-value"
 }
 
 @test "explicit provider overrides default_provider" {
-    # Skip if age not installed
-    if ! command -v age-keygen >/dev/null 2>&1; then
-        skip "age-keygen not installed"
-    fi
+	# Skip if age not installed
+	if ! command -v age-keygen >/dev/null 2>&1; then
+		skip "age-keygen not installed"
+	fi
 
-    # Generate two age keys
-    local keygen_output1
-    keygen_output1=$(age-keygen -o key1.txt 2>&1)
-    local public_key1
-    public_key1=$(echo "$keygen_output1" | grep "^Public key:" | cut -d' ' -f3)
+	# Generate two age keys
+	local keygen_output1
+	keygen_output1=$(age-keygen -o key1.txt 2>&1)
+	local public_key1
+	public_key1=$(echo "$keygen_output1" | grep "^Public key:" | cut -d' ' -f3)
 
-    local keygen_output2
-    keygen_output2=$(age-keygen -o key2.txt 2>&1)
-    local public_key2
-    public_key2=$(echo "$keygen_output2" | grep "^Public key:" | cut -d' ' -f3)
+	local keygen_output2
+	keygen_output2=$(age-keygen -o key2.txt 2>&1)
+	local public_key2
+	public_key2=$(echo "$keygen_output2" | grep "^Public key:" | cut -d' ' -f3)
 
-    # Create config with default_provider
-    cat > fnox.toml << EOF
+	# Create config with default_provider
+	cat >fnox.toml <<EOF
 root = true
 default_provider = "age1"
 
@@ -310,16 +310,16 @@ recipients = ["$public_key2"]
 [secrets]
 EOF
 
-    # Set a secret with explicit provider (should override default)
-    run "$FNOX_BIN" set MY_SECRET "secret-value" --provider age2
-    assert_success
+	# Set a secret with explicit provider (should override default)
+	run "$FNOX_BIN" set MY_SECRET "secret-value" --provider age2
+	assert_success
 
-    # Should need key2 to decrypt (not key1)
-    run "$FNOX_BIN" get MY_SECRET --age-key-file key2.txt
-    assert_success
-    assert_output "secret-value"
+	# Should need key2 to decrypt (not key1)
+	run "$FNOX_BIN" get MY_SECRET --age-key-file key2.txt
+	assert_success
+	assert_output "secret-value"
 
-    # Should fail with key1
-    run "$FNOX_BIN" get MY_SECRET --age-key-file key1.txt
-    assert_failure
+	# Should fail with key1
+	run "$FNOX_BIN" get MY_SECRET --age-key-file key1.txt
+	assert_failure
 }

--- a/test/doctor.bats
+++ b/test/doctor.bats
@@ -1,97 +1,97 @@
 #!/usr/bin/env bats
 
 setup() {
-    load 'test_helper/common_setup'
-    _common_setup
+	load 'test_helper/common_setup'
+	_common_setup
 }
 
 teardown() {
-    _common_teardown
+	_common_teardown
 }
 
 @test "fnox doctor shows config info" {
-    create_test_config
-    assert_fnox_success doctor
-    assert_output --partial "Fnox Doctor Report"
-    assert_output --partial "Configuration:"
-    assert_output --partial "File:"
-    assert_output --partial "Profile:"
+	create_test_config
+	assert_fnox_success doctor
+	assert_output --partial "Fnox Doctor Report"
+	assert_output --partial "Configuration:"
+	assert_output --partial "File:"
+	assert_output --partial "Profile:"
 }
 
 @test "fnox doctor shows secrets info" {
-    create_test_config
-    assert_fnox_success doctor
-    assert_output --partial "Secrets:"
-    assert_output --partial "Count:"
+	create_test_config
+	assert_fnox_success doctor
+	assert_output --partial "Secrets:"
+	assert_output --partial "Count:"
 }
 
 @test "fnox doctor shows providers info" {
-    create_test_config
-    assert_fnox_success doctor
-    assert_output --partial "Providers:"
-    assert_output --partial "age"
+	create_test_config
+	assert_fnox_success doctor
+	assert_output --partial "Providers:"
+	assert_output --partial "age"
 }
 
 @test "fnox doctor shows environment info" {
-    create_test_config
-    assert_fnox_success doctor
-    assert_output --partial "Environment:"
-    assert_output --partial "FNOX_PROFILE"
+	create_test_config
+	assert_fnox_success doctor
+	assert_output --partial "Environment:"
+	assert_output --partial "FNOX_PROFILE"
 }
 
 @test "fnox doctor shows summary" {
-    create_test_config
-    assert_fnox_success doctor
-    assert_output --partial "Summary:"
-    assert_output --partial "Total secrets:"
-    assert_output --partial "Total providers:"
+	create_test_config
+	assert_fnox_success doctor
+	assert_output --partial "Summary:"
+	assert_output --partial "Total secrets:"
+	assert_output --partial "Total providers:"
 }
 
 @test "fnox doctor shows tips" {
-    create_test_config
-    assert_fnox_success doctor
-    assert_output --partial "Tips:"
+	create_test_config
+	assert_fnox_success doctor
+	assert_output --partial "Tips:"
 }
 
 @test "fnox doctor with profile" {
-    create_test_config
-    assert_fnox_success doctor --profile test
-    assert_output --partial "Profile: test"
+	create_test_config
+	assert_fnox_success doctor --profile test
+	assert_output --partial "Profile: test"
 }
 
 @test "fnox doctor with no config" {
-    # Use explicit path to non-existent config to bypass recursive loading
-    run "$FNOX_BIN" --config /tmp/nonexistent-fnox-config.toml doctor
-    assert_failure
-    assert_output --partial "Failed to read"
+	# Use explicit path to non-existent config to bypass recursive loading
+	run "$FNOX_BIN" --config /tmp/nonexistent-fnox-config.toml doctor
+	assert_failure
+	assert_output --partial "Failed to read"
 }
 
 @test "fnox doctor with empty config" {
-    echo "root = true" > "${FNOX_CONFIG_FILE:-fnox.toml}"
-    assert_fnox_success doctor
-    assert_output --partial "Count: 0"
-    assert_output --partial "Add secrets"
+	echo "root = true" >"${FNOX_CONFIG_FILE:-fnox.toml}"
+	assert_fnox_success doctor
+	assert_output --partial "Count: 0"
+	assert_output --partial "Add secrets"
 }
 
 @test "fnox doctor shows provider health" {
-    create_test_config
-    # This might show connection errors for real providers, but that's expected
-    assert_fnox_success doctor
-    assert_output --partial "Provider Health"
+	create_test_config
+	# This might show connection errors for real providers, but that's expected
+	assert_fnox_success doctor
+	assert_output --partial "Provider Health"
 }
 
 @test "fnox doctor with many secrets" {
-    create_test_config
-    
-    # Add multiple secrets
-    for i in {1..15}; do
-        cat >> "${FNOX_CONFIG_FILE:-fnox.toml}" << EOF
+	create_test_config
+
+	# Add multiple secrets
+	for i in {1..15}; do
+		cat >>"${FNOX_CONFIG_FILE:-fnox.toml}" <<EOF
 
 [secrets.secret_$i]
 value = "value_$i"
 EOF
-    done
-    
-    assert_fnox_success doctor
-    assert_output --partial "Count: 16"  # 1 from create_test_config + 15 new ones
+	done
+
+	assert_fnox_success doctor
+	assert_output --partial "Count: 16" # 1 from create_test_config + 15 new ones
 }

--- a/test/edit.bats
+++ b/test/edit.bats
@@ -4,18 +4,19 @@ load 'test_helper/bats-support/load'
 load 'test_helper/bats-assert/load'
 
 setup() {
-  # Create a temporary test directory
-  TEST_DIR="$(mktemp -d)"
-  cd "$TEST_DIR"
+	# Create a temporary test directory
+	TEST_DIR="$(mktemp -d)"
+	cd "$TEST_DIR" || exit 1
 
-  # Generate age key for testing
-  AGE_KEY_FILE="$TEST_DIR/age-key.txt"
-  age-keygen -o "$AGE_KEY_FILE" 2>/dev/null
-  # Export the actual key content, not the file path
-  export FNOX_AGE_KEY="$(grep 'AGE-SECRET-KEY' "$AGE_KEY_FILE")"
+	# Generate age key for testing
+	AGE_KEY_FILE="$TEST_DIR/age-key.txt"
+	age-keygen -o "$AGE_KEY_FILE" 2>/dev/null
+	# Export the actual key content, not the file path
+	FNOX_AGE_KEY="$(grep 'AGE-SECRET-KEY' "$AGE_KEY_FILE")"
+	export FNOX_AGE_KEY
 
-  # Create a minimal fnox config with age provider (no fnox init to avoid default secrets)
-  cat > fnox.toml << EOF
+	# Create a minimal fnox config with age provider (no fnox init to avoid default secrets)
+	cat >fnox.toml <<EOF
 [providers.age]
 type = "age"
 recipients = ["$(grep 'public key:' "$AGE_KEY_FILE" | cut -d: -f2- | xargs)"]
@@ -23,21 +24,21 @@ recipients = ["$(grep 'public key:' "$AGE_KEY_FILE" | cut -d: -f2- | xargs)"]
 [secrets]
 EOF
 
-  # Add some test secrets
-  echo "secret123" | fnox set TEST_SECRET --provider age
-  echo "password456" | fnox set TEST_PASSWORD --provider age
+	# Add some test secrets
+	echo "secret123" | fnox set TEST_SECRET --provider age
+	echo "password456" | fnox set TEST_PASSWORD --provider age
 }
 
 teardown() {
-  # Clean up test directory
-  if [ -n "$TEST_DIR" ] && [ -d "$TEST_DIR" ]; then
-    rm -rf "$TEST_DIR"
-  fi
+	# Clean up test directory
+	if [ -n "$TEST_DIR" ] && [ -d "$TEST_DIR" ]; then
+		rm -rf "$TEST_DIR"
+	fi
 }
 
 @test "edit command with non-interactive editor (modify secret)" {
-  # Create a Python script that modifies a secret
-  cat > "$TEST_DIR/test-editor.py" << 'EDITOR_SCRIPT'
+	# Create a Python script that modifies a secret
+	cat >"$TEST_DIR/test-editor.py" <<'EDITOR_SCRIPT'
 #!/usr/bin/env python3
 import sys
 import re
@@ -57,147 +58,147 @@ content = re.sub(
 with open(sys.argv[1], 'w') as f:
     f.write(content)
 EDITOR_SCRIPT
-  chmod +x "$TEST_DIR/test-editor.py"
+	chmod +x "$TEST_DIR/test-editor.py"
 
-  # Set the test editor
-  export EDITOR="$TEST_DIR/test-editor.py"
+	# Set the test editor
+	export EDITOR="$TEST_DIR/test-editor.py"
 
-  # Run edit command
-  run fnox edit
-  assert_success
+	# Run edit command
+	run fnox edit
+	assert_success
 
-  # Verify the secret was changed and re-encrypted
-  run fnox get TEST_SECRET
-  assert_success
-  assert_output "newsecret789"
+	# Verify the secret was changed and re-encrypted
+	run fnox get TEST_SECRET
+	assert_success
+	assert_output "newsecret789"
 }
 
 @test "edit command preserves unchanged secrets" {
-  skip "Debugging - need to check why edit breaks the config"
+	skip "Debugging - need to check why edit breaks the config"
 
-  # Get original values before edit
-  original_secret=$(fnox get TEST_SECRET)
-  original_password=$(fnox get TEST_PASSWORD)
+	# Get original values before edit
+	original_secret=$(fnox get TEST_SECRET)
+	original_password=$(fnox get TEST_PASSWORD)
 
-  echo "Original TEST_SECRET: $original_secret" >&3
-  echo "Original TEST_PASSWORD: $original_password" >&3
+	echo "Original TEST_SECRET: $original_secret" >&3
+	echo "Original TEST_PASSWORD: $original_password" >&3
 
-  # Show config before edit
-  echo "Config before edit:" >&3
-  cat fnox.toml >&3
+	# Show config before edit
+	echo "Config before edit:" >&3
+	cat fnox.toml >&3
 
-  # Create a script that doesn't change anything (just exits)
-  cat > "$TEST_DIR/test-editor.sh" << 'EDITOR_SCRIPT'
+	# Create a script that doesn't change anything (just exits)
+	cat >"$TEST_DIR/test-editor.sh" <<'EDITOR_SCRIPT'
 #!/bin/bash
 # This script does nothing - just exits
 echo "Editor called with file: $1" >&2
 cat "$1" >&2
 exit 0
 EDITOR_SCRIPT
-  chmod +x "$TEST_DIR/test-editor.sh"
+	chmod +x "$TEST_DIR/test-editor.sh"
 
-  # Set the test editor
-  export EDITOR="$TEST_DIR/test-editor.sh"
+	# Set the test editor
+	export EDITOR="$TEST_DIR/test-editor.sh"
 
-  # Run edit command
-  run fnox edit
-  echo "Edit command output: $output" >&3
-  assert_success
+	# Run edit command
+	run fnox edit
+	echo "Edit command output: $output" >&3
+	assert_success
 
-  # Show config after edit
-  echo "Config after edit:" >&3
-  cat fnox.toml >&3
+	# Show config after edit
+	echo "Config after edit:" >&3
+	cat fnox.toml >&3
 
-  # Verify secrets are unchanged
-  run fnox get TEST_SECRET
-  echo "TEST_SECRET after edit: $output" >&3
-  assert_success
-  assert_output "$original_secret"
+	# Verify secrets are unchanged
+	run fnox get TEST_SECRET
+	echo "TEST_SECRET after edit: $output" >&3
+	assert_success
+	assert_output "$original_secret"
 
-  run fnox get TEST_PASSWORD
-  echo "TEST_PASSWORD after edit: $output" >&3
-  assert_success
-  assert_output "$original_password"
+	run fnox get TEST_PASSWORD
+	echo "TEST_PASSWORD after edit: $output" >&3
+	assert_success
+	assert_output "$original_password"
 }
 
 @test "edit command decrypts secrets in temporary file" {
-  # Create a script that captures the decrypted content
-  # Use double quotes to allow $TEST_DIR to be expanded
-  cat > "$TEST_DIR/test-editor.sh" << EDITOR_SCRIPT
+	# Create a script that captures the decrypted content
+	# Use double quotes to allow $TEST_DIR to be expanded
+	cat >"$TEST_DIR/test-editor.sh" <<EDITOR_SCRIPT
 #!/bin/bash
 # Capture the decrypted content
 cp "\$1" "$TEST_DIR/decrypted-content.txt"
 exit 0
 EDITOR_SCRIPT
-  chmod +x "$TEST_DIR/test-editor.sh"
+	chmod +x "$TEST_DIR/test-editor.sh"
 
-  # Set the test editor
-  export EDITOR="$TEST_DIR/test-editor.sh"
+	# Set the test editor
+	export EDITOR="$TEST_DIR/test-editor.sh"
 
-  # Run edit command
-  run fnox edit
-  assert_success
+	# Run edit command
+	run fnox edit
+	assert_success
 
-  # Verify the temporary file contained plaintext secrets
-  assert [ -f "$TEST_DIR/decrypted-content.txt" ]
+	# Verify the temporary file contained plaintext secrets
+	assert [ -f "$TEST_DIR/decrypted-content.txt" ]
 
-  # The decrypted file should contain the plaintext values
-  run grep -q "secret123" "$TEST_DIR/decrypted-content.txt"
-  assert_success
+	# The decrypted file should contain the plaintext values
+	run grep -q "secret123" "$TEST_DIR/decrypted-content.txt"
+	assert_success
 
-  run grep -q "password456" "$TEST_DIR/decrypted-content.txt"
-  assert_success
+	run grep -q "password456" "$TEST_DIR/decrypted-content.txt"
+	assert_success
 }
 
 @test "edit command handles editor failure" {
-  # Create a script that fails
-  cat > "$TEST_DIR/test-editor.sh" << 'EDITOR_SCRIPT'
+	# Create a script that fails
+	cat >"$TEST_DIR/test-editor.sh" <<'EDITOR_SCRIPT'
 #!/bin/bash
 exit 1
 EDITOR_SCRIPT
-  chmod +x "$TEST_DIR/test-editor.sh"
+	chmod +x "$TEST_DIR/test-editor.sh"
 
-  # Set the test editor
-  export EDITOR="$TEST_DIR/test-editor.sh"
+	# Set the test editor
+	export EDITOR="$TEST_DIR/test-editor.sh"
 
-  # Run edit command - should fail
-  run fnox edit
-  assert_failure
+	# Run edit command - should fail
+	run fnox edit
+	assert_failure
 }
 
 @test "edit command works with multiple secrets" {
-  # Add more secrets
-  echo "value1" | fnox set SECRET1 --provider age
-  echo "value2" | fnox set SECRET2 --provider age
-  echo "value3" | fnox set SECRET3 --provider age
+	# Add more secrets
+	echo "value1" | fnox set SECRET1 --provider age
+	echo "value2" | fnox set SECRET2 --provider age
+	echo "value3" | fnox set SECRET3 --provider age
 
-  # Create a script that modifies multiple secrets
-  # Note: inline table format is "KEY= { ... }" with no space before =
-  cat > "$TEST_DIR/test-editor.sh" << 'EDITOR_SCRIPT'
+	# Create a script that modifies multiple secrets
+	# Note: inline table format is "KEY= { ... }" with no space before =
+	cat >"$TEST_DIR/test-editor.sh" <<'EDITOR_SCRIPT'
 #!/bin/bash
 sed -i.bak 's/SECRET1= { provider = "age", value = "[^"]*" }/SECRET1= { provider = "age", value = "modified1" }/' "$1"
 sed -i.bak 's/SECRET2= { provider = "age", value = "[^"]*" }/SECRET2= { provider = "age", value = "modified2" }/' "$1"
 EDITOR_SCRIPT
-  chmod +x "$TEST_DIR/test-editor.sh"
+	chmod +x "$TEST_DIR/test-editor.sh"
 
-  # Set the test editor
-  export EDITOR="$TEST_DIR/test-editor.sh"
+	# Set the test editor
+	export EDITOR="$TEST_DIR/test-editor.sh"
 
-  # Run edit command
-  run fnox edit
-  assert_success
+	# Run edit command
+	run fnox edit
+	assert_success
 
-  # Verify secrets were updated correctly
-  run fnox get SECRET1
-  assert_success
-  assert_output "modified1"
+	# Verify secrets were updated correctly
+	run fnox get SECRET1
+	assert_success
+	assert_output "modified1"
 
-  run fnox get SECRET2
-  assert_success
-  assert_output "modified2"
+	run fnox get SECRET2
+	assert_success
+	assert_output "modified2"
 
-  # SECRET3 should be unchanged
-  run fnox get SECRET3
-  assert_success
-  assert_output "value3"
+	# SECRET3 should be unchanged
+	run fnox get SECRET3
+	assert_success
+	assert_output "value3"
 }

--- a/test/exec_if_missing.bats
+++ b/test/exec_if_missing.bats
@@ -3,11 +3,11 @@
 load 'test_helper/common_setup'
 
 setup() {
-    _common_setup
+	_common_setup
 }
 
 @test "fnox exec with if_missing=error fails on missing secret" {
-    cat > fnox.toml << 'TOML'
+	cat >fnox.toml <<'TOML'
 root = true
 
 [providers.age]
@@ -20,15 +20,15 @@ value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaaTFhczNBYnN3S1c0NjZwZnlDN2N
 if_missing = "error"
 TOML
 
-    # Set invalid age key to trigger error
-    export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
+	# Set invalid age key to trigger error
+	export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
 
-    run "$FNOX_BIN" exec -- echo "should not run"
-    assert_failure
+	run "$FNOX_BIN" exec -- echo "should not run"
+	assert_failure
 }
 
 @test "fnox exec with if_missing=warn continues on missing secret" {
-    cat > fnox.toml << 'TOML'
+	cat >fnox.toml <<'TOML'
 root = true
 
 [providers.age]
@@ -41,16 +41,16 @@ value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaaTFhczNBYnN3S1c0NjZwZnlDN2N
 if_missing = "warn"
 TOML
 
-    # Set invalid age key to trigger error
-    export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
+	# Set invalid age key to trigger error
+	export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
 
-    run "$FNOX_BIN" exec -- echo "command succeeded"
-    assert_success
-    assert_output --partial "command succeeded"
+	run "$FNOX_BIN" exec -- echo "command succeeded"
+	assert_success
+	assert_output --partial "command succeeded"
 }
 
 @test "fnox exec with default if_missing (warn) continues on missing secret" {
-    cat > fnox.toml << 'TOML'
+	cat >fnox.toml <<'TOML'
 root = true
 
 [providers.age]
@@ -62,16 +62,16 @@ provider = "age"
 value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaaTFhczNBYnN3S1c0NjZwZnlDN2NUMTVaSTFXd2k1OWhnWUJvckVxYmh3CjNRSmhxSWJiYXU3eHoyNlcyOVVLRWNnUlFJeFBjL2N0YlA5K2hUaU04VDQKLS0tIGN6UVYzMHZJUUhKNmlkQjFOaXRXYUpjbzBOaHRMZkFFVVRPa3FaQUs2dHcKf3AcueEBLdl8lzRwKXik+OvDVg48g44QoPZu0j0NLV4lPLDqoq0="
 TOML
 
-    # Set invalid age key to trigger error
-    export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
+	# Set invalid age key to trigger error
+	export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
 
-    run "$FNOX_BIN" exec -- echo "command succeeded"
-    assert_success
-    assert_output --partial "command succeeded"
+	run "$FNOX_BIN" exec -- echo "command succeeded"
+	assert_success
+	assert_output --partial "command succeeded"
 }
 
 @test "fnox exec with if_missing=ignore silently continues on missing secret" {
-    cat > fnox.toml << 'TOML'
+	cat >fnox.toml <<'TOML'
 root = true
 
 [providers.age]
@@ -84,10 +84,10 @@ value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaaTFhczNBYnN3S1c0NjZwZnlDN2N
 if_missing = "ignore"
 TOML
 
-    # Set invalid age key to trigger error
-    export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
+	# Set invalid age key to trigger error
+	export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
 
-    run "$FNOX_BIN" exec -- echo "command succeeded"
-    assert_success
-    assert_output --partial "command succeeded"
+	run "$FNOX_BIN" exec -- echo "command succeeded"
+	assert_success
+	assert_output --partial "command succeeded"
 }

--- a/test/export_if_missing.bats
+++ b/test/export_if_missing.bats
@@ -3,11 +3,11 @@
 load 'test_helper/common_setup'
 
 setup() {
-    _common_setup
+	_common_setup
 }
 
 @test "fnox export with if_missing=error fails on missing secret" {
-    cat > fnox.toml << 'TOML'
+	cat >fnox.toml <<'TOML'
 root = true
 
 [providers.age]
@@ -20,15 +20,15 @@ value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaaTFhczNBYnN3S1c0NjZwZnlDN2N
 if_missing = "error"
 TOML
 
-    # Set invalid age key to trigger error
-    export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
+	# Set invalid age key to trigger error
+	export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
 
-    run "$FNOX_BIN" export
-    assert_failure
+	run "$FNOX_BIN" export
+	assert_failure
 }
 
 @test "fnox export with if_missing=warn continues on missing secret" {
-    cat > fnox.toml << 'TOML'
+	cat >fnox.toml <<'TOML'
 root = true
 
 [providers.age]
@@ -41,17 +41,17 @@ value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaaTFhczNBYnN3S1c0NjZwZnlDN2N
 if_missing = "warn"
 TOML
 
-    # Set invalid age key to trigger error
-    export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
+	# Set invalid age key to trigger error
+	export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
 
-    run "$FNOX_BIN" export
-    assert_success
-    # Should output env format even though secret failed to resolve
-    assert_output --partial "# Exported from profile: default"
+	run "$FNOX_BIN" export
+	assert_success
+	# Should output env format even though secret failed to resolve
+	assert_output --partial "# Exported from profile: default"
 }
 
 @test "fnox export with default if_missing (warn) continues on missing secret" {
-    cat > fnox.toml << 'TOML'
+	cat >fnox.toml <<'TOML'
 root = true
 
 [providers.age]
@@ -63,17 +63,17 @@ provider = "age"
 value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaaTFhczNBYnN3S1c0NjZwZnlDN2NUMTVaSTFXd2k1OWhnWUJvckVxYmh3CjNRSmhxSWJiYXU3eHoyNlcyOVVLRWNnUlFJeFBjL2N0YlA5K2hUaU04VDQKLS0tIGN6UVYzMHZJUUhKNmlkQjFOaXRXYUpjbzBOaHRMZkFFVVRPa3FaQUs2dHcKf3AcueEBLdl8lzRwKXik+OvDVg48g44QoPZu0j0NLV4lPLDqoq0="
 TOML
 
-    # Set invalid age key to trigger error
-    export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
+	# Set invalid age key to trigger error
+	export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
 
-    run "$FNOX_BIN" export
-    assert_success
-    # Should output env format even though secret failed to resolve
-    assert_output --partial "# Exported from profile: default"
+	run "$FNOX_BIN" export
+	assert_success
+	# Should output env format even though secret failed to resolve
+	assert_output --partial "# Exported from profile: default"
 }
 
 @test "fnox export with if_missing=ignore silently continues on missing secret" {
-    cat > fnox.toml << 'TOML'
+	cat >fnox.toml <<'TOML'
 root = true
 
 [providers.age]
@@ -86,11 +86,11 @@ value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaaTFhczNBYnN3S1c0NjZwZnlDN2N
 if_missing = "ignore"
 TOML
 
-    # Set invalid age key to trigger error
-    export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
+	# Set invalid age key to trigger error
+	export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
 
-    run "$FNOX_BIN" export
-    assert_success
-    # Should output env format even though secret failed to resolve
-    assert_output --partial "# Exported from profile: default"
+	run "$FNOX_BIN" export
+	assert_success
+	# Should output env format even though secret failed to resolve
+	assert_output --partial "# Exported from profile: default"
 }

--- a/test/gcp_kms.bats
+++ b/test/gcp_kms.bats
@@ -15,70 +15,70 @@
 #
 
 setup() {
-    load 'test_helper/common_setup'
-    _common_setup
+	load 'test_helper/common_setup'
+	_common_setup
 
-    # Determine if we're in CI with secrets access (not a forked PR)
-    local in_ci_with_secrets=false
-    if [ "${CI:-}" = "true" ] || [ -n "${GITHUB_ACTIONS:-}" ]; then
-        # Check if age key is available (indicates secrets are decrypted)
-        if [ -f ~/.config/fnox/age.txt ] || [ -n "${FNOX_AGE_KEY:-}" ]; then
-            in_ci_with_secrets=true
-        fi
-    fi
+	# Determine if we're in CI with secrets access (not a forked PR)
+	local in_ci_with_secrets=false
+	if [ "${CI:-}" = "true" ] || [ -n "${GITHUB_ACTIONS:-}" ]; then
+		# Check if age key is available (indicates secrets are decrypted)
+		if [ -f ~/.config/fnox/age.txt ] || [ -n "${FNOX_AGE_KEY:-}" ]; then
+			in_ci_with_secrets=true
+		fi
+	fi
 
-    # Check if GCP credentials are available
-    if [ -z "$GCP_SERVICE_ACCOUNT_KEY" ] && [ -z "$GOOGLE_APPLICATION_CREDENTIALS" ]; then
-        if [ "$in_ci_with_secrets" = "true" ]; then
-            echo "# ERROR: In CI with secrets access, but GCP_SERVICE_ACCOUNT_KEY is not available!" >&3
-            return 1
-        fi
-        skip "GCP credentials not available. Ensure GCP_SERVICE_ACCOUNT_KEY or GOOGLE_APPLICATION_CREDENTIALS are configured."
-    fi
+	# Check if GCP credentials are available
+	if [ -z "$GCP_SERVICE_ACCOUNT_KEY" ] && [ -z "$GOOGLE_APPLICATION_CREDENTIALS" ]; then
+		if [ "$in_ci_with_secrets" = "true" ]; then
+			echo "# ERROR: In CI with secrets access, but GCP_SERVICE_ACCOUNT_KEY is not available!" >&3
+			return 1
+		fi
+		skip "GCP credentials not available. Ensure GCP_SERVICE_ACCOUNT_KEY or GOOGLE_APPLICATION_CREDENTIALS are configured."
+	fi
 
-    # If GCP_SERVICE_ACCOUNT_KEY is set, create a temp credentials file
-    if [ -n "$GCP_SERVICE_ACCOUNT_KEY" ]; then
-        export GOOGLE_APPLICATION_CREDENTIALS="${TEST_TEMP_DIR}/gcp-creds.json"
-        echo "$GCP_SERVICE_ACCOUNT_KEY" > "$GOOGLE_APPLICATION_CREDENTIALS"
-    fi
+	# If GCP_SERVICE_ACCOUNT_KEY is set, create a temp credentials file
+	if [ -n "$GCP_SERVICE_ACCOUNT_KEY" ]; then
+		export GOOGLE_APPLICATION_CREDENTIALS="${TEST_TEMP_DIR}/gcp-creds.json"
+		echo "$GCP_SERVICE_ACCOUNT_KEY" >"$GOOGLE_APPLICATION_CREDENTIALS"
+	fi
 
-    # Set the KMS key details
-    export GCP_PROJECT="chim-361015"
-    export GCP_LOCATION="global"
-    export GCP_KEYRING="fnox-test"
-    export GCP_KEY="fnox-test-key"
+	# Set the KMS key details
+	export GCP_PROJECT="chim-361015"
+	export GCP_LOCATION="global"
+	export GCP_KEYRING="fnox-test"
+	export GCP_KEY="fnox-test-key"
 
-    # Check if gcloud CLI is installed
-    if ! command -v gcloud >/dev/null 2>&1; then
-        if [ "$in_ci_with_secrets" = "true" ]; then
-            echo "# ERROR: In CI with secrets access, but gcloud CLI is not installed!" >&3
-            return 1
-        fi
-        skip "gcloud CLI not installed. Install with: brew install google-cloud-sdk"
-    fi
+	# Check if gcloud CLI is installed
+	if ! command -v gcloud >/dev/null 2>&1; then
+		if [ "$in_ci_with_secrets" = "true" ]; then
+			echo "# ERROR: In CI with secrets access, but gcloud CLI is not installed!" >&3
+			return 1
+		fi
+		skip "gcloud CLI not installed. Install with: brew install google-cloud-sdk"
+	fi
 
-    # Verify we can access the KMS key
-    if ! gcloud kms keys list --location="$GCP_LOCATION" --keyring="$GCP_KEYRING" --project="$GCP_PROJECT" >/dev/null 2>&1; then
-        if [ "$in_ci_with_secrets" = "true" ]; then
-            echo "# ERROR: In CI with secrets access, but cannot access GCP KMS key!" >&3
-            echo "# This indicates a real problem with GCP access that should be fixed." >&3
-            return 1
-        fi
-        skip "Cannot access GCP KMS key. Key may not exist or permissions may be insufficient."
-    fi
+	# Verify we can access the KMS key
+	if ! gcloud kms keys list --location="$GCP_LOCATION" --keyring="$GCP_KEYRING" --project="$GCP_PROJECT" >/dev/null 2>&1; then
+		if [ "$in_ci_with_secrets" = "true" ]; then
+			echo "# ERROR: In CI with secrets access, but cannot access GCP KMS key!" >&3
+			echo "# This indicates a real problem with GCP access that should be fixed." >&3
+			return 1
+		fi
+		skip "Cannot access GCP KMS key. Key may not exist or permissions may be insufficient."
+	fi
 }
 
 teardown() {
-    _common_teardown
+	_common_teardown
 }
 
 # Helper function to create a GCP KMS test config
 create_gcp_kms_config() {
-    local project="${1:-chim-361015}"
-    local location="${2:-global}"
-    local keyring="${3:-fnox-test}"
-    local key="${4:-fnox-test-key}"
-    cat > "${FNOX_CONFIG_FILE:-fnox.toml}" << EOF
+	local project="${1:-chim-361015}"
+	local location="${2:-global}"
+	local keyring="${3:-fnox-test}"
+	local key="${4:-fnox-test-key}"
+	cat >"${FNOX_CONFIG_FILE:-fnox.toml}" <<EOF
 [providers.gcp_kms]
 type = "gcp-kms"
 project = "$project"
@@ -91,153 +91,153 @@ EOF
 }
 
 @test "fnox set encrypts secret with GCP KMS" {
-    create_gcp_kms_config
+	create_gcp_kms_config
 
-    # Set a secret with KMS encryption
-    run "$FNOX_BIN" set GCP_KMS_TEST_SECRET "my-secret-value" --provider gcp_kms
-    assert_success
-    assert_output --partial "✓ Set secret GCP_KMS_TEST_SECRET"
+	# Set a secret with KMS encryption
+	run "$FNOX_BIN" set GCP_KMS_TEST_SECRET "my-secret-value" --provider gcp_kms
+	assert_success
+	assert_output --partial "✓ Set secret GCP_KMS_TEST_SECRET"
 
-    # Verify the config contains encrypted value (base64)
-    run grep "value =" "${FNOX_CONFIG_FILE}"
-    assert_success
-    assert_output --regexp 'value = "[A-Za-z0-9+/=]{50,}"'
+	# Verify the config contains encrypted value (base64)
+	run grep "value =" "${FNOX_CONFIG_FILE}"
+	assert_success
+	assert_output --regexp 'value = "[A-Za-z0-9+/=]{50,}"'
 }
 
 @test "fnox get decrypts secret from GCP KMS" {
-    create_gcp_kms_config
+	create_gcp_kms_config
 
-    # Set a secret
-    run "$FNOX_BIN" set GCP_KMS_DECRYPT_TEST "test-plaintext-value" --provider gcp_kms
-    assert_success
+	# Set a secret
+	run "$FNOX_BIN" set GCP_KMS_DECRYPT_TEST "test-plaintext-value" --provider gcp_kms
+	assert_success
 
-    # Get the secret back
-    run "$FNOX_BIN" get GCP_KMS_DECRYPT_TEST
-    assert_success
-    assert_output "test-plaintext-value"
+	# Get the secret back
+	run "$FNOX_BIN" get GCP_KMS_DECRYPT_TEST
+	assert_success
+	assert_output "test-plaintext-value"
 }
 
 @test "fnox set and get with special characters" {
-    create_gcp_kms_config
+	create_gcp_kms_config
 
-    # Set a secret with special characters
-    local special_value='{"password":"p@ssw0rd!","key":"abc=123&xyz"}'
-    run "$FNOX_BIN" set GCP_KMS_SPECIAL_CHARS "$special_value" --provider gcp_kms
-    assert_success
+	# Set a secret with special characters
+	local special_value='{"password":"p@ssw0rd!","key":"abc=123&xyz"}'
+	run "$FNOX_BIN" set GCP_KMS_SPECIAL_CHARS "$special_value" --provider gcp_kms
+	assert_success
 
-    # Get the secret back
-    run "$FNOX_BIN" get GCP_KMS_SPECIAL_CHARS
-    assert_success
-    assert_output "$special_value"
+	# Get the secret back
+	run "$FNOX_BIN" get GCP_KMS_SPECIAL_CHARS
+	assert_success
+	assert_output "$special_value"
 }
 
 @test "fnox set with multiline secret" {
-    create_gcp_kms_config
+	create_gcp_kms_config
 
-    # Set a multiline secret
-    local multiline_value="line1
+	# Set a multiline secret
+	local multiline_value="line1
 line2
 line3"
-    run "$FNOX_BIN" set GCP_KMS_MULTILINE "$multiline_value" --provider gcp_kms
-    assert_success
+	run "$FNOX_BIN" set GCP_KMS_MULTILINE "$multiline_value" --provider gcp_kms
+	assert_success
 
-    # Get the secret back
-    run "$FNOX_BIN" get GCP_KMS_MULTILINE
-    assert_success
-    assert_output "$multiline_value"
+	# Get the secret back
+	run "$FNOX_BIN" get GCP_KMS_MULTILINE
+	assert_success
+	assert_output "$multiline_value"
 }
 
 @test "fnox get fails with invalid ciphertext" {
-    create_gcp_kms_config
+	create_gcp_kms_config
 
-    # Manually create config with invalid base64 ciphertext
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	# Manually create config with invalid base64 ciphertext
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.INVALID_CIPHERTEXT]
 provider = "gcp_kms"
 value = "invalid-base64-!@#$%"
 EOF
 
-    run "$FNOX_BIN" get INVALID_CIPHERTEXT
-    assert_failure
-    assert_output --partial "Failed to decode base64 ciphertext"
+	run "$FNOX_BIN" get INVALID_CIPHERTEXT
+	assert_failure
+	assert_output --partial "Failed to decode base64 ciphertext"
 }
 
 @test "fnox list shows GCP KMS secrets" {
-    create_gcp_kms_config
+	create_gcp_kms_config
 
-    # Set a couple of secrets
-    run "$FNOX_BIN" set GCP_KMS_SECRET_1 "value1" --provider gcp_kms --description "First GCP KMS secret"
-    assert_success
+	# Set a couple of secrets
+	run "$FNOX_BIN" set GCP_KMS_SECRET_1 "value1" --provider gcp_kms --description "First GCP KMS secret"
+	assert_success
 
-    run "$FNOX_BIN" set GCP_KMS_SECRET_2 "value2" --provider gcp_kms --description "Second GCP KMS secret"
-    assert_success
+	run "$FNOX_BIN" set GCP_KMS_SECRET_2 "value2" --provider gcp_kms --description "Second GCP KMS secret"
+	assert_success
 
-    run "$FNOX_BIN" list
-    assert_success
-    assert_output --partial "GCP_KMS_SECRET_1"
-    assert_output --partial "GCP_KMS_SECRET_2"
-    assert_output --partial "First GCP KMS secret"
+	run "$FNOX_BIN" list
+	assert_success
+	assert_output --partial "GCP_KMS_SECRET_1"
+	assert_output --partial "GCP_KMS_SECRET_2"
+	assert_output --partial "First GCP KMS secret"
 }
 
 @test "fnox set with description" {
-    create_gcp_kms_config
+	create_gcp_kms_config
 
-    run "$FNOX_BIN" set GCP_KMS_WITH_DESC "test-value" --provider gcp_kms --description "My GCP KMS secret"
-    assert_success
+	run "$FNOX_BIN" set GCP_KMS_WITH_DESC "test-value" --provider gcp_kms --description "My GCP KMS secret"
+	assert_success
 
-    # Verify description is in config
-    run grep "description" "${FNOX_CONFIG_FILE}"
-    assert_success
-    assert_output --partial "My GCP KMS secret"
+	# Verify description is in config
+	run grep "description" "${FNOX_CONFIG_FILE}"
+	assert_success
+	assert_output --partial "My GCP KMS secret"
 }
 
 @test "GCP KMS encryption produces different ciphertext each time" {
-    create_gcp_kms_config
+	create_gcp_kms_config
 
-    # Set a secret twice with the same value
-    run "$FNOX_BIN" set GCP_KMS_UNIQUE_1 "same-value" --provider gcp_kms
-    assert_success
+	# Set a secret twice with the same value
+	run "$FNOX_BIN" set GCP_KMS_UNIQUE_1 "same-value" --provider gcp_kms
+	assert_success
 
-    # Set again with same value
-    run "$FNOX_BIN" set GCP_KMS_UNIQUE_2 "same-value" --provider gcp_kms
-    assert_success
+	# Set again with same value
+	run "$FNOX_BIN" set GCP_KMS_UNIQUE_2 "same-value" --provider gcp_kms
+	assert_success
 
-    # Get the encrypted values from config (inline table format)
-    # Secrets are now stored as: GCP_KMS_UNIQUE_1 = { provider = "gcp_kms", value = "..." }
-    cipher1=$(grep "^GCP_KMS_UNIQUE_1\s*=" "${FNOX_CONFIG_FILE}" | sed 's/.*value = "\([^"]*\)".*/\1/')
-    cipher2=$(grep "^GCP_KMS_UNIQUE_2\s*=" "${FNOX_CONFIG_FILE}" | sed 's/.*value = "\([^"]*\)".*/\1/')
+	# Get the encrypted values from config (inline table format)
+	# Secrets are now stored as: GCP_KMS_UNIQUE_1 = { provider = "gcp_kms", value = "..." }
+	cipher1=$(grep "^GCP_KMS_UNIQUE_1\s*=" "${FNOX_CONFIG_FILE}" | sed 's/.*value = "\([^"]*\)".*/\1/')
+	cipher2=$(grep "^GCP_KMS_UNIQUE_2\s*=" "${FNOX_CONFIG_FILE}" | sed 's/.*value = "\([^"]*\)".*/\1/')
 
-    # Verify ciphertexts were extracted
-    [ -n "$cipher1" ]
-    [ -n "$cipher2" ]
+	# Verify ciphertexts were extracted
+	[ -n "$cipher1" ]
+	[ -n "$cipher2" ]
 
-    # Ciphertexts should be different (KMS adds randomness)
-    [ "$cipher1" != "$cipher2" ]
+	# Ciphertexts should be different (KMS adds randomness)
+	[ "$cipher1" != "$cipher2" ]
 
-    # But both should decrypt to the same value
-    run "$FNOX_BIN" get GCP_KMS_UNIQUE_1
-    assert_success
-    assert_output "same-value"
+	# But both should decrypt to the same value
+	run "$FNOX_BIN" get GCP_KMS_UNIQUE_1
+	assert_success
+	assert_output "same-value"
 
-    run "$FNOX_BIN" get GCP_KMS_UNIQUE_2
-    assert_success
-    assert_output "same-value"
+	run "$FNOX_BIN" get GCP_KMS_UNIQUE_2
+	assert_success
+	assert_output "same-value"
 }
 
 @test "fnox set updates existing GCP KMS secret" {
-    create_gcp_kms_config
+	create_gcp_kms_config
 
-    # Set initial value
-    run "$FNOX_BIN" set GCP_KMS_UPDATE_TEST "initial-value" --provider gcp_kms
-    assert_success
+	# Set initial value
+	run "$FNOX_BIN" set GCP_KMS_UPDATE_TEST "initial-value" --provider gcp_kms
+	assert_success
 
-    # Update with new value
-    run "$FNOX_BIN" set GCP_KMS_UPDATE_TEST "updated-value" --provider gcp_kms
-    assert_success
+	# Update with new value
+	run "$FNOX_BIN" set GCP_KMS_UPDATE_TEST "updated-value" --provider gcp_kms
+	assert_success
 
-    # Verify new value is retrieved
-    run "$FNOX_BIN" get GCP_KMS_UPDATE_TEST
-    assert_success
-    assert_output "updated-value"
+	# Verify new value is retrieved
+	run "$FNOX_BIN" get GCP_KMS_UPDATE_TEST
+	assert_success
+	assert_output "updated-value"
 }

--- a/test/gcp_secret_manager.bats
+++ b/test/gcp_secret_manager.bats
@@ -15,153 +15,153 @@
 #
 
 setup() {
-    load 'test_helper/common_setup'
-    _common_setup
+	load 'test_helper/common_setup'
+	_common_setup
 
-    # Determine if we're in CI with secrets access (not a forked PR)
-    local in_ci_with_secrets=false
-    if [ "${CI:-}" = "true" ] || [ -n "${GITHUB_ACTIONS:-}" ]; then
-        # Check if age key is available (indicates secrets are decrypted)
-        if [ -f ~/.config/fnox/age.txt ] || [ -n "${FNOX_AGE_KEY:-}" ]; then
-            in_ci_with_secrets=true
-        fi
-    fi
+	# Determine if we're in CI with secrets access (not a forked PR)
+	local in_ci_with_secrets=false
+	if [ "${CI:-}" = "true" ] || [ -n "${GITHUB_ACTIONS:-}" ]; then
+		# Check if age key is available (indicates secrets are decrypted)
+		if [ -f ~/.config/fnox/age.txt ] || [ -n "${FNOX_AGE_KEY:-}" ]; then
+			in_ci_with_secrets=true
+		fi
+	fi
 
-    # Check if GCP credentials are available
-    if [ -z "$GCP_SERVICE_ACCOUNT_KEY" ] && [ -z "$GOOGLE_APPLICATION_CREDENTIALS" ]; then
-        if [ "$in_ci_with_secrets" = "true" ]; then
-            echo "# ERROR: In CI with secrets access, but GCP_SERVICE_ACCOUNT_KEY is not available!" >&3
-            return 1
-        fi
-        skip "GCP credentials not available. Ensure GCP_SERVICE_ACCOUNT_KEY or GOOGLE_APPLICATION_CREDENTIALS are configured."
-    fi
+	# Check if GCP credentials are available
+	if [ -z "$GCP_SERVICE_ACCOUNT_KEY" ] && [ -z "$GOOGLE_APPLICATION_CREDENTIALS" ]; then
+		if [ "$in_ci_with_secrets" = "true" ]; then
+			echo "# ERROR: In CI with secrets access, but GCP_SERVICE_ACCOUNT_KEY is not available!" >&3
+			return 1
+		fi
+		skip "GCP credentials not available. Ensure GCP_SERVICE_ACCOUNT_KEY or GOOGLE_APPLICATION_CREDENTIALS are configured."
+	fi
 
-    # If GCP_SERVICE_ACCOUNT_KEY is set, create a temp credentials file
-    if [ -n "$GCP_SERVICE_ACCOUNT_KEY" ]; then
-        export GOOGLE_APPLICATION_CREDENTIALS="${TEST_TEMP_DIR}/gcp-creds.json"
-        echo "$GCP_SERVICE_ACCOUNT_KEY" > "$GOOGLE_APPLICATION_CREDENTIALS"
-    fi
+	# If GCP_SERVICE_ACCOUNT_KEY is set, create a temp credentials file
+	if [ -n "$GCP_SERVICE_ACCOUNT_KEY" ]; then
+		export GOOGLE_APPLICATION_CREDENTIALS="${TEST_TEMP_DIR}/gcp-creds.json"
+		echo "$GCP_SERVICE_ACCOUNT_KEY" >"$GOOGLE_APPLICATION_CREDENTIALS"
+	fi
 
-    # Set the project
-    export GCP_PROJECT="chim-361015"
+	# Set the project
+	export GCP_PROJECT="chim-361015"
 
-    # Check if gcloud CLI is installed
-    if ! command -v gcloud >/dev/null 2>&1; then
-        if [ "$in_ci_with_secrets" = "true" ]; then
-            echo "# ERROR: In CI with secrets access, but gcloud CLI is not installed!" >&3
-            return 1
-        fi
-        skip "gcloud CLI not installed. Install with: brew install google-cloud-sdk"
-    fi
+	# Check if gcloud CLI is installed
+	if ! command -v gcloud >/dev/null 2>&1; then
+		if [ "$in_ci_with_secrets" = "true" ]; then
+			echo "# ERROR: In CI with secrets access, but gcloud CLI is not installed!" >&3
+			return 1
+		fi
+		skip "gcloud CLI not installed. Install with: brew install google-cloud-sdk"
+	fi
 
-    # Verify we can access Secret Manager
-    if ! gcloud secrets list --project="$GCP_PROJECT" --limit=1 >/dev/null 2>&1; then
-        if [ "$in_ci_with_secrets" = "true" ]; then
-            echo "# ERROR: In CI with secrets access, but cannot access GCP Secret Manager!" >&3
-            echo "# This indicates a real problem with GCP access that should be fixed." >&3
-            return 1
-        fi
-        skip "Cannot access GCP Secret Manager. Permissions may be insufficient."
-    fi
+	# Verify we can access Secret Manager
+	if ! gcloud secrets list --project="$GCP_PROJECT" --limit=1 >/dev/null 2>&1; then
+		if [ "$in_ci_with_secrets" = "true" ]; then
+			echo "# ERROR: In CI with secrets access, but cannot access GCP Secret Manager!" >&3
+			echo "# This indicates a real problem with GCP access that should be fixed." >&3
+			return 1
+		fi
+		skip "Cannot access GCP Secret Manager. Permissions may be insufficient."
+	fi
 }
 
 teardown() {
-    _common_teardown
+	_common_teardown
 }
 
 # Helper function to create a GCP Secret Manager test config
 create_gcp_sm_config() {
-    local project="${1:-chim-361015}"
-    local prefix="${2:-}"
-    cat > "${FNOX_CONFIG_FILE:-fnox.toml}" << EOF
+	local project="${1:-chim-361015}"
+	local prefix="${2:-}"
+	cat >"${FNOX_CONFIG_FILE:-fnox.toml}" <<EOF
 [providers.gcp_sm]
 type = "gcp-sm"
 project = "$project"
 EOF
 
-    if [ -n "$prefix" ]; then
-        echo "prefix = \"$prefix\"" >> "${FNOX_CONFIG_FILE}"
-    fi
+	if [ -n "$prefix" ]; then
+		echo "prefix = \"$prefix\"" >>"${FNOX_CONFIG_FILE}"
+	fi
 
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets]
 EOF
 }
 
 @test "fnox get retrieves secret from GCP Secret Manager" {
-    create_gcp_sm_config
+	create_gcp_sm_config
 
-    # Add secret reference to config (using existing test secret)
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	# Add secret reference to config (using existing test secret)
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.GCP_SM_TEST]
 provider = "gcp_sm"
 value = "fnox-test-secret-1"
 EOF
 
-    # Get the secret
-    run "$FNOX_BIN" get GCP_SM_TEST
-    assert_success
-    assert_output "test-secret-value-1"
+	# Get the secret
+	run "$FNOX_BIN" get GCP_SM_TEST
+	assert_success
+	assert_output "test-secret-value-1"
 }
 
 @test "fnox get retrieves second test secret" {
-    create_gcp_sm_config
+	create_gcp_sm_config
 
-    # Add secret reference to config
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	# Add secret reference to config
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.GCP_SM_TEST_2]
 provider = "gcp_sm"
 value = "fnox-test-secret-2"
 EOF
 
-    # Get the secret
-    run "$FNOX_BIN" get GCP_SM_TEST_2
-    assert_success
-    assert_output "test-secret-value-2"
+	# Get the secret
+	run "$FNOX_BIN" get GCP_SM_TEST_2
+	assert_success
+	assert_output "test-secret-value-2"
 }
 
 @test "fnox get retrieves JSON secret from GCP Secret Manager" {
-    create_gcp_sm_config
+	create_gcp_sm_config
 
-    # Add secret reference to config
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	# Add secret reference to config
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.GCP_SM_JSON]
 provider = "gcp_sm"
 value = "fnox-test-secret-json"
 EOF
 
-    # Get the secret
-    run "$FNOX_BIN" get GCP_SM_JSON
-    assert_success
-    assert_output '{"key":"value"}'
+	# Get the secret
+	run "$FNOX_BIN" get GCP_SM_JSON
+	assert_success
+	assert_output '{"key":"value"}'
 }
 
 @test "fnox get fails with non-existent secret" {
-    create_gcp_sm_config
+	create_gcp_sm_config
 
-    # Add reference to non-existent secret
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	# Add reference to non-existent secret
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.GCP_SM_NONEXISTENT]
 provider = "gcp_sm"
 value = "this-secret-does-not-exist"
 EOF
 
-    # Try to get the secret
-    run "$FNOX_BIN" get GCP_SM_NONEXISTENT
-    assert_failure
-    assert_output --partial "Failed to access secret"
+	# Try to get the secret
+	run "$FNOX_BIN" get GCP_SM_NONEXISTENT
+	assert_failure
+	assert_output --partial "Failed to access secret"
 }
 
 @test "fnox list shows GCP Secret Manager secrets" {
-    create_gcp_sm_config
+	create_gcp_sm_config
 
-    # Add multiple secret references
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	# Add multiple secret references
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.GCP_SM_LIST_1]
 description = "First GCP SM secret"
@@ -174,57 +174,58 @@ provider = "gcp_sm"
 value = "fnox-test-secret-2"
 EOF
 
-    run "$FNOX_BIN" list
-    assert_success
-    assert_output --partial "GCP_SM_LIST_1"
-    assert_output --partial "GCP_SM_LIST_2"
-    assert_output --partial "First GCP SM secret"
-    assert_output --partial "Second GCP SM secret"
+	run "$FNOX_BIN" list
+	assert_success
+	assert_output --partial "GCP_SM_LIST_1"
+	assert_output --partial "GCP_SM_LIST_2"
+	assert_output --partial "First GCP SM secret"
+	assert_output --partial "Second GCP SM secret"
 }
 
 @test "GCP Secret Manager uses latest version" {
-    create_gcp_sm_config
+	create_gcp_sm_config
 
-    # Add secret reference (should use latest version)
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	# Add secret reference (should use latest version)
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.GCP_SM_LATEST]
 provider = "gcp_sm"
 value = "fnox-test-secret-1"
 EOF
 
-    # Get the secret (should retrieve latest version)
-    run "$FNOX_BIN" get GCP_SM_LATEST
-    assert_success
-    assert_output "test-secret-value-1"
+	# Get the secret (should retrieve latest version)
+	run "$FNOX_BIN" get GCP_SM_LATEST
+	assert_success
+	assert_output "test-secret-value-1"
 }
 
 @test "fnox exec sets GCP Secret Manager environment variables" {
-    # Skip: Test isolation issue - fnox exec inherits parent config with age secrets
-    # Exec functionality is tested in other test files
-    skip "Test isolation issue with fnox exec under bats"
+	# Skip: Test isolation issue - fnox exec inherits parent config with age secrets
+	# Exec functionality is tested in other test files
+	skip "Test isolation issue with fnox exec under bats"
 
-    create_gcp_sm_config
+	create_gcp_sm_config
 
-    # Add secret reference
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	# Add secret reference
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.MY_GCP_SM_VAR]
 provider = "gcp_sm"
 value = "fnox-test-secret-1"
 EOF
 
-    # Use exec to run a command with the secret as env var
-    run "$FNOX_BIN" exec -- sh -c 'echo $MY_GCP_SM_VAR'
-    assert_success
-    assert_output "test-secret-value-1"
+	# Use exec to run a command with the secret as env var
+	# shellcheck disable=SC2016 # Single quotes intentional - variable should expand in subshell
+	run "$FNOX_BIN" exec -- sh -c 'echo $MY_GCP_SM_VAR'
+	assert_success
+	assert_output "test-secret-value-1"
 }
 
 @test "GCP Secret Manager provider works with description" {
-    create_gcp_sm_config
+	create_gcp_sm_config
 
-    # Add secret reference with description
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	# Add secret reference with description
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.GCP_SM_WITH_DESC]
 description = "My GCP Secret Manager secret"
@@ -232,62 +233,64 @@ provider = "gcp_sm"
 value = "fnox-test-secret-1"
 EOF
 
-    # Verify description is in config
-    run grep "description" "${FNOX_CONFIG_FILE}"
-    assert_success
-    assert_output --partial "My GCP Secret Manager secret"
+	# Verify description is in config
+	run grep "description" "${FNOX_CONFIG_FILE}"
+	assert_success
+	assert_output --partial "My GCP Secret Manager secret"
 
-    # Verify secret can be retrieved
-    run "$FNOX_BIN" get GCP_SM_WITH_DESC
-    assert_success
-    assert_output "test-secret-value-1"
+	# Verify secret can be retrieved
+	run "$FNOX_BIN" get GCP_SM_WITH_DESC
+	assert_success
+	assert_output "test-secret-value-1"
 }
 
 @test "GCP Secret Manager provider works without prefix" {
-    create_gcp_sm_config "chim-361015" ""
+	create_gcp_sm_config "chim-361015" ""
 
-    # Add secret reference without prefix
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	# Add secret reference without prefix
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.GCP_SM_NO_PREFIX]
 provider = "gcp_sm"
 value = "fnox-test-secret-1"
 EOF
 
-    # Get the secret
-    run "$FNOX_BIN" get GCP_SM_NO_PREFIX
-    assert_success
-    assert_output "test-secret-value-1"
+	# Get the secret
+	run "$FNOX_BIN" get GCP_SM_NO_PREFIX
+	assert_success
+	assert_output "test-secret-value-1"
 }
 
 @test "fnox set creates secret in GCP Secret Manager" {
-    create_gcp_sm_config
+	create_gcp_sm_config
 
-    # Create a temporary secret with unique name using fnox set
-    local secret_name="fnox-test-create-$(date +%s)-$$-${BATS_TEST_NUMBER:-0}"
-    local secret_value="my-test-secret-value-$(date +%s)-$$-${BATS_TEST_NUMBER:-0}"
-    
-    # Set the secret name for teardown cleanup
-    export TEST_SECRET_NAME="fnox-test-create-GCP_SM_CREATE_TEST"
+	# Create a temporary secret with unique name using fnox set
+	local secret_name
+	secret_name="fnox-test-create-$(date +%s)-$$-${BATS_TEST_NUMBER:-0}"
+	local secret_value
+	secret_value="my-test-secret-value-$(date +%s)-$$-${BATS_TEST_NUMBER:-0}"
 
-    # Add secret to config so fnox set will use GCP SM provider
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	# Set the secret name for teardown cleanup
+	export TEST_SECRET_NAME="fnox-test-create-GCP_SM_CREATE_TEST"
+
+	# Add secret to config so fnox set will use GCP SM provider
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.GCP_SM_CREATE_TEST]
 provider = "gcp_sm"
 value = "$secret_name"
 EOF
 
-    # Create the secret using fnox set (should use GCP SM provider)
-    run "$FNOX_BIN" set GCP_SM_CREATE_TEST "$secret_value" --provider gcp_sm
-    assert_success
+	# Create the secret using fnox set (should use GCP SM provider)
+	run "$FNOX_BIN" set GCP_SM_CREATE_TEST "$secret_value" --provider gcp_sm
+	assert_success
 
-    # Get the secret back to verify it was created correctly
-    run "$FNOX_BIN" get GCP_SM_CREATE_TEST
-    assert_success
-    assert_output "$secret_value"
+	# Get the secret back to verify it was created correctly
+	run "$FNOX_BIN" get GCP_SM_CREATE_TEST
+	assert_success
+	assert_output "$secret_value"
 
-    # Cleanup - delete actual secret created by fnox set
-    # fnox set creates a secret with the provider prefix + secret key
-    gcloud secrets delete "$TEST_SECRET_NAME" --project="$GCP_PROJECT" --quiet >/dev/null 2>&1 || true
+	# Cleanup - delete actual secret created by fnox set
+	# fnox set creates a secret with the provider prefix + secret key
+	gcloud secrets delete "$TEST_SECRET_NAME" --project="$GCP_PROJECT" --quiet >/dev/null 2>&1 || true
 }

--- a/test/hook_env_plain_inheritance.bats
+++ b/test/hook_env_plain_inheritance.bats
@@ -4,23 +4,23 @@
 #
 
 setup() {
-    load 'test_helper/common_setup'
-    _common_setup
+	load 'test_helper/common_setup'
+	_common_setup
 
-    # Suppress shell integration output for cleaner test output
-    export FNOX_SHELL_INTEGRATION_OUTPUT="none"
+	# Suppress shell integration output for cleaner test output
+	export FNOX_SHELL_INTEGRATION_OUTPUT="none"
 }
 
 teardown() {
-    _common_teardown
+	_common_teardown
 }
 
 @test "hook-env inherits plain provider from parent config" {
-    # Create directory structure
-    mkdir -p parent/child
+	# Create directory structure
+	mkdir -p parent/child
 
-    # Create parent config with plain provider
-    cat > parent/fnox.toml <<EOF
+	# Create parent config with plain provider
+	cat >parent/fnox.toml <<EOF
 [providers.plain]
 type = "plain"
 
@@ -30,45 +30,45 @@ value = "parent-plain-value"
 description = "Parent secret"
 EOF
 
-    # Create child config that uses plain provider but doesn't define it
-    cat > parent/child/fnox.toml <<EOF
+	# Create child config that uses plain provider but doesn't define it
+	cat >parent/child/fnox.toml <<EOF
 [secrets.CHILD_SECRET]
 provider = "plain"
 value = "child-plain-value"
 description = "Child secret"
 EOF
 
-    # Change to child directory
-    cd parent/child
+	# Change to child directory
+	cd parent/child
 
-    # Test 1: fnox ls should show both secrets merged
-    run "$FNOX_BIN" ls
-    assert_success
-    assert_output --partial "PARENT_SECRET"
-    assert_output --partial "CHILD_SECRET"
+	# Test 1: fnox ls should show both secrets merged
+	run "$FNOX_BIN" ls
+	assert_success
+	assert_output --partial "PARENT_SECRET"
+	assert_output --partial "CHILD_SECRET"
 
-    # Test 2: fnox get should work for child secret (inheriting parent provider)
-    run "$FNOX_BIN" get CHILD_SECRET
-    assert_success
-    assert_output "child-plain-value"
+	# Test 2: fnox get should work for child secret (inheriting parent provider)
+	run "$FNOX_BIN" get CHILD_SECRET
+	assert_success
+	assert_output "child-plain-value"
 
-    # Test 3: fnox hook-env should load both secrets without error
-    run bash -c "eval \"\$('$FNOX_BIN' hook-env -s bash 2>/dev/null)\" && echo \$CHILD_SECRET"
-    assert_success
-    assert_output "child-plain-value"
+	# Test 3: fnox hook-env should load both secrets without error
+	run bash -c "eval \"\$('$FNOX_BIN' hook-env -s bash 2>/dev/null)\" && echo \$CHILD_SECRET"
+	assert_success
+	assert_output "child-plain-value"
 
-    # Test 4: Verify no warning about provider not found
-    run "$FNOX_BIN" hook-env -s bash 2>&1
-    assert_success
-    refute_output --partial "Provider 'plain' not found"
+	# Test 4: Verify no warning about provider not found
+	run "$FNOX_BIN" hook-env -s bash 2>&1
+	assert_success
+	refute_output --partial "Provider 'plain' not found"
 }
 
 @test "hook-env with nested provider inheritance (3 levels)" {
-    # Create directory structure
-    mkdir -p root/parent/child
+	# Create directory structure
+	mkdir -p root/parent/child
 
-    # Create root config with plain provider
-    cat > root/fnox.toml <<EOF
+	# Create root config with plain provider
+	cat >root/fnox.toml <<EOF
 [providers.plain]
 type = "plain"
 
@@ -78,62 +78,62 @@ value = "root-value"
 description = "Root secret"
 EOF
 
-    # Create parent config (no provider, just secrets)
-    cat > root/parent/fnox.toml <<EOF
+	# Create parent config (no provider, just secrets)
+	cat >root/parent/fnox.toml <<EOF
 [secrets.PARENT_SECRET]
 provider = "plain"
 value = "parent-value"
 description = "Parent secret"
 EOF
 
-    # Create child config (no provider, just secrets)
-    cat > root/parent/child/fnox.toml <<EOF
+	# Create child config (no provider, just secrets)
+	cat >root/parent/child/fnox.toml <<EOF
 [secrets.CHILD_SECRET]
 provider = "plain"
 value = "child-value"
 description = "Child secret"
 EOF
 
-    # Change to child directory (deepest level)
-    cd root/parent/child
+	# Change to child directory (deepest level)
+	cd root/parent/child
 
-    # Test 1: fnox ls should show all three secrets
-    run "$FNOX_BIN" ls
-    assert_success
-    assert_output --partial "ROOT_SECRET"
-    assert_output --partial "PARENT_SECRET"
-    assert_output --partial "CHILD_SECRET"
+	# Test 1: fnox ls should show all three secrets
+	run "$FNOX_BIN" ls
+	assert_success
+	assert_output --partial "ROOT_SECRET"
+	assert_output --partial "PARENT_SECRET"
+	assert_output --partial "CHILD_SECRET"
 
-    # Test 2: fnox get should work for all secrets
-    run "$FNOX_BIN" get ROOT_SECRET
-    assert_success
-    assert_output "root-value"
+	# Test 2: fnox get should work for all secrets
+	run "$FNOX_BIN" get ROOT_SECRET
+	assert_success
+	assert_output "root-value"
 
-    run "$FNOX_BIN" get PARENT_SECRET
-    assert_success
-    assert_output "parent-value"
+	run "$FNOX_BIN" get PARENT_SECRET
+	assert_success
+	assert_output "parent-value"
 
-    run "$FNOX_BIN" get CHILD_SECRET
-    assert_success
-    assert_output "child-value"
+	run "$FNOX_BIN" get CHILD_SECRET
+	assert_success
+	assert_output "child-value"
 
-    # Test 3: hook-env should load all secrets without error
-    run bash -c "eval \"\$('$FNOX_BIN' hook-env -s bash 2>/dev/null)\" && echo \$CHILD_SECRET"
-    assert_success
-    assert_output "child-value"
+	# Test 3: hook-env should load all secrets without error
+	run bash -c "eval \"\$('$FNOX_BIN' hook-env -s bash 2>/dev/null)\" && echo \$CHILD_SECRET"
+	assert_success
+	assert_output "child-value"
 
-    # Test 4: Verify no warnings
-    run "$FNOX_BIN" hook-env -s bash 2>&1
-    assert_success
-    refute_output --partial "Provider 'plain' not found"
+	# Test 4: Verify no warnings
+	run "$FNOX_BIN" hook-env -s bash 2>&1
+	assert_success
+	refute_output --partial "Provider 'plain' not found"
 }
 
 @test "hook-env merges secrets from multiple config levels" {
-    # Create directory structure
-    mkdir -p parent/child
+	# Create directory structure
+	mkdir -p parent/child
 
-    # Create parent config
-    cat > parent/fnox.toml <<EOF
+	# Create parent config
+	cat >parent/fnox.toml <<EOF
 [providers.plain]
 type = "plain"
 
@@ -146,8 +146,8 @@ provider = "plain"
 value = "value2"
 EOF
 
-    # Create child config with additional secrets
-    cat > parent/child/fnox.toml <<EOF
+	# Create child config with additional secrets
+	cat >parent/child/fnox.toml <<EOF
 [secrets.SECRET3]
 provider = "plain"
 value = "value3"
@@ -157,21 +157,21 @@ provider = "plain"
 value = "value4"
 EOF
 
-    # Change to child directory
-    cd parent/child
+	# Change to child directory
+	cd parent/child
 
-    # hook-env should load all 4 secrets
-    run bash -c "eval \"\$('$FNOX_BIN' hook-env -s bash 2>/dev/null)\" && echo \$SECRET1 \$SECRET2 \$SECRET3 \$SECRET4"
-    assert_success
-    assert_output "value1 value2 value3 value4"
+	# hook-env should load all 4 secrets
+	run bash -c "eval \"\$('$FNOX_BIN' hook-env -s bash 2>/dev/null)\" && echo \$SECRET1 \$SECRET2 \$SECRET3 \$SECRET4"
+	assert_success
+	assert_output "value1 value2 value3 value4"
 }
 
 @test "hook-env respects child override of parent secret" {
-    # Create directory structure
-    mkdir -p parent/child
+	# Create directory structure
+	mkdir -p parent/child
 
-    # Create parent config
-    cat > parent/fnox.toml <<EOF
+	# Create parent config
+	cat >parent/fnox.toml <<EOF
 [providers.plain]
 type = "plain"
 
@@ -180,28 +180,28 @@ provider = "plain"
 value = "parent-value"
 EOF
 
-    # Create child config that overrides parent secret
-    cat > parent/child/fnox.toml <<EOF
+	# Create child config that overrides parent secret
+	cat >parent/child/fnox.toml <<EOF
 [secrets.SHARED_SECRET]
 provider = "plain"
 value = "child-override-value"
 EOF
 
-    # Change to child directory
-    cd parent/child
+	# Change to child directory
+	cd parent/child
 
-    # Should get the child's value, not the parent's
-    run bash -c "eval \"\$('$FNOX_BIN' hook-env -s bash 2>/dev/null)\" && echo \$SHARED_SECRET"
-    assert_success
-    assert_output "child-override-value"
+	# Should get the child's value, not the parent's
+	run bash -c "eval \"\$('$FNOX_BIN' hook-env -s bash 2>/dev/null)\" && echo \$SHARED_SECRET"
+	assert_success
+	assert_output "child-override-value"
 }
 
 @test "hook-env loads fnox.local.toml and merges with fnox.toml" {
-    # Create directory with both fnox.toml and fnox.local.toml
-    mkdir -p test_dir
+	# Create directory with both fnox.toml and fnox.local.toml
+	mkdir -p test_dir
 
-    # Create main config
-    cat > test_dir/fnox.toml <<EOF
+	# Create main config
+	cat >test_dir/fnox.toml <<EOF
 [providers.plain]
 type = "plain"
 
@@ -210,8 +210,8 @@ provider = "plain"
 value = "main-value"
 EOF
 
-    # Create local config that overrides and adds secrets
-    cat > test_dir/fnox.local.toml <<EOF
+	# Create local config that overrides and adds secrets
+	cat >test_dir/fnox.local.toml <<EOF
 [secrets.MAIN_SECRET]
 provider = "plain"
 value = "local-override"
@@ -221,20 +221,20 @@ provider = "plain"
 value = "local-only"
 EOF
 
-    cd test_dir
+	cd test_dir
 
-    # Both secrets should be loaded, with local override taking precedence
-    run bash -c "eval \"\$('$FNOX_BIN' hook-env -s bash 2>/dev/null)\" && echo \$MAIN_SECRET \$LOCAL_SECRET"
-    assert_success
-    assert_output "local-override local-only"
+	# Both secrets should be loaded, with local override taking precedence
+	run bash -c "eval \"\$('$FNOX_BIN' hook-env -s bash 2>/dev/null)\" && echo \$MAIN_SECRET \$LOCAL_SECRET"
+	assert_success
+	assert_output "local-override local-only"
 }
 
 @test "hook-env inherits provider from parent with local config override" {
-    # Create directory structure
-    mkdir -p parent/child
+	# Create directory structure
+	mkdir -p parent/child
 
-    # Create parent config with provider
-    cat > parent/fnox.toml <<EOF
+	# Create parent config with provider
+	cat >parent/fnox.toml <<EOF
 [providers.plain]
 type = "plain"
 
@@ -243,24 +243,24 @@ provider = "plain"
 value = "parent-value"
 EOF
 
-    # Create child main config
-    cat > parent/child/fnox.toml <<EOF
+	# Create child main config
+	cat >parent/child/fnox.toml <<EOF
 [secrets.CHILD_SECRET]
 provider = "plain"
 value = "child-value"
 EOF
 
-    # Create child local config (inherits provider from parent)
-    cat > parent/child/fnox.local.toml <<EOF
+	# Create child local config (inherits provider from parent)
+	cat >parent/child/fnox.local.toml <<EOF
 [secrets.LOCAL_SECRET]
 provider = "plain"
 value = "local-value"
 EOF
 
-    cd parent/child
+	cd parent/child
 
-    # All three secrets should be loaded
-    run bash -c "eval \"\$('$FNOX_BIN' hook-env -s bash 2>/dev/null)\" && echo \$PARENT_SECRET \$CHILD_SECRET \$LOCAL_SECRET"
-    assert_success
-    assert_output "parent-value child-value local-value"
+	# All three secrets should be loaded
+	run bash -c "eval \"\$('$FNOX_BIN' hook-env -s bash 2>/dev/null)\" && echo \$PARENT_SECRET \$CHILD_SECRET \$LOCAL_SECRET"
+	assert_success
+	assert_output "parent-value child-value local-value"
 }

--- a/test/hook_env_provider_inheritance.bats
+++ b/test/hook_env_provider_inheritance.bats
@@ -4,60 +4,60 @@
 #
 
 setup() {
-    load 'test_helper/common_setup'
-    _common_setup
+	load 'test_helper/common_setup'
+	_common_setup
 
-    # Check if keychain tests are disabled via env var
-    if [ -n "$SKIP_KEYCHAIN_TESTS" ]; then
-        skip "Keychain tests disabled via SKIP_KEYCHAIN_TESTS env var"
-    fi
+	# Check if keychain tests are disabled via env var
+	if [ -n "$SKIP_KEYCHAIN_TESTS" ]; then
+		skip "Keychain tests disabled via SKIP_KEYCHAIN_TESTS env var"
+	fi
 
-    # Check if we're on macOS for keychain tests
-    if [[ "$(uname)" != "Darwin" ]]; then
-        skip "Keychain provider tests require macOS"
-    fi
+	# Check if we're on macOS for keychain tests
+	if [[ "$(uname)" != "Darwin" ]]; then
+		skip "Keychain provider tests require macOS"
+	fi
 
-    # Check if keychain is accessible
-    if ! security list-keychains >/dev/null 2>&1; then
-        skip "macOS keychain not accessible (may be locked or unavailable in this environment)"
-    fi
+	# Check if keychain is accessible
+	if ! security list-keychains >/dev/null 2>&1; then
+		skip "macOS keychain not accessible (may be locked or unavailable in this environment)"
+	fi
 
-    # Try to verify keychain access by creating a test entry with timeout
-    # Use timeout to prevent hanging in CI environments
-    if ! timeout 5 security add-generic-password -s "fnox-test-access-check-$$" -a "test" -w "test" -U >/dev/null 2>&1; then
-        skip "macOS keychain not accessible for write operations (may require GUI/interactive session)"
-    fi
+	# Try to verify keychain access by creating a test entry with timeout
+	# Use timeout to prevent hanging in CI environments
+	if ! timeout 5 security add-generic-password -s "fnox-test-access-check-$$" -a "test" -w "test" -U >/dev/null 2>&1; then
+		skip "macOS keychain not accessible for write operations (may require GUI/interactive session)"
+	fi
 
-    # Clean up the test entry
-    timeout 5 security delete-generic-password -s "fnox-test-access-check-$$" -a "test" >/dev/null 2>&1 || true
+	# Clean up the test entry
+	timeout 5 security delete-generic-password -s "fnox-test-access-check-$$" -a "test" >/dev/null 2>&1 || true
 
-    # Set a unique service name for tests
-    export KEYCHAIN_SERVICE="fnox-test-$$"
+	# Set a unique service name for tests
+	export KEYCHAIN_SERVICE="fnox-test-$$"
 }
 
 teardown() {
-    # Clean up any test secrets from keychain
-    if [ -n "$TEST_SECRET_KEYS" ]; then
-        for key in $TEST_SECRET_KEYS; do
-            security delete-generic-password -s "$KEYCHAIN_SERVICE" -a "$key" >/dev/null 2>&1 || true
-        done
-    fi
+	# Clean up any test secrets from keychain
+	if [ -n "$TEST_SECRET_KEYS" ]; then
+		for key in $TEST_SECRET_KEYS; do
+			security delete-generic-password -s "$KEYCHAIN_SERVICE" -a "$key" >/dev/null 2>&1 || true
+		done
+	fi
 
-    _common_teardown
+	_common_teardown
 }
 
 # Helper to track secret keys for cleanup
 track_secret() {
-    local key="$1"
-    TEST_SECRET_KEYS="${TEST_SECRET_KEYS:-} $key"
+	local key="$1"
+	TEST_SECRET_KEYS="${TEST_SECRET_KEYS:-} $key"
 }
 
 @test "hook-env inherits keychain provider from parent config" {
-    # Create directory structure
-    mkdir -p parent/child
+	# Create directory structure
+	mkdir -p parent/child
 
-    # Create parent config with keychain provider
-    cat > parent/fnox.toml <<EOF
+	# Create parent config with keychain provider
+	cat >parent/fnox.toml <<EOF
 [providers.keychain]
 type = "keychain"
 service = "$KEYCHAIN_SERVICE"
@@ -67,51 +67,51 @@ description = "Parent secret"
 default = "parent-value"
 EOF
 
-    # Store a secret in the keychain for the child
-    cd parent
-    run "$FNOX_BIN" set CHILD_SECRET "child-keychain-value" --provider keychain
-    assert_success
-    track_secret "CHILD_SECRET"
+	# Store a secret in the keychain for the child
+	cd parent
+	run "$FNOX_BIN" set CHILD_SECRET "child-keychain-value" --provider keychain
+	assert_success
+	track_secret "CHILD_SECRET"
 
-    # Create child config that references keychain provider but doesn't define it
-    cat > child/fnox.toml <<EOF
+	# Create child config that references keychain provider but doesn't define it
+	cat >child/fnox.toml <<EOF
 [secrets.CHILD_SECRET]
 provider = "keychain"
 value = "CHILD_SECRET"
 description = "Child secret stored in keychain"
 EOF
 
-    # Change to child directory
-    cd child
+	# Change to child directory
+	cd child
 
-    # Test 1: fnox ls should work and show both secrets merged
-    run "$FNOX_BIN" ls
-    assert_success
-    assert_output --partial "PARENT_SECRET"
-    assert_output --partial "CHILD_SECRET"
+	# Test 1: fnox ls should work and show both secrets merged
+	run "$FNOX_BIN" ls
+	assert_success
+	assert_output --partial "PARENT_SECRET"
+	assert_output --partial "CHILD_SECRET"
 
-    # Test 2: fnox get should work for child secret (inheriting parent provider)
-    run "$FNOX_BIN" get CHILD_SECRET
-    assert_success
-    assert_output "child-keychain-value"
+	# Test 2: fnox get should work for child secret (inheriting parent provider)
+	run "$FNOX_BIN" get CHILD_SECRET
+	assert_success
+	assert_output "child-keychain-value"
 
-    # Test 3: fnox hook-env should load both secrets without error
-    run bash -c "eval \"\$('$FNOX_BIN' hook-env -s bash)\" && echo \$CHILD_SECRET"
-    assert_success
-    assert_output "child-keychain-value"
+	# Test 3: fnox hook-env should load both secrets without error
+	run bash -c "eval \"\$('$FNOX_BIN' hook-env -s bash)\" && echo \$CHILD_SECRET"
+	assert_success
+	assert_output "child-keychain-value"
 
-    # Test 4: Verify no warning about provider not found
-    run "$FNOX_BIN" hook-env -s bash
-    assert_success
-    refute_output --partial "Provider 'keychain' not found"
+	# Test 4: Verify no warning about provider not found
+	run "$FNOX_BIN" hook-env -s bash
+	assert_success
+	refute_output --partial "Provider 'keychain' not found"
 }
 
 @test "hook-env with nested keychain provider inheritance (3 levels)" {
-    # Create directory structure
-    mkdir -p root/parent/child
+	# Create directory structure
+	mkdir -p root/parent/child
 
-    # Create root config with keychain provider
-    cat > root/fnox.toml <<EOF
+	# Create root config with keychain provider
+	cat >root/fnox.toml <<EOF
 [providers.keychain]
 type = "keychain"
 service = "$KEYCHAIN_SERVICE"
@@ -121,62 +121,62 @@ description = "Root secret"
 default = "root-value"
 EOF
 
-    # Store secrets in the keychain
-    cd root
-    run "$FNOX_BIN" set PARENT_SECRET "parent-keychain-value" --provider keychain
-    assert_success
-    track_secret "PARENT_SECRET"
+	# Store secrets in the keychain
+	cd root
+	run "$FNOX_BIN" set PARENT_SECRET "parent-keychain-value" --provider keychain
+	assert_success
+	track_secret "PARENT_SECRET"
 
-    run "$FNOX_BIN" set CHILD_SECRET "child-keychain-value" --provider keychain
-    assert_success
-    track_secret "CHILD_SECRET"
+	run "$FNOX_BIN" set CHILD_SECRET "child-keychain-value" --provider keychain
+	assert_success
+	track_secret "CHILD_SECRET"
 
-    # Create parent config (no provider, just secrets)
-    cat > parent/fnox.toml <<EOF
+	# Create parent config (no provider, just secrets)
+	cat >parent/fnox.toml <<EOF
 [secrets.PARENT_SECRET]
 provider = "keychain"
 value = "PARENT_SECRET"
 description = "Parent secret"
 EOF
 
-    # Create child config (no provider, just secrets)
-    cat > parent/child/fnox.toml <<EOF
+	# Create child config (no provider, just secrets)
+	cat >parent/child/fnox.toml <<EOF
 [secrets.CHILD_SECRET]
 provider = "keychain"
 value = "CHILD_SECRET"
 description = "Child secret"
 EOF
 
-    # Change to child directory (deepest level)
-    cd parent/child
+	# Change to child directory (deepest level)
+	cd parent/child
 
-    # Test 1: fnox ls should show all three secrets
-    run "$FNOX_BIN" ls
-    assert_success
-    assert_output --partial "ROOT_SECRET"
-    assert_output --partial "PARENT_SECRET"
-    assert_output --partial "CHILD_SECRET"
+	# Test 1: fnox ls should show all three secrets
+	run "$FNOX_BIN" ls
+	assert_success
+	assert_output --partial "ROOT_SECRET"
+	assert_output --partial "PARENT_SECRET"
+	assert_output --partial "CHILD_SECRET"
 
-    # Test 2: fnox get should work for all secrets
-    run "$FNOX_BIN" get ROOT_SECRET
-    assert_success
-    assert_output "root-value"
+	# Test 2: fnox get should work for all secrets
+	run "$FNOX_BIN" get ROOT_SECRET
+	assert_success
+	assert_output "root-value"
 
-    run "$FNOX_BIN" get PARENT_SECRET
-    assert_success
-    assert_output "parent-keychain-value"
+	run "$FNOX_BIN" get PARENT_SECRET
+	assert_success
+	assert_output "parent-keychain-value"
 
-    run "$FNOX_BIN" get CHILD_SECRET
-    assert_success
-    assert_output "child-keychain-value"
+	run "$FNOX_BIN" get CHILD_SECRET
+	assert_success
+	assert_output "child-keychain-value"
 
-    # Test 3: hook-env should load all secrets without error
-    run bash -c "eval \"\$('$FNOX_BIN' hook-env -s bash)\" && echo \$CHILD_SECRET"
-    assert_success
-    assert_output "child-keychain-value"
+	# Test 3: hook-env should load all secrets without error
+	run bash -c "eval \"\$('$FNOX_BIN' hook-env -s bash)\" && echo \$CHILD_SECRET"
+	assert_success
+	assert_output "child-keychain-value"
 
-    # Test 4: Verify no warnings
-    run "$FNOX_BIN" hook-env -s bash
-    assert_success
-    refute_output --partial "Provider 'keychain' not found"
+	# Test 4: Verify no warnings
+	run "$FNOX_BIN" hook-env -s bash
+	assert_success
+	refute_output --partial "Provider 'keychain' not found"
 }

--- a/test/if_missing_priority.bats
+++ b/test/if_missing_priority.bats
@@ -3,11 +3,11 @@
 load 'test_helper/common_setup'
 
 setup() {
-    _common_setup
+	_common_setup
 }
 
 @test "fnox exec with top-level if_missing=error fails on missing secret" {
-    cat > fnox.toml << 'TOML'
+	cat >fnox.toml <<'TOML'
 root = true
 if_missing = "error"
 
@@ -20,15 +20,15 @@ provider = "age"
 value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaaTFhczNBYnN3S1c0NjZwZnlDN2NUMTVaSTFXd2k1OWhnWUJvckVxYmh3CjNRSmhxSWJiYXU3eHoyNlcyOVVLRWNnUlFJeFBjL2N0YlA5K2hUaU04VDQKLS0tIGN6UVYzMHZJUUhKNmlkQjFOaXRXYUpjbzBOaHRMZkFFVVRPa3FaQUs2dHcKf3AcueEBLdl8lzRwKXik+OvDVg48g44QoPZu0j0NLV4lPLDqoq0="
 TOML
 
-    # Set invalid age key to trigger error
-    export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
+	# Set invalid age key to trigger error
+	export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
 
-    run "$FNOX_BIN" exec -- echo "should not run"
-    assert_failure
+	run "$FNOX_BIN" exec -- echo "should not run"
+	assert_failure
 }
 
 @test "fnox exec with top-level if_missing=warn continues on missing secret" {
-    cat > fnox.toml << 'TOML'
+	cat >fnox.toml <<'TOML'
 root = true
 if_missing = "warn"
 
@@ -41,16 +41,16 @@ provider = "age"
 value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaaTFhczNBYnN3S1c0NjZwZnlDN2NUMTVaSTFXd2k1OWhnWUJvckVxYmh3CjNRSmhxSWJiYXU3eHoyNlcyOVVLRWNnUlFJeFBjL2N0YlA5K2hUaU04VDQKLS0tIGN6UVYzMHZJUUhKNmlkQjFOaXRXYUpjbzBOaHRMZkFFVVRPa3FaQUs2dHcKf3AcueEBLdl8lzRwKXik+OvDVg48g44QoPZu0j0NLV4lPLDqoq0="
 TOML
 
-    # Set invalid age key to trigger error
-    export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
+	# Set invalid age key to trigger error
+	export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
 
-    run "$FNOX_BIN" exec -- echo "command succeeded"
-    assert_success
-    assert_output --partial "command succeeded"
+	run "$FNOX_BIN" exec -- echo "command succeeded"
+	assert_success
+	assert_output --partial "command succeeded"
 }
 
 @test "fnox exec with top-level if_missing=ignore silently continues on missing secret" {
-    cat > fnox.toml << 'TOML'
+	cat >fnox.toml <<'TOML'
 root = true
 if_missing = "ignore"
 
@@ -63,18 +63,18 @@ provider = "age"
 value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaaTFhczNBYnN3S1c0NjZwZnlDN2NUMTVaSTFXd2k1OWhnWUJvckVxYmh3CjNRSmhxSWJiYXU3eHoyNlcyOVVLRWNnUlFJeFBjL2N0YlA5K2hUaU04VDQKLS0tIGN6UVYzMHZJUUhKNmlkQjFOaXRXYUpjbzBOaHRMZkFFVVRPa3FaQUs2dHcKf3AcueEBLdl8lzRwKXik+OvDVg48g44QoPZu0j0NLV4lPLDqoq0="
 TOML
 
-    # Set invalid age key to trigger error
-    export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
+	# Set invalid age key to trigger error
+	export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
 
-    run "$FNOX_BIN" exec -- echo "command succeeded"
-    assert_success
-    assert_output --partial "command succeeded"
-    # Should not have warning message
-    refute_output --partial "Warning:"
+	run "$FNOX_BIN" exec -- echo "command succeeded"
+	assert_success
+	assert_output --partial "command succeeded"
+	# Should not have warning message
+	refute_output --partial "Warning:"
 }
 
 @test "fnox exec with FNOX_IF_MISSING=error fails on missing secret" {
-    cat > fnox.toml << 'TOML'
+	cat >fnox.toml <<'TOML'
 root = true
 
 [providers.age]
@@ -86,16 +86,16 @@ provider = "age"
 value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaaTFhczNBYnN3S1c0NjZwZnlDN2NUMTVaSTFXd2k1OWhnWUJvckVxYmh3CjNRSmhxSWJiYXU3eHoyNlcyOVVLRWNnUlFJeFBjL2N0YlA5K2hUaU04VDQKLS0tIGN6UVYzMHZJUUhKNmlkQjFOaXRXYUpjbzBOaHRMZkFFVVRPa3FaQUs2dHcKf3AcueEBLdl8lzRwKXik+OvDVg48g44QoPZu0j0NLV4lPLDqoq0="
 TOML
 
-    # Set invalid age key to trigger error
-    export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
-    export FNOX_IF_MISSING="error"
+	# Set invalid age key to trigger error
+	export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
+	export FNOX_IF_MISSING="error"
 
-    run "$FNOX_BIN" exec -- echo "should not run"
-    assert_failure
+	run "$FNOX_BIN" exec -- echo "should not run"
+	assert_failure
 }
 
 @test "fnox exec with FNOX_IF_MISSING=ignore silently continues on missing secret" {
-    cat > fnox.toml << 'TOML'
+	cat >fnox.toml <<'TOML'
 root = true
 
 [providers.age]
@@ -107,19 +107,19 @@ provider = "age"
 value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaaTFhczNBYnN3S1c0NjZwZnlDN2NUMTVaSTFXd2k1OWhnWUJvckVxYmh3CjNRSmhxSWJiYXU3eHoyNlcyOVVLRWNnUlFJeFBjL2N0YlA5K2hUaU04VDQKLS0tIGN6UVYzMHZJUUhKNmlkQjFOaXRXYUpjbzBOaHRMZkFFVVRPa3FaQUs2dHcKf3AcueEBLdl8lzRwKXik+OvDVg48g44QoPZu0j0NLV4lPLDqoq0="
 TOML
 
-    # Set invalid age key to trigger error
-    export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
-    export FNOX_IF_MISSING="ignore"
+	# Set invalid age key to trigger error
+	export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
+	export FNOX_IF_MISSING="ignore"
 
-    run "$FNOX_BIN" exec -- echo "command succeeded"
-    assert_success
-    assert_output --partial "command succeeded"
-    # Should not have warning message
-    refute_output --partial "Warning:"
+	run "$FNOX_BIN" exec -- echo "command succeeded"
+	assert_success
+	assert_output --partial "command succeeded"
+	# Should not have warning message
+	refute_output --partial "Warning:"
 }
 
 @test "fnox exec CLI flag --if-missing overrides secret-level config" {
-    cat > fnox.toml << 'TOML'
+	cat >fnox.toml <<'TOML'
 root = true
 
 [providers.age]
@@ -132,16 +132,16 @@ value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaaTFhczNBYnN3S1c0NjZwZnlDN2N
 if_missing = "ignore"
 TOML
 
-    # Set invalid age key to trigger error
-    export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
+	# Set invalid age key to trigger error
+	export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
 
-    # Should fail because --if-missing error overrides secret-level if_missing=ignore
-    run "$FNOX_BIN" exec --if-missing error -- echo "should not run"
-    assert_failure
+	# Should fail because --if-missing error overrides secret-level if_missing=ignore
+	run "$FNOX_BIN" exec --if-missing error -- echo "should not run"
+	assert_failure
 }
 
 @test "fnox exec secret-level if_missing overrides top-level config" {
-    cat > fnox.toml << 'TOML'
+	cat >fnox.toml <<'TOML'
 root = true
 if_missing = "error"
 
@@ -155,17 +155,17 @@ value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaaTFhczNBYnN3S1c0NjZwZnlDN2N
 if_missing = "ignore"
 TOML
 
-    # Set invalid age key to trigger error
-    export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
+	# Set invalid age key to trigger error
+	export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
 
-    # Should succeed because secret-level if_missing=ignore overrides top-level if_missing=error
-    run "$FNOX_BIN" exec -- echo "command succeeded"
-    assert_success
-    assert_output --partial "command succeeded"
+	# Should succeed because secret-level if_missing=ignore overrides top-level if_missing=error
+	run "$FNOX_BIN" exec -- echo "command succeeded"
+	assert_success
+	assert_output --partial "command succeeded"
 }
 
 @test "fnox exec FNOX_IF_MISSING env var overrides secret-level config" {
-    cat > fnox.toml << 'TOML'
+	cat >fnox.toml <<'TOML'
 root = true
 
 [providers.age]
@@ -178,17 +178,17 @@ value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaaTFhczNBYnN3S1c0NjZwZnlDN2N
 if_missing = "ignore"
 TOML
 
-    # Set invalid age key to trigger error
-    export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
-    export FNOX_IF_MISSING="error"
+	# Set invalid age key to trigger error
+	export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
+	export FNOX_IF_MISSING="error"
 
-    # Should fail because FNOX_IF_MISSING=error overrides secret-level if_missing=ignore
-    run "$FNOX_BIN" exec -- echo "should not run"
-    assert_failure
+	# Should fail because FNOX_IF_MISSING=error overrides secret-level if_missing=ignore
+	run "$FNOX_BIN" exec -- echo "should not run"
+	assert_failure
 }
 
 @test "fnox exec FNOX_IF_MISSING env var overrides top-level config" {
-    cat > fnox.toml << 'TOML'
+	cat >fnox.toml <<'TOML'
 root = true
 if_missing = "ignore"
 
@@ -201,17 +201,17 @@ provider = "age"
 value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaaTFhczNBYnN3S1c0NjZwZnlDN2NUMTVaSTFXd2k1OWhnWUJvckVxYmh3CjNRSmhxSWJiYXU3eHoyNlcyOVVLRWNnUlFJeFBjL2N0YlA5K2hUaU04VDQKLS0tIGN6UVYzMHZJUUhKNmlkQjFOaXRXYUpjbzBOaHRMZkFFVVRPa3FaQUs2dHcKf3AcueEBLdl8lzRwKXik+OvDVg48g44QoPZu0j0NLV4lPLDqoq0="
 TOML
 
-    # Set invalid age key to trigger error
-    export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
-    export FNOX_IF_MISSING="error"
+	# Set invalid age key to trigger error
+	export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
+	export FNOX_IF_MISSING="error"
 
-    # Should fail because FNOX_IF_MISSING=error overrides top-level if_missing=ignore
-    run "$FNOX_BIN" exec -- echo "should not run"
-    assert_failure
+	# Should fail because FNOX_IF_MISSING=error overrides top-level if_missing=ignore
+	run "$FNOX_BIN" exec -- echo "should not run"
+	assert_failure
 }
 
 @test "fnox exec explicit --if-missing warn overrides config ignore" {
-    cat > fnox.toml << 'TOML'
+	cat >fnox.toml <<'TOML'
 root = true
 if_missing = "ignore"
 
@@ -224,18 +224,18 @@ provider = "age"
 value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaaTFhczNBYnN3S1c0NjZwZnlDN2NUMTVaSTFXd2k1OWhnWUJvckVxYmh3CjNRSmhxSWJiYXU3eHoyNlcyOVVLRWNnUlFJeFBjL2N0YlA5K2hUaU04VDQKLS0tIGN6UVYzMHZJUUhKNmlkQjFOaXRXYUpjbzBOaHRMZkFFVVRPa3FaQUs2dHcKf3AcueEBLdl8lzRwKXik+OvDVg48g44QoPZu0j0NLV4lPLDqoq0="
 TOML
 
-    # Set invalid age key to trigger error
-    export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
+	# Set invalid age key to trigger error
+	export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
 
-    # Should show warning because explicit --if-missing warn overrides config if_missing=ignore
-    run "$FNOX_BIN" exec --if-missing warn -- echo "command succeeded"
-    assert_success
-    assert_output --partial "command succeeded"
-    assert_output --partial "WARN"
+	# Should show warning because explicit --if-missing warn overrides config if_missing=ignore
+	run "$FNOX_BIN" exec --if-missing warn -- echo "command succeeded"
+	assert_success
+	assert_output --partial "command succeeded"
+	assert_output --partial "WARN"
 }
 
 @test "fnox exec explicit FNOX_IF_MISSING=warn overrides config ignore" {
-    cat > fnox.toml << 'TOML'
+	cat >fnox.toml <<'TOML'
 root = true
 if_missing = "ignore"
 
@@ -248,19 +248,19 @@ provider = "age"
 value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaaTFhczNBYnN3S1c0NjZwZnlDN2NUMTVaSTFXd2k1OWhnWUJvckVxYmh3CjNRSmhxSWJiYXU3eHoyNlcyOVVLRWNnUlFJeFBjL2N0YlA5K2hUaU04VDQKLS0tIGN6UVYzMHZJUUhKNmlkQjFOaXRXYUpjbzBOaHRMZkFFVVRPa3FaQUs2dHcKf3AcueEBLdl8lzRwKXik+OvDVg48g44QoPZu0j0NLV4lPLDqoq0="
 TOML
 
-    # Set invalid age key to trigger error
-    export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
-    export FNOX_IF_MISSING="warn"
+	# Set invalid age key to trigger error
+	export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
+	export FNOX_IF_MISSING="warn"
 
-    # Should show warning because explicit FNOX_IF_MISSING=warn overrides config if_missing=ignore
-    run "$FNOX_BIN" exec -- echo "command succeeded"
-    assert_success
-    assert_output --partial "command succeeded"
-    assert_output --partial "WARN"
+	# Should show warning because explicit FNOX_IF_MISSING=warn overrides config if_missing=ignore
+	run "$FNOX_BIN" exec -- echo "command succeeded"
+	assert_success
+	assert_output --partial "command succeeded"
+	assert_output --partial "WARN"
 }
 
 @test "fnox exec with FNOX_IF_MISSING_DEFAULT=error fails on missing secret" {
-    cat > fnox.toml << 'TOML'
+	cat >fnox.toml <<'TOML'
 root = true
 
 [providers.age]
@@ -272,16 +272,16 @@ provider = "age"
 value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaaTFhczNBYnN3S1c0NjZwZnlDN2NUMTVaSTFXd2k1OWhnWUJvckVxYmh3CjNRSmhxSWJiYXU3eHoyNlcyOVVLRWNnUlFJeFBjL2N0YlA5K2hUaU04VDQKLS0tIGN6UVYzMHZJUUhKNmlkQjFOaXRXYUpjbzBOaHRMZkFFVVRPa3FaQUs2dHcKf3AcueEBLdl8lzRwKXik+OvDVg48g44QoPZu0j0NLV4lPLDqoq0="
 TOML
 
-    # Set invalid age key to trigger error
-    export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
-    export FNOX_IF_MISSING_DEFAULT="error"
+	# Set invalid age key to trigger error
+	export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
+	export FNOX_IF_MISSING_DEFAULT="error"
 
-    run "$FNOX_BIN" exec -- echo "should not run"
-    assert_failure
+	run "$FNOX_BIN" exec -- echo "should not run"
+	assert_failure
 }
 
 @test "fnox exec top-level config overrides FNOX_IF_MISSING_DEFAULT" {
-    cat > fnox.toml << 'TOML'
+	cat >fnox.toml <<'TOML'
 root = true
 if_missing = "ignore"
 
@@ -294,18 +294,18 @@ provider = "age"
 value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaaTFhczNBYnN3S1c0NjZwZnlDN2NUMTVaSTFXd2k1OWhnWUJvckVxYmh3CjNRSmhxSWJiYXU3eHoyNlcyOVVLRWNnUlFJeFBjL2N0YlA5K2hUaU04VDQKLS0tIGN6UVYzMHZJUUhKNmlkQjFOaXRXYUpjbzBOaHRMZkFFVVRPa3FaQUs2dHcKf3AcueEBLdl8lzRwKXik+OvDVg48g44QoPZu0j0NLV4lPLDqoq0="
 TOML
 
-    # Set invalid age key to trigger error
-    export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
-    export FNOX_IF_MISSING_DEFAULT="error"
+	# Set invalid age key to trigger error
+	export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
+	export FNOX_IF_MISSING_DEFAULT="error"
 
-    # Should succeed because config if_missing=ignore overrides FNOX_IF_MISSING_DEFAULT=error
-    run "$FNOX_BIN" exec -- echo "command succeeded"
-    assert_success
-    assert_output --partial "command succeeded"
+	# Should succeed because config if_missing=ignore overrides FNOX_IF_MISSING_DEFAULT=error
+	run "$FNOX_BIN" exec -- echo "command succeeded"
+	assert_success
+	assert_output --partial "command succeeded"
 }
 
 @test "fnox exec FNOX_IF_MISSING overrides FNOX_IF_MISSING_DEFAULT" {
-    cat > fnox.toml << 'TOML'
+	cat >fnox.toml <<'TOML'
 root = true
 
 [providers.age]
@@ -317,13 +317,13 @@ provider = "age"
 value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaaTFhczNBYnN3S1c0NjZwZnlDN2NUMTVaSTFXd2k1OWhnWUJvckVxYmh3CjNRSmhxSWJiYXU3eHoyNlcyOVVLRWNnUlFJeFBjL2N0YlA5K2hUaU04VDQKLS0tIGN6UVYzMHZJUUhKNmlkQjFOaXRXYUpjbzBOaHRMZkFFVVRPa3FaQUs2dHcKf3AcueEBLdl8lzRwKXik+OvDVg48g44QoPZu0j0NLV4lPLDqoq0="
 TOML
 
-    # Set invalid age key to trigger error
-    export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
-    export FNOX_IF_MISSING_DEFAULT="error"
-    export FNOX_IF_MISSING="ignore"
+	# Set invalid age key to trigger error
+	export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
+	export FNOX_IF_MISSING_DEFAULT="error"
+	export FNOX_IF_MISSING="ignore"
 
-    # Should succeed because FNOX_IF_MISSING=ignore overrides FNOX_IF_MISSING_DEFAULT=error
-    run "$FNOX_BIN" exec -- echo "command succeeded"
-    assert_success
-    assert_output --partial "command succeeded"
+	# Should succeed because FNOX_IF_MISSING=ignore overrides FNOX_IF_MISSING_DEFAULT=error
+	run "$FNOX_BIN" exec -- echo "command succeeded"
+	assert_success
+	assert_output --partial "command succeeded"
 }

--- a/test/import.bats
+++ b/test/import.bats
@@ -1,28 +1,28 @@
 #!/usr/bin/env bats
 
 setup() {
-    load 'test_helper/common_setup'
-    _common_setup
+	load 'test_helper/common_setup'
+	_common_setup
 }
 
 teardown() {
-    _common_teardown
+	_common_teardown
 }
 
 # Helper function to setup age provider
 setup_age_provider() {
-    if ! command -v age-keygen >/dev/null 2>&1; then
-        skip "age-keygen not installed"
-    fi
+	if ! command -v age-keygen >/dev/null 2>&1; then
+		skip "age-keygen not installed"
+	fi
 
-    # Generate age key
-    local keygen_output
-    keygen_output=$(age-keygen -o key.txt 2>&1)
-    local public_key
-    public_key=$(echo "$keygen_output" | grep "^Public key:" | cut -d' ' -f3)
+	# Generate age key
+	local keygen_output
+	keygen_output=$(age-keygen -o key.txt 2>&1)
+	local public_key
+	public_key=$(echo "$keygen_output" | grep "^Public key:" | cut -d' ' -f3)
 
-    # Create config with age provider
-    cat > fnox.toml << EOF
+	# Create config with age provider
+	cat >fnox.toml <<EOF
 root = true
 
 [providers.age]
@@ -34,96 +34,96 @@ EOF
 }
 
 @test "fnox import requires --provider flag" {
-    setup_age_provider
+	setup_age_provider
 
-    # Create a .env file
-    cat > .env << EOF
+	# Create a .env file
+	cat >.env <<EOF
 TEST_SECRET=value123
 EOF
 
-    # Import without --provider should fail
-    assert_fnox_failure import -i .env --force
-    assert_output --partial "required arguments were not provided"
-    assert_output --partial "--provider"
+	# Import without --provider should fail
+	assert_fnox_failure import -i .env --force
+	assert_output --partial "required arguments were not provided"
+	assert_output --partial "--provider"
 }
 
 @test "fnox import reads from .env file with -i flag" {
-    setup_age_provider
+	setup_age_provider
 
-    # Create a .env file with test secrets
-    cat > .env << EOF
+	# Create a .env file with test secrets
+	cat >.env <<EOF
 DATABASE_URL=postgresql://localhost:5432/mydb
 API_KEY=secret-key-123
 DEBUG_MODE=true
 EOF
 
-    # Import from .env file with age provider
-    assert_fnox_success import -i .env --provider age --force
+	# Import from .env file with age provider
+	assert_fnox_success import -i .env --provider age --force
 
-    # Verify secrets were imported and encrypted (not plaintext)
-    assert_config_not_contains "postgresql://localhost:5432/mydb"
-    assert_config_not_contains "secret-key-123"
+	# Verify secrets were imported and encrypted (not plaintext)
+	assert_config_not_contains "postgresql://localhost:5432/mydb"
+	assert_config_not_contains "secret-key-123"
 
-    # Verify secrets can be retrieved with age key
-    assert_fnox_success get DATABASE_URL --age-key-file key.txt
-    assert_output "postgresql://localhost:5432/mydb"
+	# Verify secrets can be retrieved with age key
+	assert_fnox_success get DATABASE_URL --age-key-file key.txt
+	assert_output "postgresql://localhost:5432/mydb"
 
-    assert_fnox_success get API_KEY --age-key-file key.txt
-    assert_output "secret-key-123"
+	assert_fnox_success get API_KEY --age-key-file key.txt
+	assert_output "secret-key-123"
 
-    assert_fnox_success get DEBUG_MODE --age-key-file key.txt
-    assert_output "true"
+	assert_fnox_success get DEBUG_MODE --age-key-file key.txt
+	assert_output "true"
 }
 
 @test "fnox import handles quoted values in .env file" {
-    setup_age_provider
+	setup_age_provider
 
-    # Create a .env file with quoted values
-    cat > .env << EOF
+	# Create a .env file with quoted values
+	cat >.env <<EOF
 SINGLE_QUOTED='value with spaces'
 DOUBLE_QUOTED="another value with spaces"
 UNQUOTED=no_spaces
 EOF
 
-    assert_fnox_success import -i .env --provider age --force
+	assert_fnox_success import -i .env --provider age --force
 
-    assert_fnox_success get SINGLE_QUOTED --age-key-file key.txt
-    assert_output "value with spaces"
+	assert_fnox_success get SINGLE_QUOTED --age-key-file key.txt
+	assert_output "value with spaces"
 
-    assert_fnox_success get DOUBLE_QUOTED --age-key-file key.txt
-    assert_output "another value with spaces"
+	assert_fnox_success get DOUBLE_QUOTED --age-key-file key.txt
+	assert_output "another value with spaces"
 
-    assert_fnox_success get UNQUOTED --age-key-file key.txt
-    assert_output "no_spaces"
+	assert_fnox_success get UNQUOTED --age-key-file key.txt
+	assert_output "no_spaces"
 }
 
 @test "fnox import handles export statements in .env file" {
-    setup_age_provider
+	setup_age_provider
 
-    # Create a .env file with export statements
-    cat > .env << EOF
+	# Create a .env file with export statements
+	cat >.env <<EOF
 export DATABASE_URL=postgresql://localhost:5432/mydb
 export API_KEY=secret-key-456
 REGULAR_VAR=regular-value
 EOF
 
-    assert_fnox_success import -i .env --provider age --force
+	assert_fnox_success import -i .env --provider age --force
 
-    assert_fnox_success get DATABASE_URL --age-key-file key.txt
-    assert_output "postgresql://localhost:5432/mydb"
+	assert_fnox_success get DATABASE_URL --age-key-file key.txt
+	assert_output "postgresql://localhost:5432/mydb"
 
-    assert_fnox_success get API_KEY --age-key-file key.txt
-    assert_output "secret-key-456"
+	assert_fnox_success get API_KEY --age-key-file key.txt
+	assert_output "secret-key-456"
 
-    assert_fnox_success get REGULAR_VAR --age-key-file key.txt
-    assert_output "regular-value"
+	assert_fnox_success get REGULAR_VAR --age-key-file key.txt
+	assert_output "regular-value"
 }
 
 @test "fnox import skips comments and empty lines" {
-    setup_age_provider
+	setup_age_provider
 
-    # Create a .env file with comments and empty lines
-    cat > .env << EOF
+	# Create a .env file with comments and empty lines
+	cat >.env <<EOF
 # This is a comment
 DATABASE_URL=postgresql://localhost:5432/mydb
 
@@ -132,20 +132,20 @@ API_KEY=secret-key-789
 
 EOF
 
-    assert_fnox_success import -i .env --provider age --force
+	assert_fnox_success import -i .env --provider age --force
 
-    # Should only import the two actual variables
-    assert_fnox_success list
-    assert_output --partial "DATABASE_URL"
-    assert_output --partial "API_KEY"
-    refute_output --partial "#"
+	# Should only import the two actual variables
+	assert_fnox_success list
+	assert_output --partial "DATABASE_URL"
+	assert_output --partial "API_KEY"
+	refute_output --partial "#"
 }
 
 @test "fnox import with --filter flag filters secrets by regex" {
-    setup_age_provider
+	setup_age_provider
 
-    # Create a .env file
-    cat > .env << EOF
+	# Create a .env file
+	cat >.env <<EOF
 DATABASE_URL=postgresql://localhost:5432/mydb
 DATABASE_PASSWORD=secret123
 API_KEY=secret-key-abc
@@ -153,148 +153,148 @@ API_SECRET=secret-abc-456
 DEBUG_MODE=true
 EOF
 
-    # Import only DATABASE_* secrets
-    assert_fnox_success import -i .env --filter "^DATABASE_" --provider age --force
+	# Import only DATABASE_* secrets
+	assert_fnox_success import -i .env --filter "^DATABASE_" --provider age --force
 
-    # Should have DATABASE_* secrets
-    assert_fnox_success get DATABASE_URL --age-key-file key.txt
-    assert_output "postgresql://localhost:5432/mydb"
+	# Should have DATABASE_* secrets
+	assert_fnox_success get DATABASE_URL --age-key-file key.txt
+	assert_output "postgresql://localhost:5432/mydb"
 
-    assert_fnox_success get DATABASE_PASSWORD --age-key-file key.txt
-    assert_output "secret123"
+	assert_fnox_success get DATABASE_PASSWORD --age-key-file key.txt
+	assert_output "secret123"
 
-    # Should not have API_* or DEBUG_MODE
-    assert_fnox_failure get API_KEY
-    assert_fnox_failure get DEBUG_MODE
+	# Should not have API_* or DEBUG_MODE
+	assert_fnox_failure get API_KEY
+	assert_fnox_failure get DEBUG_MODE
 }
 
 @test "fnox import with --prefix flag adds prefix to secret names" {
-    setup_age_provider
+	setup_age_provider
 
-    # Create a .env file
-    cat > .env << EOF
+	# Create a .env file
+	cat >.env <<EOF
 DATABASE_URL=postgresql://localhost:5432/mydb
 API_KEY=secret-key-xyz
 EOF
 
-    # Import with prefix
-    assert_fnox_success import -i .env --prefix "MYAPP_" --provider age --force
+	# Import with prefix
+	assert_fnox_success import -i .env --prefix "MYAPP_" --provider age --force
 
-    # Should be accessible with prefix
-    assert_fnox_success get MYAPP_DATABASE_URL --age-key-file key.txt
-    assert_output "postgresql://localhost:5432/mydb"
+	# Should be accessible with prefix
+	assert_fnox_success get MYAPP_DATABASE_URL --age-key-file key.txt
+	assert_output "postgresql://localhost:5432/mydb"
 
-    assert_fnox_success get MYAPP_API_KEY --age-key-file key.txt
-    assert_output "secret-key-xyz"
+	assert_fnox_success get MYAPP_API_KEY --age-key-file key.txt
+	assert_output "secret-key-xyz"
 
-    # Should not be accessible without prefix
-    assert_fnox_failure get DATABASE_URL
-    assert_fnox_failure get API_KEY
+	# Should not be accessible without prefix
+	assert_fnox_failure get DATABASE_URL
+	assert_fnox_failure get API_KEY
 }
 
 @test "fnox import requires confirmation by default" {
-    setup_age_provider
+	setup_age_provider
 
-    # Create a .env file
-    cat > .env << EOF
+	# Create a .env file
+	cat >.env <<EOF
 DATABASE_URL=postgresql://localhost:5432/mydb
 EOF
 
-    # Import without --force should prompt for confirmation
-    run bash -c "echo 'n' | $FNOX_BIN import -i .env --provider age"
-    assert_output --partial "Continue? [y/N]"
-    assert_output --partial "Import cancelled"
+	# Import without --force should prompt for confirmation
+	run bash -c "echo 'n' | $FNOX_BIN import -i .env --provider age"
+	assert_output --partial "Continue? [y/N]"
+	assert_output --partial "Import cancelled"
 
-    # Secret should not have been imported
-    assert_fnox_failure get DATABASE_URL
+	# Secret should not have been imported
+	assert_fnox_failure get DATABASE_URL
 }
 
 @test "fnox import reads from stdin when -i is not specified" {
-    setup_age_provider
+	setup_age_provider
 
-    # Import from stdin
-    run bash -c "echo -e 'DATABASE_URL=postgresql://localhost:5432/mydb\nAPI_KEY=secret-key' | $FNOX_BIN import --provider age --force"
-    assert_success
+	# Import from stdin
+	run bash -c "echo -e 'DATABASE_URL=postgresql://localhost:5432/mydb\nAPI_KEY=secret-key' | $FNOX_BIN import --provider age --force"
+	assert_success
 
-    # Verify secrets were imported
-    assert_fnox_success get DATABASE_URL --age-key-file key.txt
-    assert_output "postgresql://localhost:5432/mydb"
+	# Verify secrets were imported
+	assert_fnox_success get DATABASE_URL --age-key-file key.txt
+	assert_output "postgresql://localhost:5432/mydb"
 
-    assert_fnox_success get API_KEY --age-key-file key.txt
-    assert_output "secret-key"
+	assert_fnox_success get API_KEY --age-key-file key.txt
+	assert_output "secret-key"
 }
 
 @test "fnox import from stdin requires --force flag" {
-    setup_age_provider
+	setup_age_provider
 
-    # FIXED: stdin imports now require --force to avoid double-stdin consumption bug
-    # Without --force, importing from stdin would consume stdin twice:
-    #   1. First to read import data (read_input)
-    #   2. Then to read confirmation (stdin.read_line)
-    # This would cause the import to fail because stdin is at EOF after reading data
+	# FIXED: stdin imports now require --force to avoid double-stdin consumption bug
+	# Without --force, importing from stdin would consume stdin twice:
+	#   1. First to read import data (read_input)
+	#   2. Then to read confirmation (stdin.read_line)
+	# This would cause the import to fail because stdin is at EOF after reading data
 
-    # First test: import without --provider should fail with missing provider error
-    run bash -c "echo -e 'TEST_VAR=test123' | $FNOX_BIN import"
-    assert_failure
-    assert_output --partial "required arguments were not provided"
-    assert_output --partial "--provider"
+	# First test: import without --provider should fail with missing provider error
+	run bash -c "echo -e 'TEST_VAR=test123' | $FNOX_BIN import"
+	assert_failure
+	assert_output --partial "required arguments were not provided"
+	assert_output --partial "--provider"
 
-    # Second test: import with --provider but without --force should fail with stdin consumption error
-    run bash -c "echo -e 'TEST_VAR=test456' | $FNOX_BIN import --provider age"
-    assert_failure
-    assert_output --partial "the --force flag"
-    assert_output --partial "stdin is consumed"
+	# Second test: import with --provider but without --force should fail with stdin consumption error
+	run bash -c "echo -e 'TEST_VAR=test456' | $FNOX_BIN import --provider age"
+	assert_failure
+	assert_output --partial "the --force flag"
+	assert_output --partial "stdin is consumed"
 
-    # Verify secrets were NOT imported
-    assert_fnox_failure get TEST_VAR
+	# Verify secrets were NOT imported
+	assert_fnox_failure get TEST_VAR
 
-    # Now try with both --provider and --force - should succeed
-    run bash -c "echo -e 'TEST_VAR=test123' | $FNOX_BIN import --provider age --force"
-    assert_success
+	# Now try with both --provider and --force - should succeed
+	run bash -c "echo -e 'TEST_VAR=test123' | $FNOX_BIN import --provider age --force"
+	assert_success
 
-    # Verify secret WAS imported
-    assert_fnox_success get TEST_VAR --age-key-file key.txt
-    assert_output "test123"
+	# Verify secret WAS imported
+	assert_fnox_success get TEST_VAR --age-key-file key.txt
+	assert_output "test123"
 }
 
 @test "fnox import supports json format" {
-    setup_age_provider
+	setup_age_provider
 
-    # Create a JSON file
-    cat > secrets.json << EOF
+	# Create a JSON file
+	cat >secrets.json <<EOF
 {
   "DATABASE_URL": "postgresql://localhost:5432/mydb",
   "API_KEY": "secret-key-json"
 }
 EOF
 
-    assert_fnox_success import -i secrets.json json --provider age --force
+	assert_fnox_success import -i secrets.json json --provider age --force
 
-    assert_fnox_success get DATABASE_URL --age-key-file key.txt
-    assert_output "postgresql://localhost:5432/mydb"
+	assert_fnox_success get DATABASE_URL --age-key-file key.txt
+	assert_output "postgresql://localhost:5432/mydb"
 
-    assert_fnox_success get API_KEY --age-key-file key.txt
-    assert_output "secret-key-json"
+	assert_fnox_success get API_KEY --age-key-file key.txt
+	assert_output "secret-key-json"
 }
 
 @test "fnox import shows helpful error when file does not exist" {
-    setup_age_provider
+	setup_age_provider
 
-    # Try to import from non-existent file
-    assert_fnox_failure import -i nonexistent.env --provider age --force
-    assert_output --partial "Failed to read input file"
+	# Try to import from non-existent file
+	assert_fnox_failure import -i nonexistent.env --provider age --force
+	assert_output --partial "Failed to read input file"
 }
 
 @test "fnox import fails with non-existent provider" {
-    setup_age_provider
+	setup_age_provider
 
-    # Create a .env file
-    cat > .env << EOF
+	# Create a .env file
+	cat >.env <<EOF
 SECRET=value
 EOF
 
-    # Try to import with non-existent provider
-    assert_fnox_failure import -i .env --provider nonexistent --force
-    assert_output --partial "Provider 'nonexistent' not found"
-    assert_output --partial "Available providers: age"
+	# Try to import with non-existent provider
+	assert_fnox_failure import -i .env --provider nonexistent --force
+	assert_output --partial "Provider 'nonexistent' not found"
+	assert_output --partial "Available providers: age"
 }

--- a/test/infisical.bats
+++ b/test/infisical.bats
@@ -22,63 +22,63 @@
 #
 
 setup() {
-    load 'test_helper/common_setup'
-    _common_setup
+	load 'test_helper/common_setup'
+	_common_setup
 
-    # Check if infisical CLI is installed
-    if ! command -v infisical >/dev/null 2>&1; then
-        skip "Infisical CLI not installed. Install with: brew install infisical/get-cli/infisical"
-    fi
+	# Check if infisical CLI is installed
+	if ! command -v infisical >/dev/null 2>&1; then
+		skip "Infisical CLI not installed. Install with: brew install infisical/get-cli/infisical"
+	fi
 
-    # Some tests don't need credentials (like 'fnox list')
-    # Some tests only need CLIENT_ID/SECRET (like 'fails with invalid')
-    # Only skip if this test actually needs full authentication
-    if [[ "$BATS_TEST_DESCRIPTION" != *"list"* ]]; then
-        # All non-list tests need CLIENT_ID and CLIENT_SECRET for fnox provider
-        if [ -z "$INFISICAL_CLIENT_ID" ] || [ -z "$INFISICAL_CLIENT_SECRET" ]; then
-            skip "INFISICAL_CLIENT_ID and INFISICAL_CLIENT_SECRET not available. Set up Universal Auth credentials."
-        fi
+	# Some tests don't need credentials (like 'fnox list')
+	# Some tests only need CLIENT_ID/SECRET (like 'fails with invalid')
+	# Only skip if this test actually needs full authentication
+	if [[ $BATS_TEST_DESCRIPTION != *"list"* ]]; then
+		# All non-list tests need CLIENT_ID and CLIENT_SECRET for fnox provider
+		if [ -z "$INFISICAL_CLIENT_ID" ] || [ -z "$INFISICAL_CLIENT_SECRET" ]; then
+			skip "INFISICAL_CLIENT_ID and INFISICAL_CLIENT_SECRET not available. Set up Universal Auth credentials."
+		fi
 
-        # Tests that create/modify secrets need INFISICAL_TOKEN for CLI test helpers
-        # Error handling tests (like 'fails with invalid') don't need these
-        if [[ "$BATS_TEST_DESCRIPTION" != *"fails with invalid"* ]] && [[ "$BATS_TEST_DESCRIPTION" != *"fails gracefully"* ]]; then
-            # Check if INFISICAL_TOKEN is available (for CLI test helpers)
-            if [ -z "$INFISICAL_TOKEN" ]; then
-                skip "INFISICAL_TOKEN not available. Required for CLI test helpers."
-            fi
-        fi
-    fi
+		# Tests that create/modify secrets need INFISICAL_TOKEN for CLI test helpers
+		# Error handling tests (like 'fails with invalid') don't need these
+		if [[ $BATS_TEST_DESCRIPTION != *"fails with invalid"* ]] && [[ $BATS_TEST_DESCRIPTION != *"fails gracefully"* ]]; then
+			# Check if INFISICAL_TOKEN is available (for CLI test helpers)
+			if [ -z "$INFISICAL_TOKEN" ]; then
+				skip "INFISICAL_TOKEN not available. Required for CLI test helpers."
+			fi
+		fi
+	fi
 }
 
 teardown() {
-    _common_teardown
+	_common_teardown
 }
 
 # Helper function to create an Infisical test config
 create_infisical_config() {
-    # Default to INFISICAL_PROJECT_ID from environment if not provided
-    local project_id="${1:-${INFISICAL_PROJECT_ID:-}}"
-    local environment="${2:-dev}"
-    local path="${3:-/}"
+	# Default to INFISICAL_PROJECT_ID from environment if not provided
+	local project_id="${1:-${INFISICAL_PROJECT_ID:-}}"
+	local environment="${2:-dev}"
+	local path="${3:-/}"
 
-    cat > "${FNOX_CONFIG_FILE:-fnox.toml}" << EOF
+	cat >"${FNOX_CONFIG_FILE:-fnox.toml}" <<EOF
 [providers.infisical]
 type = "infisical"
 EOF
 
-    if [ -n "$project_id" ]; then
-        echo "project_id = \"$project_id\"" >> "${FNOX_CONFIG_FILE:-fnox.toml}"
-    fi
+	if [ -n "$project_id" ]; then
+		echo "project_id = \"$project_id\"" >>"${FNOX_CONFIG_FILE:-fnox.toml}"
+	fi
 
-    if [ -n "$environment" ]; then
-        echo "environment = \"$environment\"" >> "${FNOX_CONFIG_FILE:-fnox.toml}"
-    fi
+	if [ -n "$environment" ]; then
+		echo "environment = \"$environment\"" >>"${FNOX_CONFIG_FILE:-fnox.toml}"
+	fi
 
-    if [ -n "$path" ]; then
-        echo "path = \"$path\"" >> "${FNOX_CONFIG_FILE:-fnox.toml}"
-    fi
+	if [ -n "$path" ]; then
+		echo "path = \"$path\"" >>"${FNOX_CONFIG_FILE:-fnox.toml}"
+	fi
 
-    cat >> "${FNOX_CONFIG_FILE:-fnox.toml}" << EOF
+	cat >>"${FNOX_CONFIG_FILE:-fnox.toml}" <<EOF
 
 [secrets]
 EOF
@@ -87,106 +87,109 @@ EOF
 # Helper function to create a test secret in Infisical
 # Returns the secret name
 create_test_infisical_secret() {
-    local secret_name="FNOX_TEST_$(date +%s)_$(( RANDOM % 10000 ))"
-    local secret_value="test-secret-value-$(date +%s)"
-    local project_id="${1:-${INFISICAL_PROJECT_ID:-}}"
-    local environment="${2:-dev}"
+	local secret_name
+	secret_name="FNOX_TEST_$(date +%s)_$((RANDOM % 10000))"
+	local secret_value
+	secret_value="test-secret-value-$(date +%s)"
+	local project_id="${1:-${INFISICAL_PROJECT_ID:-}}"
+	local environment="${2:-dev}"
 
-    # Create secret with infisical CLI (format: KEY=VALUE)
-    local cmd_args=("secrets" "set" "${secret_name}=${secret_value}")
+	# Create secret with infisical CLI (format: KEY=VALUE)
+	local cmd_args=("secrets" "set" "${secret_name}=${secret_value}")
 
-    if [ -n "$project_id" ]; then
-        cmd_args+=("--projectId=$project_id")
-    fi
+	if [ -n "$project_id" ]; then
+		cmd_args+=("--projectId=$project_id")
+	fi
 
-    if [ -n "$environment" ]; then
-        cmd_args+=("--env=$environment")
-    fi
+	if [ -n "$environment" ]; then
+		cmd_args+=("--env=$environment")
+	fi
 
-    # Use INFISICAL_TOKEN if available for authentication
-    if [ -n "${INFISICAL_TOKEN:-}" ]; then
-        cmd_args+=("--token=$INFISICAL_TOKEN")
-    fi
+	# Use INFISICAL_TOKEN if available for authentication
+	if [ -n "${INFISICAL_TOKEN:-}" ]; then
+		cmd_args+=("--token=$INFISICAL_TOKEN")
+	fi
 
-    if ! infisical "${cmd_args[@]}" >/dev/null 2>&1; then
-        echo "ERROR:Failed to create secret" >&2
-        return 1
-    fi
+	if ! infisical "${cmd_args[@]}" >/dev/null 2>&1; then
+		echo "ERROR:Failed to create secret" >&2
+		return 1
+	fi
 
-    echo "$secret_name"
+	echo "$secret_name"
 }
 
 # Helper function to delete a test secret from Infisical
 delete_test_infisical_secret() {
-    local secret_name="${1}"
-    local project_id="${2:-${INFISICAL_PROJECT_ID:-}}"
-    local environment="${3:-dev}"
+	local secret_name="${1}"
+	local project_id="${2:-${INFISICAL_PROJECT_ID:-}}"
+	local environment="${3:-dev}"
 
-    local cmd_args=("secrets" "delete" "$secret_name")
+	local cmd_args=("secrets" "delete" "$secret_name")
 
-    if [ -n "$project_id" ]; then
-        cmd_args+=("--projectId=$project_id")
-    fi
+	if [ -n "$project_id" ]; then
+		cmd_args+=("--projectId=$project_id")
+	fi
 
-    if [ -n "$environment" ]; then
-        cmd_args+=("--env=$environment")
-    fi
+	if [ -n "$environment" ]; then
+		cmd_args+=("--env=$environment")
+	fi
 
-    # Use INFISICAL_TOKEN if available for authentication
-    if [ -n "${INFISICAL_TOKEN:-}" ]; then
-        cmd_args+=("--token=$INFISICAL_TOKEN")
-    fi
+	# Use INFISICAL_TOKEN if available for authentication
+	if [ -n "${INFISICAL_TOKEN:-}" ]; then
+		cmd_args+=("--token=$INFISICAL_TOKEN")
+	fi
 
-    infisical "${cmd_args[@]}" >/dev/null 2>&1 || true
+	infisical "${cmd_args[@]}" >/dev/null 2>&1 || true
 }
 
 @test "fnox get retrieves secret from Infisical" {
-    # Skip in CI - requires machine identity to be added to project (endpoint unavailable)
-    if [ -n "$GITHUB_ACTIONS" ]; then
-        skip "Requires project access - machine identity not added to project in CI"
-    fi
+	# Skip in CI - requires machine identity to be added to project (endpoint unavailable)
+	if [ -n "$GITHUB_ACTIONS" ]; then
+		skip "Requires project access - machine identity not added to project in CI"
+	fi
 
-    create_infisical_config
+	create_infisical_config
 
-    # Create a test secret
-    secret_name=$(create_test_infisical_secret)
+	# Create a test secret
+	secret_name=$(create_test_infisical_secret)
 
-    # Add secret reference to config
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	# Add secret reference to config
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.TEST_INFISICAL_SECRET]
 provider = "infisical"
 value = "$secret_name"
 EOF
 
-    # Get the secret
-    run "$FNOX_BIN" get TEST_INFISICAL_SECRET
-    assert_success
-    assert_output --partial "test-secret-value-"
+	# Get the secret
+	run "$FNOX_BIN" get TEST_INFISICAL_SECRET
+	assert_success
+	assert_output --partial "test-secret-value-"
 
-    # Cleanup
-    delete_test_infisical_secret "$secret_name"
+	# Cleanup
+	delete_test_infisical_secret "$secret_name"
 }
 
 @test "fnox get fails with invalid secret name" {
-    # Use explicit project_id - either from env or a dummy value for CI
-    # This ensures the CLI tries to access a project and fails appropriately
-    local test_project_id="${INFISICAL_PROJECT_ID:-00000000-0000-0000-0000-000000000000}"
-    create_infisical_config "$test_project_id"
+	# Use explicit project_id - either from env or a dummy value for CI
+	# This ensures the CLI tries to access a project and fails appropriately
+	local test_project_id="${INFISICAL_PROJECT_ID:-00000000-0000-0000-0000-000000000000}"
+	create_infisical_config "$test_project_id"
 
-    # Use a highly unique secret name to avoid collisions
-    local unique_secret="FNOX_TEST_NONEXISTENT_$(date +%s)_$(( RANDOM % 100000 ))_SHOULD_NOT_EXIST"
+	# Use a highly unique secret name to avoid collisions
+	local unique_secret
+	unique_secret="FNOX_TEST_NONEXISTENT_$(date +%s)_$((RANDOM % 100000))_SHOULD_NOT_EXIST"
 
-    # If we have INFISICAL_TOKEN, ensure the secret doesn't exist
-    if [ -n "${INFISICAL_TOKEN:-}" ]; then
-        infisical secrets delete "$unique_secret" \
-            --projectId="$test_project_id" \
-            --env=dev \
-            --token="$INFISICAL_TOKEN" \
-            --silent 2>/dev/null || true
-    fi
+	# If we have INFISICAL_TOKEN, ensure the secret doesn't exist
+	if [ -n "${INFISICAL_TOKEN:-}" ]; then
+		infisical secrets delete "$unique_secret" \
+			--projectId="$test_project_id" \
+			--env=dev \
+			--token="$INFISICAL_TOKEN" \
+			--silent 2>/dev/null || true
+	fi
 
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.INVALID_SECRET]
 provider = "infisical"
@@ -194,22 +197,22 @@ value = "$unique_secret"
 if_missing = "error"
 EOF
 
-    # Try to get non-existent secret
-    # Should fail because the secret doesn't exist and if_missing = "error"
-    run "$FNOX_BIN" get INVALID_SECRET
-    assert_failure
-    # Accept multiple error messages (use partial match to handle line wrapping):
-    # - "Secret '...' not found in Infisical" (*not found* placeholder)
-    # - "Secret '...' not found or inaccessible" (empty array)
-    # - "Infisical CLI command failed" (CLI error)
-    assert_output --partial "not found"
+	# Try to get non-existent secret
+	# Should fail because the secret doesn't exist and if_missing = "error"
+	run "$FNOX_BIN" get INVALID_SECRET
+	assert_failure
+	# Accept multiple error messages (use partial match to handle line wrapping):
+	# - "Secret '...' not found in Infisical" (*not found* placeholder)
+	# - "Secret '...' not found or inaccessible" (empty array)
+	# - "Infisical CLI command failed" (CLI error)
+	assert_output --partial "not found"
 }
 
 @test "fnox list shows Infisical secrets" {
-    # This test doesn't need INFISICAL_TOKEN since list just reads the config file
-    create_infisical_config
+	# This test doesn't need INFISICAL_TOKEN since list just reads the config file
+	create_infisical_config
 
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.INFISICAL_SECRET_1]
 description = "First Infisical secret"
@@ -222,149 +225,150 @@ provider = "infisical"
 value = "API_KEY"
 EOF
 
-    run "$FNOX_BIN" list
-    assert_success
-    assert_output --partial "INFISICAL_SECRET_1"
-    assert_output --partial "INFISICAL_SECRET_2"
-    assert_output --partial "First Infisical secret"
+	run "$FNOX_BIN" list
+	assert_success
+	assert_output --partial "INFISICAL_SECRET_1"
+	assert_output --partial "INFISICAL_SECRET_2"
+	assert_output --partial "First Infisical secret"
 }
 
 @test "Infisical provider works with token from environment" {
-    # Skip in CI - requires machine identity to be added to project (endpoint unavailable)
-    if [ -n "$GITHUB_ACTIONS" ]; then
-        skip "Requires project access - machine identity not added to project in CI"
-    fi
+	# Skip in CI - requires machine identity to be added to project (endpoint unavailable)
+	if [ -n "$GITHUB_ACTIONS" ]; then
+		skip "Requires project access - machine identity not added to project in CI"
+	fi
 
-    # This test verifies that infisical CLI uses INFISICAL_TOKEN from environment
-    # The token should be set by setup() from fnox config or environment
+	# This test verifies that infisical CLI uses INFISICAL_TOKEN from environment
+	# The token should be set by setup() from fnox config or environment
 
-    create_infisical_config
+	create_infisical_config
 
-    secret_name=$(create_test_infisical_secret)
+	secret_name=$(create_test_infisical_secret)
 
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.TEST_WITH_ENV_TOKEN]
 provider = "infisical"
 value = "$secret_name"
 EOF
 
-    # The INFISICAL_TOKEN should be set by setup()
-    run "$FNOX_BIN" get TEST_WITH_ENV_TOKEN
-    assert_success
-    assert_output --partial "test-secret-value-"
+	# The INFISICAL_TOKEN should be set by setup()
+	run "$FNOX_BIN" get TEST_WITH_ENV_TOKEN
+	assert_success
+	assert_output --partial "test-secret-value-"
 
-    # Cleanup
-    delete_test_infisical_secret "$secret_name"
+	# Cleanup
+	delete_test_infisical_secret "$secret_name"
 }
 
 @test "Infisical provider with project_id configuration" {
-    # Note: This test will skip if you don't have a specific project configured
-    # In real usage, you'd provide your project ID
-    create_infisical_config "your-project-id" "dev" "/"
+	# Note: This test will skip if you don't have a specific project configured
+	# In real usage, you'd provide your project ID
+	create_infisical_config "your-project-id" "dev" "/"
 
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.TEST_SECRET]
 provider = "infisical"
 value = "TEST_SECRET"
 EOF
 
-    # This test just verifies the configuration is accepted
-    # It will fail if the project doesn't exist or secret isn't found
-    run "$FNOX_BIN" list
-    assert_success
-    assert_output --partial "TEST_SECRET"
+	# This test just verifies the configuration is accepted
+	# It will fail if the project doesn't exist or secret isn't found
+	run "$FNOX_BIN" list
+	assert_success
+	assert_output --partial "TEST_SECRET"
 }
 
 @test "Infisical provider with environment configuration" {
-    # Test that environment parameter is properly passed
-    create_infisical_config "" "staging" "/"
+	# Test that environment parameter is properly passed
+	create_infisical_config "" "staging" "/"
 
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.STAGING_SECRET]
 provider = "infisical"
 value = "STAGING_SECRET"
 EOF
 
-    # This test just verifies the configuration is accepted
-    run "$FNOX_BIN" list
-    assert_success
-    assert_output --partial "STAGING_SECRET"
+	# This test just verifies the configuration is accepted
+	run "$FNOX_BIN" list
+	assert_success
+	assert_output --partial "STAGING_SECRET"
 }
 
 @test "Infisical provider with path configuration" {
-    # Test that path parameter is properly passed
-    create_infisical_config "" "dev" "/api"
+	# Test that path parameter is properly passed
+	create_infisical_config "" "dev" "/api"
 
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.API_SECRET]
 provider = "infisical"
 value = "API_KEY"
 EOF
 
-    # This test just verifies the configuration is accepted
-    run "$FNOX_BIN" list
-    assert_success
-    assert_output --partial "API_SECRET"
+	# This test just verifies the configuration is accepted
+	run "$FNOX_BIN" list
+	assert_success
+	assert_output --partial "API_SECRET"
 }
 
 @test "fnox exec loads Infisical secrets into environment" {
-    # Skip in CI - requires machine identity to be added to project (endpoint unavailable)
-    if [ -n "$GITHUB_ACTIONS" ]; then
-        skip "Requires project access - machine identity not added to project in CI"
-    fi
+	# Skip in CI - requires machine identity to be added to project (endpoint unavailable)
+	if [ -n "$GITHUB_ACTIONS" ]; then
+		skip "Requires project access - machine identity not added to project in CI"
+	fi
 
-    create_infisical_config
+	create_infisical_config
 
-    secret_name=$(create_test_infisical_secret)
+	secret_name=$(create_test_infisical_secret)
 
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.TEST_EXEC_SECRET]
 provider = "infisical"
 value = "$secret_name"
 EOF
 
-    # Run a command that prints the environment variable
-    run "$FNOX_BIN" exec -- sh -c 'echo "$TEST_EXEC_SECRET"'
-    assert_success
-    assert_output --partial "test-secret-value-"
+	# Run a command that prints the environment variable
+	# shellcheck disable=SC2016 # Single quotes intentional - variable should expand in subshell
+	run "$FNOX_BIN" exec -- sh -c 'echo "$TEST_EXEC_SECRET"'
+	assert_success
+	assert_output --partial "test-secret-value-"
 
-    # Cleanup
-    delete_test_infisical_secret "$secret_name"
+	# Cleanup
+	delete_test_infisical_secret "$secret_name"
 }
 
 @test "Infisical provider fails gracefully with missing credentials" {
-    # Create config with explicit project_id to bypass that check
-    create_infisical_config "test-project-id"
+	# Create config with explicit project_id to bypass that check
+	create_infisical_config "test-project-id"
 
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.TEST_SECRET]
 provider = "infisical"
 value = "DATABASE_URL"
 EOF
 
-    # Temporarily unset all credentials
-    local original_token="$INFISICAL_TOKEN"
-    local original_client_id="$INFISICAL_CLIENT_ID"
-    local original_client_secret="$INFISICAL_CLIENT_SECRET"
-    unset INFISICAL_TOKEN
-    unset INFISICAL_CLIENT_ID
-    unset INFISICAL_CLIENT_SECRET
-    unset FNOX_INFISICAL_TOKEN
-    unset FNOX_INFISICAL_CLIENT_ID
-    unset FNOX_INFISICAL_CLIENT_SECRET
+	# Temporarily unset all credentials
+	local original_token="$INFISICAL_TOKEN"
+	local original_client_id="$INFISICAL_CLIENT_ID"
+	local original_client_secret="$INFISICAL_CLIENT_SECRET"
+	unset INFISICAL_TOKEN
+	unset INFISICAL_CLIENT_ID
+	unset INFISICAL_CLIENT_SECRET
+	unset FNOX_INFISICAL_TOKEN
+	unset FNOX_INFISICAL_CLIENT_ID
+	unset FNOX_INFISICAL_CLIENT_SECRET
 
-    run "$FNOX_BIN" get TEST_SECRET
-    assert_failure
-    assert_output --partial "Infisical authentication not found"
+	run "$FNOX_BIN" get TEST_SECRET
+	assert_failure
+	assert_output --partial "Infisical authentication not found"
 
-    # Restore credentials
-    export INFISICAL_TOKEN="$original_token"
-    export INFISICAL_CLIENT_ID="$original_client_id"
-    export INFISICAL_CLIENT_SECRET="$original_client_secret"
+	# Restore credentials
+	export INFISICAL_TOKEN="$original_token"
+	export INFISICAL_CLIENT_ID="$original_client_id"
+	export INFISICAL_CLIENT_SECRET="$original_client_secret"
 }

--- a/test/init.bats
+++ b/test/init.bats
@@ -1,52 +1,52 @@
 #!/usr/bin/env bats
 
 setup() {
-    load 'test_helper/common_setup'
-    _common_setup
+	load 'test_helper/common_setup'
+	_common_setup
 }
 
 teardown() {
-    _common_teardown
+	_common_teardown
 }
 
 @test "fnox init creates default config file" {
-    assert_fnox_success init
-    assert_file_exists "fnox.toml"
+	assert_fnox_success init
+	assert_file_exists "fnox.toml"
 }
 
 @test "fnox init fails if config already exists" {
-    # First init should succeed
-    assert_fnox_success init
-    
-    # Second init should fail
-    assert_fnox_failure init
-    assert_output --partial "already exists"
+	# First init should succeed
+	assert_fnox_success init
+
+	# Second init should fail
+	assert_fnox_failure init
+	assert_output --partial "already exists"
 }
 
 @test "fnox init creates config with specified path" {
-    assert_fnox_success --config custom-fnox.toml init
-    assert_file_exists "custom-fnox.toml"
+	assert_fnox_success --config custom-fnox.toml init
+	assert_file_exists "custom-fnox.toml"
 }
 
 @test "fnox init creates minimal config" {
-    assert_fnox_success init
-    assert_file_exists "fnox.toml"
+	assert_fnox_success init
+	assert_file_exists "fnox.toml"
 }
 
 @test "fnox commands show helpful error when no config found" {
-    # Create an isolated directory in /tmp with no parent configs
-    local isolated_dir
-    isolated_dir=$(mktemp -d /tmp/fnox-no-config-test.XXXXXX)
+	# Create an isolated directory in /tmp with no parent configs
+	local isolated_dir
+	isolated_dir=$(mktemp -d /tmp/fnox-no-config-test.XXXXXX)
 
-    # Change to isolated directory
-    cd "$isolated_dir" || exit 1
+	# Change to isolated directory
+	cd "$isolated_dir" || exit 1
 
-    # Try to run a command that needs config
-    run "$FNOX_BIN" get MY_SECRET
-    assert_failure
-    assert_output --partial "fnox init"
-    assert_output --partial "No configuration file found"
+	# Try to run a command that needs config
+	run "$FNOX_BIN" get MY_SECRET
+	assert_failure
+	assert_output --partial "fnox init"
+	assert_output --partial "No configuration file found"
 
-    # Clean up
-    rm -rf "$isolated_dir"
+	# Clean up
+	rm -rf "$isolated_dir"
 }

--- a/test/keychain.bats
+++ b/test/keychain.bats
@@ -13,105 +13,105 @@
 #
 
 setup() {
-    load 'test_helper/common_setup'
-    _common_setup
+	load 'test_helper/common_setup'
+	_common_setup
 
-    # Check if keychain tests are disabled via env var
-    if [ -n "$SKIP_KEYCHAIN_TESTS" ]; then
-        skip "Keychain tests disabled via SKIP_KEYCHAIN_TESTS env var"
-    fi
+	# Check if keychain tests are disabled via env var
+	if [ -n "$SKIP_KEYCHAIN_TESTS" ]; then
+		skip "Keychain tests disabled via SKIP_KEYCHAIN_TESTS env var"
+	fi
 
-    # Detect platform
-    local platform
-    platform="$(uname)"
-    export PLATFORM="$platform"
+	# Detect platform
+	local platform
+	platform="$(uname)"
+	export PLATFORM="$platform"
 
-    # Platform-specific setup
-    if [[ "$platform" == "Darwin" ]]; then
-        setup_macos_keychain
-    elif [[ "$platform" == "Linux" ]]; then
-        setup_linux_keychain
-    else
-        skip "OS keychain tests only support macOS and Linux (detected: $platform)"
-    fi
+	# Platform-specific setup
+	if [[ $platform == "Darwin" ]]; then
+		setup_macos_keychain
+	elif [[ $platform == "Linux" ]]; then
+		setup_linux_keychain
+	else
+		skip "OS keychain tests only support macOS and Linux (detected: $platform)"
+	fi
 
-    # Set a unique service name for tests
-    export KEYCHAIN_SERVICE="fnox-test-$$"
+	# Set a unique service name for tests
+	export KEYCHAIN_SERVICE="fnox-test-$$"
 }
 
 setup_macos_keychain() {
-    # In CI environments, skip keychain tests on macOS (they hang)
-    if [ "${CI:-}" = "true" ] || [ -n "${GITHUB_ACTIONS:-}" ] || [ -n "${GITLAB_CI:-}" ] || [ -n "${CIRCLECI:-}" ]; then
-        skip "Keychain tests disabled on macOS CI (tests hang)"
-    fi
+	# In CI environments, skip keychain tests on macOS (they hang)
+	if [ "${CI:-}" = "true" ] || [ -n "${GITHUB_ACTIONS:-}" ] || [ -n "${GITLAB_CI:-}" ] || [ -n "${CIRCLECI:-}" ]; then
+		skip "Keychain tests disabled on macOS CI (tests hang)"
+	fi
 
-    # Verify keychain is accessible by attempting to list keychains
-    security list-keychains >/dev/null 2>&1
+	# Verify keychain is accessible by attempting to list keychains
+	security list-keychains >/dev/null 2>&1
 
-    # Verify keychain access by creating a test entry
-    security add-generic-password -s "fnox-test-access-check-$$" -a "test" -w "test" -U 2>&1
+	# Verify keychain access by creating a test entry
+	security add-generic-password -s "fnox-test-access-check-$$" -a "test" -w "test" -U 2>&1
 
-    # Clean up the test entry
-    security delete-generic-password -s "fnox-test-access-check-$$" -a "test" 2>&1 || true
+	# Clean up the test entry
+	security delete-generic-password -s "fnox-test-access-check-$$" -a "test" 2>&1 || true
 }
 
 setup_linux_keychain() {
-    # Check if secret-tool is available (for manual testing verification)
-    if ! command -v secret-tool >/dev/null 2>&1; then
-        echo "# Warning: secret-tool not found (install libsecret-tools for manual testing)" >&3
-    fi
+	# Check if secret-tool is available (for manual testing verification)
+	if ! command -v secret-tool >/dev/null 2>&1; then
+		echo "# Warning: secret-tool not found (install libsecret-tools for manual testing)" >&3
+	fi
 
-    # In CI environments, assume gnome-keyring-daemon is already running
-    # (started by CI workflow before tests begin)
-    if [ "${CI:-}" = "true" ] || [ -n "${GITHUB_ACTIONS:-}" ] || [ -n "${GITLAB_CI:-}" ] || [ -n "${CIRCLECI:-}" ]; then
-        export USING_TEST_KEYRING=1
-        return 0
-    fi
+	# In CI environments, assume gnome-keyring-daemon is already running
+	# (started by CI workflow before tests begin)
+	if [ "${CI:-}" = "true" ] || [ -n "${GITHUB_ACTIONS:-}" ] || [ -n "${GITLAB_CI:-}" ] || [ -n "${CIRCLECI:-}" ]; then
+		export USING_TEST_KEYRING=1
+		return 0
+	fi
 
-    # For non-CI Linux, verify that a secret service is available via D-Bus
-    if [ -z "${USING_TEST_KEYRING:-}" ]; then
-        # Connect to the secret service (fail if not available)
-        dbus-send --print-reply --dest=org.freedesktop.secrets /org/freedesktop/secrets org.freedesktop.DBus.Peer.Ping >/dev/null 2>&1
-    fi
+	# For non-CI Linux, verify that a secret service is available via D-Bus
+	if [ -z "${USING_TEST_KEYRING:-}" ]; then
+		# Connect to the secret service (fail if not available)
+		dbus-send --print-reply --dest=org.freedesktop.secrets /org/freedesktop/secrets org.freedesktop.DBus.Peer.Ping >/dev/null 2>&1
+	fi
 }
 
 teardown() {
-    # Clean up any test secrets from keychain (platform-specific)
-    if [ -n "$TEST_SECRET_KEYS" ]; then
-        for key in $TEST_SECRET_KEYS; do
-            if [[ "$PLATFORM" == "Darwin" ]]; then
-                # macOS: Use security command to delete test secrets
-                security delete-generic-password -s "$KEYCHAIN_SERVICE" -a "$key" >/dev/null 2>&1 || true
-            elif [[ "$PLATFORM" == "Linux" ]] && command -v secret-tool >/dev/null 2>&1; then
-                # Linux: Use secret-tool to delete test secrets
-                secret-tool clear service "$KEYCHAIN_SERVICE" account "$key" >/dev/null 2>&1 || true
-            fi
-        done
-    fi
+	# Clean up any test secrets from keychain (platform-specific)
+	if [ -n "$TEST_SECRET_KEYS" ]; then
+		for key in $TEST_SECRET_KEYS; do
+			if [[ $PLATFORM == "Darwin" ]]; then
+				# macOS: Use security command to delete test secrets
+				security delete-generic-password -s "$KEYCHAIN_SERVICE" -a "$key" >/dev/null 2>&1 || true
+			elif [[ $PLATFORM == "Linux" ]] && command -v secret-tool >/dev/null 2>&1; then
+				# Linux: Use secret-tool to delete test secrets
+				secret-tool clear service "$KEYCHAIN_SERVICE" account "$key" >/dev/null 2>&1 || true
+			fi
+		done
+	fi
 
-    # Note: Don't kill gnome-keyring-daemon or dbus in CI
-    # They are started by the CI workflow and shared across all tests
+	# Note: Don't kill gnome-keyring-daemon or dbus in CI
+	# They are started by the CI workflow and shared across all tests
 
-    _common_teardown
+	_common_teardown
 }
 
 # Helper function to create a keychain provider config
 create_keychain_config() {
-    local service="${1:-fnox-test}"
-    local prefix="${2:-}"
-    cat > "${FNOX_CONFIG_FILE:-fnox.toml}" << EOF
+	local service="${1:-fnox-test}"
+	local prefix="${2:-}"
+	cat >"${FNOX_CONFIG_FILE:-fnox.toml}" <<EOF
 [providers.keychain]
 type = "keychain"
 service = "$service"
 EOF
 
-    if [ -n "$prefix" ]; then
-        cat >> "${FNOX_CONFIG_FILE}" << EOF
+	if [ -n "$prefix" ]; then
+		cat >>"${FNOX_CONFIG_FILE}" <<EOF
 prefix = "$prefix"
 EOF
-    fi
+	fi
 
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets]
 EOF
@@ -119,241 +119,241 @@ EOF
 
 # Helper to track secret keys for cleanup
 track_secret() {
-    local key="$1"
-    TEST_SECRET_KEYS="${TEST_SECRET_KEYS:-} $key"
+	local key="$1"
+	TEST_SECRET_KEYS="${TEST_SECRET_KEYS:-} $key"
 }
 
 @test "fnox set stores secret in OS keychain" {
-    create_keychain_config "$KEYCHAIN_SERVICE"
+	create_keychain_config "$KEYCHAIN_SERVICE"
 
-    # Set a secret using the keychain provider
-    run "$FNOX_BIN" set MY_SECRET "my-secret-value" --provider keychain
-    assert_success
-    assert_output --partial "Set secret MY_SECRET"
+	# Set a secret using the keychain provider
+	run "$FNOX_BIN" set MY_SECRET "my-secret-value" --provider keychain
+	assert_success
+	assert_output --partial "Set secret MY_SECRET"
 
-    track_secret "MY_SECRET"
+	track_secret "MY_SECRET"
 
-    # Verify the config contains only a reference (not the value)
-    run cat "${FNOX_CONFIG_FILE}"
-    assert_success
-    # Check for inline table or TOML table format (both are valid)
-    assert_output --partial 'MY_SECRET'
-    assert_output --partial 'provider = "keychain"'
-    assert_output --partial 'value = "MY_SECRET"'
-    refute_output --partial "my-secret-value"
+	# Verify the config contains only a reference (not the value)
+	run cat "${FNOX_CONFIG_FILE}"
+	assert_success
+	# Check for inline table or TOML table format (both are valid)
+	assert_output --partial 'MY_SECRET'
+	assert_output --partial 'provider = "keychain"'
+	assert_output --partial 'value = "MY_SECRET"'
+	refute_output --partial "my-secret-value"
 }
 
 @test "fnox get retrieves secret from OS keychain" {
-    create_keychain_config "$KEYCHAIN_SERVICE"
+	create_keychain_config "$KEYCHAIN_SERVICE"
 
-    # Set a secret
-    run "$FNOX_BIN" set TEST_GET "test-value-123" --provider keychain
-    assert_success
-    track_secret "TEST_GET"
+	# Set a secret
+	run "$FNOX_BIN" set TEST_GET "test-value-123" --provider keychain
+	assert_success
+	track_secret "TEST_GET"
 
-    # Get the secret back
-    run "$FNOX_BIN" get TEST_GET
-    assert_success
-    assert_output "test-value-123"
+	# Get the secret back
+	run "$FNOX_BIN" get TEST_GET
+	assert_success
+	assert_output "test-value-123"
 }
 
 @test "fnox set and get with prefix" {
-    create_keychain_config "$KEYCHAIN_SERVICE" "myapp/"
+	create_keychain_config "$KEYCHAIN_SERVICE" "myapp/"
 
-    # Set a secret with prefix
-    run "$FNOX_BIN" set PREFIXED_SECRET "prefixed-value" --provider keychain
-    assert_success
-    track_secret "myapp/PREFIXED_SECRET"
+	# Set a secret with prefix
+	run "$FNOX_BIN" set PREFIXED_SECRET "prefixed-value" --provider keychain
+	assert_success
+	track_secret "myapp/PREFIXED_SECRET"
 
-    # Get the secret (prefix is applied automatically)
-    run "$FNOX_BIN" get PREFIXED_SECRET
-    assert_success
-    assert_output "prefixed-value"
+	# Get the secret (prefix is applied automatically)
+	run "$FNOX_BIN" get PREFIXED_SECRET
+	assert_success
+	assert_output "prefixed-value"
 }
 
 @test "fnox get fails with non-existent secret" {
-    create_keychain_config "$KEYCHAIN_SERVICE"
+	create_keychain_config "$KEYCHAIN_SERVICE"
 
-    # Manually add a reference to a non-existent secret
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	# Manually add a reference to a non-existent secret
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.NONEXISTENT]
 provider = "keychain"
 value = "does-not-exist-$$"
 EOF
 
-    # Try to get non-existent secret
-    run "$FNOX_BIN" get NONEXISTENT
-    assert_failure
-    assert_output --partial "Failed to retrieve secret"
+	# Try to get non-existent secret
+	run "$FNOX_BIN" get NONEXISTENT
+	assert_failure
+	assert_output --partial "Failed to retrieve secret"
 }
 
 @test "fnox set with special characters" {
-    create_keychain_config "$KEYCHAIN_SERVICE"
+	create_keychain_config "$KEYCHAIN_SERVICE"
 
-    local secret_value='p@ssw0rd!#$%^&*()_+-={}[]|\:";'\''<>?,./~`'
+	local secret_value='p@ssw0rd!#$%^&*()_+-={}[]|\:";'\''<>?,./~`'
 
-    # Set a secret with special characters
-    run "$FNOX_BIN" set SPECIAL_CHARS "$secret_value" --provider keychain
-    assert_success
-    track_secret "SPECIAL_CHARS"
+	# Set a secret with special characters
+	run "$FNOX_BIN" set SPECIAL_CHARS "$secret_value" --provider keychain
+	assert_success
+	track_secret "SPECIAL_CHARS"
 
-    # Get it back
-    run "$FNOX_BIN" get SPECIAL_CHARS
-    assert_success
-    assert_output "$secret_value"
+	# Get it back
+	run "$FNOX_BIN" get SPECIAL_CHARS
+	assert_success
+	assert_output "$secret_value"
 }
 
 @test "fnox set with multiline value" {
-    create_keychain_config "$KEYCHAIN_SERVICE"
+	create_keychain_config "$KEYCHAIN_SERVICE"
 
-    local multiline_value="line1
+	local multiline_value="line1
 line2
 line3"
 
-    # Set a multiline secret (using bash -c for stdin pipe)
-    run bash -c "echo '$multiline_value' | '$FNOX_BIN' set MULTILINE --provider keychain"
-    assert_success
-    track_secret "MULTILINE"
+	# Set a multiline secret (using bash -c for stdin pipe)
+	run bash -c "echo '$multiline_value' | '$FNOX_BIN' set MULTILINE --provider keychain"
+	assert_success
+	track_secret "MULTILINE"
 
-    # Get it back
-    run "$FNOX_BIN" get MULTILINE
-    assert_success
-    assert_output "$multiline_value"
+	# Get it back
+	run "$FNOX_BIN" get MULTILINE
+	assert_success
+	assert_output "$multiline_value"
 }
 
 @test "fnox set with interactive prompt" {
-    skip "Interactive test - requires manual testing"
-    # This test would require interactive input
-    # Manual test: fnox set INTERACTIVE_SECRET --provider keychain
-    # (will prompt for value when no value provided and stdin is a tty)
+	skip "Interactive test - requires manual testing"
+	# This test would require interactive input
+	# Manual test: fnox set INTERACTIVE_SECRET --provider keychain
+	# (will prompt for value when no value provided and stdin is a tty)
 }
 
 @test "fnox set updates existing secret" {
-    create_keychain_config "$KEYCHAIN_SERVICE"
+	create_keychain_config "$KEYCHAIN_SERVICE"
 
-    # Set initial value
-    run "$FNOX_BIN" set UPDATE_TEST "initial-value" --provider keychain
-    assert_success
-    track_secret "UPDATE_TEST"
+	# Set initial value
+	run "$FNOX_BIN" set UPDATE_TEST "initial-value" --provider keychain
+	assert_success
+	track_secret "UPDATE_TEST"
 
-    # Update the value
-    run "$FNOX_BIN" set UPDATE_TEST "updated-value" --provider keychain
-    assert_success
+	# Update the value
+	run "$FNOX_BIN" set UPDATE_TEST "updated-value" --provider keychain
+	assert_success
 
-    # Get the updated value
-    run "$FNOX_BIN" get UPDATE_TEST
-    assert_success
-    assert_output "updated-value"
+	# Get the updated value
+	run "$FNOX_BIN" get UPDATE_TEST
+	assert_success
+	assert_output "updated-value"
 }
 
 @test "fnox list shows keychain secrets" {
-    create_keychain_config "$KEYCHAIN_SERVICE"
+	create_keychain_config "$KEYCHAIN_SERVICE"
 
-    # Set multiple secrets
-    run "$FNOX_BIN" set SECRET1 "value1" --provider keychain --description "First secret"
-    assert_success
-    track_secret "SECRET1"
+	# Set multiple secrets
+	run "$FNOX_BIN" set SECRET1 "value1" --provider keychain --description "First secret"
+	assert_success
+	track_secret "SECRET1"
 
-    run "$FNOX_BIN" set SECRET2 "value2" --provider keychain --description "Second secret"
-    assert_success
-    track_secret "SECRET2"
+	run "$FNOX_BIN" set SECRET2 "value2" --provider keychain --description "Second secret"
+	assert_success
+	track_secret "SECRET2"
 
-    # List secrets
-    run "$FNOX_BIN" list
-    assert_success
-    assert_output --partial "SECRET1"
-    assert_output --partial "SECRET2"
-    assert_output --partial "First secret"
-    assert_output --partial "Second secret"
+	# List secrets
+	run "$FNOX_BIN" list
+	assert_success
+	assert_output --partial "SECRET1"
+	assert_output --partial "SECRET2"
+	assert_output --partial "First secret"
+	assert_output --partial "Second secret"
 }
 
 @test "fnox exec with keychain secrets" {
-    create_keychain_config "$KEYCHAIN_SERVICE"
+	create_keychain_config "$KEYCHAIN_SERVICE"
 
-    # Set a secret
-    run "$FNOX_BIN" set EXEC_TEST "exec-value" --provider keychain
-    assert_success
-    track_secret "EXEC_TEST"
+	# Set a secret
+	run "$FNOX_BIN" set EXEC_TEST "exec-value" --provider keychain
+	assert_success
+	track_secret "EXEC_TEST"
 
-    # Use it in exec (redirect stderr to filter age warnings from global config)
-    run bash -c "'$FNOX_BIN' exec -- bash -c 'echo \$EXEC_TEST' 2>/dev/null"
-    assert_success
-    assert_output "exec-value"
+	# Use it in exec (redirect stderr to filter age warnings from global config)
+	run bash -c "'$FNOX_BIN' exec -- bash -c 'echo \$EXEC_TEST' 2>/dev/null"
+	assert_success
+	assert_output "exec-value"
 }
 
 @test "fnox set with description metadata" {
-    create_keychain_config "$KEYCHAIN_SERVICE"
+	create_keychain_config "$KEYCHAIN_SERVICE"
 
-    # Set secret with description
-    run "$FNOX_BIN" set DESCRIBED "value" --provider keychain --description "Test description"
-    assert_success
-    track_secret "DESCRIBED"
+	# Set secret with description
+	run "$FNOX_BIN" set DESCRIBED "value" --provider keychain --description "Test description"
+	assert_success
+	track_secret "DESCRIBED"
 
-    # Verify description in list
-    run "$FNOX_BIN" list
-    assert_success
-    assert_output --partial "DESCRIBED"
-    assert_output --partial "Test description"
+	# Verify description in list
+	run "$FNOX_BIN" list
+	assert_success
+	assert_output --partial "DESCRIBED"
+	assert_output --partial "Test description"
 }
 
 @test "fnox get with JSON-like value" {
-    create_keychain_config "$KEYCHAIN_SERVICE"
+	create_keychain_config "$KEYCHAIN_SERVICE"
 
-    local json_value='{"api_key":"test123","endpoint":"https://api.example.com"}'
+	local json_value='{"api_key":"test123","endpoint":"https://api.example.com"}'
 
-    # Set JSON value
-    run "$FNOX_BIN" set JSON_SECRET "$json_value" --provider keychain
-    assert_success
-    track_secret "JSON_SECRET"
+	# Set JSON value
+	run "$FNOX_BIN" set JSON_SECRET "$json_value" --provider keychain
+	assert_success
+	track_secret "JSON_SECRET"
 
-    # Get it back
-    run "$FNOX_BIN" get JSON_SECRET
-    assert_success
-    assert_output "$json_value"
+	# Get it back
+	run "$FNOX_BIN" get JSON_SECRET
+	assert_success
+	assert_output "$json_value"
 }
 
 @test "keychain provider isolation with different service names" {
-    # Create config with first service
-    create_keychain_config "${KEYCHAIN_SERVICE}-1"
-    run "$FNOX_BIN" set ISOLATED1 "value1" --provider keychain
-    assert_success
-    track_secret "ISOLATED1"
+	# Create config with first service
+	create_keychain_config "${KEYCHAIN_SERVICE}-1"
+	run "$FNOX_BIN" set ISOLATED1 "value1" --provider keychain
+	assert_success
+	track_secret "ISOLATED1"
 
-    # Create config with second service
-    create_keychain_config "${KEYCHAIN_SERVICE}-2"
-    run "$FNOX_BIN" set ISOLATED2 "value2" --provider keychain
-    assert_success
-    track_secret "ISOLATED2"
+	# Create config with second service
+	create_keychain_config "${KEYCHAIN_SERVICE}-2"
+	run "$FNOX_BIN" set ISOLATED2 "value2" --provider keychain
+	assert_success
+	track_secret "ISOLATED2"
 
-    # First secret should not be accessible with second config
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	# First secret should not be accessible with second config
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.ISOLATED1]
 provider = "keychain"
 value = "ISOLATED1"
 EOF
 
-    run "$FNOX_BIN" get ISOLATED1
-    assert_failure
+	run "$FNOX_BIN" get ISOLATED1
+	assert_failure
 }
 
 @test "fnox set reads from stdin" {
-    create_keychain_config "$KEYCHAIN_SERVICE"
+	create_keychain_config "$KEYCHAIN_SERVICE"
 
-    # Set secret from stdin (using bash -c for stdin pipe)
-    run bash -c "echo 'stdin-value' | '$FNOX_BIN' set STDIN_SECRET --provider keychain"
-    assert_success
-    track_secret "STDIN_SECRET"
+	# Set secret from stdin (using bash -c for stdin pipe)
+	run bash -c "echo 'stdin-value' | '$FNOX_BIN' set STDIN_SECRET --provider keychain"
+	assert_success
+	track_secret "STDIN_SECRET"
 
-    # Get it back
-    run "$FNOX_BIN" get STDIN_SECRET
-    assert_success
-    assert_output "stdin-value"
+	# Get it back
+	run "$FNOX_BIN" get STDIN_SECRET
+	assert_success
+	assert_output "stdin-value"
 }
 
 @test "fnox with empty service name fails gracefully" {
-    cat > "${FNOX_CONFIG_FILE}" << EOF
+	cat >"${FNOX_CONFIG_FILE}" <<EOF
 [providers.keychain]
 type = "keychain"
 service = ""
@@ -363,34 +363,34 @@ provider = "keychain"
 value = "test"
 EOF
 
-    # Should fail with helpful error
-    run "$FNOX_BIN" get TEST
-    assert_failure
+	# Should fail with helpful error
+	run "$FNOX_BIN" get TEST
+	assert_failure
 }
 
 @test "keychain provider with long values" {
-    create_keychain_config "$KEYCHAIN_SERVICE"
+	create_keychain_config "$KEYCHAIN_SERVICE"
 
-    # Create a long value (4KB)
-    local long_value
-    long_value=$(python3 -c "print('a' * 4096)")
+	# Create a long value (4KB)
+	local long_value
+	long_value=$(python3 -c "print('a' * 4096)")
 
-    # Set long value
-    run "$FNOX_BIN" set LONG_SECRET "$long_value" --provider keychain
-    assert_success
-    track_secret "LONG_SECRET"
+	# Set long value
+	run "$FNOX_BIN" set LONG_SECRET "$long_value" --provider keychain
+	assert_success
+	track_secret "LONG_SECRET"
 
-    # Get it back
-    run "$FNOX_BIN" get LONG_SECRET
-    assert_success
-    assert_output "$long_value"
+	# Get it back
+	run "$FNOX_BIN" get LONG_SECRET
+	assert_success
+	assert_output "$long_value"
 }
 
 @test "fnox check detects missing keychain secrets" {
-    create_keychain_config "$KEYCHAIN_SERVICE"
+	create_keychain_config "$KEYCHAIN_SERVICE"
 
-    # Add reference without actually storing in keychain
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	# Add reference without actually storing in keychain
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.MISSING_SECRET]
 provider = "keychain"
@@ -398,8 +398,8 @@ value = "not-in-keychain"
 if_missing = "error"
 EOF
 
-    # Check should detect the missing secret
-    run "$FNOX_BIN" check
-    assert_failure
-    assert_output --partial "MISSING_SECRET"
+	# Check should detect the missing secret
+	run "$FNOX_BIN" check
+	assert_failure
+	assert_output --partial "MISSING_SECRET"
 }

--- a/test/list.bats
+++ b/test/list.bats
@@ -1,27 +1,27 @@
 #!/usr/bin/env bats
 
 setup() {
-    load 'test_helper/common_setup'
-    _common_setup
+	load 'test_helper/common_setup'
+	_common_setup
 }
 
 teardown() {
-    _common_teardown
+	_common_teardown
 }
 
 @test "fnox list shows empty message with no secrets" {
-    # Create empty config with root=true to prevent recursion
-    echo "root = true" > "${FNOX_CONFIG_FILE:-fnox.toml}"
+	# Create empty config with root=true to prevent recursion
+	echo "root = true" >"${FNOX_CONFIG_FILE:-fnox.toml}"
 
-    assert_fnox_success list
-    assert_output --partial "No secrets defined"
+	assert_fnox_success list
+	assert_output --partial "No secrets defined"
 }
 
 @test "fnox list displays table with secrets" {
-    create_test_config
+	create_test_config
 
-    # Add more secrets for a richer test
-    cat >> "${FNOX_CONFIG_FILE:-fnox.toml}" << EOF
+	# Add more secrets for a richer test
+	cat >>"${FNOX_CONFIG_FILE:-fnox.toml}" <<EOF
 
 [secrets.db_password]
 default = "default_password"
@@ -33,33 +33,33 @@ value = "api-key-name"
 description = "API key from provider"
 EOF
 
-    assert_fnox_success list
-    assert_output --partial "Key"
-    assert_output --partial "Type"
-    assert_output --partial "test_secret"
-    assert_output --partial "db_password"
-    assert_output --partial "api_key"
+	assert_fnox_success list
+	assert_output --partial "Key"
+	assert_output --partial "Type"
+	assert_output --partial "test_secret"
+	assert_output --partial "db_password"
+	assert_output --partial "api_key"
 }
 
 @test "fnox list shows descriptions" {
-    create_test_config
+	create_test_config
 
-    cat >> "${FNOX_CONFIG_FILE:-fnox.toml}" << EOF
+	cat >>"${FNOX_CONFIG_FILE:-fnox.toml}" <<EOF
 
 [secrets.my_secret]
 default = "secret_value"
 description = "My test secret"
 EOF
 
-    assert_fnox_success list
-    assert_output --partial "my_secret"
-    assert_output --partial "My test secret"
+	assert_fnox_success list
+	assert_output --partial "my_secret"
+	assert_output --partial "My test secret"
 }
 
 @test "fnox list shows provider information" {
-    create_test_config
+	create_test_config
 
-    cat >> "${FNOX_CONFIG_FILE:-fnox.toml}" << EOF
+	cat >>"${FNOX_CONFIG_FILE:-fnox.toml}" <<EOF
 
 [secrets.provider_secret]
 provider = "test-provider"
@@ -67,16 +67,16 @@ value = "provider-key-123"
 description = "Secret from provider"
 EOF
 
-    assert_fnox_success list
-    assert_output --partial "provider_secret"
-    assert_output --partial "provider (test-provider)"
-    assert_output --partial "provider-key-123"
+	assert_fnox_success list
+	assert_output --partial "provider_secret"
+	assert_output --partial "provider (test-provider)"
+	assert_output --partial "provider-key-123"
 }
 
 @test "fnox list shows secrets with if_missing defined" {
-    create_test_config
+	create_test_config
 
-    cat >> "${FNOX_CONFIG_FILE:-fnox.toml}" << EOF
+	cat >>"${FNOX_CONFIG_FILE:-fnox.toml}" <<EOF
 
 [secrets.required_secret]
 if_missing = "error"
@@ -87,15 +87,15 @@ if_missing = "warn"
 description = "Optional secret"
 EOF
 
-    assert_fnox_success list
-    assert_output --partial "required_secret"
-    assert_output --partial "optional_secret"
+	assert_fnox_success list
+	assert_output --partial "required_secret"
+	assert_output --partial "optional_secret"
 }
 
 @test "fnox list with specific profile" {
-    create_test_config
+	create_test_config
 
-    cat >> "${FNOX_CONFIG_FILE:-fnox.toml}" << EOF
+	cat >>"${FNOX_CONFIG_FILE:-fnox.toml}" <<EOF
 
 [profiles.production]
 [profiles.production.secrets]
@@ -105,51 +105,51 @@ default = "prod_value"
 description = "Production secret"
 EOF
 
-    assert_fnox_success list --profile production
-    assert_output --partial "prod_secret"
+	assert_fnox_success list --profile production
+	assert_output --partial "prod_secret"
 }
 
 @test "fnox list shows values with --values flag" {
-    create_test_config
+	create_test_config
 
-    cat >> "${FNOX_CONFIG_FILE:-fnox.toml}" << EOF
+	cat >>"${FNOX_CONFIG_FILE:-fnox.toml}" <<EOF
 
 [secrets.visible_secret]
 default = "visible_value"
 description = "Secret with visible value"
 EOF
 
-    assert_fnox_success list --values
-    assert_output --partial "visible_secret"
-    assert_output --partial "visible_value"
+	assert_fnox_success list --values
+	assert_output --partial "visible_secret"
+	assert_output --partial "visible_value"
 }
 
 @test "fnox list without --values flag does not show values" {
-    create_test_config
+	create_test_config
 
-    cat >> "${FNOX_CONFIG_FILE:-fnox.toml}" << EOF
+	cat >>"${FNOX_CONFIG_FILE:-fnox.toml}" <<EOF
 
 [secrets.hidden_secret]
 default = "hidden_value"
 description = "Secret with hidden value"
 EOF
 
-    assert_fnox_success list
-    assert_output --partial "hidden_secret"
-    refute_output --partial "hidden_value"
+	assert_fnox_success list
+	assert_output --partial "hidden_secret"
+	refute_output --partial "hidden_value"
 }
 
 @test "fnox list works with ls alias" {
-    create_test_config
+	create_test_config
 
-    assert_fnox_success ls
-    assert_output --partial "test_secret"
+	assert_fnox_success ls
+	assert_output --partial "test_secret"
 }
 
 @test "fnox list shows different source types" {
-    create_test_config
+	create_test_config
 
-    cat >> "${FNOX_CONFIG_FILE:-fnox.toml}" << EOF
+	cat >>"${FNOX_CONFIG_FILE:-fnox.toml}" <<EOF
 
 [secrets.stored_secret]
 value = "stored_value"
@@ -168,17 +168,17 @@ value = "provider-key"
 description = "Provider secret"
 EOF
 
-    assert_fnox_success list
-    assert_output --partial "stored_secret"
-    assert_output --partial "default_secret"
-    assert_output --partial "env_secret"
-    assert_output --partial "provider_secret"
+	assert_fnox_success list
+	assert_output --partial "stored_secret"
+	assert_output --partial "default_secret"
+	assert_output --partial "env_secret"
+	assert_output --partial "provider_secret"
 }
 
 @test "fnox list with --full flag shows full provider keys" {
-    create_test_config
+	create_test_config
 
-    cat >> "${FNOX_CONFIG_FILE:-fnox.toml}" << EOF
+	cat >>"${FNOX_CONFIG_FILE:-fnox.toml}" <<EOF
 
 [secrets.long_key]
 provider = "test-provider"
@@ -186,113 +186,113 @@ value = "this-is-a-very-long-provider-key-that-exceeds-forty-characters-in-lengt
 description = "Secret with long key"
 EOF
 
-    # Without --full, should be truncated
-    run "$FNOX_BIN" list
-    assert_success
-    assert_output --partial "this-is-a-very-long-provider-key-that..."
+	# Without --full, should be truncated
+	run "$FNOX_BIN" list
+	assert_success
+	assert_output --partial "this-is-a-very-long-provider-key-that..."
 
-    # With --full, should show complete key
-    run "$FNOX_BIN" list --full
-    assert_success
-    assert_output --partial "this-is-a-very-long-provider-key-that-exceeds-forty-characters-in-length"
+	# With --full, should show complete key
+	run "$FNOX_BIN" list --full
+	assert_success
+	assert_output --partial "this-is-a-very-long-provider-key-that-exceeds-forty-characters-in-length"
 }
 
 @test "fnox list --values shows comprehensive information" {
-    create_test_config
+	create_test_config
 
-    cat >> "${FNOX_CONFIG_FILE:-fnox.toml}" << EOF
+	cat >>"${FNOX_CONFIG_FILE:-fnox.toml}" <<EOF
 
 [secrets.complete_secret]
 default = "secret_value_123"
 description = "Complete secret"
 EOF
 
-    assert_fnox_success list --values
-    assert_output --partial "complete_secret"
-    assert_output --partial "secret_value_123"
-    assert_output --partial "Value"
+	assert_fnox_success list --values
+	assert_output --partial "complete_secret"
+	assert_output --partial "secret_value_123"
+	assert_output --partial "Value"
 }
 
 @test "fnox list with --no-color flag works" {
-    create_test_config
+	create_test_config
 
-    # Should work without error
-    assert_fnox_success list --no-color
-    assert_output --partial "test_secret"
+	# Should work without error
+	assert_fnox_success list --no-color
+	assert_output --partial "test_secret"
 }
 
 @test "fnox list with --sources flag shows source file paths" {
-    create_test_config
+	create_test_config
 
-    cat >> "${FNOX_CONFIG_FILE:-fnox.toml}" << EOF
+	cat >>"${FNOX_CONFIG_FILE:-fnox.toml}" <<EOF
 
 [secrets.source_test]
 default = "test_value"
 description = "Test secret for source tracking"
 EOF
 
-    assert_fnox_success list --sources
-    assert_output --partial "Source File"
-    assert_output --partial "source_test"
-    assert_output --partial "fnox.toml"
+	assert_fnox_success list --sources
+	assert_output --partial "Source File"
+	assert_output --partial "source_test"
+	assert_output --partial "fnox.toml"
 }
 
 @test "fnox list --sources shows correct file path" {
-    create_test_config
+	create_test_config
 
-    # Create a config with secrets
-    cat >> "${FNOX_CONFIG_FILE:-fnox.toml}" << EOF
+	# Create a config with secrets
+	cat >>"${FNOX_CONFIG_FILE:-fnox.toml}" <<EOF
 
 [secrets.tracked_secret]
 default = "tracked_value"
 description = "Secret with source tracking"
 EOF
 
-    run "$FNOX_BIN" list --sources
-    assert_success
-    # Should show the full path to the config file
-    assert_output --partial "$(pwd)/fnox.toml"
+	run "$FNOX_BIN" list --sources
+	assert_success
+	# Should show the full path to the config file
+	assert_output --partial "$(pwd)/fnox.toml"
 }
 
 @test "fnox list --sources --values shows both source and values" {
-    create_test_config
+	create_test_config
 
-    cat >> "${FNOX_CONFIG_FILE:-fnox.toml}" << EOF
+	cat >>"${FNOX_CONFIG_FILE:-fnox.toml}" <<EOF
 
 [secrets.combined_test]
 default = "combined_value"
 description = "Test for combined flags"
 EOF
 
-    assert_fnox_success list --sources --values
-    assert_output --partial "Source File"
-    assert_output --partial "Value"
-    assert_output --partial "combined_test"
-    assert_output --partial "combined_value"
-    assert_output --partial "fnox.toml"
+	assert_fnox_success list --sources --values
+	assert_output --partial "Source File"
+	assert_output --partial "Value"
+	assert_output --partial "combined_test"
+	assert_output --partial "combined_value"
+	assert_output --partial "fnox.toml"
 }
 
 @test "fnox list without --sources does not show Source File column" {
-    create_test_config
+	create_test_config
 
-    cat >> "${FNOX_CONFIG_FILE:-fnox.toml}" << EOF
+	cat >>"${FNOX_CONFIG_FILE:-fnox.toml}" <<EOF
 
 [secrets.no_source]
 default = "no_source_value"
 EOF
 
-    assert_fnox_success list
-    refute_output --partial "Source File"
-    assert_output --partial "no_source"
+	assert_fnox_success list
+	refute_output --partial "Source File"
+	assert_output --partial "no_source"
 }
 
 @test "fnox list --values resolves secrets from age provider" {
-    # Generate age key pair
-    AGE_KEY=$(age-keygen 2>&1 | grep "^AGE-SECRET-KEY" || true)
-    AGE_PUB=$(echo "$AGE_KEY" | age-keygen -y 2>/dev/null || true)
+	# Generate age key pair
+	AGE_KEY=$(age-keygen 2>&1 | grep "^AGE-SECRET-KEY" || true)
+	AGE_PUB=$(echo "$AGE_KEY" | age-keygen -y 2>/dev/null || true)
 
-    # Create a config with age provider
-    cat > "${FNOX_CONFIG_FILE:-fnox.toml}" << EOF
+	# Create a config with age provider
+	cat >"${FNOX_CONFIG_FILE:-fnox.toml}" <<EOF
 root = true
 
 [providers.age]
@@ -300,29 +300,29 @@ type = "age"
 recipients = ["$AGE_PUB"]
 EOF
 
-    # Store the age key for decryption
-    mkdir -p "$HOME/.config/fnox"
-    echo "$AGE_KEY" > "$HOME/.config/fnox/age.txt"
+	# Store the age key for decryption
+	mkdir -p "$HOME/.config/fnox"
+	echo "$AGE_KEY" >"$HOME/.config/fnox/age.txt"
 
-    # Set a secret using age provider
-    run "$FNOX_BIN" set MY_SECRET "decrypted-value-123" --provider age
-    assert_success
+	# Set a secret using age provider
+	run "$FNOX_BIN" set MY_SECRET "decrypted-value-123" --provider age
+	assert_success
 
-    # List with --values should show the decrypted value
-    run "$FNOX_BIN" list --values
-    assert_success
-    assert_output --partial "MY_SECRET"
-    assert_output --partial "decrypted-value-123"
-    assert_output --partial "Value"
+	# List with --values should show the decrypted value
+	run "$FNOX_BIN" list --values
+	assert_success
+	assert_output --partial "MY_SECRET"
+	assert_output --partial "decrypted-value-123"
+	assert_output --partial "Value"
 }
 
 @test "fnox list --values shows decrypted values in Value column" {
-    # Generate age key pair
-    AGE_KEY=$(age-keygen 2>&1 | grep "^AGE-SECRET-KEY" || true)
-    AGE_PUB=$(echo "$AGE_KEY" | age-keygen -y 2>/dev/null || true)
+	# Generate age key pair
+	AGE_KEY=$(age-keygen 2>&1 | grep "^AGE-SECRET-KEY" || true)
+	AGE_PUB=$(echo "$AGE_KEY" | age-keygen -y 2>/dev/null || true)
 
-    # Create a config with age provider
-    cat > "${FNOX_CONFIG_FILE:-fnox.toml}" << EOF
+	# Create a config with age provider
+	cat >"${FNOX_CONFIG_FILE:-fnox.toml}" <<EOF
 root = true
 
 [providers.age]
@@ -330,29 +330,29 @@ type = "age"
 recipients = ["$AGE_PUB"]
 EOF
 
-    # Store the age key for decryption
-    mkdir -p "$HOME/.config/fnox"
-    echo "$AGE_KEY" > "$HOME/.config/fnox/age.txt"
+	# Store the age key for decryption
+	mkdir -p "$HOME/.config/fnox"
+	echo "$AGE_KEY" >"$HOME/.config/fnox/age.txt"
 
-    # Set a secret using age provider
-    run "$FNOX_BIN" set TEST_SECRET "my-secret-plaintext" --provider age
-    assert_success
+	# Set a secret using age provider
+	run "$FNOX_BIN" set TEST_SECRET "my-secret-plaintext" --provider age
+	assert_success
 
-    # List with --values should show plaintext in Value column
-    # (Provider Key column will still show the encrypted value, which is expected)
-    run "$FNOX_BIN" list --values
-    assert_success
-    assert_output --partial "Value"
-    assert_output --partial "my-secret-plaintext"
+	# List with --values should show plaintext in Value column
+	# (Provider Key column will still show the encrypted value, which is expected)
+	run "$FNOX_BIN" list --values
+	assert_success
+	assert_output --partial "Value"
+	assert_output --partial "my-secret-plaintext"
 }
 
 @test "fnox list --values resolves multiple secrets from age provider" {
-    # Generate age key pair
-    AGE_KEY=$(age-keygen 2>&1 | grep "^AGE-SECRET-KEY" || true)
-    AGE_PUB=$(echo "$AGE_KEY" | age-keygen -y 2>/dev/null || true)
+	# Generate age key pair
+	AGE_KEY=$(age-keygen 2>&1 | grep "^AGE-SECRET-KEY" || true)
+	AGE_PUB=$(echo "$AGE_KEY" | age-keygen -y 2>/dev/null || true)
 
-    # Create a config with age provider
-    cat > "${FNOX_CONFIG_FILE:-fnox.toml}" << EOF
+	# Create a config with age provider
+	cat >"${FNOX_CONFIG_FILE:-fnox.toml}" <<EOF
 root = true
 
 [providers.age]
@@ -360,36 +360,36 @@ type = "age"
 recipients = ["$AGE_PUB"]
 EOF
 
-    # Store the age key for decryption
-    mkdir -p "$HOME/.config/fnox"
-    echo "$AGE_KEY" > "$HOME/.config/fnox/age.txt"
+	# Store the age key for decryption
+	mkdir -p "$HOME/.config/fnox"
+	echo "$AGE_KEY" >"$HOME/.config/fnox/age.txt"
 
-    # Set multiple secrets
-    run "$FNOX_BIN" set SECRET_ONE "value-one" --provider age
-    assert_success
-    run "$FNOX_BIN" set SECRET_TWO "value-two" --provider age
-    assert_success
-    run "$FNOX_BIN" set SECRET_THREE "value-three" --provider age
-    assert_success
+	# Set multiple secrets
+	run "$FNOX_BIN" set SECRET_ONE "value-one" --provider age
+	assert_success
+	run "$FNOX_BIN" set SECRET_TWO "value-two" --provider age
+	assert_success
+	run "$FNOX_BIN" set SECRET_THREE "value-three" --provider age
+	assert_success
 
-    # List with --values should show all decrypted values
-    run "$FNOX_BIN" list --values
-    assert_success
-    assert_output --partial "SECRET_ONE"
-    assert_output --partial "value-one"
-    assert_output --partial "SECRET_TWO"
-    assert_output --partial "value-two"
-    assert_output --partial "SECRET_THREE"
-    assert_output --partial "value-three"
+	# List with --values should show all decrypted values
+	run "$FNOX_BIN" list --values
+	assert_success
+	assert_output --partial "SECRET_ONE"
+	assert_output --partial "value-one"
+	assert_output --partial "SECRET_TWO"
+	assert_output --partial "value-two"
+	assert_output --partial "SECRET_THREE"
+	assert_output --partial "value-three"
 }
 
 @test "fnox list --values --sources shows both decrypted values and source files" {
-    # Generate age key pair
-    AGE_KEY=$(age-keygen 2>&1 | grep "^AGE-SECRET-KEY" || true)
-    AGE_PUB=$(echo "$AGE_KEY" | age-keygen -y 2>/dev/null || true)
+	# Generate age key pair
+	AGE_KEY=$(age-keygen 2>&1 | grep "^AGE-SECRET-KEY" || true)
+	AGE_PUB=$(echo "$AGE_KEY" | age-keygen -y 2>/dev/null || true)
 
-    # Create a config with age provider
-    cat > "${FNOX_CONFIG_FILE:-fnox.toml}" << EOF
+	# Create a config with age provider
+	cat >"${FNOX_CONFIG_FILE:-fnox.toml}" <<EOF
 root = true
 
 [providers.age]
@@ -397,48 +397,48 @@ type = "age"
 recipients = ["$AGE_PUB"]
 EOF
 
-    # Store the age key for decryption
-    mkdir -p "$HOME/.config/fnox"
-    echo "$AGE_KEY" > "$HOME/.config/fnox/age.txt"
+	# Store the age key for decryption
+	mkdir -p "$HOME/.config/fnox"
+	echo "$AGE_KEY" >"$HOME/.config/fnox/age.txt"
 
-    # Set a secret using age provider
-    run "$FNOX_BIN" set COMBINED_SECRET "combined-value" --provider age
-    assert_success
+	# Set a secret using age provider
+	run "$FNOX_BIN" set COMBINED_SECRET "combined-value" --provider age
+	assert_success
 
-    # List with both flags
-    run "$FNOX_BIN" list --values --sources
-    assert_success
-    assert_output --partial "COMBINED_SECRET"
-    assert_output --partial "combined-value"
-    assert_output --partial "Source File"
-    assert_output --partial "Value"
-    assert_output --partial "fnox.toml"
+	# List with both flags
+	run "$FNOX_BIN" list --values --sources
+	assert_success
+	assert_output --partial "COMBINED_SECRET"
+	assert_output --partial "combined-value"
+	assert_output --partial "Source File"
+	assert_output --partial "Value"
+	assert_output --partial "fnox.toml"
 }
 
 @test "fnox list --values with default values still works" {
-    create_test_config
+	create_test_config
 
-    cat >> "${FNOX_CONFIG_FILE:-fnox.toml}" << EOF
+	cat >>"${FNOX_CONFIG_FILE:-fnox.toml}" <<EOF
 
 [secrets.default_secret]
 default = "default_value_123"
 description = "Secret with default"
 EOF
 
-    # List with --values should show default value
-    run "$FNOX_BIN" list --values
-    assert_success
-    assert_output --partial "default_secret"
-    assert_output --partial "default_value_123"
+	# List with --values should show default value
+	run "$FNOX_BIN" list --values
+	assert_success
+	assert_output --partial "default_secret"
+	assert_output --partial "default_value_123"
 }
 
 @test "fnox list --values shows mix of provider and default secrets" {
-    # Generate age key pair
-    AGE_KEY=$(age-keygen 2>&1 | grep "^AGE-SECRET-KEY" || true)
-    AGE_PUB=$(echo "$AGE_KEY" | age-keygen -y 2>/dev/null || true)
+	# Generate age key pair
+	AGE_KEY=$(age-keygen 2>&1 | grep "^AGE-SECRET-KEY" || true)
+	AGE_PUB=$(echo "$AGE_KEY" | age-keygen -y 2>/dev/null || true)
 
-    # Create a config with age provider
-    cat > "${FNOX_CONFIG_FILE:-fnox.toml}" << EOF
+	# Create a config with age provider
+	cat >"${FNOX_CONFIG_FILE:-fnox.toml}" <<EOF
 root = true
 
 [providers.age]
@@ -450,19 +450,19 @@ default = "default-value"
 
 EOF
 
-    # Store the age key for decryption
-    mkdir -p "$HOME/.config/fnox"
-    echo "$AGE_KEY" > "$HOME/.config/fnox/age.txt"
+	# Store the age key for decryption
+	mkdir -p "$HOME/.config/fnox"
+	echo "$AGE_KEY" >"$HOME/.config/fnox/age.txt"
 
-    # Add a provider-based secret
-    run "$FNOX_BIN" set PROVIDER_SECRET "provider-value" --provider age
-    assert_success
+	# Add a provider-based secret
+	run "$FNOX_BIN" set PROVIDER_SECRET "provider-value" --provider age
+	assert_success
 
-    # List should show both types with their resolved values
-    run "$FNOX_BIN" list --values
-    assert_success
-    assert_output --partial "default_secret"
-    assert_output --partial "default-value"
-    assert_output --partial "PROVIDER_SECRET"
-    assert_output --partial "provider-value"
+	# List should show both types with their resolved values
+	run "$FNOX_BIN" list --values
+	assert_success
+	assert_output --partial "default_secret"
+	assert_output --partial "default-value"
+	assert_output --partial "PROVIDER_SECRET"
+	assert_output --partial "provider-value"
 }

--- a/test/local_config.bats
+++ b/test/local_config.bats
@@ -1,17 +1,17 @@
 #!/usr/bin/env bats
 
 setup() {
-    load 'test_helper/common_setup'
-    _common_setup
+	load 'test_helper/common_setup'
+	_common_setup
 }
 
 teardown() {
-    _common_teardown
+	_common_teardown
 }
 
 @test "fnox.local.toml overrides fnox.toml secrets" {
-    # Create main config
-    cat > fnox.toml <<EOF
+	# Create main config
+	cat >fnox.toml <<EOF
 root = true
 
 [providers.test]
@@ -23,32 +23,32 @@ SHARED_SECRET = { description = "Main config secret", default = "main-value" }
 MAIN_ONLY_SECRET = { description = "Main only secret", default = "main-only-value" }
 EOF
 
-    # Create local config that overrides SHARED_SECRET
-    cat > fnox.local.toml <<EOF
+	# Create local config that overrides SHARED_SECRET
+	cat >fnox.local.toml <<EOF
 [secrets]
 SHARED_SECRET = { description = "Local override", default = "local-value" }
 LOCAL_ONLY_SECRET = { description = "Local only secret", default = "local-only-value" }
 EOF
 
-    # Test that local config overrides shared secret
-    run "$FNOX_BIN" get SHARED_SECRET
-    assert_success
-    assert_output --partial "local-value"
+	# Test that local config overrides shared secret
+	run "$FNOX_BIN" get SHARED_SECRET
+	assert_success
+	assert_output --partial "local-value"
 
-    # Test that main-only secret is still accessible
-    run "$FNOX_BIN" get MAIN_ONLY_SECRET
-    assert_success
-    assert_output --partial "main-only-value"
+	# Test that main-only secret is still accessible
+	run "$FNOX_BIN" get MAIN_ONLY_SECRET
+	assert_success
+	assert_output --partial "main-only-value"
 
-    # Test that local-only secret is accessible
-    run "$FNOX_BIN" get LOCAL_ONLY_SECRET
-    assert_success
-    assert_output --partial "local-only-value"
+	# Test that local-only secret is accessible
+	run "$FNOX_BIN" get LOCAL_ONLY_SECRET
+	assert_success
+	assert_output --partial "local-only-value"
 }
 
 @test "fnox.local.toml can add new providers" {
-    # Create main config with one provider
-    cat > fnox.toml <<EOF
+	# Create main config with one provider
+	cat >fnox.toml <<EOF
 root = true
 
 [providers.main_provider]
@@ -59,8 +59,8 @@ recipients = ["age1test"]
 MAIN_SECRET = { provider = "main_provider", default = "main-value" }
 EOF
 
-    # Create local config with additional provider
-    cat > fnox.local.toml <<EOF
+	# Create local config with additional provider
+	cat >fnox.local.toml <<EOF
 [providers.local_provider]
 type = "age"
 recipients = ["age1localtest"]
@@ -69,19 +69,19 @@ recipients = ["age1localtest"]
 LOCAL_SECRET = { provider = "local_provider", default = "local-value" }
 EOF
 
-    # Test that both secrets work
-    run "$FNOX_BIN" get MAIN_SECRET
-    assert_success
-    assert_output --partial "main-value"
+	# Test that both secrets work
+	run "$FNOX_BIN" get MAIN_SECRET
+	assert_success
+	assert_output --partial "main-value"
 
-    run "$FNOX_BIN" get LOCAL_SECRET
-    assert_success
-    assert_output --partial "local-value"
+	run "$FNOX_BIN" get LOCAL_SECRET
+	assert_success
+	assert_output --partial "local-value"
 }
 
 @test "fnox.local.toml works with profile-specific secrets" {
-    # Create main config
-    cat > fnox.toml <<EOF
+	# Create main config
+	cat >fnox.toml <<EOF
 root = true
 
 [providers.test]
@@ -92,30 +92,30 @@ recipients = ["age1test"]
 PROD_SECRET = { description = "Production secret", default = "prod-value" }
 EOF
 
-    # Create local config with production profile override
-    cat > fnox.local.toml <<EOF
+	# Create local config with production profile override
+	cat >fnox.local.toml <<EOF
 [profiles.production.secrets]
 PROD_SECRET = { description = "Local prod override", default = "local-prod-value" }
 LOCAL_PROD_SECRET = { description = "Local prod secret", default = "local-prod-only" }
 EOF
 
-    # Test that local overrides production secret
-    run "$FNOX_BIN" get PROD_SECRET --profile production
-    assert_success
-    assert_output --partial "local-prod-value"
+	# Test that local overrides production secret
+	run "$FNOX_BIN" get PROD_SECRET --profile production
+	assert_success
+	assert_output --partial "local-prod-value"
 
-    # Test that local-only production secret is accessible
-    run "$FNOX_BIN" get LOCAL_PROD_SECRET --profile production
-    assert_success
-    assert_output --partial "local-prod-only"
+	# Test that local-only production secret is accessible
+	run "$FNOX_BIN" get LOCAL_PROD_SECRET --profile production
+	assert_success
+	assert_output --partial "local-prod-only"
 }
 
 @test "fnox.local.toml works with config recursion" {
-    # Create directory structure
-    mkdir -p parent/child
+	# Create directory structure
+	mkdir -p parent/child
 
-    # Create parent config
-    cat > parent/fnox.toml <<EOF
+	# Create parent config
+	cat >parent/fnox.toml <<EOF
 [providers.test]
 type = "age"
 recipients = ["age1test"]
@@ -124,53 +124,53 @@ recipients = ["age1test"]
 PARENT_SECRET = { description = "Parent secret", default = "parent-value" }
 EOF
 
-    # Create parent local config
-    cat > parent/fnox.local.toml <<EOF
+	# Create parent local config
+	cat >parent/fnox.local.toml <<EOF
 [secrets]
 PARENT_SECRET = { description = "Parent local override", default = "parent-local-value" }
 PARENT_LOCAL_SECRET = { description = "Parent local secret", default = "parent-local-only" }
 EOF
 
-    # Create child config
-    cat > parent/child/fnox.toml <<EOF
+	# Create child config
+	cat >parent/child/fnox.toml <<EOF
 [secrets]
 CHILD_SECRET = { description = "Child secret", default = "child-value" }
 EOF
 
-    # Create child local config
-    cat > parent/child/fnox.local.toml <<EOF
+	# Create child local config
+	cat >parent/child/fnox.local.toml <<EOF
 [secrets]
 CHILD_SECRET = { description = "Child local override", default = "child-local-value" }
 CHILD_LOCAL_SECRET = { description = "Child local secret", default = "child-local-only" }
 EOF
 
-    # Change to child directory
-    cd parent/child
+	# Change to child directory
+	cd parent/child
 
-    # Test that child local overrides child config
-    run "$FNOX_BIN" get CHILD_SECRET
-    assert_success
-    assert_output --partial "child-local-value"
+	# Test that child local overrides child config
+	run "$FNOX_BIN" get CHILD_SECRET
+	assert_success
+	assert_output --partial "child-local-value"
 
-    # Test that child local secrets are accessible
-    run "$FNOX_BIN" get CHILD_LOCAL_SECRET
-    assert_success
-    assert_output --partial "child-local-only"
+	# Test that child local secrets are accessible
+	run "$FNOX_BIN" get CHILD_LOCAL_SECRET
+	assert_success
+	assert_output --partial "child-local-only"
 
-    # Test that parent local overrides parent config
-    run "$FNOX_BIN" get PARENT_SECRET
-    assert_success
-    assert_output --partial "parent-local-value"
+	# Test that parent local overrides parent config
+	run "$FNOX_BIN" get PARENT_SECRET
+	assert_success
+	assert_output --partial "parent-local-value"
 
-    # Test that parent local secrets are accessible
-    run "$FNOX_BIN" get PARENT_LOCAL_SECRET
-    assert_success
-    assert_output --partial "parent-local-only"
+	# Test that parent local secrets are accessible
+	run "$FNOX_BIN" get PARENT_LOCAL_SECRET
+	assert_success
+	assert_output --partial "parent-local-only"
 }
 
 @test "fnox.local.toml alone without fnox.toml works" {
-    # Create only local config (no main config)
-    cat > fnox.local.toml <<EOF
+	# Create only local config (no main config)
+	cat >fnox.local.toml <<EOF
 root = true
 
 [providers.test]
@@ -181,15 +181,15 @@ recipients = ["age1test"]
 LOCAL_ONLY = { description = "Local only secret", default = "local-only-value" }
 EOF
 
-    # Test that local config works on its own
-    run "$FNOX_BIN" get LOCAL_ONLY
-    assert_success
-    assert_output --partial "local-only-value"
+	# Test that local config works on its own
+	run "$FNOX_BIN" get LOCAL_ONLY
+	assert_success
+	assert_output --partial "local-only-value"
 }
 
 @test "fnox.local.toml can override default_provider" {
-    # Create main config with default provider
-    cat > fnox.toml <<EOF
+	# Create main config with default provider
+	cat >fnox.toml <<EOF
 root = true
 default_provider = "main_provider"
 
@@ -202,25 +202,25 @@ type = "age"
 recipients = ["age1alttest"]
 EOF
 
-    # Create local config that changes default provider
-    cat > fnox.local.toml <<EOF
+	# Create local config that changes default provider
+	cat >fnox.local.toml <<EOF
 default_provider = "alt_provider"
 EOF
 
-    # Set a secret without specifying provider (should use default)
-    run "$FNOX_BIN" set TEST_SECRET "test-value"
-    assert_success
+	# Set a secret without specifying provider (should use default)
+	run "$FNOX_BIN" set TEST_SECRET "test-value"
+	assert_success
 
-    # Check that it used the local default provider
-    # The config should show the secret was set with alt_provider
-    run cat fnox.toml
-    assert_success
-    assert_output --partial 'TEST_SECRET'
+	# Check that it used the local default provider
+	# The config should show the secret was set with alt_provider
+	run cat fnox.toml
+	assert_success
+	assert_output --partial 'TEST_SECRET'
 }
 
 @test "fnox.local.toml can set if_missing default" {
-    # Create main config
-    cat > fnox.toml <<EOF
+	# Create main config
+	cat >fnox.toml <<EOF
 root = true
 
 [providers.test]
@@ -231,20 +231,20 @@ recipients = ["age1test"]
 NO_VALUE_SECRET = { description = "Secret without value" }
 EOF
 
-    # Create local config with if_missing = ignore
-    cat > fnox.local.toml <<EOF
+	# Create local config with if_missing = ignore
+	cat >fnox.local.toml <<EOF
 if_missing = "ignore"
 EOF
 
-    # Test that missing secret is ignored (no error)
-    run "$FNOX_BIN" exec -- env
-    assert_success
-    # Should not fail even though NO_VALUE_SECRET has no value
+	# Test that missing secret is ignored (no error)
+	run "$FNOX_BIN" exec -- env
+	assert_success
+	# Should not fail even though NO_VALUE_SECRET has no value
 }
 
 @test "fnox list shows secrets from both fnox.toml and fnox.local.toml" {
-    # Create main config
-    cat > fnox.toml <<EOF
+	# Create main config
+	cat >fnox.toml <<EOF
 root = true
 
 [providers.test]
@@ -256,26 +256,26 @@ MAIN_SECRET = { description = "Main config secret", default = "main-value" }
 SHARED_SECRET = { description = "Shared secret", default = "main-value" }
 EOF
 
-    # Create local config
-    cat > fnox.local.toml <<EOF
+	# Create local config
+	cat >fnox.local.toml <<EOF
 [secrets]
 LOCAL_SECRET = { description = "Local config secret", default = "local-value" }
 SHARED_SECRET = { description = "Local override", default = "local-value" }
 EOF
 
-    # Test that list shows all secrets
-    run "$FNOX_BIN" list --complete
-    assert_success
+	# Test that list shows all secrets
+	run "$FNOX_BIN" list --complete
+	assert_success
 
-    # Should show MAIN_SECRET, LOCAL_SECRET, and SHARED_SECRET (merged)
-    assert_output --partial "MAIN_SECRET"
-    assert_output --partial "LOCAL_SECRET"
-    assert_output --partial "SHARED_SECRET"
+	# Should show MAIN_SECRET, LOCAL_SECRET, and SHARED_SECRET (merged)
+	assert_output --partial "MAIN_SECRET"
+	assert_output --partial "LOCAL_SECRET"
+	assert_output --partial "SHARED_SECRET"
 }
 
 @test "fnox.local.toml respects root flag" {
-    # Create parent config
-    cat > fnox.toml <<EOF
+	# Create parent config
+	cat >fnox.toml <<EOF
 [providers.test]
 type = "age"
 recipients = ["age1test"]
@@ -284,8 +284,8 @@ recipients = ["age1test"]
 PARENT_SECRET = { description = "Parent secret", default = "parent-value" }
 EOF
 
-    # Create local config with root=true to stop recursion
-    cat > fnox.local.toml <<EOF
+	# Create local config with root=true to stop recursion
+	cat >fnox.local.toml <<EOF
 root = true
 
 [providers.test]
@@ -296,21 +296,21 @@ recipients = ["age1test"]
 LOCAL_SECRET = { description = "Local secret", default = "local-value" }
 EOF
 
-    # Test that local config's root flag is respected
-    run "$FNOX_BIN" get LOCAL_SECRET
-    assert_success
-    assert_output --partial "local-value"
+	# Test that local config's root flag is respected
+	run "$FNOX_BIN" get LOCAL_SECRET
+	assert_success
+	assert_output --partial "local-value"
 
-    # Parent secret should still be accessible because it's in the same directory
-    # (Both fnox.toml and fnox.local.toml are loaded before checking root)
-    run "$FNOX_BIN" get PARENT_SECRET
-    assert_success
-    assert_output --partial "parent-value"
+	# Parent secret should still be accessible because it's in the same directory
+	# (Both fnox.toml and fnox.local.toml are loaded before checking root)
+	run "$FNOX_BIN" get PARENT_SECRET
+	assert_success
+	assert_output --partial "parent-value"
 }
 
 @test "explicit config path ignores fnox.local.toml" {
-    # Create main config
-    cat > fnox.toml <<EOF
+	# Create main config
+	cat >fnox.toml <<EOF
 root = true
 
 [providers.test]
@@ -321,28 +321,28 @@ recipients = ["age1test"]
 MAIN_SECRET = { description = "Main secret", default = "main-value" }
 EOF
 
-    # Create local config
-    cat > fnox.local.toml <<EOF
+	# Create local config
+	cat >fnox.local.toml <<EOF
 [secrets]
 LOCAL_SECRET = { description = "Local secret", default = "local-value" }
 MAIN_SECRET = { description = "Local override", default = "local-override" }
 EOF
 
-    # Using explicit path with ./ prefix should only load that specific file
-    # (bypasses recursion and local config merging)
-    run "$FNOX_BIN" -c ./fnox.toml get MAIN_SECRET
-    assert_success
-    assert_output --partial "main-value"
+	# Using explicit path with ./ prefix should only load that specific file
+	# (bypasses recursion and local config merging)
+	run "$FNOX_BIN" -c ./fnox.toml get MAIN_SECRET
+	assert_success
+	assert_output --partial "main-value"
 
-    # Local secret should not be accessible with explicit path
-    run "$FNOX_BIN" -c ./fnox.toml get LOCAL_SECRET
-    assert_failure
-    assert_output --partial "not found"
+	# Local secret should not be accessible with explicit path
+	run "$FNOX_BIN" -c ./fnox.toml get LOCAL_SECRET
+	assert_failure
+	assert_output --partial "not found"
 }
 
 @test "fnox.local.toml can have imports" {
-    # Create imported config
-    cat > shared.toml <<EOF
+	# Create imported config
+	cat >shared.toml <<EOF
 root = true
 
 [providers.test]
@@ -353,8 +353,8 @@ recipients = ["age1test"]
 SHARED_IMPORT = { description = "Shared import secret", default = "shared-value" }
 EOF
 
-    # Create main config
-    cat > fnox.toml <<EOF
+	# Create main config
+	cat >fnox.toml <<EOF
 root = true
 
 [providers.test]
@@ -365,25 +365,25 @@ recipients = ["age1test"]
 MAIN_SECRET = { description = "Main secret", default = "main-value" }
 EOF
 
-    # Create local config with import
-    cat > fnox.local.toml <<EOF
+	# Create local config with import
+	cat >fnox.local.toml <<EOF
 import = ["./shared.toml"]
 
 [secrets]
 LOCAL_SECRET = { description = "Local secret", default = "local-value" }
 EOF
 
-    # Test that imported secret is accessible
-    run "$FNOX_BIN" get SHARED_IMPORT
-    assert_success
-    assert_output --partial "shared-value"
+	# Test that imported secret is accessible
+	run "$FNOX_BIN" get SHARED_IMPORT
+	assert_success
+	assert_output --partial "shared-value"
 
-    # Test that main and local secrets are still accessible
-    run "$FNOX_BIN" get MAIN_SECRET
-    assert_success
-    assert_output --partial "main-value"
+	# Test that main and local secrets are still accessible
+	run "$FNOX_BIN" get MAIN_SECRET
+	assert_success
+	assert_output --partial "main-value"
 
-    run "$FNOX_BIN" get LOCAL_SECRET
-    assert_success
-    assert_output --partial "local-value"
+	run "$FNOX_BIN" get LOCAL_SECRET
+	assert_success
+	assert_output --partial "local-value"
 }

--- a/test/onepassword.bats
+++ b/test/onepassword.bats
@@ -33,46 +33,46 @@
 #
 
 setup() {
-    load 'test_helper/common_setup'
-    _common_setup
+	load 'test_helper/common_setup'
+	_common_setup
 
-    # Check if op CLI is installed
-    if ! command -v op >/dev/null 2>&1; then
-        skip "1Password CLI (op) not installed. Install with: brew install 1password-cli"
-    fi
+	# Check if op CLI is installed
+	if ! command -v op >/dev/null 2>&1; then
+		skip "1Password CLI (op) not installed. Install with: brew install 1password-cli"
+	fi
 
-    # Check if OP_SERVICE_ACCOUNT_TOKEN is available
-    # (mise run test:bats automatically loads secrets via fnox exec)
-    if [ -z "$OP_SERVICE_ACCOUNT_TOKEN" ]; then
-        skip "OP_SERVICE_ACCOUNT_TOKEN not available. Ensure it's configured in fnox.toml or set in environment."
-    fi
+	# Check if OP_SERVICE_ACCOUNT_TOKEN is available
+	# (mise run test:bats automatically loads secrets via fnox exec)
+	if [ -z "$OP_SERVICE_ACCOUNT_TOKEN" ]; then
+		skip "OP_SERVICE_ACCOUNT_TOKEN not available. Ensure it's configured in fnox.toml or set in environment."
+	fi
 
-    # Verify we can authenticate with 1Password by trying to list vaults
-    if ! op vault list >/dev/null 2>&1; then
-        skip "Cannot authenticate with 1Password. Token may be invalid or expired."
-    fi
+	# Verify we can authenticate with 1Password by trying to list vaults
+	if ! op vault list >/dev/null 2>&1; then
+		skip "Cannot authenticate with 1Password. Token may be invalid or expired."
+	fi
 
-    # Check if the 'fnox' vault exists
-    if ! op vault get fnox >/dev/null 2>&1; then
-        skip "The 'fnox' vault does not exist. Create it with: op vault create fnox"
-    fi
+	# Check if the 'fnox' vault exists
+	if ! op vault get fnox >/dev/null 2>&1; then
+		skip "The 'fnox' vault does not exist. Create it with: op vault create fnox"
+	fi
 
-    # Test if we have write permissions by creating and deleting a test item
-    local test_item="fnox-permission-test-$$"
-    if ! op item create --category=password --title="$test_item" --vault=fnox "password=test" >/dev/null 2>&1; then
-        skip "Cannot create items in 'fnox' vault. Token may not have write permissions."
-    fi
-    op item delete "$test_item" --vault=fnox >/dev/null 2>&1 || true
+	# Test if we have write permissions by creating and deleting a test item
+	local test_item="fnox-permission-test-$$"
+	if ! op item create --category=password --title="$test_item" --vault=fnox "password=test" >/dev/null 2>&1; then
+		skip "Cannot create items in 'fnox' vault. Token may not have write permissions."
+	fi
+	op item delete "$test_item" --vault=fnox >/dev/null 2>&1 || true
 }
 
 teardown() {
-    _common_teardown
+	_common_teardown
 }
 
 # Helper function to create a 1Password test config
 create_onepassword_config() {
-    local vault="${1:-fnox}"
-    cat > "${FNOX_CONFIG_FILE:-fnox.toml}" << EOF
+	local vault="${1:-fnox}"
+	cat >"${FNOX_CONFIG_FILE:-fnox.toml}" <<EOF
 [providers.onepass]
 type = "1password"
 vault = "$vault"
@@ -84,148 +84,150 @@ EOF
 # Helper function to create a test item in 1Password
 # Returns the item name on success, empty string on failure
 create_test_op_item() {
-    local vault="${1:-fnox}"
-    local item_name="fnox-test-$(date +%s)-$$-${BATS_TEST_NUMBER:-0}"
-    local password="test-secret-value-$(date +%s)-$$-${BATS_TEST_NUMBER:-0}"
+	local vault="${1:-fnox}"
+	local item_name
+	item_name="fnox-test-$(date +%s)-$$-${BATS_TEST_NUMBER:-0}"
+	local password
+	password="test-secret-value-$(date +%s)-$$-${BATS_TEST_NUMBER:-0}"
 
-    # Create item with op CLI and capture output
-    if op item create \
-        --category=password \
-        --title="$item_name" \
-        --vault="$vault" \
-        "password=$password" >/dev/null 2>&1; then
-        echo "$item_name"
-        return 0
-    else
-        # Return empty string on failure
-        return 1
-    fi
+	# Create item with op CLI and capture output
+	if op item create \
+		--category=password \
+		--title="$item_name" \
+		--vault="$vault" \
+		"password=$password" >/dev/null 2>&1; then
+		echo "$item_name"
+		return 0
+	else
+		# Return empty string on failure
+		return 1
+	fi
 }
 
 # Helper function to delete a test item from 1Password
 delete_test_op_item() {
-    local vault="${1}"
-    local item_name="${2}"
-    op item delete "$item_name" --vault="$vault" >/dev/null 2>&1 || true
+	local vault="${1}"
+	local item_name="${2}"
+	op item delete "$item_name" --vault="$vault" >/dev/null 2>&1 || true
 }
 
 @test "fnox get retrieves secret from 1Password" {
-    create_onepassword_config "fnox"
+	create_onepassword_config "fnox"
 
-    # Create a test item
-    if ! item_name=$(create_test_op_item "fnox"); then
-        skip "Failed to create test item in 1Password"
-    fi
+	# Create a test item
+	if ! item_name=$(create_test_op_item "fnox"); then
+		skip "Failed to create test item in 1Password"
+	fi
 
-    # Add secret reference to config
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	# Add secret reference to config
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.TEST_OP_SECRET]
 provider = "onepass"
 value = "$item_name"
 EOF
 
-    # Get the secret
-    run "$FNOX_BIN" get TEST_OP_SECRET
-    assert_success
-    assert_output --partial "test-secret-value-"
+	# Get the secret
+	run "$FNOX_BIN" get TEST_OP_SECRET
+	assert_success
+	assert_output --partial "test-secret-value-"
 
-    # Cleanup
-    delete_test_op_item "fnox" "$item_name"
+	# Cleanup
+	delete_test_op_item "fnox" "$item_name"
 }
 
 @test "fnox get retrieves specific field from 1Password item" {
-    create_onepassword_config "fnox"
+	create_onepassword_config "fnox"
 
-    # Create a test item with custom field
-    item_name="fnox-test-field-$(date +%s)-$$-${BATS_TEST_NUMBER:-0}"
-    if ! op item create \
-        --category=password \
-        --title="$item_name" \
-        --vault="fnox" \
-        "username=testuser" \
-        "password=testpass" >/dev/null 2>&1; then
-        skip "Failed to create test item in 1Password"
-    fi
+	# Create a test item with custom field
+	item_name="fnox-test-field-$(date +%s)-$$-${BATS_TEST_NUMBER:-0}"
+	if ! op item create \
+		--category=password \
+		--title="$item_name" \
+		--vault="fnox" \
+		"username=testuser" \
+		"password=testpass" >/dev/null 2>&1; then
+		skip "Failed to create test item in 1Password"
+	fi
 
-    # Add secret reference to config (fetch username field)
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	# Add secret reference to config (fetch username field)
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.TEST_USERNAME]
 provider = "onepass"
 value = "$item_name/username"
 EOF
 
-    # Get the secret
-    run "$FNOX_BIN" get TEST_USERNAME
-    assert_success
-    assert_output "testuser"
+	# Get the secret
+	run "$FNOX_BIN" get TEST_USERNAME
+	assert_success
+	assert_output "testuser"
 
-    # Cleanup
-    delete_test_op_item "fnox" "$item_name"
+	# Cleanup
+	delete_test_op_item "fnox" "$item_name"
 }
 
 @test "fnox get handles full op:// reference" {
-    create_onepassword_config "fnox"
+	create_onepassword_config "fnox"
 
-    # Create a test item
-    if ! item_name=$(create_test_op_item "fnox"); then
-        skip "Failed to create test item in 1Password"
-    fi
+	# Create a test item
+	if ! item_name=$(create_test_op_item "fnox"); then
+		skip "Failed to create test item in 1Password"
+	fi
 
-    # Add secret reference to config using full op:// format
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	# Add secret reference to config using full op:// format
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.TEST_OP_FULL_REF]
 provider = "onepass"
 value = "op://fnox/$item_name/password"
 EOF
 
-    # Get the secret
-    run "$FNOX_BIN" get TEST_OP_FULL_REF
-    assert_success
-    assert_output --partial "test-secret-value-"
+	# Get the secret
+	run "$FNOX_BIN" get TEST_OP_FULL_REF
+	assert_success
+	assert_output --partial "test-secret-value-"
 
-    # Cleanup
-    delete_test_op_item "fnox" "$item_name"
+	# Cleanup
+	delete_test_op_item "fnox" "$item_name"
 }
 
 @test "fnox get fails with invalid item name" {
-    create_onepassword_config "fnox"
+	create_onepassword_config "fnox"
 
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.INVALID_ITEM]
 provider = "onepass"
 value = "nonexistent-item-$(date +%s)"
 EOF
 
-    # Try to get non-existent secret
-    run "$FNOX_BIN" get INVALID_ITEM
-    assert_failure
-    assert_output --partial "1Password CLI command failed"
+	# Try to get non-existent secret
+	run "$FNOX_BIN" get INVALID_ITEM
+	assert_failure
+	assert_output --partial "1Password CLI command failed"
 }
 
 @test "fnox get fails with invalid vault" {
-    create_onepassword_config "nonexistent-vault-$(date +%s)"
+	create_onepassword_config "nonexistent-vault-$(date +%s)"
 
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.TEST_SECRET]
 provider = "onepass"
 value = "some-item"
 EOF
 
-    # Try to get secret from non-existent vault
-    run "$FNOX_BIN" get TEST_SECRET
-    assert_failure
+	# Try to get secret from non-existent vault
+	run "$FNOX_BIN" get TEST_SECRET
+	assert_failure
 }
 
 @test "fnox get with 1Password account parameter" {
-    skip "Requires 1Password account configuration"
+	skip "Requires 1Password account configuration"
 
-    # Create config with account parameter
-    cat > "${FNOX_CONFIG_FILE:-fnox.toml}" << EOF
+	# Create config with account parameter
+	cat >"${FNOX_CONFIG_FILE:-fnox.toml}" <<EOF
 [providers.onepass]
 type = "1password"
 vault = "fnox"
@@ -236,16 +238,16 @@ provider = "onepass"
 value = "test-item"
 EOF
 
-    # This should pass account flag to op CLI
-    run "$FNOX_BIN" get TEST_SECRET
-    # Will fail if account doesn't exist, but that's expected
-    assert_failure
+	# This should pass account flag to op CLI
+	run "$FNOX_BIN" get TEST_SECRET
+	# Will fail if account doesn't exist, but that's expected
+	assert_failure
 }
 
 @test "fnox list shows 1Password secrets" {
-    create_onepassword_config "fnox"
+	create_onepassword_config "fnox"
 
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.OP_SECRET_1]
 description = "First 1Password secret"
@@ -258,50 +260,50 @@ provider = "onepass"
 value = "item2/username"
 EOF
 
-    run "$FNOX_BIN" list
-    assert_success
-    assert_output --partial "OP_SECRET_1"
-    assert_output --partial "OP_SECRET_2"
-    assert_output --partial "First 1Password secret"
+	run "$FNOX_BIN" list
+	assert_success
+	assert_output --partial "OP_SECRET_1"
+	assert_output --partial "OP_SECRET_2"
+	assert_output --partial "First 1Password secret"
 }
 
 @test "fnox get handles invalid secret reference format" {
-    create_onepassword_config "fnox"
+	create_onepassword_config "fnox"
 
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.INVALID_FORMAT]
 provider = "onepass"
 value = "invalid/format/with/too/many/slashes"
 EOF
 
-    run "$FNOX_BIN" get INVALID_FORMAT
-    assert_failure
-    assert_output --partial "Invalid secret reference format"
+	run "$FNOX_BIN" get INVALID_FORMAT
+	assert_failure
+	assert_output --partial "Invalid secret reference format"
 }
 
 @test "1Password provider works with service account token from environment" {
-    # This test verifies that op CLI uses OP_SERVICE_ACCOUNT_TOKEN from environment
-    # The token should be set by setup() from fnox config
+	# This test verifies that op CLI uses OP_SERVICE_ACCOUNT_TOKEN from environment
+	# The token should be set by setup() from fnox config
 
-    create_onepassword_config "fnox"
-    if ! item_name=$(create_test_op_item "fnox"); then
-        skip "Failed to create test item in 1Password"
-    fi
+	create_onepassword_config "fnox"
+	if ! item_name=$(create_test_op_item "fnox"); then
+		skip "Failed to create test item in 1Password"
+	fi
 
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.TEST_WITH_ENV_TOKEN]
 provider = "onepass"
 value = "$item_name"
 EOF
 
-    # The OP_SERVICE_ACCOUNT_TOKEN should be set by setup()
+	# The OP_SERVICE_ACCOUNT_TOKEN should be set by setup()
 
-    run "$FNOX_BIN" get TEST_WITH_ENV_TOKEN
-    assert_success
-    assert_output --partial "test-secret-value-"
+	run "$FNOX_BIN" get TEST_WITH_ENV_TOKEN
+	assert_success
+	assert_output --partial "test-secret-value-"
 
-    # Cleanup
-    delete_test_op_item "fnox" "$item_name"
+	# Cleanup
+	delete_test_op_item "fnox" "$item_name"
 }

--- a/test/plain.bats
+++ b/test/plain.bats
@@ -1,17 +1,17 @@
 #!/usr/bin/env bats
 
 setup() {
-    load 'test_helper/common_setup'
-    _common_setup
+	load 'test_helper/common_setup'
+	_common_setup
 }
 
 teardown() {
-    _common_teardown
+	_common_teardown
 }
 
 @test "plain provider stores values as-is" {
-    # Create config with plain provider
-    cat > fnox.toml << 'EOF'
+	# Create config with plain provider
+	cat >fnox.toml <<'EOF'
 root = true
 
 [providers.plain]
@@ -20,23 +20,23 @@ type = "plain"
 [secrets]
 EOF
 
-    # Set a secret with plain provider
-    run "$FNOX_BIN" set MY_SECRET "test-value" --provider plain
-    assert_success
+	# Set a secret with plain provider
+	run "$FNOX_BIN" set MY_SECRET "test-value" --provider plain
+	assert_success
 
-    # Verify the secret was stored in plain text
-    assert_config_contains "MY_SECRET"
-    assert_config_contains "test-value"
+	# Verify the secret was stored in plain text
+	assert_config_contains "MY_SECRET"
+	assert_config_contains "test-value"
 
-    # Should be able to get it back
-    run "$FNOX_BIN" get MY_SECRET
-    assert_success
-    assert_output "test-value"
+	# Should be able to get it back
+	run "$FNOX_BIN" get MY_SECRET
+	assert_success
+	assert_output "test-value"
 }
 
 @test "plain provider as default provider" {
-    # Create config with plain as default provider
-    cat > fnox.toml << 'EOF'
+	# Create config with plain as default provider
+	cat >fnox.toml <<'EOF'
 root = true
 default_provider = "plain"
 
@@ -46,23 +46,23 @@ type = "plain"
 [secrets]
 EOF
 
-    # Set a secret without specifying provider - should use default
-    run "$FNOX_BIN" set MY_SECRET "secret-value"
-    assert_success
+	# Set a secret without specifying provider - should use default
+	run "$FNOX_BIN" set MY_SECRET "secret-value"
+	assert_success
 
-    # Verify the secret was stored in plain text
-    assert_config_contains "MY_SECRET"
-    assert_config_contains "secret-value"
+	# Verify the secret was stored in plain text
+	assert_config_contains "MY_SECRET"
+	assert_config_contains "secret-value"
 
-    # Get should work
-    run "$FNOX_BIN" get MY_SECRET
-    assert_success
-    assert_output "secret-value"
+	# Get should work
+	run "$FNOX_BIN" get MY_SECRET
+	assert_success
+	assert_output "secret-value"
 }
 
 @test "plain provider auto-selected when only provider" {
-    # Create config with plain as the only provider
-    cat > fnox.toml << 'EOF'
+	# Create config with plain as the only provider
+	cat >fnox.toml <<'EOF'
 root = true
 
 [providers.plain]
@@ -71,23 +71,23 @@ type = "plain"
 [secrets]
 EOF
 
-    # Set a secret without specifying provider - should auto-select plain
-    run "$FNOX_BIN" set AUTO_SECRET "auto-value"
-    assert_success
+	# Set a secret without specifying provider - should auto-select plain
+	run "$FNOX_BIN" set AUTO_SECRET "auto-value"
+	assert_success
 
-    # Verify the secret was stored
-    assert_config_contains "AUTO_SECRET"
-    assert_config_contains "auto-value"
+	# Verify the secret was stored
+	assert_config_contains "AUTO_SECRET"
+	assert_config_contains "auto-value"
 
-    # Get should work
-    run "$FNOX_BIN" get AUTO_SECRET
-    assert_success
-    assert_output "auto-value"
+	# Get should work
+	run "$FNOX_BIN" get AUTO_SECRET
+	assert_success
+	assert_output "auto-value"
 }
 
 @test "plain provider with special characters" {
-    # Create config with plain provider
-    cat > fnox.toml << 'EOF'
+	# Create config with plain provider
+	cat >fnox.toml <<'EOF'
 root = true
 
 [providers.plain]
@@ -96,19 +96,19 @@ type = "plain"
 [secrets]
 EOF
 
-    # Set a secret with special characters
-    run "$FNOX_BIN" set SPECIAL_SECRET "value with spaces & symbols!@#$%^&*()"
-    assert_success
+	# Set a secret with special characters
+	run "$FNOX_BIN" set SPECIAL_SECRET "value with spaces & symbols!@#$%^&*()"
+	assert_success
 
-    # Get should return the exact value
-    run "$FNOX_BIN" get SPECIAL_SECRET
-    assert_success
-    assert_output "value with spaces & symbols!@#$%^&*()"
+	# Get should return the exact value
+	run "$FNOX_BIN" get SPECIAL_SECRET
+	assert_success
+	assert_output "value with spaces & symbols!@#$%^&*()"
 }
 
 @test "plain provider with multiline values" {
-    # Create config with plain provider
-    cat > fnox.toml << 'EOF'
+	# Create config with plain provider
+	cat >fnox.toml <<'EOF'
 root = true
 
 [providers.plain]
@@ -117,20 +117,20 @@ type = "plain"
 [secrets]
 EOF
 
-    # Set a secret with newlines (escaped)
-    run "$FNOX_BIN" set MULTILINE_SECRET "line1\nline2\nline3"
-    assert_success
+	# Set a secret with newlines (escaped)
+	run "$FNOX_BIN" set MULTILINE_SECRET "line1\nline2\nline3"
+	assert_success
 
-    # Get should preserve the content
-    run "$FNOX_BIN" get MULTILINE_SECRET
-    assert_success
-    # Note: The actual output will depend on how fnox handles multiline values
-    assert_output --partial "line1"
+	# Get should preserve the content
+	run "$FNOX_BIN" get MULTILINE_SECRET
+	assert_success
+	# Note: The actual output will depend on how fnox handles multiline values
+	assert_output --partial "line1"
 }
 
 @test "plain provider with empty value" {
-    # Create config with plain provider
-    cat > fnox.toml << 'EOF'
+	# Create config with plain provider
+	cat >fnox.toml <<'EOF'
 root = true
 
 [providers.plain]
@@ -139,19 +139,19 @@ type = "plain"
 [secrets]
 EOF
 
-    # Set a secret with empty value
-    run "$FNOX_BIN" set EMPTY_SECRET ""
-    assert_success
+	# Set a secret with empty value
+	run "$FNOX_BIN" set EMPTY_SECRET ""
+	assert_success
 
-    # Get should return empty string
-    run "$FNOX_BIN" get EMPTY_SECRET
-    assert_success
-    assert_output ""
+	# Get should return empty string
+	run "$FNOX_BIN" get EMPTY_SECRET
+	assert_success
+	assert_output ""
 }
 
 @test "plain provider with profile" {
-    # Create config with plain provider in a profile
-    cat > fnox.toml << 'EOF'
+	# Create config with plain provider in a profile
+	cat >fnox.toml <<'EOF'
 root = true
 
 [secrets]
@@ -164,22 +164,22 @@ type = "plain"
 [profiles.dev.secrets]
 EOF
 
-    # Set a secret in dev profile
-    run "$FNOX_BIN" set --profile dev DEV_SECRET "dev-value"
-    assert_success
+	# Set a secret in dev profile
+	run "$FNOX_BIN" set --profile dev DEV_SECRET "dev-value"
+	assert_success
 
-    # Get from dev profile should work
-    run "$FNOX_BIN" get --profile dev DEV_SECRET
-    assert_success
-    assert_output "dev-value"
+	# Get from dev profile should work
+	run "$FNOX_BIN" get --profile dev DEV_SECRET
+	assert_success
+	assert_output "dev-value"
 
-    # Secret should be in plain text in config
-    assert_config_contains "dev-value"
+	# Secret should be in plain text in config
+	assert_config_contains "dev-value"
 }
 
 @test "plain provider test connection" {
-    # Create config with plain provider
-    cat > fnox.toml << 'EOF'
+	# Create config with plain provider
+	cat >fnox.toml <<'EOF'
 root = true
 
 [providers.plain]
@@ -188,15 +188,15 @@ type = "plain"
 [secrets]
 EOF
 
-    # Test provider connection
-    run "$FNOX_BIN" provider test plain
-    assert_success
-    assert_output --partial "plain"
+	# Test provider connection
+	run "$FNOX_BIN" provider test plain
+	assert_success
+	assert_output --partial "plain"
 }
 
 @test "plain provider in doctor output" {
-    # Create config with plain provider
-    cat > fnox.toml << 'EOF'
+	# Create config with plain provider
+	cat >fnox.toml <<'EOF'
 root = true
 
 [providers.plain]
@@ -205,15 +205,15 @@ type = "plain"
 [secrets]
 EOF
 
-    # Run doctor command
-    run "$FNOX_BIN" doctor
-    assert_success
-    assert_output --partial "plain (plain)"
+	# Run doctor command
+	run "$FNOX_BIN" doctor
+	assert_success
+	assert_output --partial "plain (plain)"
 }
 
 @test "plain provider updates existing secret" {
-    # Create config with plain provider
-    cat > fnox.toml << 'EOF'
+	# Create config with plain provider
+	cat >fnox.toml <<'EOF'
 root = true
 
 [providers.plain]
@@ -222,32 +222,32 @@ type = "plain"
 [secrets]
 EOF
 
-    # Set initial value
-    run "$FNOX_BIN" set UPDATE_SECRET "initial-value"
-    assert_success
+	# Set initial value
+	run "$FNOX_BIN" set UPDATE_SECRET "initial-value"
+	assert_success
 
-    # Verify initial value
-    run "$FNOX_BIN" get UPDATE_SECRET
-    assert_success
-    assert_output "initial-value"
+	# Verify initial value
+	run "$FNOX_BIN" get UPDATE_SECRET
+	assert_success
+	assert_output "initial-value"
 
-    # Update the value
-    run "$FNOX_BIN" set UPDATE_SECRET "updated-value"
-    assert_success
+	# Update the value
+	run "$FNOX_BIN" set UPDATE_SECRET "updated-value"
+	assert_success
 
-    # Verify updated value
-    run "$FNOX_BIN" get UPDATE_SECRET
-    assert_success
-    assert_output "updated-value"
+	# Verify updated value
+	run "$FNOX_BIN" get UPDATE_SECRET
+	assert_success
+	assert_output "updated-value"
 
-    # Old value should not be in config
-    assert_config_not_contains "initial-value"
-    assert_config_contains "updated-value"
+	# Old value should not be in config
+	assert_config_not_contains "initial-value"
+	assert_config_contains "updated-value"
 }
 
 @test "plain provider with description" {
-    # Create config with plain provider
-    cat > fnox.toml << 'EOF'
+	# Create config with plain provider
+	cat >fnox.toml <<'EOF'
 root = true
 
 [providers.plain]
@@ -256,17 +256,17 @@ type = "plain"
 [secrets]
 EOF
 
-    # Set a secret with description
-    run "$FNOX_BIN" set DESCRIBED_SECRET "value" --description "This is a test secret"
-    assert_success
+	# Set a secret with description
+	run "$FNOX_BIN" set DESCRIBED_SECRET "value" --description "This is a test secret"
+	assert_success
 
-    # Verify description is in config
-    assert_config_contains "This is a test secret"
+	# Verify description is in config
+	assert_config_contains "This is a test secret"
 }
 
 @test "plain provider list shows secrets" {
-    # Create config with plain provider and some secrets
-    cat > fnox.toml << 'EOF'
+	# Create config with plain provider and some secrets
+	cat >fnox.toml <<'EOF'
 root = true
 
 [providers.plain]
@@ -278,12 +278,12 @@ SECRET2 = { provider = "plain", value = "value2", description = "Second secret" 
 SECRET3 = { provider = "plain", value = "value3" }
 EOF
 
-    # List should show all secrets
-    run "$FNOX_BIN" list
-    assert_success
-    assert_output --partial "SECRET1"
-    assert_output --partial "SECRET2"
-    assert_output --partial "SECRET3"
-    assert_output --partial "First secret"
-    assert_output --partial "Second secret"
+	# List should show all secrets
+	run "$FNOX_BIN" list
+	assert_success
+	assert_output --partial "SECRET1"
+	assert_output --partial "SECRET2"
+	assert_output --partial "SECRET3"
+	assert_output --partial "First secret"
+	assert_output --partial "Second secret"
 }

--- a/test/profile_config.bats
+++ b/test/profile_config.bats
@@ -1,17 +1,17 @@
 #!/usr/bin/env bats
 
 setup() {
-    load 'test_helper/common_setup'
-    _common_setup
+	load 'test_helper/common_setup'
+	_common_setup
 }
 
 teardown() {
-    _common_teardown
+	_common_teardown
 }
 
-@test "fnox.\$FNOX_PROFILE.toml overrides fnox.toml secrets" {
-    # Create main config
-    cat > fnox.toml <<EOF
+@test 'fnox.$FNOX_PROFILE.toml overrides fnox.toml secrets' {
+	# Create main config
+	cat >fnox.toml <<EOF
 root = true
 
 [providers.test]
@@ -23,39 +23,39 @@ SHARED_SECRET = { description = "Main config secret", default = "main-value" }
 MAIN_ONLY_SECRET = { description = "Main only secret", default = "main-only-value" }
 EOF
 
-    # Create production profile config that overrides SHARED_SECRET
-    # Note: This works with the default profile but loads when FNOX_PROFILE=production
-    cat > fnox.production.toml <<EOF
+	# Create production profile config that overrides SHARED_SECRET
+	# Note: This works with the default profile but loads when FNOX_PROFILE=production
+	cat >fnox.production.toml <<EOF
 [secrets]
 SHARED_SECRET = { description = "Production override", default = "prod-value" }
 PROD_ONLY_SECRET = { description = "Production only secret", default = "prod-only-value" }
 EOF
 
-    # Test with default profile (no FNOX_PROFILE) - should use main config values
-    run "$FNOX_BIN" get SHARED_SECRET
-    assert_success
-    assert_output --partial "main-value"
+	# Test with default profile (no FNOX_PROFILE) - should use main config values
+	run "$FNOX_BIN" get SHARED_SECRET
+	assert_success
+	assert_output --partial "main-value"
 
-    # Test with production profile env var - should use production config values
-    # This still uses the "default" profile's secrets, but loads fnox.production.toml
-    run env FNOX_PROFILE=production "$FNOX_BIN" get SHARED_SECRET
-    assert_success
-    assert_output --partial "prod-value"
+	# Test with production profile env var - should use production config values
+	# This still uses the "default" profile's secrets, but loads fnox.production.toml
+	run env FNOX_PROFILE=production "$FNOX_BIN" get SHARED_SECRET
+	assert_success
+	assert_output --partial "prod-value"
 
-    # Test that main-only secret is still accessible with production env
-    run env FNOX_PROFILE=production "$FNOX_BIN" get MAIN_ONLY_SECRET
-    assert_success
-    assert_output --partial "main-only-value"
+	# Test that main-only secret is still accessible with production env
+	run env FNOX_PROFILE=production "$FNOX_BIN" get MAIN_ONLY_SECRET
+	assert_success
+	assert_output --partial "main-only-value"
 
-    # Test that production-only secret is accessible
-    run env FNOX_PROFILE=production "$FNOX_BIN" get PROD_ONLY_SECRET
-    assert_success
-    assert_output --partial "prod-only-value"
+	# Test that production-only secret is accessible
+	run env FNOX_PROFILE=production "$FNOX_BIN" get PROD_ONLY_SECRET
+	assert_success
+	assert_output --partial "prod-only-value"
 }
 
-@test "fnox.\$FNOX_PROFILE.toml loading order: fnox.toml < fnox.\$FNOX_PROFILE.toml < fnox.local.toml" {
-    # Create main config
-    cat > fnox.toml <<EOF
+@test 'fnox.$FNOX_PROFILE.toml loading order: fnox.toml < fnox.$FNOX_PROFILE.toml < fnox.local.toml' {
+	# Create main config
+	cat >fnox.toml <<EOF
 root = true
 
 [providers.test]
@@ -68,39 +68,39 @@ SECRET_B = { description = "Secret B", default = "main-b" }
 SECRET_C = { description = "Secret C", default = "main-c" }
 EOF
 
-    # Create staging profile config
-    cat > fnox.staging.toml <<EOF
+	# Create staging profile config
+	cat >fnox.staging.toml <<EOF
 [secrets]
 SECRET_B = { description = "Secret B staging", default = "staging-b" }
 SECRET_C = { description = "Secret C staging", default = "staging-c" }
 EOF
 
-    # Create local config (highest priority)
-    cat > fnox.local.toml <<EOF
+	# Create local config (highest priority)
+	cat >fnox.local.toml <<EOF
 [secrets]
 SECRET_C = { description = "Secret C local", default = "local-c" }
 EOF
 
-    # Test with staging profile
-    # SECRET_A should come from fnox.toml (main-a)
-    run env FNOX_PROFILE=staging "$FNOX_BIN" get SECRET_A
-    assert_success
-    assert_output --partial "main-a"
+	# Test with staging profile
+	# SECRET_A should come from fnox.toml (main-a)
+	run env FNOX_PROFILE=staging "$FNOX_BIN" get SECRET_A
+	assert_success
+	assert_output --partial "main-a"
 
-    # SECRET_B should come from fnox.staging.toml (staging-b)
-    run env FNOX_PROFILE=staging "$FNOX_BIN" get SECRET_B
-    assert_success
-    assert_output --partial "staging-b"
+	# SECRET_B should come from fnox.staging.toml (staging-b)
+	run env FNOX_PROFILE=staging "$FNOX_BIN" get SECRET_B
+	assert_success
+	assert_output --partial "staging-b"
 
-    # SECRET_C should come from fnox.local.toml (local-c) - highest priority
-    run env FNOX_PROFILE=staging "$FNOX_BIN" get SECRET_C
-    assert_success
-    assert_output --partial "local-c"
+	# SECRET_C should come from fnox.local.toml (local-c) - highest priority
+	run env FNOX_PROFILE=staging "$FNOX_BIN" get SECRET_C
+	assert_success
+	assert_output --partial "local-c"
 }
 
-@test "fnox.\$FNOX_PROFILE.toml works with FNOX_PROFILE env var" {
-    # Create main config
-    cat > fnox.toml <<EOF
+@test 'fnox.$FNOX_PROFILE.toml works with FNOX_PROFILE env var' {
+	# Create main config
+	cat >fnox.toml <<EOF
 root = true
 
 [providers.test]
@@ -111,29 +111,29 @@ recipients = ["age1test"]
 MY_SECRET = { description = "My secret", default = "main-value" }
 EOF
 
-    # Create dev profile config
-    cat > fnox.dev.toml <<EOF
+	# Create dev profile config
+	cat >fnox.dev.toml <<EOF
 [secrets]
 MY_SECRET = { description = "Dev secret", default = "dev-value" }
 EOF
 
-    # Test with FNOX_PROFILE env var (should load fnox.dev.toml)
-    run env FNOX_PROFILE=dev "$FNOX_BIN" get MY_SECRET
-    assert_success
-    assert_output --partial "dev-value"
+	# Test with FNOX_PROFILE env var (should load fnox.dev.toml)
+	run env FNOX_PROFILE=dev "$FNOX_BIN" get MY_SECRET
+	assert_success
+	assert_output --partial "dev-value"
 
-    # Test without FNOX_PROFILE (should use main config only)
-    run "$FNOX_BIN" get MY_SECRET
-    assert_success
-    assert_output --partial "main-value"
+	# Test without FNOX_PROFILE (should use main config only)
+	run "$FNOX_BIN" get MY_SECRET
+	assert_success
+	assert_output --partial "main-value"
 }
 
-@test "fnox.\$FNOX_PROFILE.toml works with config recursion" {
-    # Create directory structure
-    mkdir -p parent/child
+@test 'fnox.$FNOX_PROFILE.toml works with config recursion' {
+	# Create directory structure
+	mkdir -p parent/child
 
-    # Create parent config
-    cat > parent/fnox.toml <<EOF
+	# Create parent config
+	cat >parent/fnox.toml <<EOF
 [providers.test]
 type = "age"
 recipients = ["age1test"]
@@ -142,61 +142,61 @@ recipients = ["age1test"]
 PARENT_SECRET = { description = "Parent secret", default = "parent-value" }
 EOF
 
-    # Create parent production profile config
-    cat > parent/fnox.production.toml <<EOF
+	# Create parent production profile config
+	cat >parent/fnox.production.toml <<EOF
 [secrets]
 PARENT_SECRET = { description = "Parent production override", default = "parent-prod-value" }
 PARENT_PROD_SECRET = { description = "Parent prod secret", default = "parent-prod-only" }
 EOF
 
-    # Create child config
-    cat > parent/child/fnox.toml <<EOF
+	# Create child config
+	cat >parent/child/fnox.toml <<EOF
 [secrets]
 CHILD_SECRET = { description = "Child secret", default = "child-value" }
 EOF
 
-    # Create child production profile config
-    cat > parent/child/fnox.production.toml <<EOF
+	# Create child production profile config
+	cat >parent/child/fnox.production.toml <<EOF
 [secrets]
 CHILD_SECRET = { description = "Child production override", default = "child-prod-value" }
 CHILD_PROD_SECRET = { description = "Child prod secret", default = "child-prod-only" }
 EOF
 
-    # Change to child directory
-    cd parent/child
+	# Change to child directory
+	cd parent/child
 
-    # Test default profile - child overrides parent
-    run "$FNOX_BIN" get CHILD_SECRET
-    assert_success
-    assert_output --partial "child-value"
+	# Test default profile - child overrides parent
+	run "$FNOX_BIN" get CHILD_SECRET
+	assert_success
+	assert_output --partial "child-value"
 
-    run "$FNOX_BIN" get PARENT_SECRET
-    assert_success
-    assert_output --partial "parent-value"
+	run "$FNOX_BIN" get PARENT_SECRET
+	assert_success
+	assert_output --partial "parent-value"
 
-    # Test production profile - child production overrides parent production
-    run env FNOX_PROFILE=production "$FNOX_BIN" get CHILD_SECRET
-    assert_success
-    assert_output --partial "child-prod-value"
+	# Test production profile - child production overrides parent production
+	run env FNOX_PROFILE=production "$FNOX_BIN" get CHILD_SECRET
+	assert_success
+	assert_output --partial "child-prod-value"
 
-    # Parent secret should use parent production value
-    run env FNOX_PROFILE=production "$FNOX_BIN" get PARENT_SECRET
-    assert_success
-    assert_output --partial "parent-prod-value"
+	# Parent secret should use parent production value
+	run env FNOX_PROFILE=production "$FNOX_BIN" get PARENT_SECRET
+	assert_success
+	assert_output --partial "parent-prod-value"
 
-    # Production-only secrets should be accessible
-    run env FNOX_PROFILE=production "$FNOX_BIN" get CHILD_PROD_SECRET
-    assert_success
-    assert_output --partial "child-prod-only"
+	# Production-only secrets should be accessible
+	run env FNOX_PROFILE=production "$FNOX_BIN" get CHILD_PROD_SECRET
+	assert_success
+	assert_output --partial "child-prod-only"
 
-    run env FNOX_PROFILE=production "$FNOX_BIN" get PARENT_PROD_SECRET
-    assert_success
-    assert_output --partial "parent-prod-only"
+	run env FNOX_PROFILE=production "$FNOX_BIN" get PARENT_PROD_SECRET
+	assert_success
+	assert_output --partial "parent-prod-only"
 }
 
-@test "fnox.\$FNOX_PROFILE.toml can add new providers" {
-    # Create main config with one provider
-    cat > fnox.toml <<EOF
+@test 'fnox.$FNOX_PROFILE.toml can add new providers' {
+	# Create main config with one provider
+	cat >fnox.toml <<EOF
 root = true
 
 [providers.main_provider]
@@ -207,8 +207,8 @@ recipients = ["age1test"]
 MAIN_SECRET = { provider = "main_provider", default = "main-value" }
 EOF
 
-    # Create ci profile config with additional provider
-    cat > fnox.ci.toml <<EOF
+	# Create ci profile config with additional provider
+	cat >fnox.ci.toml <<EOF
 [providers.ci_provider]
 type = "age"
 recipients = ["age1citest"]
@@ -217,28 +217,28 @@ recipients = ["age1citest"]
 CI_SECRET = { provider = "ci_provider", default = "ci-value" }
 EOF
 
-    # Test default profile - only main provider accessible
-    run "$FNOX_BIN" get MAIN_SECRET
-    assert_success
-    assert_output --partial "main-value"
+	# Test default profile - only main provider accessible
+	run "$FNOX_BIN" get MAIN_SECRET
+	assert_success
+	assert_output --partial "main-value"
 
-    # Test ci profile - both providers accessible
-    run env FNOX_PROFILE=ci "$FNOX_BIN" get MAIN_SECRET
-    assert_success
-    assert_output --partial "main-value"
+	# Test ci profile - both providers accessible
+	run env FNOX_PROFILE=ci "$FNOX_BIN" get MAIN_SECRET
+	assert_success
+	assert_output --partial "main-value"
 
-    run env FNOX_PROFILE=ci "$FNOX_BIN" get CI_SECRET
-    assert_success
-    assert_output --partial "ci-value"
+	run env FNOX_PROFILE=ci "$FNOX_BIN" get CI_SECRET
+	assert_success
+	assert_output --partial "ci-value"
 
-    # CI secret should not be accessible in default profile
-    run "$FNOX_BIN" get CI_SECRET
-    assert_failure
+	# CI secret should not be accessible in default profile
+	run "$FNOX_BIN" get CI_SECRET
+	assert_failure
 }
 
-@test "fnox.\$FNOX_PROFILE.toml is not loaded for default profile" {
-    # Create main config
-    cat > fnox.toml <<EOF
+@test 'fnox.$FNOX_PROFILE.toml is not loaded for default profile' {
+	# Create main config
+	cat >fnox.toml <<EOF
 root = true
 
 [providers.test]
@@ -249,25 +249,25 @@ recipients = ["age1test"]
 MY_SECRET = { description = "My secret", default = "main-value" }
 EOF
 
-    # Create default profile config (should be ignored)
-    cat > fnox.default.toml <<EOF
+	# Create default profile config (should be ignored)
+	cat >fnox.default.toml <<EOF
 [secrets]
 MY_SECRET = { description = "Default override", default = "default-value" }
 EOF
 
-    # Test with default profile - should NOT use fnox.default.toml
-    run "$FNOX_BIN" get MY_SECRET
-    assert_success
-    assert_output --partial "main-value"
+	# Test with default profile - should NOT use fnox.default.toml
+	run "$FNOX_BIN" get MY_SECRET
+	assert_success
+	assert_output --partial "main-value"
 
-    run env FNOX_PROFILE=default "$FNOX_BIN" get MY_SECRET
-    assert_success
-    assert_output --partial "main-value"
+	run env FNOX_PROFILE=default "$FNOX_BIN" get MY_SECRET
+	assert_success
+	assert_output --partial "main-value"
 }
 
-@test "fnox list shows secrets from fnox.\$FNOX_PROFILE.toml" {
-    # Create main config
-    cat > fnox.toml <<EOF
+@test 'fnox list shows secrets from fnox.$FNOX_PROFILE.toml' {
+	# Create main config
+	cat >fnox.toml <<EOF
 root = true
 
 [providers.test]
@@ -279,32 +279,32 @@ MAIN_SECRET = { description = "Main config secret", default = "main-value" }
 SHARED_SECRET = { description = "Shared secret", default = "main-value" }
 EOF
 
-    # Create testing profile config (renamed from 'test' to 'testing' to avoid confusion)
-    cat > fnox.testing.toml <<EOF
+	# Create testing profile config (renamed from 'test' to 'testing' to avoid confusion)
+	cat >fnox.testing.toml <<EOF
 [secrets]
 TESTING_SECRET = { description = "Testing config secret", default = "testing-value" }
 SHARED_SECRET = { description = "Testing override", default = "testing-value" }
 EOF
 
-    # Test list without FNOX_PROFILE
-    run "$FNOX_BIN" list --complete
-    assert_success
-    assert_output --partial "MAIN_SECRET"
-    assert_output --partial "SHARED_SECRET"
-    # Should NOT show TESTING_SECRET without FNOX_PROFILE
-    refute_output --partial "TESTING_SECRET"
+	# Test list without FNOX_PROFILE
+	run "$FNOX_BIN" list --complete
+	assert_success
+	assert_output --partial "MAIN_SECRET"
+	assert_output --partial "SHARED_SECRET"
+	# Should NOT show TESTING_SECRET without FNOX_PROFILE
+	refute_output --partial "TESTING_SECRET"
 
-    # Test list with FNOX_PROFILE=testing
-    run env FNOX_PROFILE=testing "$FNOX_BIN" list --complete
-    assert_success
-    assert_output --partial "MAIN_SECRET"
-    assert_output --partial "TESTING_SECRET"
-    assert_output --partial "SHARED_SECRET"
+	# Test list with FNOX_PROFILE=testing
+	run env FNOX_PROFILE=testing "$FNOX_BIN" list --complete
+	assert_success
+	assert_output --partial "MAIN_SECRET"
+	assert_output --partial "TESTING_SECRET"
+	assert_output --partial "SHARED_SECRET"
 }
 
-@test "explicit config path ignores fnox.\$FNOX_PROFILE.toml" {
-    # Create main config
-    cat > fnox.toml <<EOF
+@test 'explicit config path ignores fnox.$FNOX_PROFILE.toml' {
+	# Create main config
+	cat >fnox.toml <<EOF
 root = true
 
 [providers.test]
@@ -315,28 +315,28 @@ recipients = ["age1test"]
 MAIN_SECRET = { description = "Main secret", default = "main-value" }
 EOF
 
-    # Create production profile config
-    cat > fnox.production.toml <<EOF
+	# Create production profile config
+	cat >fnox.production.toml <<EOF
 [secrets]
 PROD_SECRET = { description = "Production secret", default = "prod-value" }
 MAIN_SECRET = { description = "Production override", default = "prod-override" }
 EOF
 
-    # Using explicit path should only load that specific file
-    # (bypasses profile-specific config loading)
-    run env FNOX_PROFILE=production "$FNOX_BIN" -c ./fnox.toml get MAIN_SECRET
-    assert_success
-    assert_output --partial "main-value"
+	# Using explicit path should only load that specific file
+	# (bypasses profile-specific config loading)
+	run env FNOX_PROFILE=production "$FNOX_BIN" -c ./fnox.toml get MAIN_SECRET
+	assert_success
+	assert_output --partial "main-value"
 
-    # Production secret should not be accessible with explicit path
-    run env FNOX_PROFILE=production "$FNOX_BIN" -c ./fnox.toml get PROD_SECRET
-    assert_failure
-    assert_output --partial "not found"
+	# Production secret should not be accessible with explicit path
+	run env FNOX_PROFILE=production "$FNOX_BIN" -c ./fnox.toml get PROD_SECRET
+	assert_failure
+	assert_output --partial "not found"
 }
 
-@test "fnox.\$FNOX_PROFILE.toml can override default_provider" {
-    # Create main config with default provider
-    cat > fnox.toml <<EOF
+@test 'fnox.$FNOX_PROFILE.toml can override default_provider' {
+	# Create main config with default provider
+	cat >fnox.toml <<EOF
 root = true
 default_provider = "main_provider"
 
@@ -349,21 +349,21 @@ type = "age"
 recipients = ["age1alttest"]
 EOF
 
-    # Create profile config that changes default provider
-    cat > fnox.prod.toml <<EOF
+	# Create profile config that changes default provider
+	cat >fnox.prod.toml <<EOF
 default_provider = "alt_provider"
 EOF
 
-    # Set a secret with default profile (should use main_provider)
-    run "$FNOX_BIN" set TEST_SECRET_DEFAULT "test-value"
-    assert_success
+	# Set a secret with default profile (should use main_provider)
+	run "$FNOX_BIN" set TEST_SECRET_DEFAULT "test-value"
+	assert_success
 
-    # Set a secret with prod profile (should use alt_provider)
-    run env FNOX_PROFILE=prod "$FNOX_BIN" set TEST_SECRET_PROD "test-value"
-    assert_success
+	# Set a secret with prod profile (should use alt_provider)
+	run env FNOX_PROFILE=prod "$FNOX_BIN" set TEST_SECRET_PROD "test-value"
+	assert_success
 
-    # Check the configs
-    run cat fnox.toml
-    assert_success
-    assert_output --partial 'TEST_SECRET_DEFAULT'
+	# Check the configs
+	run cat fnox.toml
+	assert_success
+	assert_output --partial 'TEST_SECRET_DEFAULT'
 }

--- a/test/secret_resolution_priority.bats
+++ b/test/secret_resolution_priority.bats
@@ -6,17 +6,17 @@
 # 3. Environment variable
 
 setup() {
-    load 'test_helper/common_setup'
-    _common_setup
+	load 'test_helper/common_setup'
+	_common_setup
 }
 
 teardown() {
-    _common_teardown
+	_common_teardown
 }
 
 @test "provider takes priority over default value" {
-    # Create config with plain provider, secret has both provider value and default
-    cat > fnox.toml << 'EOF'
+	# Create config with plain provider, secret has both provider value and default
+	cat >fnox.toml <<'EOF'
 root = true
 
 [providers.plain]
@@ -28,15 +28,15 @@ value = "from-provider"
 default = "from-default"
 EOF
 
-    # Should return provider value, not default
-    run "$FNOX_BIN" get MY_SECRET
-    assert_success
-    assert_output "from-provider"
+	# Should return provider value, not default
+	run "$FNOX_BIN" get MY_SECRET
+	assert_success
+	assert_output "from-provider"
 }
 
 @test "provider takes priority over environment variable" {
-    # Create config with plain provider
-    cat > fnox.toml << 'EOF'
+	# Create config with plain provider
+	cat >fnox.toml <<'EOF'
 root = true
 
 [providers.plain]
@@ -47,18 +47,18 @@ provider = "plain"
 value = "from-provider"
 EOF
 
-    # Set env var
-    export MY_SECRET="from-env-var"
+	# Set env var
+	export MY_SECRET="from-env-var"
 
-    # Should return provider value, not env var
-    run "$FNOX_BIN" get MY_SECRET
-    assert_success
-    assert_output "from-provider"
+	# Should return provider value, not env var
+	run "$FNOX_BIN" get MY_SECRET
+	assert_success
+	assert_output "from-provider"
 }
 
 @test "provider takes priority over both default and env var" {
-    # Create config with plain provider, secret has provider, default, and env var
-    cat > fnox.toml << 'EOF'
+	# Create config with plain provider, secret has provider, default, and env var
+	cat >fnox.toml <<'EOF'
 root = true
 
 [providers.plain]
@@ -70,18 +70,18 @@ value = "from-provider"
 default = "from-default"
 EOF
 
-    # Set env var
-    export MY_SECRET="from-env-var"
+	# Set env var
+	export MY_SECRET="from-env-var"
 
-    # Should return provider value (highest priority)
-    run "$FNOX_BIN" get MY_SECRET
-    assert_success
-    assert_output "from-provider"
+	# Should return provider value (highest priority)
+	run "$FNOX_BIN" get MY_SECRET
+	assert_success
+	assert_output "from-provider"
 }
 
 @test "default takes priority over environment variable" {
-    # Create config with default but no provider value
-    cat > fnox.toml << 'EOF'
+	# Create config with default but no provider value
+	cat >fnox.toml <<'EOF'
 root = true
 
 [providers.plain]
@@ -91,18 +91,18 @@ type = "plain"
 default = "from-default"
 EOF
 
-    # Set env var
-    export MY_SECRET="from-env-var"
+	# Set env var
+	export MY_SECRET="from-env-var"
 
-    # Should return default value, not env var
-    run "$FNOX_BIN" get MY_SECRET
-    assert_success
-    assert_output "from-default"
+	# Should return default value, not env var
+	run "$FNOX_BIN" get MY_SECRET
+	assert_success
+	assert_output "from-default"
 }
 
 @test "environment variable used when no provider and no default" {
-    # Create config with no provider value and no default
-    cat > fnox.toml << 'EOF'
+	# Create config with no provider value and no default
+	cat >fnox.toml <<'EOF'
 root = true
 
 [providers.plain]
@@ -111,19 +111,19 @@ type = "plain"
 [secrets.MY_SECRET]
 EOF
 
-    # Set env var
-    export MY_SECRET="from-env-var"
+	# Set env var
+	export MY_SECRET="from-env-var"
 
-    # Should return env var (lowest priority, but only option)
-    run "$FNOX_BIN" get MY_SECRET
-    assert_success
-    assert_output "from-env-var"
+	# Should return env var (lowest priority, but only option)
+	run "$FNOX_BIN" get MY_SECRET
+	assert_success
+	assert_output "from-env-var"
 }
 
 @test "error when secret not found and no fallback" {
-    # Create config with no provider, no default, no env var
-    # Set if_missing = "error" to require the secret
-    cat > fnox.toml << 'EOF'
+	# Create config with no provider, no default, no env var
+	# Set if_missing = "error" to require the secret
+	cat >fnox.toml <<'EOF'
 root = true
 
 [providers.plain]
@@ -133,15 +133,15 @@ type = "plain"
 if_missing = "error"
 EOF
 
-    # Don't set env var - should error
-    run "$FNOX_BIN" get MY_SECRET
-    assert_failure
-    assert_output --partial "Secret 'MY_SECRET' not found"
+	# Don't set env var - should error
+	run "$FNOX_BIN" get MY_SECRET
+	assert_failure
+	assert_output --partial "Secret 'MY_SECRET' not found"
 }
 
 @test "priority order works with fnox exec" {
-    # Create config with provider value and default
-    cat > fnox.toml << 'EOF'
+	# Create config with provider value and default
+	cat >fnox.toml <<'EOF'
 root = true
 
 [providers.plain]
@@ -158,25 +158,25 @@ default = "from-default"
 [secrets.ENV_SECRET]
 EOF
 
-    # Set env vars
-    export PROVIDER_SECRET="from-env-var"
-    export DEFAULT_SECRET="from-env-var"
-    export ENV_SECRET="from-env-var"
+	# Set env vars
+	export PROVIDER_SECRET="from-env-var"
+	export DEFAULT_SECRET="from-env-var"
+	export ENV_SECRET="from-env-var"
 
-    # Run a command that prints the env vars
-    run "$FNOX_BIN" exec -- sh -c 'echo "$PROVIDER_SECRET|$DEFAULT_SECRET|$ENV_SECRET"'
-    assert_success
-    # Provider > default > env
-    assert_output "from-provider|from-default|from-env-var"
+	# Run a command that prints the env vars
+	run "$FNOX_BIN" exec -- sh -c 'echo "$PROVIDER_SECRET|$DEFAULT_SECRET|$ENV_SECRET"'
+	assert_success
+	# Provider > default > env
+	assert_output "from-provider|from-default|from-env-var"
 }
 
 @test "priority order works in CI redact mode" {
-    # Skip if not in a CI environment (we'll simulate GitHub Actions)
-    export CI=true
-    export GITHUB_ACTIONS=true
+	# Skip if not in a CI environment (we'll simulate GitHub Actions)
+	export CI=true
+	export GITHUB_ACTIONS=true
 
-    # Create config
-    cat > fnox.toml << 'EOF'
+	# Create config
+	cat >fnox.toml <<'EOF'
 root = true
 
 [providers.plain]
@@ -191,25 +191,25 @@ default = "default-value"
 default = "default-value-to-mask"
 EOF
 
-    # Set env vars (should be ignored)
-    export PROVIDER_SECRET="env-value"
-    export DEFAULT_SECRET="env-value"
+	# Set env vars (should be ignored)
+	export PROVIDER_SECRET="env-value"
+	export DEFAULT_SECRET="env-value"
 
-    # Run ci-redact
-    run "$FNOX_BIN" ci-redact
-    assert_success
+	# Run ci-redact
+	run "$FNOX_BIN" ci-redact
+	assert_success
 
-    # Should mask provider value, not default or env
-    assert_output --partial "::add-mask::provider-value-to-mask"
-    assert_output --partial "::add-mask::default-value-to-mask"
+	# Should mask provider value, not default or env
+	assert_output --partial "::add-mask::provider-value-to-mask"
+	assert_output --partial "::add-mask::default-value-to-mask"
 
-    # Should NOT contain env value
-    refute_output --partial "env-value"
+	# Should NOT contain env value
+	refute_output --partial "env-value"
 }
 
 @test "value field requires provider to be used" {
-    # Create config with value but no provider specified and no default provider
-    cat > fnox.toml << 'EOF'
+	# Create config with value but no provider specified and no default provider
+	cat >fnox.toml <<'EOF'
 root = true
 
 [providers.plain1]
@@ -223,17 +223,17 @@ value = "value-needs-provider"
 default = "from-default"
 EOF
 
-    # With multiple providers and no default, can't auto-select provider
-    # So value field can't be used - should fall back to default
-    run "$FNOX_BIN" get MY_SECRET
-    assert_success
-    assert_output "from-default"
+	# With multiple providers and no default, can't auto-select provider
+	# So value field can't be used - should fall back to default
+	run "$FNOX_BIN" get MY_SECRET
+	assert_success
+	assert_output "from-default"
 }
 
 @test "provider value used as provider input, not direct output" {
-    # This tests that the 'value' field is used as input to the provider
-    # not returned directly
-    cat > fnox.toml << 'EOF'
+	# This tests that the 'value' field is used as input to the provider
+	# not returned directly
+	cat >fnox.toml <<'EOF'
 root = true
 
 [providers.plain]
@@ -244,15 +244,15 @@ provider = "plain"
 value = "plain-provider-input-value"
 EOF
 
-    # The plain provider should return the value as-is
-    # (demonstrating value is passed to provider)
-    run "$FNOX_BIN" get MY_SECRET
-    assert_success
-    assert_output "plain-provider-input-value"
+	# The plain provider should return the value as-is
+	# (demonstrating value is passed to provider)
+	run "$FNOX_BIN" get MY_SECRET
+	assert_success
+	assert_output "plain-provider-input-value"
 }
 
 @test "multiple secrets respect individual priorities" {
-    cat > fnox.toml << 'EOF'
+	cat >fnox.toml <<'EOF'
 root = true
 
 [providers.plain]
@@ -270,29 +270,29 @@ default = "b-default"
 # No provider, no default - will use env
 EOF
 
-    # Set env vars for all
-    export SECRET_A="a-env"
-    export SECRET_B="b-env"
-    export SECRET_C="c-env"
+	# Set env vars for all
+	export SECRET_A="a-env"
+	export SECRET_B="b-env"
+	export SECRET_C="c-env"
 
-    # A: provider wins
-    run "$FNOX_BIN" get SECRET_A
-    assert_success
-    assert_output "a-provider"
+	# A: provider wins
+	run "$FNOX_BIN" get SECRET_A
+	assert_success
+	assert_output "a-provider"
 
-    # B: default wins over env
-    run "$FNOX_BIN" get SECRET_B
-    assert_success
-    assert_output "b-default"
+	# B: default wins over env
+	run "$FNOX_BIN" get SECRET_B
+	assert_success
+	assert_output "b-default"
 
-    # C: env var is used (only option)
-    run "$FNOX_BIN" get SECRET_C
-    assert_success
-    assert_output "c-env"
+	# C: env var is used (only option)
+	run "$FNOX_BIN" get SECRET_C
+	assert_success
+	assert_output "c-env"
 }
 
 @test "default provider with explicit value follows priority" {
-    cat > fnox.toml << 'EOF'
+	cat >fnox.toml <<'EOF'
 root = true
 default_provider = "plain"
 
@@ -305,16 +305,16 @@ value = "provider-value"
 default = "default-value"
 EOF
 
-    export MY_SECRET="env-value"
+	export MY_SECRET="env-value"
 
-    # Should use provider (default provider) with value
-    run "$FNOX_BIN" get MY_SECRET
-    assert_success
-    assert_output "provider-value"
+	# Should use provider (default provider) with value
+	run "$FNOX_BIN" get MY_SECRET
+	assert_success
+	assert_output "provider-value"
 }
 
 @test "secret with provider but no value falls back to default" {
-    cat > fnox.toml << 'EOF'
+	cat >fnox.toml <<'EOF'
 root = true
 
 [providers.plain]
@@ -326,16 +326,16 @@ provider = "plain"
 default = "default-value"
 EOF
 
-    export MY_SECRET="env-value"
+	export MY_SECRET="env-value"
 
-    # Can't use provider without value, should fall back to default
-    run "$FNOX_BIN" get MY_SECRET
-    assert_success
-    assert_output "default-value"
+	# Can't use provider without value, should fall back to default
+	run "$FNOX_BIN" get MY_SECRET
+	assert_success
+	assert_output "default-value"
 }
 
 @test "if_missing=warn allows missing secrets without error" {
-    cat > fnox.toml << 'EOF'
+	cat >fnox.toml <<'EOF'
 root = true
 
 [providers.plain]
@@ -345,14 +345,14 @@ type = "plain"
 if_missing = "warn"
 EOF
 
-    # Don't set env var - should warn but not error
-    run "$FNOX_BIN" get OPTIONAL_SECRET
-    assert_success
-    # Should produce warning on stderr
+	# Don't set env var - should warn but not error
+	run "$FNOX_BIN" get OPTIONAL_SECRET
+	assert_success
+	# Should produce warning on stderr
 }
 
 @test "if_missing=ignore silently skips missing secrets" {
-    cat > fnox.toml << 'EOF'
+	cat >fnox.toml <<'EOF'
 root = true
 
 [providers.plain]
@@ -362,14 +362,14 @@ type = "plain"
 if_missing = "ignore"
 EOF
 
-    # Don't set env var - should silently skip
-    run "$FNOX_BIN" get OPTIONAL_SECRET
-    assert_success
-    assert_output ""
+	# Don't set env var - should silently skip
+	run "$FNOX_BIN" get OPTIONAL_SECRET
+	assert_success
+	assert_output ""
 }
 
 @test "priority works with profile-specific secrets" {
-    cat > fnox.toml << 'EOF'
+	cat >fnox.toml <<'EOF'
 root = true
 
 [providers.plain]
@@ -393,22 +393,22 @@ provider = "plain"
 value = "profile-provider"
 EOF
 
-    export GLOBAL_SECRET="env-value"
-    export DEV_SECRET="env-value"
-    export PROFILE_PROVIDER="env-value"
+	export GLOBAL_SECRET="env-value"
+	export DEV_SECRET="env-value"
+	export PROFILE_PROVIDER="env-value"
 
-    # Global secret from default profile should still use provider
-    run "$FNOX_BIN" get GLOBAL_SECRET
-    assert_success
-    assert_output "global-provider"
+	# Global secret from default profile should still use provider
+	run "$FNOX_BIN" get GLOBAL_SECRET
+	assert_success
+	assert_output "global-provider"
 
-    # Dev profile secret should use default over env
-    run "$FNOX_BIN" get --profile dev DEV_SECRET
-    assert_success
-    assert_output "dev-default"
+	# Dev profile secret should use default over env
+	run "$FNOX_BIN" get --profile dev DEV_SECRET
+	assert_success
+	assert_output "dev-default"
 
-    # Profile secret with provider should use provider over env
-    run "$FNOX_BIN" get --profile dev PROFILE_PROVIDER
-    assert_success
-    assert_output "profile-provider"
+	# Profile secret with provider should use provider over env
+	run "$FNOX_BIN" get --profile dev PROFILE_PROVIDER
+	assert_success
+	assert_output "profile-provider"
 }

--- a/test/set_no_provider.bats
+++ b/test/set_no_provider.bats
@@ -1,60 +1,60 @@
 #!/usr/bin/env bats
 
 setup() {
-    load 'test_helper/common_setup'
-    _common_setup
+	load 'test_helper/common_setup'
+	_common_setup
 }
 
 teardown() {
-    _common_teardown
+	_common_teardown
 }
 
 @test "fnox set fails when no default provider is configured" {
-    # Create a minimal config with no providers and no default provider set
-    # Use a custom config name to avoid recursive search finding project config
-    cat > test-config.toml << EOF
+	# Create a minimal config with no providers and no default provider set
+	# Use a custom config name to avoid recursive search finding project config
+	cat >test-config.toml <<EOF
 [secrets]
 EOF
 
-    # Try to set a secret without specifying a provider
-    # This should fail because there's no default provider
-    run "$FNOX_BIN" --config test-config.toml set TEST_SECRET "some-secret-value"
-    assert_failure
-    
-    # Should contain an error message about no providers
-    assert_output --partial "No providers configured"
-    assert_output --partial "provider"
+	# Try to set a secret without specifying a provider
+	# This should fail because there's no default provider
+	run "$FNOX_BIN" --config test-config.toml set TEST_SECRET "some-secret-value"
+	assert_failure
+
+	# Should contain an error message about no providers
+	assert_output --partial "No providers configured"
+	assert_output --partial "provider"
 }
 
 @test "fnox set fails when no default provider and no providers exist" {
-    # Create an empty config (no providers section)
-    # Use a custom config name to avoid recursive search finding project config
-    cat > test-config2.toml << EOF
+	# Create an empty config (no providers section)
+	# Use a custom config name to avoid recursive search finding project config
+	cat >test-config2.toml <<EOF
 [secrets]
 EOF
 
-    # Try to set a secret without specifying a provider
-    run "$FNOX_BIN" --config test-config2.toml set ANOTHER_SECRET "another-value"
-    assert_failure
-    
-    # Should contain an error about no provider
-    assert_output --partial "No providers configured"
-    assert_output --partial "provider"
+	# Try to set a secret without specifying a provider
+	run "$FNOX_BIN" --config test-config2.toml set ANOTHER_SECRET "another-value"
+	assert_failure
+
+	# Should contain an error about no provider
+	assert_output --partial "No providers configured"
+	assert_output --partial "provider"
 }
 
 @test "fnox set succeeds when provider is explicitly specified" {
-    # Generate age key
-    if ! command -v age-keygen >/dev/null 2>&1; then
-        skip "age-keygen not installed"
-    fi
+	# Generate age key
+	if ! command -v age-keygen >/dev/null 2>&1; then
+		skip "age-keygen not installed"
+	fi
 
-    local keygen_output
-    keygen_output=$(age-keygen -o key.txt 2>&1)
-    local public_key
-    public_key=$(echo "$keygen_output" | grep "^Public key:" | cut -d' ' -f3)
+	local keygen_output
+	keygen_output=$(age-keygen -o key.txt 2>&1)
+	local public_key
+	public_key=$(echo "$keygen_output" | grep "^Public key:" | cut -d' ' -f3)
 
-    # Create config with age provider but no default
-    cat > test-config3.toml << EOF
+	# Create config with age provider but no default
+	cat >test-config3.toml <<EOF
 [providers.age]
 type = "age"
 recipients = ["$public_key"]
@@ -62,48 +62,48 @@ recipients = ["$public_key"]
 [secrets]
 EOF
 
-    # This should succeed because we explicitly specify the provider
-    run "$FNOX_BIN" --config test-config3.toml set EXPLICIT_SECRET "explicit-value" --provider age
-    assert_success
-    
-    # Verify the secret was encrypted
-    assert_file_contains test-config3.toml "EXPLICIT_SECRET"
-    assert_file_contains test-config3.toml "provider = \"age\""
-    assert_file_not_contains test-config3.toml "explicit-value"
+	# This should succeed because we explicitly specify the provider
+	run "$FNOX_BIN" --config test-config3.toml set EXPLICIT_SECRET "explicit-value" --provider age
+	assert_success
+
+	# Verify the secret was encrypted
+	assert_file_contains test-config3.toml "EXPLICIT_SECRET"
+	assert_file_contains test-config3.toml 'provider = "age"'
+	assert_file_not_contains test-config3.toml "explicit-value"
 }
 
 @test "fnox set fails when default provider is configured but no providers exist" {
-    # Create config with a default provider but no providers section
-    # Use a custom config name to avoid recursive search finding project config
-    cat > test-config4.toml << EOF
+	# Create config with a default provider but no providers section
+	# Use a custom config name to avoid recursive search finding project config
+	cat >test-config4.toml <<EOF
 default_provider = "nonexistent"
 
 [secrets]
 EOF
 
-    # Try to set a secret without specifying a provider
-    run "$FNOX_BIN" --config test-config4.toml set BROKEN_SECRET "broken-value"
-    assert_failure
-    
-    # Should contain an error about no providers (takes precedence over default provider)
-    assert_output --partial "No providers configured"
-    assert_output --partial "provider"
+	# Try to set a secret without specifying a provider
+	run "$FNOX_BIN" --config test-config4.toml set BROKEN_SECRET "broken-value"
+	assert_failure
+
+	# Should contain an error about no providers (takes precedence over default provider)
+	assert_output --partial "No providers configured"
+	assert_output --partial "provider"
 }
 
 @test "fnox set succeeds with valid default provider" {
-    # Generate age key
-    if ! command -v age-keygen >/dev/null 2>&1; then
-        skip "age-keygen not installed"
-    fi
+	# Generate age key
+	if ! command -v age-keygen >/dev/null 2>&1; then
+		skip "age-keygen not installed"
+	fi
 
-    local keygen_output
-    keygen_output=$(age-keygen -o key.txt 2>&1)
-    local public_key
-    public_key=$(echo "$keygen_output" | grep "^Public key:" | cut -d' ' -f3)
+	local keygen_output
+	keygen_output=$(age-keygen -o key.txt 2>&1)
+	local public_key
+	public_key=$(echo "$keygen_output" | grep "^Public key:" | cut -d' ' -f3)
 
-    # Create config with age provider and default_provider set
-    # Use a custom config name to avoid recursive search finding project config
-    cat > test-config5.toml << EOF
+	# Create config with age provider and default_provider set
+	# Use a custom config name to avoid recursive search finding project config
+	cat >test-config5.toml <<EOF
 default_provider = "age"
 
 [providers.age]
@@ -113,12 +113,12 @@ recipients = ["$public_key"]
 [secrets]
 EOF
 
-    # This should succeed because default_provider is properly configured
-    run "$FNOX_BIN" --config test-config5.toml set DEFAULT_SECRET "default-value"
-    assert_success
-    
-    # Verify the secret was encrypted with the default provider
-    assert_file_contains test-config5.toml "DEFAULT_SECRET"
-    assert_file_contains test-config5.toml "provider = \"age\""
-    assert_file_not_contains test-config5.toml "default-value"
+	# This should succeed because default_provider is properly configured
+	run "$FNOX_BIN" --config test-config5.toml set DEFAULT_SECRET "default-value"
+	assert_success
+
+	# Verify the secret was encrypted with the default provider
+	assert_file_contains test-config5.toml "DEFAULT_SECRET"
+	assert_file_contains test-config5.toml 'provider = "age"'
+	assert_file_not_contains test-config5.toml "default-value"
 }

--- a/test/shell-integration.bats
+++ b/test/shell-integration.bats
@@ -484,7 +484,7 @@ teardown() {
 		[secrets.AGE_SECRET]
 		provider = "age"
 		value = """
-$encrypted"""
+		$encrypted"""
 	EOF
 
 	# Run hook-env
@@ -526,8 +526,8 @@ $encrypted"""
 		[secrets.MULTILINE]
 		provider = "plain"
 		value = """line1
-line2
-line3"""
+		line2
+		line3"""
 	EOF
 
 	run "$FNOX_BIN" hook-env -s bash

--- a/test/ssh-support.bats
+++ b/test/ssh-support.bats
@@ -3,36 +3,36 @@
 load test_helper/common_setup
 
 setup() {
-    _common_setup
+	_common_setup
 }
 
 @test "age provider supports SSH keys for decryption" {
-    # Create a temporary directory for test keys
-    local tmpdir
-    tmpdir=$(mktemp -d)
-    cd "$tmpdir"
+	# Create a temporary directory for test keys
+	local tmpdir
+	tmpdir=$(mktemp -d)
+	cd "$tmpdir"
 
-    # Generate a test SSH key (Ed25519)
-    ssh-keygen -t ed25519 -f test_ssh_key -N "" -C "test@example.com" >/dev/null 2>&1
+	# Generate a test SSH key (Ed25519)
+	ssh-keygen -t ed25519 -f test_ssh_key -N "" -C "test@example.com" >/dev/null 2>&1
 
-    # Get SSH public key in format age expects
-    local ssh_pubkey
-    ssh_pubkey=$(cat test_ssh_key.pub)
+	# Get SSH public key in format age expects
+	local ssh_pubkey
+	ssh_pubkey=$(cat test_ssh_key.pub)
 
-    # Set up fnox config with age provider using SSH public key as recipient
-    printf "[providers.age]\ntype = \"age\"\nrecipients = [\"%s\"]\n" "$ssh_pubkey" > fnox.toml
+	# Set up fnox config with age provider using SSH public key as recipient
+	printf "[providers.age]\ntype = \"age\"\nrecipients = [\"%s\"]\n" "$ssh_pubkey" >fnox.toml
 
-    # Test encrypting to SSH public key and decrypting with SSH private key
-    run "$FNOX_BIN" set SSH_TEST "ssh-test-value" --provider age --age-key-file test_ssh_key
-    assert_success
-    assert_output --partial "Set secret SSH_TEST"
+	# Test encrypting to SSH public key and decrypting with SSH private key
+	run "$FNOX_BIN" set SSH_TEST "ssh-test-value" --provider age --age-key-file test_ssh_key
+	assert_success
+	assert_output --partial "Set secret SSH_TEST"
 
-    # Try to decrypt with SSH private key (should work now)
-    run "$FNOX_BIN" get SSH_TEST --age-key-file test_ssh_key
-    assert_success
-    assert_output "ssh-test-value"
+	# Try to decrypt with SSH private key (should work now)
+	run "$FNOX_BIN" get SSH_TEST --age-key-file test_ssh_key
+	assert_success
+	assert_output "ssh-test-value"
 }
 
 @test "age provider supports password-protected SSH keys" {
-    skip "Password-protected SSH keys require interactive prompts which bats cannot handle"
+	skip "Password-protected SSH keys require interactive prompts which bats cannot handle"
 }

--- a/test/toml-formatting.bats
+++ b/test/toml-formatting.bats
@@ -5,23 +5,23 @@ load 'test_helper/common_setup'
 # Test TOML formatting behavior for secrets - visitor pattern approach
 
 setup() {
-    _common_setup
+	_common_setup
 }
 
 teardown() {
-    _common_teardown
+	_common_teardown
 }
 
 @test "fnox set uses inline table format by default for new secrets" {
-    # Generate age key
-    if ! command -v age-keygen >/dev/null 2>&1; then
-        skip "age-keygen not installed"
-    fi
-    mkdir -p "$HOME/.config/fnox"
-    age-keygen -o "$HOME/.config/fnox/age.txt" 2>/dev/null
+	# Generate age key
+	if ! command -v age-keygen >/dev/null 2>&1; then
+		skip "age-keygen not installed"
+	fi
+	mkdir -p "$HOME/.config/fnox"
+	age-keygen -o "$HOME/.config/fnox/age.txt" 2>/dev/null
 
-    # Create minimal config with age provider
-    cat > fnox.toml << EOF
+	# Create minimal config with age provider
+	cat >fnox.toml <<EOF
 root = true
 
 [providers.age]
@@ -29,33 +29,34 @@ type = "age"
 recipients = ["age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"]
 EOF
 
-    # Set a secret with provider and description
-    run fnox set MY_SECRET "test-value" --provider age --description "Test secret"
-    assert_success
+	# Set a secret with provider and description
+	run fnox set MY_SECRET "test-value" --provider age --description "Test secret"
+	assert_success
 
-    # Check that the secret is formatted as an inline table
-    run cat fnox.toml
-    assert_output --partial 'MY_SECRET'
-    assert_output --partial '{'
-    assert_output --partial 'provider = "age"'
-    assert_output --partial 'description = "Test secret"'
+	# Check that the secret is formatted as an inline table
+	run cat fnox.toml
+	assert_output --partial 'MY_SECRET'
+	assert_output --partial '{'
+	assert_output --partial 'provider = "age"'
+	assert_output --partial 'description = "Test secret"'
 
-    # Verify it's on a single line (inline table format)
-    local secret_line=$(grep "^MY_SECRET" fnox.toml)
-    assert [ -n "$secret_line" ]
-    echo "$secret_line" | grep -q '{'
+	# Verify it's on a single line (inline table format)
+	local secret_line
+	secret_line=$(grep "^MY_SECRET" fnox.toml)
+	assert [ -n "$secret_line" ]
+	echo "$secret_line" | grep -q '{'
 }
 
 @test "fnox set with multiple fields uses inline table format" {
-    # Generate age key
-    if ! command -v age-keygen >/dev/null 2>&1; then
-        skip "age-keygen not installed"
-    fi
-    mkdir -p "$HOME/.config/fnox"
-    age-keygen -o "$HOME/.config/fnox/age.txt" 2>/dev/null
+	# Generate age key
+	if ! command -v age-keygen >/dev/null 2>&1; then
+		skip "age-keygen not installed"
+	fi
+	mkdir -p "$HOME/.config/fnox"
+	age-keygen -o "$HOME/.config/fnox/age.txt" 2>/dev/null
 
-    # Create minimal config
-    cat > fnox.toml << EOF
+	# Create minimal config
+	cat >fnox.toml <<EOF
 root = true
 
 [providers.age]
@@ -63,29 +64,29 @@ type = "age"
 recipients = ["age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"]
 EOF
 
-    # Set a secret with provider, description, and default value
-    run fnox set COMPLEX_SECRET "test-value" --provider age --description "Complex secret" --default "fallback"
-    assert_success
+	# Set a secret with provider, description, and default value
+	run fnox set COMPLEX_SECRET "test-value" --provider age --description "Complex secret" --default "fallback"
+	assert_success
 
-    # Check that all fields are in the inline table
-    run cat fnox.toml
-    assert_output --partial 'COMPLEX_SECRET'
-    assert_output --partial '{'
-    assert_output --partial 'provider = "age"'
-    assert_output --partial 'description = "Complex secret"'
-    assert_output --partial 'default = "fallback"'
+	# Check that all fields are in the inline table
+	run cat fnox.toml
+	assert_output --partial 'COMPLEX_SECRET'
+	assert_output --partial '{'
+	assert_output --partial 'provider = "age"'
+	assert_output --partial 'description = "Complex secret"'
+	assert_output --partial 'default = "fallback"'
 }
 
 @test "multiple secrets all use inline table format by default" {
-    # Generate age key
-    if ! command -v age-keygen >/dev/null 2>&1; then
-        skip "age-keygen not installed"
-    fi
-    mkdir -p "$HOME/.config/fnox"
-    age-keygen -o "$HOME/.config/fnox/age.txt" 2>/dev/null
+	# Generate age key
+	if ! command -v age-keygen >/dev/null 2>&1; then
+		skip "age-keygen not installed"
+	fi
+	mkdir -p "$HOME/.config/fnox"
+	age-keygen -o "$HOME/.config/fnox/age.txt" 2>/dev/null
 
-    # Create minimal config
-    cat > fnox.toml << EOF
+	# Create minimal config
+	cat >fnox.toml <<EOF
 root = true
 
 [providers.age]
@@ -93,21 +94,21 @@ type = "age"
 recipients = ["age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"]
 EOF
 
-    # Set multiple secrets
-    run fnox set SECRET1 "value1" --provider age
-    assert_success
-    run fnox set SECRET2 "value2" --provider age --description "Second"
-    assert_success
-    run fnox set SECRET3 "value3" --provider age
-    assert_success
+	# Set multiple secrets
+	run fnox set SECRET1 "value1" --provider age
+	assert_success
+	run fnox set SECRET2 "value2" --provider age --description "Second"
+	assert_success
+	run fnox set SECRET3 "value3" --provider age
+	assert_success
 
-    # Check that all are inline tables
-    run cat fnox.toml
-    assert_output --partial 'SECRET1'
-    assert_output --partial 'SECRET2'
-    assert_output --partial 'SECRET3'
-    # Verify all contain inline table brackets
-    grep -q "SECRET1.*{" fnox.toml
-    grep -q "SECRET2.*{" fnox.toml
-    grep -q "SECRET3.*{" fnox.toml
+	# Check that all are inline tables
+	run cat fnox.toml
+	assert_output --partial 'SECRET1'
+	assert_output --partial 'SECRET2'
+	assert_output --partial 'SECRET3'
+	# Verify all contain inline table brackets
+	grep -q "SECRET1.*{" fnox.toml
+	grep -q "SECRET2.*{" fnox.toml
+	grep -q "SECRET3.*{" fnox.toml
 }

--- a/test/toplevel_secrets.bats
+++ b/test/toplevel_secrets.bats
@@ -1,17 +1,17 @@
 #!/usr/bin/env bats
 
 setup() {
-    load 'test_helper/common_setup'
-    _common_setup
+	load 'test_helper/common_setup'
+	_common_setup
 }
 
 teardown() {
-    _common_teardown
+	_common_teardown
 }
 
 @test "top-level secrets are inherited by all profiles" {
-    # Create config with top-level secrets and multiple profiles
-    cat > fnox.toml << 'EOF'
+	# Create config with top-level secrets and multiple profiles
+	cat >fnox.toml <<'EOF'
 root = true
 
 [providers.plain]
@@ -39,25 +39,25 @@ type = "plain"
 type = "plain"
 EOF
 
-    # Get top-level secret from default profile
-    run "$FNOX_BIN" get SHARED_API_KEY
-    assert_success
-    assert_output "top-level-api-key"
+	# Get top-level secret from default profile
+	run "$FNOX_BIN" get SHARED_API_KEY
+	assert_success
+	assert_output "top-level-api-key"
 
-    # Get top-level secret from dev profile
-    run "$FNOX_BIN" get --profile dev SHARED_API_KEY
-    assert_success
-    assert_output "top-level-api-key"
+	# Get top-level secret from dev profile
+	run "$FNOX_BIN" get --profile dev SHARED_API_KEY
+	assert_success
+	assert_output "top-level-api-key"
 
-    # Get top-level secret from prod profile
-    run "$FNOX_BIN" get --profile prod SHARED_DATABASE_URL
-    assert_success
-    assert_output "postgres://localhost/default"
+	# Get top-level secret from prod profile
+	run "$FNOX_BIN" get --profile prod SHARED_DATABASE_URL
+	assert_success
+	assert_output "postgres://localhost/default"
 }
 
 @test "profile-specific secrets override top-level secrets" {
-    # Create config where profile overrides top-level secret
-    cat > fnox.toml << 'EOF'
+	# Create config where profile overrides top-level secret
+	cat >fnox.toml <<'EOF'
 root = true
 
 [providers.plain]
@@ -85,32 +85,32 @@ value = "postgres://dev-server/devdb"
 type = "plain"
 EOF
 
-    # Default profile uses top-level value
-    run "$FNOX_BIN" get DATABASE_URL
-    assert_success
-    assert_output "postgres://localhost/default"
+	# Default profile uses top-level value
+	run "$FNOX_BIN" get DATABASE_URL
+	assert_success
+	assert_output "postgres://localhost/default"
 
-    # Dev profile uses overridden value
-    run "$FNOX_BIN" get --profile dev DATABASE_URL
-    assert_success
-    assert_output "postgres://dev-server/devdb"
+	# Dev profile uses overridden value
+	run "$FNOX_BIN" get --profile dev DATABASE_URL
+	assert_success
+	assert_output "postgres://dev-server/devdb"
 
-    # Prod profile inherits top-level value
-    run "$FNOX_BIN" get --profile prod DATABASE_URL
-    assert_success
-    assert_output "postgres://localhost/default"
+	# Prod profile inherits top-level value
+	run "$FNOX_BIN" get --profile prod DATABASE_URL
+	assert_success
+	assert_output "postgres://localhost/default"
 }
 
 @test "top-level secrets with different providers per profile" {
-    # Set up age keys for different profiles
-    AGE_KEY_DEV=$(age-keygen 2>&1 | grep "^AGE-SECRET-KEY" || true)
-    AGE_PUB_DEV=$(echo "$AGE_KEY_DEV" | age-keygen -y 2>/dev/null || true)
+	# Set up age keys for different profiles
+	AGE_KEY_DEV=$(age-keygen 2>&1 | grep "^AGE-SECRET-KEY" || true)
+	AGE_PUB_DEV=$(echo "$AGE_KEY_DEV" | age-keygen -y 2>/dev/null || true)
 
-    AGE_KEY_PROD=$(age-keygen 2>&1 | grep "^AGE-SECRET-KEY" || true)
-    AGE_PUB_PROD=$(echo "$AGE_KEY_PROD" | age-keygen -y 2>/dev/null || true)
+	AGE_KEY_PROD=$(age-keygen 2>&1 | grep "^AGE-SECRET-KEY" || true)
+	AGE_PUB_PROD=$(echo "$AGE_KEY_PROD" | age-keygen -y 2>/dev/null || true)
 
-    # Create config with top-level secrets but different encryption keys per profile
-    cat > fnox.toml << EOF
+	# Create config with top-level secrets but different encryption keys per profile
+	cat >fnox.toml <<EOF
 root = true
 
 [providers.age]
@@ -137,22 +137,22 @@ type = "age"
 recipients = ["$AGE_PUB_PROD"]
 EOF
 
-    # The secret should be accessible from both profiles
-    # (This will use the encrypted value from top-level, but with profile-specific decryption)
+	# The secret should be accessible from both profiles
+	# (This will use the encrypted value from top-level, but with profile-specific decryption)
 
-    # List should show the inherited secret in both profiles
-    run "$FNOX_BIN" list --profile dev
-    assert_success
-    assert_output --partial "ENCRYPTED_SECRET"
+	# List should show the inherited secret in both profiles
+	run "$FNOX_BIN" list --profile dev
+	assert_success
+	assert_output --partial "ENCRYPTED_SECRET"
 
-    run "$FNOX_BIN" list --profile prod
-    assert_success
-    assert_output --partial "ENCRYPTED_SECRET"
+	run "$FNOX_BIN" list --profile prod
+	assert_success
+	assert_output --partial "ENCRYPTED_SECRET"
 }
 
 @test "list shows both top-level and profile-specific secrets" {
-    # Create config with mix of top-level and profile secrets
-    cat > fnox.toml << 'EOF'
+	# Create config with mix of top-level and profile secrets
+	cat >fnox.toml <<'EOF'
 root = true
 
 [providers.plain]
@@ -178,24 +178,24 @@ provider = "plain"
 value = "dev-only-value"
 EOF
 
-    # Default profile shows only top-level secrets
-    run "$FNOX_BIN" list --complete
-    assert_success
-    assert_line "SHARED_SECRET"
-    assert_line "ANOTHER_SHARED"
-    refute_output --partial "DEV_ONLY_SECRET"
+	# Default profile shows only top-level secrets
+	run "$FNOX_BIN" list --complete
+	assert_success
+	assert_line "SHARED_SECRET"
+	assert_line "ANOTHER_SHARED"
+	refute_output --partial "DEV_ONLY_SECRET"
 
-    # Dev profile shows both inherited and profile-specific secrets
-    run "$FNOX_BIN" list --profile dev --complete
-    assert_success
-    assert_line "SHARED_SECRET"
-    assert_line "ANOTHER_SHARED"
-    assert_line "DEV_ONLY_SECRET"
+	# Dev profile shows both inherited and profile-specific secrets
+	run "$FNOX_BIN" list --profile dev --complete
+	assert_success
+	assert_line "SHARED_SECRET"
+	assert_line "ANOTHER_SHARED"
+	assert_line "DEV_ONLY_SECRET"
 }
 
 @test "export includes top-level secrets in profiles" {
-    # Create config with top-level secrets
-    cat > fnox.toml << 'EOF'
+	# Create config with top-level secrets
+	cat >fnox.toml <<'EOF'
 root = true
 
 [providers.plain]
@@ -217,16 +217,16 @@ provider = "plain"
 value = "dev-value"
 EOF
 
-    # Export from dev profile should include both
-    run "$FNOX_BIN" export --profile dev --format env
-    assert_success
-    assert_output --partial "export SHARED_VAR='shared-value'"
-    assert_output --partial "export DEV_VAR='dev-value'"
+	# Export from dev profile should include both
+	run "$FNOX_BIN" export --profile dev --format env
+	assert_success
+	assert_output --partial "export SHARED_VAR='shared-value'"
+	assert_output --partial "export DEV_VAR='dev-value'"
 }
 
 @test "top-level secrets work with exec command" {
-    # Create config with top-level secret
-    cat > fnox.toml << 'EOF'
+	# Create config with top-level secret
+	cat >fnox.toml <<'EOF'
 root = true
 
 [providers.plain]
@@ -242,13 +242,15 @@ value = "exec-test-value"
 type = "plain"
 EOF
 
-    # Test exec in default profile
-    run "$FNOX_BIN" exec -- sh -c 'echo $EXEC_TEST_VAR'
-    assert_success
-    assert_output "exec-test-value"
+	# Test exec in default profile
+	# shellcheck disable=SC2016 # Single quotes intentional - variable should expand in subshell
+	run "$FNOX_BIN" exec -- sh -c 'echo $EXEC_TEST_VAR'
+	assert_success
+	assert_output "exec-test-value"
 
-    # Test exec in dev profile (should inherit)
-    run "$FNOX_BIN" exec --profile dev -- sh -c 'echo $EXEC_TEST_VAR'
-    assert_success
-    assert_output "exec-test-value"
+	# Test exec in dev profile (should inherit)
+	# shellcheck disable=SC2016 # Single quotes intentional - variable should expand in subshell
+	run "$FNOX_BIN" exec --profile dev -- sh -c 'echo $EXEC_TEST_VAR'
+	assert_success
+	assert_output "exec-test-value"
 }

--- a/test/vault.bats
+++ b/test/vault.bats
@@ -14,42 +14,42 @@
 #
 
 setup() {
-    load 'test_helper/common_setup'
-    _common_setup
+	load 'test_helper/common_setup'
+	_common_setup
 
-    # Check if vault CLI is installed
-    if ! command -v vault >/dev/null 2>&1; then
-        skip "Vault CLI not installed. Install with: mise install vault"
-    fi
+	# Check if vault CLI is installed
+	if ! command -v vault >/dev/null 2>&1; then
+		skip "Vault CLI not installed. Install with: mise install vault"
+	fi
 
-    # Some tests don't need VAULT_TOKEN (like 'fnox list')
-    # Only skip if this test actually needs authentication
-    if [[ "$BATS_TEST_DESCRIPTION" != *"list"* ]]; then
-        # Check if VAULT_TOKEN is available
-        if [ -z "$VAULT_TOKEN" ]; then
-            skip "VAULT_TOKEN not available. Run: source ./test/setup-vault-test.sh"
-        fi
+	# Some tests don't need VAULT_TOKEN (like 'fnox list')
+	# Only skip if this test actually needs authentication
+	if [[ $BATS_TEST_DESCRIPTION != *"list"* ]]; then
+		# Check if VAULT_TOKEN is available
+		if [ -z "$VAULT_TOKEN" ]; then
+			skip "VAULT_TOKEN not available. Run: source ./test/setup-vault-test.sh"
+		fi
 
-        # Set default VAULT_ADDR if not set
-        if [ -z "$VAULT_ADDR" ]; then
-            export VAULT_ADDR="http://localhost:8200"
-        fi
+		# Set default VAULT_ADDR if not set
+		if [ -z "$VAULT_ADDR" ]; then
+			export VAULT_ADDR="http://localhost:8200"
+		fi
 
-        # Verify we can authenticate with Vault by checking status
-        if ! vault status >/dev/null 2>&1; then
-            skip "Cannot authenticate with Vault. Server may not be running or token invalid."
-        fi
-    fi
+		# Verify we can authenticate with Vault by checking status
+		if ! vault status >/dev/null 2>&1; then
+			skip "Cannot authenticate with Vault. Server may not be running or token invalid."
+		fi
+	fi
 }
 
 teardown() {
-    _common_teardown
+	_common_teardown
 }
 
 # Helper function to create a Vault test config
 create_vault_config() {
-    local vault_addr="${1:-http://localhost:8200}"
-    cat > "${FNOX_CONFIG_FILE:-fnox.toml}" << EOF
+	local vault_addr="${1:-http://localhost:8200}"
+	cat >"${FNOX_CONFIG_FILE:-fnox.toml}" <<EOF
 [providers.vault]
 type = "vault"
 address = "$vault_addr"
@@ -61,132 +61,134 @@ EOF
 # Helper function to create a test secret in Vault
 # Returns the secret name
 create_test_vault_secret() {
-    local secret_name="fnox-test-$(date +%s)-$$-${BATS_TEST_NUMBER:-0}"
-    local secret_value="test-secret-value-$(date +%s)-$$-${BATS_TEST_NUMBER:-0}"
-    local username="testuser"
+	local secret_name
+	secret_name="fnox-test-$(date +%s)-$$-${BATS_TEST_NUMBER:-0}"
+	local secret_value
+	secret_value="test-secret-value-$(date +%s)-$$-${BATS_TEST_NUMBER:-0}"
+	local username="testuser"
 
-    # Create secret with vault CLI
-    # vault kv put secret/data/<name> key=value
-    vault kv put "secret/$secret_name" \
-        value="$secret_value" \
-        username="$username" \
-        description="Created by fnox test" \
-        >/dev/null 2>&1
+	# Create secret with vault CLI
+	# vault kv put secret/data/<name> key=value
+	vault kv put "secret/$secret_name" \
+		value="$secret_value" \
+		username="$username" \
+		description="Created by fnox test" \
+		>/dev/null 2>&1
 
-    echo "$secret_name"
+	echo "$secret_name"
 }
 
 # Helper function to delete a test secret from Vault
 delete_test_vault_secret() {
-    local secret_name="${1}"
-    vault kv delete "secret/$secret_name" >/dev/null 2>&1 || true
+	local secret_name="${1}"
+	vault kv delete "secret/$secret_name" >/dev/null 2>&1 || true
 }
 
 @test "fnox get retrieves secret from Vault" {
-    create_vault_config
+	create_vault_config
 
-    # Create a test secret
-    secret_name=$(create_test_vault_secret)
+	# Create a test secret
+	secret_name=$(create_test_vault_secret)
 
-    # Add secret reference to config
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	# Add secret reference to config
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.TEST_VAULT_SECRET]
 provider = "vault"
 value = "$secret_name"
 EOF
 
-    # Get the secret
-    run "$FNOX_BIN" get TEST_VAULT_SECRET
-    assert_success
-    assert_output --partial "test-secret-value-"
+	# Get the secret
+	run "$FNOX_BIN" get TEST_VAULT_SECRET
+	assert_success
+	assert_output --partial "test-secret-value-"
 
-    # Cleanup
-    delete_test_vault_secret "$secret_name"
+	# Cleanup
+	delete_test_vault_secret "$secret_name"
 }
 
 @test "fnox get retrieves specific field from Vault secret" {
-    create_vault_config
+	create_vault_config
 
-    # Create a test secret
-    secret_name=$(create_test_vault_secret)
+	# Create a test secret
+	secret_name=$(create_test_vault_secret)
 
-    # Add secret reference to config (fetch username field)
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	# Add secret reference to config (fetch username field)
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.TEST_USERNAME]
 provider = "vault"
 value = "$secret_name/username"
 EOF
 
-    # Get the secret
-    run "$FNOX_BIN" get TEST_USERNAME
-    assert_success
-    assert_output "testuser"
+	# Get the secret
+	run "$FNOX_BIN" get TEST_USERNAME
+	assert_success
+	assert_output "testuser"
 
-    # Cleanup
-    delete_test_vault_secret "$secret_name"
+	# Cleanup
+	delete_test_vault_secret "$secret_name"
 }
 
 @test "fnox get retrieves value field from Vault secret" {
-    create_vault_config
+	create_vault_config
 
-    # Create a test secret
-    secret_name=$(create_test_vault_secret)
+	# Create a test secret
+	secret_name=$(create_test_vault_secret)
 
-    # Add secret reference to config (explicit value field)
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	# Add secret reference to config (explicit value field)
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.TEST_VALUE]
 provider = "vault"
 value = "$secret_name/value"
 EOF
 
-    # Get the secret
-    run "$FNOX_BIN" get TEST_VALUE
-    assert_success
-    assert_output --partial "test-secret-value-"
+	# Get the secret
+	run "$FNOX_BIN" get TEST_VALUE
+	assert_success
+	assert_output --partial "test-secret-value-"
 
-    # Cleanup
-    delete_test_vault_secret "$secret_name"
+	# Cleanup
+	delete_test_vault_secret "$secret_name"
 }
 
 @test "fnox get fails with invalid secret name" {
-    create_vault_config
+	create_vault_config
 
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.INVALID_SECRET]
 provider = "vault"
 value = "nonexistent-secret-$(date +%s)"
 EOF
 
-    # Try to get non-existent secret
-    run "$FNOX_BIN" get INVALID_SECRET
-    assert_failure
-    assert_output --partial "Vault CLI command failed"
+	# Try to get non-existent secret
+	run "$FNOX_BIN" get INVALID_SECRET
+	assert_failure
+	assert_output --partial "Vault CLI command failed"
 }
 
 @test "fnox get handles invalid secret reference format" {
-    create_vault_config
+	create_vault_config
 
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.INVALID_FORMAT]
 provider = "vault"
 value = "invalid/format/with/too/many/slashes"
 EOF
 
-    run "$FNOX_BIN" get INVALID_FORMAT
-    assert_failure
-    assert_output --partial "Invalid secret reference format"
+	run "$FNOX_BIN" get INVALID_FORMAT
+	assert_failure
+	assert_output --partial "Invalid secret reference format"
 }
 
 @test "fnox list shows Vault secrets" {
-    # This test doesn't need VAULT_TOKEN since list just reads the config file
-    create_vault_config
+	# This test doesn't need VAULT_TOKEN since list just reads the config file
+	create_vault_config
 
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.VAULT_SECRET_1]
 description = "First Vault secret"
@@ -199,40 +201,40 @@ provider = "vault"
 value = "secret2/username"
 EOF
 
-    run "$FNOX_BIN" list
-    assert_success
-    assert_output --partial "VAULT_SECRET_1"
-    assert_output --partial "VAULT_SECRET_2"
-    assert_output --partial "First Vault secret"
+	run "$FNOX_BIN" list
+	assert_success
+	assert_output --partial "VAULT_SECRET_1"
+	assert_output --partial "VAULT_SECRET_2"
+	assert_output --partial "First Vault secret"
 }
 
 @test "Vault provider works with token from environment" {
-    # This test verifies that vault CLI uses VAULT_TOKEN from environment
-    # The token should be set by setup() from fnox config or environment
+	# This test verifies that vault CLI uses VAULT_TOKEN from environment
+	# The token should be set by setup() from fnox config or environment
 
-    create_vault_config
+	create_vault_config
 
-    secret_name=$(create_test_vault_secret)
+	secret_name=$(create_test_vault_secret)
 
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.TEST_WITH_ENV_TOKEN]
 provider = "vault"
 value = "$secret_name"
 EOF
 
-    # The VAULT_TOKEN should be set by setup()
-    run "$FNOX_BIN" get TEST_WITH_ENV_TOKEN
-    assert_success
-    assert_output --partial "test-secret-value-"
+	# The VAULT_TOKEN should be set by setup()
+	run "$FNOX_BIN" get TEST_WITH_ENV_TOKEN
+	assert_success
+	assert_output --partial "test-secret-value-"
 
-    # Cleanup
-    delete_test_vault_secret "$secret_name"
+	# Cleanup
+	delete_test_vault_secret "$secret_name"
 }
 
 @test "Vault provider with custom path prefix" {
-    # Create config with custom path (no /data/ - vault kv adds it automatically)
-    cat > "${FNOX_CONFIG_FILE:-fnox.toml}" << EOF
+	# Create config with custom path (no /data/ - vault kv adds it automatically)
+	cat >"${FNOX_CONFIG_FILE:-fnox.toml}" <<EOF
 [providers.vault]
 type = "vault"
 address = "http://localhost:8200"
@@ -243,21 +245,21 @@ provider = "vault"
 value = "test-item"
 EOF
 
-    # Create a secret at the custom path
-    vault kv put "secret/custom/test-item" value="custom-path-value" >/dev/null 2>&1
+	# Create a secret at the custom path
+	vault kv put "secret/custom/test-item" value="custom-path-value" >/dev/null 2>&1
 
-    # Get the secret
-    run "$FNOX_BIN" get TEST_SECRET
-    assert_success
-    assert_output "custom-path-value"
+	# Get the secret
+	run "$FNOX_BIN" get TEST_SECRET
+	assert_success
+	assert_output "custom-path-value"
 
-    # Cleanup
-    vault kv delete "secret/custom/test-item" >/dev/null 2>&1 || true
+	# Cleanup
+	vault kv delete "secret/custom/test-item" >/dev/null 2>&1 || true
 }
 
 @test "Vault provider with token in config" {
-    # Create config with token in provider config (not recommended for real use)
-    cat > "${FNOX_CONFIG_FILE:-fnox.toml}" << EOF
+	# Create config with token in provider config (not recommended for real use)
+	cat >"${FNOX_CONFIG_FILE:-fnox.toml}" <<EOF
 [providers.vault]
 type = "vault"
 address = "http://localhost:8200"
@@ -268,61 +270,61 @@ provider = "vault"
 value = "test-secret"
 EOF
 
-    # Create a test secret
-    vault kv put "secret/test-secret" value="token-in-config-test" >/dev/null 2>&1
+	# Create a test secret
+	vault kv put "secret/test-secret" value="token-in-config-test" >/dev/null 2>&1
 
-    # Temporarily unset VAULT_TOKEN to force using config token
-    VAULT_TOKEN_BACKUP="$VAULT_TOKEN"
-    unset VAULT_TOKEN
+	# Temporarily unset VAULT_TOKEN to force using config token
+	VAULT_TOKEN_BACKUP="$VAULT_TOKEN"
+	unset VAULT_TOKEN
 
-    # Get the secret
-    run "$FNOX_BIN" get TEST_TOKEN_IN_CONFIG
-    assert_success
-    assert_output "token-in-config-test"
+	# Get the secret
+	run "$FNOX_BIN" get TEST_TOKEN_IN_CONFIG
+	assert_success
+	assert_output "token-in-config-test"
 
-    # Restore token
-    export VAULT_TOKEN="$VAULT_TOKEN_BACKUP"
+	# Restore token
+	export VAULT_TOKEN="$VAULT_TOKEN_BACKUP"
 
-    # Cleanup
-    vault kv delete "secret/test-secret" >/dev/null 2>&1 || true
+	# Cleanup
+	vault kv delete "secret/test-secret" >/dev/null 2>&1 || true
 }
 
 @test "Vault provider test connection works" {
-    create_vault_config
+	create_vault_config
 
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.DUMMY_SECRET]
 provider = "vault"
 value = "dummy"
 EOF
 
-    # The test_connection is called during provider initialization
-    # If vault is accessible, get should work (even if secret doesn't exist)
-    # We're just testing that the connection test doesn't fail
-    run "$FNOX_BIN" list
-    assert_success
+	# The test_connection is called during provider initialization
+	# If vault is accessible, get should work (even if secret doesn't exist)
+	# We're just testing that the connection test doesn't fail
+	run "$FNOX_BIN" list
+	assert_success
 }
 
 @test "Vault provider with description field" {
-    create_vault_config
+	create_vault_config
 
-    # Create a test secret
-    secret_name=$(create_test_vault_secret)
+	# Create a test secret
+	secret_name=$(create_test_vault_secret)
 
-    # Add secret reference to config (fetch description field)
-    cat >> "${FNOX_CONFIG_FILE}" << EOF
+	# Add secret reference to config (fetch description field)
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.TEST_DESCRIPTION]
 provider = "vault"
 value = "$secret_name/description"
 EOF
 
-    # Get the secret
-    run "$FNOX_BIN" get TEST_DESCRIPTION
-    assert_success
-    assert_output "Created by fnox test"
+	# Get the secret
+	run "$FNOX_BIN" get TEST_DESCRIPTION
+	assert_success
+	assert_output "Created by fnox test"
 
-    # Cleanup
-    delete_test_vault_secret "$secret_name"
+	# Cleanup
+	delete_test_vault_secret "$secret_name"
 }

--- a/test/version.bats
+++ b/test/version.bats
@@ -1,35 +1,35 @@
 #!/usr/bin/env bats
 
 setup() {
-    load 'test_helper/common_setup'
-    _common_setup
+	load 'test_helper/common_setup'
+	_common_setup
 }
 
 teardown() {
-    _common_teardown
+	_common_teardown
 }
 
 @test "fnox --version prints version" {
-    run "$FNOX_BIN" --version
-    assert_success
-    assert_fnox_version_output
+	run "$FNOX_BIN" --version
+	assert_success
+	assert_fnox_version_output
 }
 
 @test "fnox --help prints help" {
-    run "$FNOX_BIN" --help
-    assert_success
-    assert_output --partial "Usage:"
-    assert_output --partial "fnox"
+	run "$FNOX_BIN" --help
+	assert_success
+	assert_output --partial "Usage:"
+	assert_output --partial "fnox"
 }
 
 @test "fnox version prints version" {
-    run "$FNOX_BIN" version
-    assert_success
-    assert_fnox_version_output
+	run "$FNOX_BIN" version
+	assert_success
+	assert_fnox_version_output
 }
 
 @test "fnox shows error with unknown flag" {
-    run "$FNOX_BIN" --unknown-flag
-    assert_failure
-    assert_output --partial "unexpected argument"
+	run "$FNOX_BIN" --unknown-flag
+	assert_failure
+	assert_output --partial "unexpected argument"
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add shellcheck config and run shfmt/shellcheck on .bats/.sh/.bash files; apply formatting and minor shellcheck-friendly fixes across test suite.
> 
> - **Tooling**:
>   - Add `.shellcheckrc` disabling `SC2030`, `SC2031`, `SC2016` for bats patterns.
>   - Update `hk.pkl` to run `shfmt` and `shellcheck` on `**/*.bats`, `**/*.sh`, `**/*.bash`.
> - **Tests**:
>   - Apply `shfmt`-driven formatting and quoting tweaks across `test/*.bats` (consistent redirections, locals, here-docs, and minor shellcheck annotations).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e155a0b0080bf4f04e0f4db053364196a77b864a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->