### PR TITLE
fix(ci): install dbus dependencies for autofix and release-plz workflows

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -26,6 +26,10 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.FNOX_GH_TOKEN }}
       - uses: Swatinem/rust-cache@v2
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libdbus-1-dev pkg-config
       - uses: jdx/mise-action@v2
         with:
           experimental: true


### PR DESCRIPTION
## Summary
- Install libdbus-1-dev and pkg-config in autofix workflow
- Install libdbus-1-dev and pkg-config in release-plz workflow

## Context
Both workflows run `mise run lint-fix` which requires building the keychain provider. The keychain provider depends on libdbus-sys which requires these system packages on Linux.

This matches the dependency installation already present in the main CI workflow.

## Test plan
- CI should pass after these changes
- autofix and release-plz workflows should no longer fail with dbus-1.pc not found errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)