### PR TITLE
fix(ci): install dbus dependencies for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.FNOX_GH_TOKEN }}
+      - name: Install system dependencies (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libdbus-1-dev pkg-config
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: rust-${{ matrix.target }}


### PR DESCRIPTION
## Summary
- Install libdbus-1-dev and pkg-config in release workflow Linux builds

## Context
The release workflow fails when building for Linux targets (x86_64 and aarch64)
because the keychain provider (added in #86) depends on libdbus-sys which
requires these system packages on Linux.

This fix was previously applied to autofix and release-plz workflows in #89,
but was missed for the release workflow.

## Root Cause
The v1.4.0 release failed with exit code 101 during Linux cross-compilation
builds because the sync-secret-service backend for the keychain crate requires
libdbus-1-dev at compile time.

Fixes https://github.com/jdx/fnox/actions/runs/19389843169

## Test plan
- This should fix the failed v1.4.0 release build
- Matches dependency installation pattern from CI workflow and other workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>