### PR TITLE
refactor(password-store): implement Provider trait with put_secret returning key

### DIFF
--- a/src/commands/set.rs
+++ b/src/commands/set.rs
@@ -167,6 +167,8 @@ impl SetCommand {
                                 store_dir,
                                 gpg_opts,
                             } => {
+                                use crate::providers::Provider;
+
                                 let pass_provider =
                                     crate::providers::password_store::PasswordStoreProvider::new(
                                         prefix.clone(),
@@ -175,10 +177,9 @@ impl SetCommand {
                                     );
 
                                 let key_name = self.key_name.as_deref().unwrap_or(&self.key);
-                                pass_provider.put_secret(key_name, value).await?;
+                                let key = pass_provider.put_secret(key_name, value, None).await?;
 
-                                // Store just the key name (without prefix) in config
-                                (None, Some(key_name.to_string()))
+                                (None, Some(key))
                             }
                             ProviderConfig::AzureSecretsManager { vault_url, prefix } => {
                                 let azure_sm_provider =


### PR DESCRIPTION
Update password-store provider to properly implement the Provider trait by:
- Moving Provider trait implementation methods together
- Changing put_secret signature to return Result<String> with the key name
- Updating set command to use the returned key from put_secret
