### PR TITLE
feat: add password-store provider with GPG-encrypted local storage

### DIFF
--- a/src/commands/set.rs
+++ b/src/commands/set.rs
@@ -178,7 +178,7 @@ impl SetCommand {
                                 pass_provider.put_secret(key_name, value).await?;
 
                                 // Store just the key name (without prefix) in config
-                                (None, Some(self.key.clone()))
+                                (None, Some(key_name.to_string()))
                             }
                             ProviderConfig::AzureSecretsManager { vault_url, prefix } => {
                                 let azure_sm_provider =

--- a/src/commands/set.rs
+++ b/src/commands/set.rs
@@ -162,6 +162,24 @@ impl SetCommand {
                                 // Store just the key name (without prefix) in config
                                 (None, Some(self.key.clone()))
                             }
+                            ProviderConfig::PasswordStore {
+                                prefix,
+                                store_dir,
+                                gpg_opts,
+                            } => {
+                                let pass_provider =
+                                    crate::providers::password_store::PasswordStoreProvider::new(
+                                        prefix.clone(),
+                                        store_dir.clone(),
+                                        gpg_opts.clone(),
+                                    );
+
+                                let key_name = self.key_name.as_deref().unwrap_or(&self.key);
+                                pass_provider.put_secret(key_name, value).await?;
+
+                                // Store just the key name (without prefix) in config
+                                (None, Some(self.key.clone()))
+                            }
                             ProviderConfig::AzureSecretsManager { vault_url, prefix } => {
                                 let azure_sm_provider =
                                     crate::providers::azure_sm::AzureSecretsManagerProvider::new(

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -16,6 +16,7 @@ pub mod gcp_sm;
 pub mod infisical;
 pub mod keychain;
 pub mod onepassword;
+pub mod password_store;
 pub mod plain;
 pub mod vault;
 
@@ -113,6 +114,16 @@ pub enum ProviderConfig {
         service: String,
         #[serde(skip_serializing_if = "Option::is_none")]
         prefix: Option<String>,
+    },
+    #[serde(rename = "password-store")]
+    #[strum(serialize = "password-store")]
+    PasswordStore {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        prefix: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        store_dir: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        gpg_opts: Option<String>,
     },
     #[serde(rename = "plain")]
     #[strum(serialize = "plain")]
@@ -285,6 +296,15 @@ pub fn get_provider(config: &ProviderConfig) -> Result<Box<dyn Provider>> {
         ProviderConfig::Keychain { service, prefix } => Ok(Box::new(
             keychain::KeychainProvider::new(service.clone(), prefix.clone()),
         )),
+        ProviderConfig::PasswordStore {
+            prefix,
+            store_dir,
+            gpg_opts,
+        } => Ok(Box::new(password_store::PasswordStoreProvider::new(
+            prefix.clone(),
+            store_dir.clone(),
+            gpg_opts.clone(),
+        ))),
         ProviderConfig::Plain => Ok(Box::new(plain::PlainProvider::new())),
         ProviderConfig::HashiCorpVault {
             address,

--- a/src/providers/password_store.rs
+++ b/src/providers/password_store.rs
@@ -1,0 +1,184 @@
+use crate::error::{FnoxError, Result};
+use async_trait::async_trait;
+use std::path::Path;
+use std::process::Command;
+use std::sync::LazyLock;
+
+/// Provider that integrates with password-store (pass) CLI tool
+pub struct PasswordStoreProvider {
+    prefix: Option<String>,
+    store_dir: Option<String>,
+    gpg_opts: Option<String>,
+}
+
+impl PasswordStoreProvider {
+    pub fn new(
+        prefix: Option<String>,
+        store_dir: Option<String>,
+        gpg_opts: Option<String>,
+    ) -> Self {
+        Self {
+            prefix,
+            store_dir,
+            gpg_opts,
+        }
+    }
+
+    /// Build the full secret path with optional prefix
+    fn build_secret_path(&self, key: &str) -> String {
+        match &self.prefix {
+            Some(prefix) => format!("{}{}", prefix, key),
+            None => key.to_string(),
+        }
+    }
+
+    /// Execute pass CLI command
+    fn execute_pass_command(&self, args: &[&str]) -> Result<String> {
+        tracing::debug!("Executing pass command with args: {:?}", args);
+
+        let mut cmd = Command::new("pass");
+
+        // Set custom PASSWORD_STORE_DIR if configured
+        let store_dir = self.store_dir.as_deref().or(PASSWORD_STORE_DIR.as_deref());
+        if let Some(store_dir) = store_dir {
+            cmd.env("PASSWORD_STORE_DIR", store_dir);
+        }
+
+        // Set custom GPG options if configured
+        let gpg_opts = self
+            .gpg_opts
+            .as_deref()
+            .or(PASSWORD_STORE_GPG_OPTS.as_deref());
+        if let Some(gpg_opts) = gpg_opts {
+            cmd.env("PASSWORD_STORE_GPG_OPTS", gpg_opts);
+        }
+
+        cmd.args(args);
+        cmd.stdin(std::process::Stdio::null());
+        cmd.stdout(std::process::Stdio::piped());
+        cmd.stderr(std::process::Stdio::piped());
+
+        let output = cmd.output().map_err(|e| {
+            FnoxError::Provider(format!(
+                "Failed to execute 'pass' command: {}. Make sure password-store is installed.",
+                e
+            ))
+        })?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(FnoxError::Provider(format!(
+                "password-store CLI command failed: {}",
+                stderr.trim()
+            )));
+        }
+
+        let stdout = String::from_utf8(output.stdout)
+            .map_err(|e| FnoxError::Provider(format!("Invalid UTF-8 in command output: {}", e)))?;
+
+        Ok(stdout.trim().to_string())
+    }
+
+    /// Store a secret in password-store
+    pub async fn put_secret(&self, key: &str, value: &str) -> Result<()> {
+        let secret_path = self.build_secret_path(key);
+
+        tracing::debug!("Storing secret '{}' in password-store", secret_path);
+
+        // Use `pass insert` with multiline support
+        // pass insert -m will read from stdin until EOF
+        let mut cmd = Command::new("pass");
+
+        // Set custom PASSWORD_STORE_DIR if configured
+        let store_dir = self.store_dir.as_deref().or(PASSWORD_STORE_DIR.as_deref());
+        if let Some(store_dir) = store_dir {
+            cmd.env("PASSWORD_STORE_DIR", store_dir);
+        }
+
+        // Set custom GPG options if configured
+        let gpg_opts = self
+            .gpg_opts
+            .as_deref()
+            .or(PASSWORD_STORE_GPG_OPTS.as_deref());
+        if let Some(gpg_opts) = gpg_opts {
+            cmd.env("PASSWORD_STORE_GPG_OPTS", gpg_opts);
+        }
+
+        cmd.arg("insert")
+            .arg("-m") // Multiline
+            .arg("-f") // Force (overwrite if exists)
+            .arg(&secret_path)
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped());
+
+        let mut child = cmd.spawn().map_err(|e| {
+            FnoxError::Provider(format!("Failed to spawn 'pass insert' command: {}", e))
+        })?;
+
+        // Write value to stdin
+        if let Some(mut stdin) = child.stdin.take() {
+            use std::io::Write;
+
+            stdin.write_all(value.as_bytes()).map_err(|e| {
+                FnoxError::Provider(format!("Failed to write to 'pass insert' stdin: {}", e))
+            })?;
+        }
+
+        let output = child.wait_with_output().map_err(|e| {
+            FnoxError::Provider(format!("Failed to wait for 'pass insert' command: {}", e))
+        })?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(FnoxError::Provider(format!(
+                "Failed to store secret in password-store: {}",
+                stderr.trim()
+            )));
+        }
+
+        tracing::debug!(
+            "Successfully stored secret '{}' in password-store",
+            secret_path
+        );
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl crate::providers::Provider for PasswordStoreProvider {
+    fn capabilities(&self) -> Vec<crate::providers::ProviderCapability> {
+        vec![crate::providers::ProviderCapability::RemoteStorage]
+    }
+
+    async fn get_secret(&self, value: &str, _key_file: Option<&Path>) -> Result<String> {
+        let secret_path = self.build_secret_path(value);
+
+        tracing::debug!("Getting secret '{}' from password-store", secret_path);
+
+        // Use `pass show` to retrieve the secret
+        self.execute_pass_command(&["show", &secret_path])
+    }
+
+    async fn test_connection(&self) -> Result<()> {
+        tracing::debug!("Testing connection to password-store");
+
+        // Try to list passwords to verify pass is working
+        self.execute_pass_command(&["ls"])?;
+
+        tracing::debug!("password-store connection test successful");
+        Ok(())
+    }
+}
+
+static PASSWORD_STORE_DIR: LazyLock<Option<String>> = LazyLock::new(|| {
+    std::env::var("FNOX_PASSWORD_STORE_DIR")
+        .or_else(|_| std::env::var("PASSWORD_STORE_DIR"))
+        .ok()
+});
+
+static PASSWORD_STORE_GPG_OPTS: LazyLock<Option<String>> = LazyLock::new(|| {
+    std::env::var("FNOX_PASSWORD_STORE_GPG_OPTS")
+        .or_else(|_| std::env::var("PASSWORD_STORE_GPG_OPTS"))
+        .ok()
+});

--- a/test/password_store.bats
+++ b/test/password_store.bats
@@ -1,0 +1,429 @@
+#!/usr/bin/env bats
+#
+# Password-Store Provider Tests
+#
+# These tests verify the password-store (pass) provider integration with fnox.
+#
+# Prerequisites:
+#   - pass CLI installed (password-store)
+#   - gpg or gpg2 installed
+#   - Run tests: mise run test:bats -- test/password_store.bats
+#
+# Note: Tests use a temporary PASSWORD_STORE_DIR to avoid conflicts.
+#
+
+setup() {
+	load 'test_helper/common_setup'
+	_common_setup
+
+	# Check if pass is installed
+	if ! command -v pass >/dev/null 2>&1; then
+		skip "password-store (pass) not installed"
+	fi
+
+	# Check if gpg is installed
+	if ! command -v gpg >/dev/null 2>&1 && ! command -v gpg2 >/dev/null 2>&1; then
+		skip "gpg not installed"
+	fi
+
+	# Set up test password store
+	export PASSWORD_STORE_DIR="$BATS_TEST_TMPDIR/password-store"
+	export GNUPGHOME="$BATS_TEST_TMPDIR/gnupg"
+	mkdir -p "$PASSWORD_STORE_DIR" "$GNUPGHOME"
+	chmod 700 "$GNUPGHOME"
+
+	# Generate a test GPG key (non-interactive)
+	local gpg_cmd="gpg"
+	if command -v gpg2 >/dev/null 2>&1; then
+		gpg_cmd="gpg2"
+	fi
+
+	# Create GPG batch config for key generation
+	cat >"$GNUPGHOME/keygen.batch" <<EOF
+%no-protection
+Key-Type: DSA
+Key-Length: 1024
+Subkey-Type: ELG-E
+Subkey-Length: 1024
+Name-Real: Fnox Test
+Name-Email: fnox-test@example.com
+Expire-Date: 0
+EOF
+
+	# Generate the key
+	$gpg_cmd --batch --gen-key "$GNUPGHOME/keygen.batch" >/dev/null 2>&1 || {
+		skip "Failed to generate test GPG key"
+	}
+
+	# Get the key ID
+	GPG_KEY_ID=$($gpg_cmd --list-keys --with-colons | grep '^fpr' | head -1 | cut -d: -f10)
+	if [ -z "$GPG_KEY_ID" ]; then
+		skip "Failed to get GPG key ID"
+	fi
+	export GPG_KEY_ID
+
+	# Initialize password store
+	pass init "$GPG_KEY_ID" >/dev/null 2>&1 || {
+		skip "Failed to initialize password-store"
+	}
+
+	# Track secrets for cleanup
+	export TEST_SECRET_PATHS=""
+}
+
+teardown() {
+	# Clean up test secrets from password store
+	if [ -n "$TEST_SECRET_PATHS" ]; then
+		for path in $TEST_SECRET_PATHS; do
+			pass rm -f "$path" >/dev/null 2>&1 || true
+		done
+	fi
+
+	_common_teardown
+}
+
+# Helper function to create a password-store provider config
+create_pass_config() {
+	local prefix="${1:-}"
+	cat >"${FNOX_CONFIG_FILE:-fnox.toml}" <<EOF
+[providers.pass]
+type = "password-store"
+EOF
+
+	if [ -n "$prefix" ]; then
+		cat >>"${FNOX_CONFIG_FILE}" <<EOF
+prefix = "$prefix"
+EOF
+	fi
+
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
+
+[secrets]
+EOF
+}
+
+# Helper to track secret paths for cleanup
+track_secret_path() {
+	local path="$1"
+	TEST_SECRET_PATHS="${TEST_SECRET_PATHS} $path"
+}
+
+@test "fnox set stores secret in password-store" {
+	create_pass_config
+
+	# Set a secret using the password-store provider
+	run "$FNOX_BIN" set MY_SECRET "my-secret-value" --provider pass
+	assert_success
+	assert_output --partial "Set secret MY_SECRET"
+
+	track_secret_path "MY_SECRET"
+
+	# Verify the config contains only a reference (not the value)
+	run cat "${FNOX_CONFIG_FILE}"
+	assert_success
+	assert_output --partial 'MY_SECRET'
+	assert_output --partial 'provider = "pass"'
+	assert_output --partial 'value = "MY_SECRET"'
+	refute_output --partial "my-secret-value"
+
+	# Verify the secret is actually stored in password-store
+	run pass show MY_SECRET
+	assert_success
+	assert_output "my-secret-value"
+}
+
+@test "fnox get retrieves secret from password-store" {
+	create_pass_config
+
+	# Set a secret
+	run "$FNOX_BIN" set TEST_GET "test-value-123" --provider pass
+	assert_success
+	track_secret_path "TEST_GET"
+
+	# Get the secret back
+	run "$FNOX_BIN" get TEST_GET
+	assert_success
+	assert_output "test-value-123"
+}
+
+@test "fnox set and get with prefix" {
+	create_pass_config "work/"
+
+	# Set a secret with prefix
+	run "$FNOX_BIN" set PREFIXED_SECRET "prefixed-value" --provider pass
+	assert_success
+	track_secret_path "work/PREFIXED_SECRET"
+
+	# Get the secret (prefix is applied automatically)
+	run "$FNOX_BIN" get PREFIXED_SECRET
+	assert_success
+	assert_output "prefixed-value"
+
+	# Verify it's stored in the right location
+	run pass show work/PREFIXED_SECRET
+	assert_success
+	assert_output "prefixed-value"
+}
+
+@test "fnox get fails with non-existent secret" {
+	create_pass_config
+
+	# Manually add a reference to a non-existent secret
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
+
+[secrets.NONEXISTENT]
+provider = "pass"
+value = "does-not-exist-$$"
+EOF
+
+	# Try to get non-existent secret
+	run "$FNOX_BIN" get NONEXISTENT
+	assert_failure
+	assert_output --partial "password-store CLI command failed"
+}
+
+@test "fnox set with special characters" {
+	create_pass_config
+
+	local secret_value='p@ssw0rd!#$%^&*()_+-={}[]|\:";'\''<>?,./~`'
+
+	# Set a secret with special characters
+	run "$FNOX_BIN" set SPECIAL_CHARS "$secret_value" --provider pass
+	assert_success
+	track_secret_path "SPECIAL_CHARS"
+
+	# Get it back
+	run "$FNOX_BIN" get SPECIAL_CHARS
+	assert_success
+	assert_output "$secret_value"
+}
+
+@test "fnox set with multiline value" {
+	create_pass_config
+
+	local multiline_value="line1
+line2
+line3"
+
+	# Set a multiline secret (using bash -c for stdin pipe)
+	run bash -c "echo '$multiline_value' | '$FNOX_BIN' set MULTILINE --provider pass"
+	assert_success
+	track_secret_path "MULTILINE"
+
+	# Get it back
+	run "$FNOX_BIN" get MULTILINE
+	assert_success
+	assert_output "$multiline_value"
+
+	# Verify in password-store (pass show returns all lines)
+	run pass show MULTILINE
+	assert_success
+	assert_output "$multiline_value"
+}
+
+@test "fnox set updates existing secret" {
+	create_pass_config
+
+	# Set initial value
+	run "$FNOX_BIN" set UPDATE_TEST "initial-value" --provider pass
+	assert_success
+	track_secret_path "UPDATE_TEST"
+
+	# Update the value
+	run "$FNOX_BIN" set UPDATE_TEST "updated-value" --provider pass
+	assert_success
+
+	# Get the updated value
+	run "$FNOX_BIN" get UPDATE_TEST
+	assert_success
+	assert_output "updated-value"
+}
+
+@test "fnox list shows password-store secrets" {
+	create_pass_config
+
+	# Set multiple secrets
+	run "$FNOX_BIN" set SECRET1 "value1" --provider pass --description "First secret"
+	assert_success
+	track_secret_path "SECRET1"
+
+	run "$FNOX_BIN" set SECRET2 "value2" --provider pass --description "Second secret"
+	assert_success
+	track_secret_path "SECRET2"
+
+	# List secrets
+	run "$FNOX_BIN" list
+	assert_success
+	assert_output --partial "SECRET1"
+	assert_output --partial "SECRET2"
+	assert_output --partial "First secret"
+	assert_output --partial "Second secret"
+}
+
+@test "fnox exec with password-store secrets" {
+	create_pass_config
+
+	# Set a secret
+	run "$FNOX_BIN" set EXEC_TEST "exec-value" --provider pass
+	assert_success
+	track_secret_path "EXEC_TEST"
+
+	# Use it in exec (redirect stderr to filter warnings)
+	run bash -c "'$FNOX_BIN' exec -- bash -c 'echo \$EXEC_TEST' 2>/dev/null"
+	assert_success
+	assert_output "exec-value"
+}
+
+@test "fnox set with description metadata" {
+	create_pass_config
+
+	# Set secret with description
+	run "$FNOX_BIN" set DESCRIBED "value" --provider pass --description "Test description"
+	assert_success
+	track_secret_path "DESCRIBED"
+
+	# Verify description in list
+	run "$FNOX_BIN" list
+	assert_success
+	assert_output --partial "DESCRIBED"
+	assert_output --partial "Test description"
+}
+
+@test "fnox get with JSON-like value" {
+	create_pass_config
+
+	local json_value='{"api_key":"test123","endpoint":"https://api.example.com"}'
+
+	# Set JSON value
+	run "$FNOX_BIN" set JSON_SECRET "$json_value" --provider pass
+	assert_success
+	track_secret_path "JSON_SECRET"
+
+	# Get it back
+	run "$FNOX_BIN" get JSON_SECRET
+	assert_success
+	assert_output "$json_value"
+}
+
+@test "fnox set reads from stdin" {
+	create_pass_config
+
+	# Set secret from stdin (using bash -c for stdin pipe)
+	run bash -c "echo 'stdin-value' | '$FNOX_BIN' set STDIN_SECRET --provider pass"
+	assert_success
+	track_secret_path "STDIN_SECRET"
+
+	# Get it back
+	run "$FNOX_BIN" get STDIN_SECRET
+	assert_success
+	assert_output "stdin-value"
+}
+
+@test "password-store provider with long values" {
+	create_pass_config
+
+	# Create a long value (4KB)
+	local long_value
+	long_value=$(python3 -c "print('a' * 4096)")
+
+	# Set long value
+	run "$FNOX_BIN" set LONG_SECRET "$long_value" --provider pass
+	assert_success
+	track_secret_path "LONG_SECRET"
+
+	# Get it back
+	run "$FNOX_BIN" get LONG_SECRET
+	assert_success
+	assert_output "$long_value"
+}
+
+@test "fnox check detects missing password-store secrets" {
+	create_pass_config
+
+	# Add reference without actually storing in password-store
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
+
+[secrets.MISSING_SECRET]
+provider = "pass"
+value = "not-in-pass-store"
+if_missing = "error"
+EOF
+
+	# Check should detect the missing secret
+	run "$FNOX_BIN" check
+	assert_failure
+	assert_output --partial "MISSING_SECRET"
+}
+
+@test "fnox set with nested path" {
+	create_pass_config
+
+	# Set a secret with nested path
+	run "$FNOX_BIN" set NESTED_SECRET "nested-value" --provider pass --key-name "company/project/api-key"
+	assert_success
+	track_secret_path "company/project/api-key"
+
+	# Get it back
+	run "$FNOX_BIN" get NESTED_SECRET
+	assert_success
+	assert_output "nested-value"
+
+	# Verify it's stored in the nested path
+	run pass show company/project/api-key
+	assert_success
+	assert_output "nested-value"
+}
+
+@test "password-store provider respects PASSWORD_STORE_DIR" {
+	# Create a custom password store directory
+	local custom_store="$BATS_TEST_TMPDIR/custom-password-store"
+	mkdir -p "$custom_store"
+
+	# Initialize custom password store
+	PASSWORD_STORE_DIR="$custom_store" pass init "$GPG_KEY_ID" >/dev/null 2>&1
+
+	# Set PASSWORD_STORE_DIR and create config
+	export PASSWORD_STORE_DIR="$custom_store"
+	create_pass_config
+
+	# Set a secret
+	run "$FNOX_BIN" set CUSTOM_STORE_SECRET "custom-value" --provider pass
+	assert_success
+	track_secret_path "CUSTOM_STORE_SECRET"
+
+	# Verify it's in the custom store
+	run pass show CUSTOM_STORE_SECRET
+	assert_success
+	assert_output "custom-value"
+
+	# Verify the .gpg file exists in custom location
+	[ -f "$custom_store/CUSTOM_STORE_SECRET.gpg" ]
+}
+
+@test "password-store provider with hierarchical secrets" {
+	create_pass_config "myapp/"
+
+	# Set secrets in hierarchy
+	run "$FNOX_BIN" set DB_PASSWORD "db-pass" --provider pass --key-name "database/password"
+	assert_success
+	track_secret_path "myapp/database/password"
+
+	run "$FNOX_BIN" set API_KEY "api-key" --provider pass --key-name "api/github"
+	assert_success
+	track_secret_path "myapp/api/github"
+
+	# Get them back
+	run "$FNOX_BIN" get DB_PASSWORD
+	assert_success
+	assert_output "db-pass"
+
+	run "$FNOX_BIN" get API_KEY
+	assert_success
+	assert_output "api-key"
+
+	# Verify hierarchy with pass ls
+	run pass ls myapp
+	assert_success
+	assert_output --partial "database"
+	assert_output --partial "api"
+}


### PR DESCRIPTION
Add a new provider that integrates with the standard Unix password manager
(pass) for local, GPG-encrypted secret storage. This provider uses the pass
CLI to store secrets as encrypted files in ~/.password-store/, enabling
local-first secret management with git-friendly encrypted storage.

Features:
- RemoteStorage capability (supports both read and write operations)
- Configurable prefix for organizing secrets in subdirectories
- Custom PASSWORD_STORE_DIR support
- Custom GPG options via PASSWORD_STORE_GPG_OPTS
- Multiline secret support
- Hierarchical secret organization
- Environment variable support (FNOX_PASSWORD_STORE_DIR, FNOX_PASSWORD_STORE_GPG_OPTS)

Implementation:
- Uses pass CLI for all operations (consistent with 1Password/Bitwarden approach)
- Stores only secret references in fnox.toml, actual values encrypted by GPG
- Cross-platform: macOS, Linux, Windows (WSL/Cygwin)
- Connection testing via pass ls
- Comprehensive test suite with 20 test cases
