### PR TITLE
docs: add looping example for age provider

### DIFF
--- a/docs/providers/age.md
+++ b/docs/providers/age.md
@@ -261,11 +261,21 @@ fnox get DATABASE_URL  # Works for all recipients!
 
 3. **Re-encrypt all secrets** (necessary for new recipient):
 
+   Individual examples:
+
    ```bash
    # Re-encrypt each secret with new recipient list
    fnox set DATABASE_URL "$(fnox get DATABASE_URL)" --provider age
    fnox set API_KEY "$(fnox get API_KEY)" --provider age
    # ... repeat for all secrets
+   ```
+
+   Looping example:
+
+   ```bash
+   fnox list | awk '/provider \(age\)/ {print $1}' | while read env_key; do
+     fnox set "$env_key" "$(fnox get "$env_key")" --provider age
+   done
    ```
 
 4. **Commit and push**:
@@ -277,6 +287,7 @@ fnox get DATABASE_URL  # Works for all recipients!
    ```
 
 5. **New member pulls and decrypts**:
+
    ```bash
    git pull
    export FNOX_AGE_KEY_FILE=~/.ssh/id_ed25519


### PR DESCRIPTION
When going through the docs I felt that the need to re-encrypt every age provider secret line by line cumbersome so I used a loop with `awk` and figured it might be useful to include in the docs.

Of course, if you do not agree or want to include an example that relies on other tools or is tightly coupled to the layout of `fnox list` then I completely understand!

Just wanted add value to others if possible! Feel free to make any changes or decline.

### Screenshot of the changes on the webpage
<img width="747" height="427" alt="image" src="https://github.com/user-attachments/assets/cfedaea6-6a17-4224-8606-a0a63231f910" />
