### PR TITLE
fix: respect --profile/-P CLI flag when loading config files

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -184,7 +184,15 @@ impl Config {
         let local_config_path = dir.join("fnox.local.toml");
 
         // Get current profile to load profile-specific config if applicable
-        let profile = (*env::FNOX_PROFILE).clone();
+        // Use Settings system which respects: CLI flag > Env var > Default
+        let profile = {
+            let settings_profile = crate::settings::Settings::get().profile.clone();
+            if settings_profile != "default" {
+                Some(settings_profile)
+            } else {
+                None
+            }
+        };
         let profile_config_path = if let Some(profile_name) = &profile {
             if profile_name != "default" {
                 Some(dir.join(format!("fnox.{}.toml", profile_name)))

--- a/src/hook_env.rs
+++ b/src/hook_env.rs
@@ -200,7 +200,6 @@ fn has_config_been_modified() -> bool {
 
 /// Collect all config files (fnox.toml, fnox.$FNOX_PROFILE.toml, and fnox.local.toml) from dir up to root
 fn collect_config_files(start_dir: &Path) -> Vec<(PathBuf, u128)> {
-    use crate::env;
     let mut configs = Vec::new();
     let mut current = start_dir.to_path_buf();
 
@@ -215,9 +214,9 @@ fn collect_config_files(start_dir: &Path) -> Vec<(PathBuf, u128)> {
         }
 
         // Check fnox.$FNOX_PROFILE.toml
-        if let Some(profile_name) = (*env::FNOX_PROFILE).as_ref()
-            && profile_name != "default"
-        {
+        // Use Settings system which respects: CLI flag > Env var > Default
+        let profile_name = crate::settings::Settings::get().profile.clone();
+        if profile_name != "default" {
             let profile_config_path = current.join(format!("fnox.{}.toml", profile_name));
             if let Ok(metadata) = std::fs::metadata(&profile_config_path)
                 && let Ok(modified) = metadata.modified()
@@ -283,7 +282,6 @@ fn hash_fnox_env_vars() -> String {
 
 /// Find fnox.toml, fnox.$FNOX_PROFILE.toml, or fnox.local.toml in current or parent directories
 pub fn find_config() -> Option<PathBuf> {
-    use crate::env;
     let mut current = std::env::current_dir().ok()?;
 
     loop {
@@ -293,9 +291,9 @@ pub fn find_config() -> Option<PathBuf> {
         }
 
         // Check for profile-specific config
-        if let Some(profile_name) = (*env::FNOX_PROFILE).as_ref()
-            && profile_name != "default"
-        {
+        // Use Settings system which respects: CLI flag > Env var > Default
+        let profile_name = crate::settings::Settings::get().profile.clone();
+        if profile_name != "default" {
             let profile_config_path = current.join(format!("fnox.{}.toml", profile_name));
             if profile_config_path.exists() {
                 return Some(profile_config_path);


### PR DESCRIPTION
## Summary

Fixes the issue where the `--profile` and `-P` CLI flags were being ignored when loading profile-specific config files.

## Problem

The `--profile` flag was not working as expected:
- `fnox get --profile prd APP_ENV` would return the default profile value instead of the production profile value
- Only the `FNOX_PROFILE` environment variable was being respected

This was caused by code directly checking `env::FNOX_PROFILE` instead of using the Settings system which implements the correct precedence: **CLI flag > Environment variable > Default**.

## Solution

Updated `config.rs` and `hook_env.rs` to use the Settings system (`Settings::get().profile`) instead of directly accessing `env::FNOX_PROFILE`.

## Testing

Verified that all of the following now work correctly:
- `fnox get APP_ENV` - Returns default profile value
- `FNOX_PROFILE=prd fnox get APP_ENV` - Returns production profile value  
- `fnox get --profile prd APP_ENV` - Returns production profile value ✅ (was broken)
- `fnox get -P prd APP_ENV` - Returns production profile value ✅ (was broken)
- `fnox exec --profile prd -- sh -c 'echo $APP_ENV'` - Works correctly ✅
- `fnox export --profile prd` - Works correctly ✅

All existing tests pass, including profile-specific integration tests.

Fixes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)