### PR TITLE
feat(bitwarden): specify profile

### DIFF
--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -265,6 +265,12 @@ impl InitCommand {
                     .ok()
                     .filter(|s| !s.is_empty());
 
+                let profile = Input::new("Bitwarden CLI profile (optional):")
+                    .placeholder("")
+                    .run()
+                    .ok()
+                    .filter(|s| !s.is_empty());
+
                 let name = Input::new("Provider name:")
                     .placeholder("bitwarden")
                     .run()
@@ -275,6 +281,7 @@ impl InitCommand {
                     ProviderConfig::Bitwarden {
                         collection,
                         organization_id,
+                        profile,
                     },
                 ))
             }

--- a/src/providers/bitwarden.rs
+++ b/src/providers/bitwarden.rs
@@ -7,13 +7,15 @@ use std::{path::Path, sync::LazyLock};
 pub struct BitwardenProvider {
     collection: Option<String>,
     organization_id: Option<String>,
+    profile: Option<String>,
 }
 
 impl BitwardenProvider {
-    pub fn new(collection: Option<String>, organization_id: Option<String>) -> Self {
+    pub fn new(collection: Option<String>, organization_id: Option<String>, profile: Option<String>) -> Self {
         Self {
             collection,
             organization_id,
+            profile,
         }
     }
 
@@ -22,6 +24,20 @@ impl BitwardenProvider {
         tracing::debug!("Executing bw command with args: {:?}", args);
 
         let mut cmd = Command::new("bw");
+        if let Some(profile) = &self.profile {
+            match std::env::var("BITWARDENCLI_APPDATA_DIR") {
+                Ok(existing_value) => {
+                    tracing::warn!(
+                        "BITWARDENCLI_APPDATA_DIR is already set to '{}', not overriding with profile '{}'",
+                        existing_value,
+                        profile
+                    );
+                }
+                Err(_) => {
+                    cmd.env("BITWARDENCLI_APPDATA_DIR", format!("{}/Bitwarden CLI {}", dirs::config_dir().unwrap().display(), profile));
+                }
+            }
+        }
 
         // Check if session token is available
         let token = if let Some(token) = &*BW_SESSION_TOKEN {

--- a/src/providers/bitwarden.rs
+++ b/src/providers/bitwarden.rs
@@ -11,7 +11,11 @@ pub struct BitwardenProvider {
 }
 
 impl BitwardenProvider {
-    pub fn new(collection: Option<String>, organization_id: Option<String>, profile: Option<String>) -> Self {
+    pub fn new(
+        collection: Option<String>,
+        organization_id: Option<String>,
+        profile: Option<String>,
+    ) -> Self {
         Self {
             collection,
             organization_id,
@@ -34,7 +38,14 @@ impl BitwardenProvider {
                     );
                 }
                 Err(_) => {
-                    cmd.env("BITWARDENCLI_APPDATA_DIR", format!("{}/Bitwarden CLI {}", dirs::config_dir().unwrap().display(), profile));
+                    cmd.env(
+                        "BITWARDENCLI_APPDATA_DIR",
+                        format!(
+                            "{}/Bitwarden CLI {}",
+                            dirs::config_dir().unwrap().display(),
+                            profile
+                        ),
+                    );
                 }
             }
         }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -72,6 +72,8 @@ pub enum ProviderConfig {
         collection: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         organization_id: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        profile: Option<String>,
     },
     #[serde(rename = "gcp-kms")]
     #[strum(serialize = "gcp-kms")]
@@ -242,9 +244,11 @@ pub fn get_provider(config: &ProviderConfig) -> Result<Box<dyn Provider>> {
         ProviderConfig::Bitwarden {
             collection,
             organization_id,
+            profile,
         } => Ok(Box::new(bitwarden::BitwardenProvider::new(
             collection.clone(),
             organization_id.clone(),
+            profile.clone(),
         ))),
         ProviderConfig::GcpKms {
             project,


### PR DESCRIPTION
As per the [bitwarden documentation](https://bitwarden.com/help/cli/#log-in-to-multiple-accounts), mulitple profiles are supported by specifying an environment variable (`BITWARDENCLI_APPDATA_DIR `).

This code change sets that environment variable if a "profile" has been specified in the bitwarden provider configuration.
 
We do not override the variable if that has already been set (conservative approach).
 
The user is prompted for profile on `fnox init --provider bitwarden`.