### PR TITLE
fix(keychain): use Secret Service backend for Linux

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -27,6 +27,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: autofix
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libdbus-1-dev pkg-config
       - uses: jdx/mise-action@v3
       - run: "mise run render ::: lint-fix"
       - uses: autofix-ci/action@v1.3.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,9 +77,14 @@ jobs:
           # Install gnome-keyring for keychain tests
           sudo apt-get update
           sudo apt-get install -y gnome-keyring libsecret-tools
+          # Start D-Bus session daemon
+          mkdir -p ~/.dbus-session
+          dbus-daemon --session --fork --print-address=1 > ~/.dbus-session/bus-address
+          DBUS_SESSION_BUS_ADDRESS=$(cat ~/.dbus-session/bus-address)
+          export DBUS_SESSION_BUS_ADDRESS
+          echo "DBUS_SESSION_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS" >> "$GITHUB_ENV"
           # Start gnome-keyring daemon for keychain tests
-          # The daemon will automatically set up D-Bus and create control sockets
-          gnome-keyring-daemon --components=secrets --daemonize --unlock <<< 'foobar'
+          echo "foobar" | gnome-keyring-daemon --unlock --components=secrets --daemonize
           # Start Vaultwarden
           docker run -d --name vaultwarden \
             -p 8080:80 \
@@ -163,7 +168,18 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
           sudo apt-get update
-          sudo apt-get install -y libdbus-1-dev pkg-config
+          sudo apt-get install -y libdbus-1-dev pkg-config gnome-keyring libsecret-tools
+      - name: Setup gnome-keyring (Ubuntu)
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: |
+          # Start D-Bus session daemon
+          mkdir -p ~/.dbus-session
+          dbus-daemon --session --fork --print-address=1 > ~/.dbus-session/bus-address
+          DBUS_SESSION_BUS_ADDRESS=$(cat ~/.dbus-session/bus-address)
+          export DBUS_SESSION_BUS_ADDRESS
+          echo "DBUS_SESSION_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS" >> "$GITHUB_ENV"
+          # Start gnome-keyring daemon for keychain tests
+          echo "foobar" | gnome-keyring-daemon --unlock --components=secrets --daemonize
       - name: Install Rust components
         run: rustup component add rustfmt clippy
       - uses: actions/download-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,11 @@ jobs:
           submodules: recursive
       - uses: jdx/mise-action@v3
       - uses: Swatinem/rust-cache@v2
+      - name: Install system dependencies (Ubuntu)
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libdbus-1-dev pkg-config
       - name: Install Rust components
         run: rustup component add rustfmt clippy
       - name: Build
@@ -154,6 +159,11 @@ jobs:
           submodules: recursive
       - uses: jdx/mise-action@v3
       - uses: Swatinem/rust-cache@v2
+      - name: Install system dependencies (Ubuntu)
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libdbus-1-dev pkg-config
       - name: Install Rust components
         run: rustup component add rustfmt clippy
       - uses: actions/download-artifact@v4
@@ -185,6 +195,10 @@ jobs:
         with:
           submodules: recursive
       - uses: Swatinem/rust-cache@v2
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libdbus-1-dev pkg-config
       - uses: jdx/mise-action@v3
       - run: cargo msrv verify
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1437,6 +1437,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
+name = "dbus"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "190b6255e8ab55a7b568df5a883e9497edc3e4821c06396612048b430e5ad1e9"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "dbus-secret-service"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
+dependencies = [
+ "dbus",
+ "zeroize",
+]
+
+[[package]]
 name = "demand"
 version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3063,7 +3084,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
 dependencies = [
  "byteorder",
- "linux-keyutils",
+ "dbus-secret-service",
  "log",
  "security-framework 2.11.1",
  "security-framework 3.5.1",
@@ -3085,6 +3106,15 @@ name = "libc"
 version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cbe856efeb50e4681f010e9aaa2bf0a644e10139e54cde10fc83a307c23bd9f"
+dependencies = [
+ "pkg-config",
+]
 
 [[package]]
 name = "libloading"
@@ -3111,16 +3141,6 @@ dependencies = [
  "bitflags",
  "libc",
  "redox_syscall",
-]
-
-[[package]]
-name = "linux-keyutils"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "761e49ec5fd8a5a463f9b84e877c373d888935b71c6be78f3767fe2ae6bed18e"
-dependencies = [
- "bitflags",
- "libc",
 ]
 
 [[package]]
@@ -6048,6 +6068,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ azure_security_keyvault = { version = "0.21" }
 google-cloud-kms = { version = "0.6" }
 google-cloud-secretmanager-v1 = { version = "1.1" }
 gcp_auth = { version = "0.12" }
-keyring = { version = "3", features = ["apple-native", "windows-native", "linux-native"] }
+keyring = { version = "3", features = ["apple-native", "windows-native", "sync-secret-service"] }
 # Required for rustls crypto provider (used by GCP SDKs)
 rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs", "std"] }
 


### PR DESCRIPTION
## Summary

Fixes the Linux keyring backend to use Secret Service (D-Bus) instead of the kernel keyring, providing proper persistent storage and GUI integration.

## Changes

- Changed `keyring` dependency feature from `linux-native` to `sync-secret-service` in Cargo.toml
- This switches the Linux keyring provider from kernel keyring (keyutils) to D-Bus Secret Service API

## Benefits

- **Persistent storage**: Secrets now survive reboots (kernel keyring is in-memory only)
- **GUI integration**: Secrets are now visible in keyring managers like Seahorse
- **Compatibility**: Works with GNOME Keyring, KWallet, and other Secret Service-compatible backends
- **Aligns with docs**: Matches the documented behavior of using libsecret/Secret Service

## Testing

- ✅ Build succeeds on macOS
- ✅ All cargo unit tests pass (including keychain test)
- 🔄 Linux CI will verify Secret Service integration

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)