### PR TITLE
fix(docs): imports -> import

### DIFF
--- a/docs/guide/hierarchical-config.md
+++ b/docs/guide/hierarchical-config.md
@@ -102,7 +102,7 @@ fnox list
 
 ```toml
 # Explicit file imports
-imports = ["./shared/secrets.toml", "./envs/dev.toml"]
+import = ["./shared/secrets.toml", "./envs/dev.toml"]
 ```
 
 Use hierarchy for location-based config (monorepos). Use imports for cross-cutting concerns (shared secret bundles).

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -16,7 +16,7 @@ fnox looks for configuration files in this order:
 ```toml
 # Top-level settings
 if_missing = "warn"  # Global default for missing secrets
-imports = ["./shared/secrets.toml"]  # Import other configs
+import = ["./shared/secrets.toml"]  # Import other configs
 
 # Provider definitions
 [providers]
@@ -54,7 +54,7 @@ if_missing = "error"  # or "warn", "ignore"
 List of config files to import.
 
 ```toml
-imports = ["./shared/base.toml", "./envs/dev.toml"]
+import = ["./shared/base.toml", "./envs/dev.toml"]
 ```
 
 **Usage:**
@@ -285,7 +285,7 @@ DATABASE_URL = { provider = "aws", value = "prod-db" }  # Overrides top-level DA
 ```toml
 # Global settings
 if_missing = "warn"
-imports = ["./shared/common.toml"]
+import = ["./shared/common.toml"]
 
 # Providers
 [providers]


### PR DESCRIPTION
thanks for such an amazing project!

just a little fix in the docs, as it seems that `imports` should currently be documented as `import` setting (discovered it after facing an error following the examples)