### PR TITLE
fix(edit): add .toml extension, decrypt secrets properly, and support adding new secrets

### DIFF
--- a/src/providers/aws_sm.rs
+++ b/src/providers/aws_sm.rs
@@ -309,4 +309,11 @@ impl crate::providers::Provider for AwsSecretsManagerProvider {
 
         Ok(())
     }
+
+    async fn put_secret(&self, key: &str, value: &str, _key_file: Option<&Path>) -> Result<String> {
+        let secret_name = self.get_secret_name(key);
+        self.put_secret(&secret_name, value).await?;
+        // Return the key name (without prefix) to store in config
+        Ok(key.to_string())
+    }
 }

--- a/src/providers/azure_sm.rs
+++ b/src/providers/azure_sm.rs
@@ -103,4 +103,11 @@ impl crate::providers::Provider for AzureSecretsManagerProvider {
 
         Ok(())
     }
+
+    async fn put_secret(&self, key: &str, value: &str, _key_file: Option<&Path>) -> Result<String> {
+        let secret_name = self.get_secret_name(key);
+        self.put_secret(&secret_name, value).await?;
+        // Return the key name (without prefix) to store in config
+        Ok(key.to_string())
+    }
 }

--- a/src/providers/gcp_sm.rs
+++ b/src/providers/gcp_sm.rs
@@ -33,6 +33,26 @@ impl GoogleSecretManagerProvider {
             FnoxError::Provider(format!("Failed to create GCP Secret Manager client: {}", e))
         })
     }
+
+    /// Get the secret ID (without version path)
+    fn get_secret_id(&self, key: &str) -> String {
+        if let Some(prefix) = &self.prefix {
+            format!("{}{}", prefix, key)
+        } else {
+            key.to_string()
+        }
+    }
+
+    /// Create or update a secret in GCP Secret Manager
+    /// Note: This is a placeholder - full implementation requires determining
+    /// the correct API for setting payload data in google-cloud-secretmanager-v1 crate
+    async fn put_secret_value(&self, _secret_id: &str, _secret_value: &str) -> Result<()> {
+        Err(FnoxError::Provider(
+            "GCP Secret Manager put_secret not yet implemented. \
+            Contributions welcome to implement payload data setting."
+                .to_string(),
+        ))
+    }
 }
 
 #[async_trait]
@@ -84,5 +104,12 @@ impl crate::providers::Provider for GoogleSecretManagerProvider {
             })?;
 
         Ok(())
+    }
+
+    async fn put_secret(&self, key: &str, value: &str, _key_file: Option<&Path>) -> Result<String> {
+        let secret_id = self.get_secret_id(key);
+        self.put_secret_value(&secret_id, value).await?;
+        // Return the key name (without prefix) to store in config
+        Ok(key.to_string())
     }
 }

--- a/src/providers/keychain.rs
+++ b/src/providers/keychain.rs
@@ -110,6 +110,12 @@ impl crate::providers::Provider for KeychainProvider {
 
         Ok(())
     }
+
+    async fn put_secret(&self, key: &str, value: &str, _key_file: Option<&Path>) -> Result<String> {
+        self.put_secret(key, value).await?;
+        // Return the key name to store in config
+        Ok(key.to_string())
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

This PR fixes two GitHub discussions (#80 and #81) and adds support for adding new secrets in edit mode.

## Changes

### 1. Add .toml extension to temp files (#81)
- Use `tempfile::Builder` with `.suffix(".toml")` to create temporary files
- Enables syntax highlighting and LSP support in editors

### 2. Decrypt secrets properly in edit mode (#80)
- Force `if_missing="error"` for all secrets during edit mode
- Ensures original errors are shown when secrets cannot be decrypted
- Prevents silent failures where secrets remain encrypted

### 3. Support both inline table and regular table formats
- Inline: `KEY = { provider = "...", value = "..." }`
- Table: `[secrets.KEY]` format
- Previously only inline tables were supported, causing table-format secrets to remain encrypted

### 4. Allow adding new secrets in edit mode
- Users can now add new secrets directly in the editor
- New secrets are automatically encrypted with the specified provider or default provider
- Supports both encryption providers (age, aws-kms) and remote storage providers (aws-sm, keychain)

## Testing

- All existing cargo tests pass
- Manually tested with age-encrypted secrets in both formats
- Verified temp files have .toml extension
- Confirmed secrets are properly decrypted in editor

## Fixes

- Closes https://github.com/jdx/fnox/discussions/80
- Closes https://github.com/jdx/fnox/discussions/81

🤖 Generated with [Claude Code](https://claude.com/claude-code)