### PR TITLE
chore: release v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,35 @@
 # Changelog
 
-## [1.6.1](https://github.com/jdx/fnox/compare/v1.6.0..v1.6.1) - 2025-11-25
+## [1.7.0](https://github.com/jdx/fnox/compare/v1.6.1..v1.7.0) - 2025-11-27
+
+### 🚀 Features
+
+- **(init)** improve wizard with traits and missing providers by [@jdx](https://github.com/jdx) in [#129](https://github.com/jdx/fnox/pull/129)
+- add KeePass provider support by [@jdx](https://github.com/jdx) in [#123](https://github.com/jdx/fnox/pull/123)
+- add AWS Parameter Store provider support by [@jdx](https://github.com/jdx) in [#126](https://github.com/jdx/fnox/pull/126)
+- support global config file for machine-wide secrets by [@jdx](https://github.com/jdx) in [#128](https://github.com/jdx/fnox/pull/128)
+
+### 🐛 Bug Fixes
+
+- **(set)** always write to local config, create override for parent secrets by [@jdx](https://github.com/jdx) in [#122](https://github.com/jdx/fnox/pull/122)
+
+### 🚜 Refactor
+
+- simplify Provider trait by removing key_file parameter by [@jdx](https://github.com/jdx) in [#124](https://github.com/jdx/fnox/pull/124)
+
+### 📚 Documentation
+
+- add KeePass provider documentation by [@jdx](https://github.com/jdx) in [#125](https://github.com/jdx/fnox/pull/125)
+
+### ⚡ Performance
+
+- **(tests)** reduce AWS Secrets Manager API calls by [@jdx](https://github.com/jdx) in [#127](https://github.com/jdx/fnox/pull/127)
+
+## [1.6.1](https://github.com/jdx/fnox/compare/v1.6.0..v1.6.1) - 2025-11-26
+
+### 🐛 Bug Fixes
+
+- **(edit)** preserve all user edits including non-secret config by [@jdx](https://github.com/jdx) in [#119](https://github.com/jdx/fnox/pull/119)
 
 ### 🚜 Refactor
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1841,7 +1841,7 @@ dependencies = [
 
 [[package]]
 name = "fnox"
-version = "1.6.1"
+version = "1.7.0"
 dependencies = [
  "age",
  "anyhow",
@@ -5564,7 +5564,7 @@ dependencies = [
  "serde_spanned",
  "toml_datetime",
  "toml_write",
- "winnow 0.7.13",
+ "winnow 0.7.14",
 ]
 
 [[package]]
@@ -5682,9 +5682,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5693,9 +5693,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "7a04e24fab5c89c6a36eb8558c9656f30d81de51dfa4d3b45f26b21d61fa0a6c"
 dependencies = [
  "once_cell",
  "valuable",
@@ -6495,9 +6495,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fnox"
-version = "1.6.1"
+version = "1.7.0"
 edition = "2024"
 authors = ["@jdx"]
 description = "A flexible secret management tool supporting multiple providers and encryption methods"

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -1036,7 +1036,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.6.1",
+  "version": "1.7.0",
   "usage": "Usage: fnox [OPTIONS] <COMMAND>",
   "complete": {
     "key": {

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -4,7 +4,7 @@
 
 **Usage**: `fnox [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.6.1
+**Version**: 1.7.0
 
 - **Usage**: `fnox [FLAGS] <SUBCOMMAND>`
 

--- a/fnox.usage.kdl
+++ b/fnox.usage.kdl
@@ -1,7 +1,7 @@
 min_usage_version "1.3"
 name fnox
 bin fnox
-version "1.6.1"
+version "1.7.0"
 about "A flexible secret management tool by @jdx"
 usage "Usage: fnox [OPTIONS] <COMMAND>"
 flag "-c --config" help="Path to the configuration file (default: fnox.toml, searches parent directories)" global=#true {


### PR DESCRIPTION
## [1.7.0](https://github.com/jdx/fnox/compare/v1.6.1..v1.7.0) - 2025-11-27

### 🚀 Features

- **(init)** improve wizard with traits and missing providers by [@jdx](https://github.com/jdx) in [#129](https://github.com/jdx/fnox/pull/129)
- add KeePass provider support by [@jdx](https://github.com/jdx) in [#123](https://github.com/jdx/fnox/pull/123)
- add AWS Parameter Store provider support by [@jdx](https://github.com/jdx) in [#126](https://github.com/jdx/fnox/pull/126)
- support global config file for machine-wide secrets by [@jdx](https://github.com/jdx) in [#128](https://github.com/jdx/fnox/pull/128)

### 🐛 Bug Fixes

- **(set)** always write to local config, create override for parent secrets by [@jdx](https://github.com/jdx) in [#122](https://github.com/jdx/fnox/pull/122)

### 🚜 Refactor

- simplify Provider trait by removing key_file parameter by [@jdx](https://github.com/jdx) in [#124](https://github.com/jdx/fnox/pull/124)

### 📚 Documentation

- add KeePass provider documentation by [@jdx](https://github.com/jdx) in [#125](https://github.com/jdx/fnox/pull/125)

### ⚡ Performance

- **(tests)** reduce AWS Secrets Manager API calls by [@jdx](https://github.com/jdx) in [#127](https://github.com/jdx/fnox/pull/127)