### PR TITLE
chore: release v1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.5.1](https://github.com/jdx/fnox/compare/v1.5.0..v1.5.1) - 2025-11-18
+
+### 🐛 Bug Fixes
+
+- **(ci)** configure dbus dependencies for cross-compilation by [@jdx](https://github.com/jdx) in [#97](https://github.com/jdx/fnox/pull/97)
+
 ## [1.5.0](https://github.com/jdx/fnox/compare/v1.4.0..v1.5.0) - 2025-11-18
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1837,7 +1837,7 @@ dependencies = [
 
 [[package]]
 name = "fnox"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "age",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fnox"
-version = "1.5.0"
+version = "1.5.1"
 edition = "2024"
 authors = ["@jdx"]
 description = "A flexible secret management tool supporting multiple providers and encryption methods"

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -972,7 +972,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.5.0",
+  "version": "1.5.1",
   "usage": "Usage: fnox [OPTIONS] <COMMAND>",
   "complete": {
     "key": {

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -4,7 +4,7 @@
 
 **Usage**: `fnox [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.5.0
+**Version**: 1.5.1
 
 - **Usage**: `fnox [FLAGS] <SUBCOMMAND>`
 

--- a/fnox.usage.kdl
+++ b/fnox.usage.kdl
@@ -1,7 +1,7 @@
 min_usage_version "1.3"
 name fnox
 bin fnox
-version "1.5.0"
+version "1.5.1"
 about "A flexible secret management tool by @jdx"
 usage "Usage: fnox [OPTIONS] <COMMAND>"
 flag "-c --config" help="Path to the configuration file (default: fnox.toml, searches parent directories)" global=#true {


### PR DESCRIPTION
## [1.5.1](https://github.com/jdx/fnox/compare/v1.5.0..v1.5.1) - 2025-11-18

### 🐛 Bug Fixes

- **(ci)** configure dbus dependencies for cross-compilation by [@jdx](https://github.com/jdx) in [#97](https://github.com/jdx/fnox/pull/97)