### PR TITLE
fix(ci): configure dbus dependencies for cross-compilation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,11 +47,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.FNOX_GH_TOKEN }}
-      - name: Install system dependencies (Linux)
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libdbus-1-dev pkg-config
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: rust-${{ matrix.target }}

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,16 @@
+[build.env]
+passthrough = [
+    "CARGO_TERM_COLOR",
+]
+
+[target.x86_64-unknown-linux-gnu]
+pre-build = [
+    "apt-get update",
+    "apt-get install -y libdbus-1-dev pkg-config",
+]
+
+[target.aarch64-unknown-linux-gnu]
+pre-build = [
+    "apt-get update",
+    "apt-get install -y libdbus-1-dev pkg-config",
+]


### PR DESCRIPTION
## Summary
- Added Cross.toml to configure dbus dependencies for cross-compilation builds
- Removed redundant apt-get installation from workflow (now handled by Cross.toml)

## Problem
The release workflow was failing when using `cross` for Linux x86_64 and aarch64 builds. Installing libdbus-1-dev on the host doesn't help because `cross` compiles inside Docker containers.

## Solution
Created Cross.toml with pre-build steps that install libdbus-1-dev and pkg-config inside the cross containers before compilation.

## Test plan
- [x] Created Cross.toml configuration
- [ ] CI build should now succeed for Linux targets

Fixes https://github.com/jdx/fnox/actions/runs/19470337054

🤖 Generated with [Claude Code](https://claude.com/claude-code)