### PR TITLE
fix: prevent config hierarchy duplication in fnox set command

### DIFF
--- a/src/commands/set.rs
+++ b/src/commands/set.rs
@@ -267,8 +267,15 @@ impl SetCommand {
             }
         }
 
+        let secret_config = profile_secrets.get(&self.key).unwrap().clone();
         let _ = profile_secrets; // Release the mutable borrow
-        config.save(&cli.config)?;
+
+        // Save the secret to its source file (or to the current directory's config)
+        let current_dir = std::env::current_dir()
+            .map_err(|e| FnoxError::Config(format!("Failed to get current directory: {}", e)))?;
+        let default_target = current_dir.join(&cli.config);
+        config.save_secret_to_source(&self.key, &secret_config, &profile, &default_target)?;
+
         let check = console::style("✓").green();
         let styled_key = console::style(&self.key).cyan();
         let styled_profile = console::style(&profile).magenta();

--- a/test/config_hierarchy_set.bats
+++ b/test/config_hierarchy_set.bats
@@ -1,0 +1,193 @@
+#!/usr/bin/env bats
+
+setup() {
+	load 'test_helper/common_setup'
+	_common_setup
+}
+
+teardown() {
+	_common_teardown
+}
+
+@test "fnox set in child directory should not duplicate parent config" {
+	# Create directory structure
+	mkdir -p parent/child
+
+	# Create parent config with provider and secrets
+	cat >parent/fnox.toml <<EOF
+[providers.age_provider]
+type = "age"
+recipients = ["age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"]
+
+[secrets]
+PARENT_SECRET = { provider = "age_provider", value = "age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p:encrypted:parent" }
+EOF
+
+	# Change to child directory
+	cd parent/child
+
+	# Set a new secret in child directory
+	run "$FNOX_BIN" set CHILD_SECRET "child-value" --provider age_provider
+	assert_success
+
+	# Check that child fnox.toml was created
+	assert [ -f fnox.toml ]
+
+	# Check that child config does NOT contain parent secrets
+	run cat fnox.toml
+	assert_success
+	refute_output --partial "PARENT_SECRET"
+
+	# Check that child config DOES contain the new secret
+	assert_output --partial "CHILD_SECRET"
+
+	# Verify parent config is unchanged
+	run cat ../fnox.toml
+	assert_success
+	assert_output --partial "PARENT_SECRET"
+	refute_output --partial "CHILD_SECRET"
+}
+
+@test "fnox set in child directory with existing child config should not duplicate parent config" {
+	# Create directory structure
+	mkdir -p parent/child
+
+	# Create parent config with provider and secrets
+	cat >parent/fnox.toml <<EOF
+[providers.age_provider]
+type = "age"
+recipients = ["age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"]
+
+[secrets]
+PARENT_SECRET = { provider = "age_provider", value = "age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p:encrypted:parent" }
+PARENT_SECRET_2 = { provider = "age_provider", value = "age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p:encrypted:parent2" }
+EOF
+
+	# Create child config with one secret
+	cat >parent/child/fnox.toml <<EOF
+[secrets]
+EXISTING_CHILD_SECRET = { default = "existing-value" }
+EOF
+
+	# Change to child directory
+	cd parent/child
+
+	# Set a new secret in child directory
+	run "$FNOX_BIN" set NEW_CHILD_SECRET "new-child-value" --provider age_provider
+	assert_success
+
+	# Check that child config does NOT contain parent secrets
+	run cat fnox.toml
+	assert_success
+	refute_output --partial "PARENT_SECRET"
+	refute_output --partial "PARENT_SECRET_2"
+
+	# Check that child config contains both child secrets
+	assert_output --partial "EXISTING_CHILD_SECRET"
+	assert_output --partial "NEW_CHILD_SECRET"
+
+	# Verify parent config is unchanged
+	run cat ../fnox.toml
+	assert_success
+	assert_output --partial "PARENT_SECRET"
+	assert_output --partial "PARENT_SECRET_2"
+	refute_output --partial "EXISTING_CHILD_SECRET"
+	refute_output --partial "NEW_CHILD_SECRET"
+}
+
+@test "fnox set in child with parent provider does not duplicate provider" {
+	# Create directory structure
+	mkdir -p parent/child
+
+	# Create parent config with a provider
+	cat >parent/fnox.toml <<EOF
+root = true
+
+[providers.plain]
+type = "age"
+recipients = ["age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"]
+
+[secrets]
+PARENT_SECRET = { default = "parent-value" }
+EOF
+
+	# Change to child directory
+	cd parent/child
+
+	# Set a new secret (uses default provider from parent)
+	run "$FNOX_BIN" set TEST_SECRET "test-value-123"
+	assert_success
+
+	# Verify child config was created with only the new secret, NOT the provider config
+	run cat fnox.toml
+	assert_success
+	assert_output --partial "TEST_SECRET"
+	refute_output --partial "PARENT_SECRET"
+	# The secret may reference the provider name, but should not duplicate the [providers] section
+	refute_output --partial "[providers"
+
+	# Verify parent config is unchanged
+	run cat ../fnox.toml
+	assert_success
+	assert_output --partial "PARENT_SECRET"
+	assert_output --partial "providers"
+	refute_output --partial "TEST_SECRET"
+}
+
+@test "fnox set should update secret in its original source file" {
+	# Create directory structure
+	mkdir -p parent/child
+
+	# Create parent config
+	cat >parent/fnox.toml <<EOF
+[providers.age_provider]
+type = "age"
+recipients = ["age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"]
+
+[secrets]
+PARENT_SECRET = { default = "original-parent-value" }
+EOF
+
+	# Create child config
+	cat >parent/child/fnox.toml <<EOF
+[secrets]
+CHILD_SECRET = { default = "original-child-value" }
+EOF
+
+	# Change to child directory
+	cd parent/child
+
+	# Update the parent secret (should update parent file, not child)
+	run "$FNOX_BIN" set PARENT_SECRET "updated-parent-value"
+	assert_success
+
+	# Verify parent config was updated
+	run cat ../fnox.toml
+	assert_success
+	assert_output --partial 'PARENT_SECRET'
+	assert_output --partial 'updated-parent-value'
+
+	# Verify child config was NOT modified
+	run cat fnox.toml
+	assert_success
+	assert_output --partial 'CHILD_SECRET = { default = "original-child-value"'
+	refute_output --partial "PARENT_SECRET"
+
+	# Update the child secret (should update child file)
+	run "$FNOX_BIN" set CHILD_SECRET "updated-child-value"
+	assert_success
+
+	# Verify child config was updated
+	run cat fnox.toml
+	assert_success
+	assert_output --partial 'CHILD_SECRET'
+	assert_output --partial 'updated-child-value'
+	refute_output --partial "PARENT_SECRET"
+
+	# Verify parent config was NOT modified (should still have old value)
+	run cat ../fnox.toml
+	assert_success
+	assert_output --partial 'PARENT_SECRET'
+	assert_output --partial 'updated-parent-value'
+	refute_output --partial "CHILD_SECRET"
+}


### PR DESCRIPTION
Fixes #104

## Problem

When running `fnox set` from a child directory, the entire merged configuration (including parent secrets and providers) was being saved to the child's `fnox.toml` file. This caused:

1. **Unintended duplication** of parent configuration in child files
2. **Invalid encrypted values** that couldn't be decrypted later

This is described in the issue: https://github.com/jdx/fnox/discussions/104#discussioncomment-15031863

## Root Cause

The `set` command was:
1. Loading config with recursion (correctly merging parent/child configs)
2. Modifying a secret in the merged config
3. **Saving the entire merged config** to a single file (incorrectly)

This meant all parent secrets, providers, and settings were dumped into the child config file.

## Solution

Introduced a new `save_secret_to_source()` method that:
- **For new secrets**: Saves to the current directory's `fnox.toml`
- **For existing secrets**: Updates the original source file where the secret was defined
- **Preserves hierarchy**: Parent configs remain separate and are inherited through recursion, not duplicated

## Changes

- Added `Config::save_secret_to_source()` - smart save that updates only the relevant source file
- Added `Config::load_single()` - helper to load a single config without recursion for targeted updates
- Modified `set` command to use the new save method
- Added comprehensive bats tests in `test/config_hierarchy_set.bats`:
  - Test 1: New secret in child doesn't duplicate parent config
  - Test 2: Adding secret to existing child config doesn't duplicate parent
  - Test 3: Provider references work correctly without duplicating provider configs
  - Test 4: Updating existing secrets modifies their source file, not a random file

## Testing

All new and existing tests pass:
- ✅ 4/4 new hierarchy tests pass
- ✅ All cargo unit tests pass
- ✅ Related bats tests pass (config_recursion, local_config, set_no_provider, plain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)