### PR TITLE
feat(bitwarden): rbw support (experimental)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
             -addext "subjectAltName=DNS:localhost,IP:127.0.0.1" 2>/dev/null || true
           # Start Vaultwarden with HTTPS enabled
           docker run -d --name vaultwarden \
-            -p 8080:443 \
+            -p 8080:80 \
             -e DOMAIN=https://localhost:8080 \
             -e SIGNUPS_ALLOWED=true \
             -e DISABLE_ADMIN_TOKEN=true \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,13 +85,23 @@ jobs:
           echo "DBUS_SESSION_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS" >> "$GITHUB_ENV"
           # Start gnome-keyring daemon for keychain tests
           echo "foobar" | gnome-keyring-daemon --unlock --components=secrets --daemonize
-          # Start Vaultwarden
+          # Start Vaultwarden with HTTPS (self-signed certificate)
+          # Generate self-signed certificate
+          mkdir -p /tmp/vaultwarden-certs
+          openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+            -keyout /tmp/vaultwarden-certs/key.pem \
+            -out /tmp/vaultwarden-certs/cert.pem \
+            -subj "/CN=localhost" \
+            -addext "subjectAltName=DNS:localhost,IP:127.0.0.1" 2>/dev/null || true
+          # Start Vaultwarden with HTTPS enabled
           docker run -d --name vaultwarden \
-            -p 8080:80 \
-            -e DOMAIN=http://localhost:8080 \
+            -p 8080:443 \
+            -e DOMAIN=https://localhost:8080 \
             -e SIGNUPS_ALLOWED=true \
             -e DISABLE_ADMIN_TOKEN=true \
             -e I_REALLY_WANT_VOLATILE_STORAGE=true \
+            -e ROCKET_TLS='{certs="/data/certs/cert.pem",key="/data/certs/key.pem"}' \
+            -v /tmp/vaultwarden-certs:/data/certs:ro \
             vaultwarden/server:latest
           # Start Vault
           docker run -d --name vault --cap-add=IPC_LOCK \

--- a/docs/providers/bitwarden.md
+++ b/docs/providers/bitwarden.md
@@ -206,6 +206,39 @@ bitwarden = { type = "bitwarden", organization_id = "prod-org-id" }
 DATABASE_URL = { provider = "bitwarden", value = "Prod Database" }
 ```
 
+## Multi-profile Example
+
+`bw` supports multiple accounts, as per the [official documentation](https://bitwarden.com/help/cli/#log-in-to-multiple-accounts).
+fnox can access secrets in a specific profile supplying an optional "profile" attribute to the prov
+
+```toml
+default_provider = "bitwarden"
+
+[providers.bitwarden]
+type = "bitwarden"
+profile = "Business"
+
+[providers.bitwarden-perso]
+type = "bitwarden"
+profile = "Personal"
+```
+
+## `rbw` support
+
+[`rbw`](https://github.com/doy/rbw) is a stateful alternative to `bw`.
+
+fnox supports rbw via an experimental backend.
+
+```toml
+default_provider = "bitwarden"
+
+[providers.bitwarden]
+type = "bitwarden"
+backend = "rbw"
+```
+
+NB: you must have set up the `rbw` CLI independently from fnox using `rbw login`.
+
 ## Self-Hosted Vaultwarden
 
 Vaultwarden is a lightweight, open-source Bitwarden-compatible server:
@@ -293,6 +326,8 @@ Filter secrets by collection or organization:
 [providers]
 bitwarden = { type = "bitwarden", collection = "abc123-collection-id", organization_id = "org-id" }
 ```
+
+NB: This feature is supported only by the `bw` backend.
 
 Get collection ID:
 

--- a/docs/providers/bitwarden.md
+++ b/docs/providers/bitwarden.md
@@ -315,8 +315,8 @@ For local development without a Bitwarden account:
 source ./test/setup-bitwarden-test.sh
 
 # Follow on-screen instructions:
-# 1. Create account at http://localhost:8080
-# 2. Login: bw login
+# 1. Create account at https://localhost:8080 (accept self-signed certificate)
+# 2. Login: export NODE_TLS_REJECT_UNAUTHORIZED=0 && bw login
 # 3. Unlock: export BW_SESSION=$(bw unlock --raw)
 
 # Run tests

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -282,6 +282,7 @@ impl InitCommand {
                         collection,
                         organization_id,
                         profile,
+                        backend: None,
                     },
                 ))
             }

--- a/src/providers/bitwarden.rs
+++ b/src/providers/bitwarden.rs
@@ -44,22 +44,14 @@ impl BitwardenProvider {
         }
     }
 
-    fn build_command(
-        &self,
-        kind: Option<&str>,
-        item_name: &str,
-    ) -> Result<Command> {
+    fn build_command(&self, kind: Option<&str>, item_name: &str) -> Result<Command> {
         match &self.backend {
             BitwardenBackend::Bw => self.build_bw_command(kind, item_name),
             BitwardenBackend::Rbw => self.build_rbw_command(kind, item_name),
         }
     }
 
-    fn build_bw_command(
-        &self,
-        kind: Option<&str>,
-        item_name: &str,
-    ) -> Result<Command> {
+    fn build_bw_command(&self, kind: Option<&str>, item_name: &str) -> Result<Command> {
         // Build the bw get command
         // bw get <type> <name> [--output json]
         // where type can be: item, username, password, uri, totp, notes, exposed, attachment
@@ -88,7 +80,6 @@ impl BitwardenProvider {
             cmd.arg(field_type);
             cmd.arg(item_name);
         }
-
 
         if let Some(ref coll) = self.collection {
             cmd.args(["--collectionid", coll]);
@@ -147,11 +138,7 @@ impl BitwardenProvider {
         Ok(cmd)
     }
 
-    fn build_rbw_command(
-        &self,
-        kind: Option<&str>,
-        item_name: &str,
-    ) -> Result<Command> {
+    fn build_rbw_command(&self, kind: Option<&str>, item_name: &str) -> Result<Command> {
         let mut cmd = Command::new("rbw");
 
         match kind {
@@ -184,7 +171,7 @@ impl BitwardenProvider {
 
         Ok(cmd)
     }
-    
+
     fn execute_command(&self, cmd: &mut Command) -> Result<String> {
         // Close stdin to prevent bw from prompting for passwords interactively
         // This is especially important in CI environments where there's no TTY

--- a/src/providers/bitwarden.rs
+++ b/src/providers/bitwarden.rs
@@ -1,6 +1,8 @@
 use crate::env;
 use crate::error::{FnoxError, Result};
 use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use std::fmt;
 use std::process::Command;
 use std::{path::Path, sync::LazyLock};
 
@@ -8,6 +10,23 @@ pub struct BitwardenProvider {
     collection: Option<String>,
     organization_id: Option<String>,
     profile: Option<String>,
+    backend: BitwardenBackend,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum BitwardenBackend {
+    Bw,
+    Rbw,
+}
+
+impl fmt::Display for BitwardenBackend {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BitwardenBackend::Bw => write!(f, "bw"),
+            BitwardenBackend::Rbw => write!(f, "rbw"),
+        }
+    }
 }
 
 impl BitwardenProvider {
@@ -15,39 +34,67 @@ impl BitwardenProvider {
         collection: Option<String>,
         organization_id: Option<String>,
         profile: Option<String>,
+        backend: Option<BitwardenBackend>,
     ) -> Self {
         Self {
             collection,
             organization_id,
             profile,
+            backend: backend.unwrap_or(BitwardenBackend::Bw),
         }
     }
 
-    /// Execute bw CLI command with proper authentication
-    fn execute_bw_command(&self, args: &[&str]) -> Result<String> {
-        tracing::debug!("Executing bw command with args: {:?}", args);
+    fn build_command(
+        &self,
+        kind: Option<&str>,
+        item_name: &str,
+    ) -> Result<Command> {
+        match &self.backend {
+            BitwardenBackend::Bw => self.build_bw_command(kind, item_name),
+            BitwardenBackend::Rbw => self.build_rbw_command(kind, item_name),
+        }
+    }
+
+    fn build_bw_command(
+        &self,
+        kind: Option<&str>,
+        item_name: &str,
+    ) -> Result<Command> {
+        // Build the bw get command
+        // bw get <type> <name> [--output json]
+        // where type can be: item, username, password, uri, totp, notes, exposed, attachment
 
         let mut cmd = Command::new("bw");
-        if let Some(profile) = &self.profile {
-            match std::env::var("BITWARDENCLI_APPDATA_DIR") {
-                Ok(existing_value) => {
-                    tracing::warn!(
-                        "BITWARDENCLI_APPDATA_DIR is already set to '{}', not overriding with profile '{}'",
-                        existing_value,
-                        profile
-                    );
-                }
-                Err(_) => {
-                    cmd.env(
-                        "BITWARDENCLI_APPDATA_DIR",
-                        format!(
-                            "{}/Bitwarden CLI {}",
-                            dirs::config_dir().unwrap().display(),
-                            profile
-                        ),
-                    );
-                }
+        cmd.arg("get");
+
+        // Determine the field type to retrieve
+        let field_type = match kind {
+            None | Some("password") => Some("password"),
+            Some("username") => Some("username"),
+            Some("notes") => Some("notes"),
+            Some("uri") | Some("url") => Some("uri"),
+            Some("totp") => Some("totp"),
+            Some(_) => {
+                // For custom fields, we need the full item JSON
+                cmd.arg("item");
+                cmd.arg(item_name);
+                cmd.args(["--output", "json"]);
+                None // Special case handled, no field type needed
             }
+        };
+
+        // For standard field types, add the field type and item name
+        if let Some(field_type) = field_type {
+            cmd.arg(field_type);
+            cmd.arg(item_name);
+        }
+
+
+        if let Some(ref coll) = self.collection {
+            cmd.args(["--collectionid", coll]);
+        }
+        if let Some(ref org) = self.organization_id {
+            cmd.args(["--organizationid", org]);
         }
 
         // Check if session token is available
@@ -70,13 +117,75 @@ impl BitwardenProvider {
             ));
         };
 
-        cmd.args(args);
-
         // Pass session token as --session flag
         // This is more reliable than environment variable in some contexts
         cmd.arg("--session");
         cmd.arg(token);
 
+        if let Some(profile) = &self.profile {
+            match std::env::var("BITWARDENCLI_APPDATA_DIR") {
+                Ok(existing_value) => {
+                    tracing::warn!(
+                        "BITWARDENCLI_APPDATA_DIR is already set to '{}', not overriding with profile '{}'",
+                        existing_value,
+                        profile
+                    );
+                }
+                Err(_) => {
+                    cmd.env(
+                        "BITWARDENCLI_APPDATA_DIR",
+                        format!(
+                            "{}/Bitwarden CLI {}",
+                            dirs::config_dir().unwrap().display(),
+                            profile
+                        ),
+                    );
+                }
+            }
+        }
+
+        Ok(cmd)
+    }
+
+    fn build_rbw_command(
+        &self,
+        kind: Option<&str>,
+        item_name: &str,
+    ) -> Result<Command> {
+        let mut cmd = Command::new("rbw");
+
+        match kind {
+            None | Some("password") => {
+                // password is default output
+                cmd.args(["get", item_name]);
+            }
+            Some("username") => {
+                cmd.args(["get", item_name, "--field", "username"]);
+            }
+            Some("notes") => {
+                cmd.args(["get", item_name, "--field", "notes"]);
+            }
+            Some("uri") | Some("url") => {
+                cmd.args(["get", item_name, "--field", "uri"]);
+            }
+            Some("totp") => {
+                // rbw uses a separate subcommand for TOTP
+                cmd.args(["code", item_name]);
+            }
+            Some(_) => {
+                // custom field path: fetch full JSON; later code can still error out
+                cmd.args(["get", item_name, "--raw"]);
+            }
+        }
+
+        if let Some(profile) = &self.profile {
+            cmd.env("RBW_PROFILE", profile);
+        }
+
+        Ok(cmd)
+    }
+    
+    fn execute_command(&self, cmd: &mut Command) -> Result<String> {
         // Close stdin to prevent bw from prompting for passwords interactively
         // This is especially important in CI environments where there's no TTY
         cmd.stdin(std::process::Stdio::null());
@@ -95,7 +204,8 @@ impl BitwardenProvider {
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
             return Err(FnoxError::Provider(format!(
-                "Bitwarden CLI command failed: {}",
+                "Bitwarden backend '{}' command failed: {}",
+                self.backend,
                 stderr.trim()
             )));
         }
@@ -133,52 +243,8 @@ impl crate::providers::Provider for BitwardenProvider {
             field_name
         );
 
-        // Build the bw get command
-        // bw get <type> <name> [--output json]
-        // where type can be: item, username, password, uri, totp, notes, exposed, attachment
-
-        let mut args = vec!["get"];
-
-        // Map field names to bw CLI types
-        match field_name {
-            "password" => args.push("password"),
-            "username" => args.push("username"),
-            "notes" => args.push("notes"),
-            "uri" | "url" => args.push("uri"),
-            "totp" => args.push("totp"),
-            // For custom fields, we need to get the item as JSON and parse it
-            _ => {
-                args.push("item");
-                args.push(item_name);
-                args.push("--output");
-                args.push("json");
-
-                let json_output = self.execute_bw_command(&args)?;
-
-                // Parse JSON and extract custom field
-                // This is stubbed - in a real implementation, we'd parse the JSON
-                return Err(FnoxError::Provider(format!(
-                    "Custom field extraction not yet implemented. Got item JSON: {}",
-                    json_output.chars().take(100).collect::<String>()
-                )));
-            }
-        };
-
-        args.push(item_name);
-
-        // Add collection filter if specified
-        if let Some(collection) = &self.collection {
-            args.push("--collectionid");
-            args.push(collection);
-        }
-
-        // Add organization filter if specified
-        if let Some(org) = &self.organization_id {
-            args.push("--organizationid");
-            args.push(org);
-        }
-
-        self.execute_bw_command(&args)
+        let mut cmd = self.build_command(Some(field_name), item_name)?;
+        self.execute_command(&mut cmd)
     }
 }
 

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -257,7 +257,7 @@ pub fn get_provider(config: &ProviderConfig) -> Result<Box<dyn Provider>> {
             collection.clone(),
             organization_id.clone(),
             profile.clone(),
-            backend.clone(),
+            *backend,
         ))),
         ProviderConfig::GcpKms {
             project,
@@ -303,7 +303,5 @@ fn default_bitwarden_backend() -> Option<BitwardenBackend> {
 }
 
 fn is_default_backend(backend: &Option<BitwardenBackend>) -> bool {
-    backend
-        .as_ref()
-        .map_or(true, |b| *b == BitwardenBackend::Bw)
+    backend.as_ref().is_none_or(|b| *b == BitwardenBackend::Bw)
 }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -19,6 +19,8 @@ pub mod onepassword;
 pub mod plain;
 pub mod vault;
 
+pub use bitwarden::BitwardenBackend;
+
 /// Provider capabilities - what a provider can do
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ProviderCapability {
@@ -74,6 +76,8 @@ pub enum ProviderConfig {
         organization_id: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         profile: Option<String>,
+        #[serde(default = "default_bitwarden_backend", skip_serializing_if = "is_default_backend")]
+        backend: Option<BitwardenBackend>,
     },
     #[serde(rename = "gcp-kms")]
     #[strum(serialize = "gcp-kms")]
@@ -245,10 +249,12 @@ pub fn get_provider(config: &ProviderConfig) -> Result<Box<dyn Provider>> {
             collection,
             organization_id,
             profile,
+            backend,
         } => Ok(Box::new(bitwarden::BitwardenProvider::new(
             collection.clone(),
             organization_id.clone(),
             profile.clone(),
+            backend.clone(),
         ))),
         ProviderConfig::GcpKms {
             project,
@@ -287,4 +293,12 @@ pub fn get_provider(config: &ProviderConfig) -> Result<Box<dyn Provider>> {
             token.clone(),
         ))),
     }
+}
+
+fn default_bitwarden_backend() -> Option<BitwardenBackend> {
+    Some(BitwardenBackend::Bw)
+}
+
+fn is_default_backend(backend: &Option<BitwardenBackend>) -> bool {
+    backend.as_ref().map_or(true, |b| *b == BitwardenBackend::Bw)
 }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -76,7 +76,10 @@ pub enum ProviderConfig {
         organization_id: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         profile: Option<String>,
-        #[serde(default = "default_bitwarden_backend", skip_serializing_if = "is_default_backend")]
+        #[serde(
+            default = "default_bitwarden_backend",
+            skip_serializing_if = "is_default_backend"
+        )]
         backend: Option<BitwardenBackend>,
     },
     #[serde(rename = "gcp-kms")]
@@ -300,5 +303,7 @@ fn default_bitwarden_backend() -> Option<BitwardenBackend> {
 }
 
 fn is_default_backend(backend: &Option<BitwardenBackend>) -> bool {
-    backend.as_ref().map_or(true, |b| *b == BitwardenBackend::Bw)
+    backend
+        .as_ref()
+        .map_or(true, |b| *b == BitwardenBackend::Bw)
 }

--- a/test/BITWARDEN_TESTING.md
+++ b/test/BITWARDEN_TESTING.md
@@ -9,7 +9,7 @@ This directory contains tools for testing fnox's Bitwarden integration using a l
 source ./test/setup-bitwarden-test.sh
 
 # 2. If this is your first time, follow the on-screen instructions to:
-#    - Open http://localhost:8080 in your browser
+#    - Open https://localhost:8080 in your browser (accept self-signed certificate)
 #    - Create an account
 #    - Login with: bw login
 #    - Unlock: export BW_SESSION=$(bw unlock --raw)
@@ -42,11 +42,12 @@ If you prefer to set things up manually:
 # Start vaultwarden
 docker compose -f test/docker-compose.bitwarden.yml up -d
 
-# Configure bw CLI to use local server
-bw config server http://localhost:8080
+# Configure bw CLI to use local server (HTTPS required)
+# Note: NODE_TLS_REJECT_UNAUTHORIZED=0 is set by the setup script to allow self-signed certificates
+bw config server https://localhost:8080
 
-# Create account via web UI
-open http://localhost:8080
+# Create account via web UI (accept self-signed certificate warning)
+open https://localhost:8080
 
 # Login with bw CLI
 bw login
@@ -127,8 +128,8 @@ If you need to update the test database (e.g., after vaultwarden version changes
 # 1. Start fresh vaultwarden
 docker compose -f test/docker-compose.bitwarden.yml up -d
 
-# 2. Create account via web UI
-open http://localhost:8080
+# 2. Create account via web UI (accept self-signed certificate warning)
+open https://localhost:8080
 # Register with: test@fnox.ci / TestCIPassword123!
 
 # 3. Extract database with WAL checkpoint
@@ -193,8 +194,8 @@ docker compose -f test/docker-compose.bitwarden.yml down -v
 Make sure you've:
 
 1. Started vaultwarden: `docker compose -f test/docker-compose.bitwarden.yml up -d`
-2. Configured bw CLI: `bw config server http://localhost:8080`
-3. Created an account at http://localhost:8080
+2. Configured bw CLI: `export NODE_TLS_REJECT_UNAUTHORIZED=0 && bw config server https://localhost:8080`
+3. Created an account at https://localhost:8080 (accept self-signed certificate)
 4. Logged in: `bw login`
 5. Unlocked: `export BW_SESSION=$(bw unlock --raw)`
 

--- a/test/bitwarden.bats
+++ b/test/bitwarden.bats
@@ -19,6 +19,9 @@ setup() {
 	load 'test_helper/common_setup'
 	_common_setup
 
+	# Allow self-signed certificates for localhost testing (required for vaultwarden HTTPS)
+	export NODE_TLS_REJECT_UNAUTHORIZED=0
+
 	# Check if bw CLI is installed
 	if ! command -v bw >/dev/null 2>&1; then
 		skip "Bitwarden CLI (bw) not installed. Install with: npm install -g @bitwarden/cli"

--- a/test/bitwarden.bats
+++ b/test/bitwarden.bats
@@ -185,7 +185,7 @@ EOF
 	# Try to get non-existent secret
 	run "$FNOX_BIN" get INVALID_ITEM
 	assert_failure
-	assert_output --partial "Bitwarden CLI command failed"
+	assert_output --partial "Bitwarden backend 'bw' command failed"
 }
 
 @test "fnox get handles invalid secret reference format" {

--- a/test/create-bitwarden-test-account.sh
+++ b/test/create-bitwarden-test-account.sh
@@ -5,7 +5,7 @@
 
 set -e
 
-BW_SERVER="http://localhost:8080"
+BW_SERVER="https://localhost:8080"
 BW_EMAIL="${BW_TEST_EMAIL:-test@fnox.local}"
 BW_PASSWORD="${BW_TEST_PASSWORD:-TestPassword123!}"
 
@@ -13,7 +13,7 @@ echo "Creating Bitwarden test account..."
 echo "Email: $BW_EMAIL"
 
 # The bw CLI doesn't have a register command, so users need to:
-# 1. Go to http://localhost:8080
+# 1. Go to https://localhost:8080 (accept self-signed certificate)
 # 2. Click "Create Account"
 # 3. Enter email: test@fnox.local
 # 4. Enter password: TestPassword123!

--- a/test/docker-compose.bitwarden-ci.yml
+++ b/test/docker-compose.bitwarden-ci.yml
@@ -9,10 +9,10 @@ services:
       # Enable HTTPS with self-signed certificate
       - ROCKET_TLS={certs="/data/certs/cert.pem",key="/data/certs/key.pem"}
     ports:
-      - "8080:443"
+      - "8080:80"
     volumes:
       - vaultwarden-ci-data:/data
-      - ./test/fixtures/bitwarden-certs/certs:/data/certs:ro
+      - ./fixtures/bitwarden-certs/certs:/data/certs:ro
     restart: unless-stopped
 
 volumes:

--- a/test/docker-compose.bitwarden-ci.yml
+++ b/test/docker-compose.bitwarden-ci.yml
@@ -3,13 +3,16 @@ services:
     image: vaultwarden/server:latest
     container_name: fnox-vaultwarden-ci
     environment:
-      - DOMAIN=http://localhost:8080
+      - DOMAIN=https://localhost:8080
       - SIGNUPS_ALLOWED=false # Disable signups in CI (account already exists)
       - DISABLE_ADMIN_TOKEN=true
+      # Enable HTTPS with self-signed certificate
+      - ROCKET_TLS={certs="/data/certs/cert.pem",key="/data/certs/key.pem"}
     ports:
-      - "8080:80"
+      - "8080:443"
     volumes:
       - vaultwarden-ci-data:/data
+      - ./test/fixtures/bitwarden-certs/certs:/data/certs:ro
     restart: unless-stopped
 
 volumes:

--- a/test/docker-compose.bitwarden.yml
+++ b/test/docker-compose.bitwarden.yml
@@ -12,10 +12,10 @@ services:
       # Enable HTTPS with self-signed certificate
       - ROCKET_TLS={certs="/data/certs/cert.pem",key="/data/certs/key.pem"}
     ports:
-      - "8080:443"
+      - "8080:80"
     volumes:
       - vaultwarden-data:/data
-      - ./test/fixtures/bitwarden-certs/certs:/data/certs:ro
+      - ./fixtures/bitwarden-certs/certs:/data/certs:ro
     restart: unless-stopped
 
 volumes:

--- a/test/docker-compose.bitwarden.yml
+++ b/test/docker-compose.bitwarden.yml
@@ -3,16 +3,19 @@ services:
     image: vaultwarden/server:latest
     container_name: fnox-vaultwarden-test
     environment:
-      - DOMAIN=http://localhost:8080
+      - DOMAIN=https://localhost:8080
       - SIGNUPS_ALLOWED=true
       - INVITATIONS_ALLOWED=true
       - WEBSOCKET_ENABLED=true
       # Disable admin token for local testing
       - DISABLE_ADMIN_TOKEN=true
+      # Enable HTTPS with self-signed certificate
+      - ROCKET_TLS={certs="/data/certs/cert.pem",key="/data/certs/key.pem"}
     ports:
-      - "8080:80"
+      - "8080:443"
     volumes:
       - vaultwarden-data:/data
+      - ./test/fixtures/bitwarden-certs/certs:/data/certs:ro
     restart: unless-stopped
 
 volumes:

--- a/test/fixtures/bitwarden-certs/README.md
+++ b/test/fixtures/bitwarden-certs/README.md
@@ -1,0 +1,34 @@
+# SSL Certificates for Vaultwarden HTTPS
+
+This directory contains the self-signed SSL certificates used by vaultwarden for HTTPS during testing.
+
+## Files
+
+- `certs/cert.pem` - Self-signed SSL certificate
+- `certs/key.pem` - Private key for the certificate
+
+Vaultwarden serves HTTPS directly using the `ROCKET_TLS` environment variable.
+
+## Regenerating Certificates
+
+If you need to regenerate the self-signed certificates:
+
+```bash
+cd test/fixtures/bitwarden-certs/certs
+openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+  -keyout key.pem \
+  -out cert.pem \
+  -subj "/CN=localhost" \
+  -addext "subjectAltName=DNS:localhost,IP:127.0.0.1"
+```
+
+## Why HTTPS?
+
+The Bitwarden CLI now requires HTTPS for all server connections. This is a security enhancement that prevents insecure HTTP connections. For local testing, we use:
+
+1. A self-signed certificate (generated above)
+2. Vaultwarden's built-in HTTPS support via `ROCKET_TLS` environment variable
+3. `NODE_TLS_REJECT_UNAUTHORIZED=0` environment variable to allow self-signed certificates
+
+**Note:** The `NODE_TLS_REJECT_UNAUTHORIZED=0` setting is only for local testing. Never use this in production!
+

--- a/test/fixtures/bitwarden-certs/README.md
+++ b/test/fixtures/bitwarden-certs/README.md
@@ -31,4 +31,3 @@ The Bitwarden CLI now requires HTTPS for all server connections. This is a secur
 3. `NODE_TLS_REJECT_UNAUTHORIZED=0` environment variable to allow self-signed certificates
 
 **Note:** The `NODE_TLS_REJECT_UNAUTHORIZED=0` setting is only for local testing. Never use this in production!
-

--- a/test/setup-bitwarden-ci.sh
+++ b/test/setup-bitwarden-ci.sh
@@ -15,9 +15,11 @@
 set -e
 
 # Configuration
-BW_SERVER="${BW_SERVER:-http://localhost:8080}"
+BW_SERVER="${BW_SERVER:-https://localhost:8080}"
 BW_EMAIL="${BW_EMAIL:-test@fnox.ci}"
 BW_PASSWORD="${BW_PASSWORD:-TestCIPassword123!}"
+# Allow self-signed certificates for localhost testing
+export NODE_TLS_REJECT_UNAUTHORIZED=0
 
 # Find the script directory (handles both sourced and executed)
 if [ -n "${BASH_SOURCE[0]}" ]; then
@@ -78,7 +80,7 @@ docker restart "$CONTAINER_NAME"
 # Wait for vaultwarden to be ready after restart
 echo "Waiting for vaultwarden to be ready..."
 for i in {1..60}; do
-	if curl -sf "$BW_SERVER" >/dev/null 2>&1; then
+	if curl -skf "$BW_SERVER" >/dev/null 2>&1; then
 		echo "✓ Vaultwarden is ready with seeded database"
 		break
 	fi
@@ -93,6 +95,7 @@ done
 echo "Configuring bw CLI..."
 # Logout first if already logged in to allow server config change
 bw logout >/dev/null 2>&1 || true
+# Note: NODE_TLS_REJECT_UNAUTHORIZED=0 is set above to allow self-signed certificates
 bw config server "$BW_SERVER"
 
 # Login with pre-created test account

--- a/test/setup-bitwarden-ci.sh
+++ b/test/setup-bitwarden-ci.sh
@@ -86,6 +86,8 @@ for i in {1..60}; do
 	fi
 	if [ "$i" -eq 60 ]; then
 		echo "Error: Vaultwarden failed to start after 60 seconds"
+		docker logs "$CONTAINER_NAME"
+		docker ps -a
 		exit 1
 	fi
 	sleep 1


### PR DESCRIPTION
Now the bitwarden provider supports two backends (`bw` and `rbw`  🆕 ). This was a popular discussion.

The init process assumes `bw` (no explicit question about this new backend). If you wish to give it a try, add an attribute in the corresponding provider configuration
```toml
[providers.bitwarden]
type = "bitwarden"
# this option ⬇️
backend = "rbw"
```

Disclaimer: the organizationID and collectionID are **not** supported by the rbw backend; this should be considered experimental in the sense that I have started using rbw today and I haven't tested anything beyond the "note" support. Any feedback is welcome!