### PR TITLE
feat: add KeePass provider support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,7 @@ jobs:
         env:
           TRANCHE: ${{ matrix.tranche }}
           TRANCHE_COUNT: 3
+          KEEPASS_PASSWORD: fnox-test-password
         with:
           timeout_minutes: 10
           max_attempts: 3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -903,6 +903,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
+name = "blake2b_simd"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06e903a20b159e944f91ec8499fe1e55651480c541ea0a584f5d967c49ad9d99"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "constant_time_eq 0.3.1",
+]
+
+[[package]]
 name = "blake3"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -912,7 +923,7 @@ dependencies = [
  "arrayvec",
  "cc",
  "cfg-if",
- "constant_time_eq",
+ "constant_time_eq 0.3.1",
 ]
 
 [[package]]
@@ -923,6 +934,12 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "block-modes"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e2211b0817f061502a8dd9f11a37e879e79763e3c698d2418cf824d8cb2f21e"
 
 [[package]]
 name = "block-padding"
@@ -1235,6 +1252,12 @@ name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "cookie-factory"
@@ -1824,6 +1847,7 @@ dependencies = [
  "google-cloud-kms",
  "google-cloud-secretmanager-v1",
  "indexmap 2.12.1",
+ "keepass",
  "keyring",
  "miette",
  "miniz_oxide",
@@ -2479,6 +2503,12 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex-literal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
 
 [[package]]
 name = "hkdf"
@@ -3143,6 +3173,37 @@ dependencies = [
  "miette",
  "num",
  "winnow 0.6.24",
+]
+
+[[package]]
+name = "keepass"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d40cdb5c00770fddffcfc2ab4c1be0acd6cdd6e2a34da549fbbeaaf307134fe"
+dependencies = [
+ "aes",
+ "base64 0.22.1",
+ "block-modes",
+ "byteorder",
+ "cbc",
+ "chacha20",
+ "chrono",
+ "cipher",
+ "flate2",
+ "getrandom 0.3.4",
+ "hex",
+ "hex-literal",
+ "hmac",
+ "js-sys",
+ "rust-argon2",
+ "salsa20",
+ "secstr",
+ "sha2",
+ "thiserror 2.0.17",
+ "twofish",
+ "uuid",
+ "xml-rs",
+ "zeroize",
 ]
 
 [[package]]
@@ -4383,6 +4444,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-argon2"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae76b7506744d254fd0eb2c0ff5c5d108201ccbb083111ac04a44eeda105680"
+dependencies = [
+ "base64 0.22.1",
+ "blake2b_simd",
+ "constant_time_eq 0.4.2",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "rust-embed"
 version = "8.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4669,6 +4742,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
 dependencies = [
  "zeroize",
+]
+
+[[package]]
+name = "secstr"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04f657244f605c4cf38f6de5993e8bd050c8a303f86aeabff142d5c7c113e12"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -5642,6 +5724,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "twofish"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a78e83a30223c757c3947cd144a31014ff04298d8719ae10d03c31c0448c8013"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "type-map"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5805,6 +5896,7 @@ checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
 dependencies = [
  "getrandom 0.3.4",
  "js-sys",
+ "serde",
  "wasm-bindgen",
 ]
 
@@ -6415,6 +6507,21 @@ dependencies = [
  "rand_core 0.6.4",
  "serde",
  "zeroize",
+]
+
+[[package]]
+name = "xml"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2df5825faced2427b2da74d9100f1e2e93c533fff063506a81ede1cf517b2e7e"
+
+[[package]]
+name = "xml-rs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3a56132a0d6ecbe77352edc10232f788fc4ceefefff4cab784a98e0e16b6b51"
+dependencies = [
+ "xml",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ azure_security_keyvault = { version = "0.21" }
 google-cloud-kms = { version = "0.6" }
 google-cloud-secretmanager-v1 = { version = "1.1" }
 gcp_auth = { version = "0.12" }
+keepass = { version = "0.8", features = ["save_kdbx4"] }
 keyring = { version = "3", features = ["apple-native", "windows-native", "sync-secret-service"] }
 # Required for rustls crypto provider (used by GCP SDKs)
 rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs", "std"] }

--- a/src/commands/set.rs
+++ b/src/commands/set.rs
@@ -193,6 +193,26 @@ impl SetCommand {
                                 // Store just the key name (without prefix) in config
                                 (None, Some(self.key.clone()))
                             }
+                            ProviderConfig::KeePass {
+                                database,
+                                keyfile,
+                                password,
+                            } => {
+                                use crate::providers::Provider;
+
+                                let keepass_provider =
+                                    crate::providers::keepass::KeePassProvider::new(
+                                        database.clone(),
+                                        keyfile.clone(),
+                                        password.clone(),
+                                    );
+
+                                let key_name = self.key_name.as_deref().unwrap_or(&self.key);
+                                let key =
+                                    keepass_provider.put_secret(key_name, value, None).await?;
+
+                                (None, Some(key))
+                            }
                             _ => {
                                 // Other remote storage providers not yet implemented
                                 tracing::warn!(

--- a/src/providers/keepass.rs
+++ b/src/providers/keepass.rs
@@ -412,12 +412,13 @@ impl crate::providers::Provider for KeePassProvider {
 
         // Verify keyfile exists if configured
         if let Some(keyfile_path) = &self.keyfile_path
-            && !keyfile_path.exists() {
-                return Err(FnoxError::Provider(format!(
-                    "KeePass keyfile '{}' does not exist",
-                    keyfile_path.display()
-                )));
-            }
+            && !keyfile_path.exists()
+        {
+            return Err(FnoxError::Provider(format!(
+                "KeePass keyfile '{}' does not exist",
+                keyfile_path.display()
+            )));
+        }
 
         // If database exists, verify we can open it
         // If it doesn't exist, that's OK - put_secret will create it

--- a/src/providers/keepass.rs
+++ b/src/providers/keepass.rs
@@ -246,11 +246,10 @@ impl KeePassProvider {
             if let Node::Entry(entry) = &mut group.children[idx] {
                 return Some(entry);
             }
-        } else if let Some(idx) = found_in_subgroup_idx {
-            if let Node::Group(subgroup) = &mut group.children[idx] {
+        } else if let Some(idx) = found_in_subgroup_idx
+            && let Node::Group(subgroup) = &mut group.children[idx] {
                 return Self::find_entry_by_title_mut(subgroup, title);
             }
-        }
         None
     }
 

--- a/src/providers/keepass.rs
+++ b/src/providers/keepass.rs
@@ -280,6 +280,13 @@ impl KeePassProvider {
             ));
         }
 
+        // Use Protected for Password field (in-memory encryption and proper KDBX marking)
+        let field_value = if field == "Password" {
+            Value::Protected(value.as_bytes().into())
+        } else {
+            Value::Unprotected(value.to_string())
+        };
+
         if path.len() == 1 {
             // Create or update entry in this group or any subgroup (recursive search)
             let entry_name = path[0];
@@ -287,9 +294,7 @@ impl KeePassProvider {
             // Look for existing entry recursively
             if let Some(entry) = Self::find_entry_by_title_mut(group, entry_name) {
                 // Update existing entry
-                entry
-                    .fields
-                    .insert(field.to_string(), Value::Unprotected(value.to_string()));
+                entry.fields.insert(field.to_string(), field_value);
                 return Ok(entry_name.to_string());
             }
 
@@ -299,9 +304,7 @@ impl KeePassProvider {
                 "Title".to_string(),
                 Value::Unprotected(entry_name.to_string()),
             );
-            entry
-                .fields
-                .insert(field.to_string(), Value::Unprotected(value.to_string()));
+            entry.fields.insert(field.to_string(), field_value);
             group.children.push(Node::Entry(entry));
             Ok(entry_name.to_string())
         } else {

--- a/src/providers/keepass.rs
+++ b/src/providers/keepass.rs
@@ -247,9 +247,10 @@ impl KeePassProvider {
                 return Some(entry);
             }
         } else if let Some(idx) = found_in_subgroup_idx
-            && let Node::Group(subgroup) = &mut group.children[idx] {
-                return Self::find_entry_by_title_mut(subgroup, title);
-            }
+            && let Node::Group(subgroup) = &mut group.children[idx]
+        {
+            return Self::find_entry_by_title_mut(subgroup, title);
+        }
         None
     }
 

--- a/src/providers/keepass.rs
+++ b/src/providers/keepass.rs
@@ -1,0 +1,388 @@
+use crate::error::{FnoxError, Result};
+use crate::providers::ProviderCapability;
+use async_trait::async_trait;
+use keepass::DatabaseKey;
+use keepass::db::{Database, Entry, Group, Node, Value};
+use std::fs::File;
+use std::io::{BufReader, BufWriter};
+use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
+
+/// Provider that reads and writes secrets from KeePass database files (.kdbx)
+pub struct KeePassProvider {
+    database_path: PathBuf,
+    keyfile_path: Option<PathBuf>,
+    password: Option<String>,
+}
+
+impl KeePassProvider {
+    pub fn new(database: String, keyfile: Option<String>, password: Option<String>) -> Self {
+        Self {
+            database_path: PathBuf::from(shellexpand::tilde(&database).to_string()),
+            keyfile_path: keyfile.map(|k| PathBuf::from(shellexpand::tilde(&k).to_string())),
+            password,
+        }
+    }
+
+    /// Get the password from environment variable or config
+    fn get_password(&self) -> Result<String> {
+        // Priority: env var > config
+        if let Some(password) = KEEPASS_PASSWORD.as_ref() {
+            return Ok(password.clone());
+        }
+
+        if let Some(password) = &self.password {
+            return Ok(password.clone());
+        }
+
+        Err(FnoxError::Provider(
+            "KeePass password not set. Set FNOX_KEEPASS_PASSWORD or KEEPASS_PASSWORD environment variable, or configure password in provider config.".to_string(),
+        ))
+    }
+
+    /// Build the database key from password and optional keyfile
+    fn build_key(&self) -> Result<DatabaseKey> {
+        let password = self.get_password()?;
+        let mut key = DatabaseKey::new();
+
+        // Add password
+        key = key.with_password(&password);
+
+        // Add keyfile if configured
+        if let Some(keyfile_path) = &self.keyfile_path {
+            let mut keyfile = File::open(keyfile_path).map_err(|e| {
+                FnoxError::Provider(format!(
+                    "Failed to open KeePass keyfile '{}': {}",
+                    keyfile_path.display(),
+                    e
+                ))
+            })?;
+            key = key
+                .with_keyfile(&mut keyfile)
+                .map_err(|e| FnoxError::Provider(format!("Failed to read KeePass keyfile: {e}")))?;
+        }
+
+        Ok(key)
+    }
+
+    /// Open and decrypt the database
+    fn open_database(&self) -> Result<Database> {
+        let file = File::open(&self.database_path).map_err(|e| {
+            FnoxError::Provider(format!(
+                "Failed to open KeePass database '{}': {}",
+                self.database_path.display(),
+                e
+            ))
+        })?;
+        let mut reader = BufReader::new(file);
+        let key = self.build_key()?;
+
+        Database::open(&mut reader, key)
+            .map_err(|e| FnoxError::Provider(format!("Failed to open KeePass database: {e}")))
+    }
+
+    /// Save the database back to disk
+    fn save_database(&self, db: &Database) -> Result<()> {
+        let file = File::create(&self.database_path).map_err(|e| {
+            FnoxError::Provider(format!(
+                "Failed to create KeePass database file '{}': {}",
+                self.database_path.display(),
+                e
+            ))
+        })?;
+        let mut writer = BufWriter::new(file);
+        let key = self.build_key()?;
+
+        db.save(&mut writer, key)
+            .map_err(|e| FnoxError::Provider(format!("Failed to save KeePass database: {e}")))
+    }
+
+    /// Parse a reference value into (entry_path, field)
+    /// Formats:
+    /// - "entry-name" -> (["entry-name"], "Password")
+    /// - "entry-name/username" -> (["entry-name"], "UserName")
+    /// - "group/subgroup/entry-name" -> (["group", "subgroup", "entry-name"], "Password")
+    /// - "group/subgroup/entry-name/password" -> (["group", "subgroup", "entry-name"], "Password")
+    fn parse_reference(value: &str) -> (Vec<&str>, &str) {
+        let parts: Vec<&str> = value.split('/').collect();
+
+        // Known field names (case-insensitive check, but return proper casing)
+        let known_fields = ["password", "username", "url", "notes", "title"];
+
+        if parts.len() == 1 {
+            // Just entry name, default to password
+            (parts, "Password")
+        } else {
+            // Check if the last part is a known field
+            let last = parts.last().unwrap().to_lowercase();
+            if known_fields.contains(&last.as_str()) {
+                let field = match last.as_str() {
+                    "password" => "Password",
+                    "username" => "UserName",
+                    "url" => "URL",
+                    "notes" => "Notes",
+                    "title" => "Title",
+                    _ => "Password",
+                };
+                (parts[..parts.len() - 1].to_vec(), field)
+            } else {
+                // Last part is not a known field, treat entire path as entry path
+                (parts, "Password")
+            }
+        }
+    }
+
+    /// Find an entry by path in the database
+    /// If path has multiple parts, navigate through groups
+    /// If path has one part, search all entries for matching title
+    fn find_entry<'a>(group: &'a Group, path: &[&str]) -> Option<&'a Entry> {
+        if path.is_empty() {
+            return None;
+        }
+
+        if path.len() == 1 {
+            // Search for entry by title in this group and all subgroups
+            let entry_name = path[0];
+            Self::find_entry_by_title(group, entry_name)
+        } else {
+            // Navigate to subgroup first
+            let group_name = path[0];
+            for node in &group.children {
+                if let Node::Group(subgroup) = node
+                    && subgroup.name == group_name
+                {
+                    return Self::find_entry(subgroup, &path[1..]);
+                }
+            }
+            None
+        }
+    }
+
+    /// Search for an entry by title in a group and all its subgroups
+    fn find_entry_by_title<'a>(group: &'a Group, title: &str) -> Option<&'a Entry> {
+        for node in &group.children {
+            match node {
+                Node::Entry(entry) => {
+                    if entry.get_title() == Some(title) {
+                        return Some(entry);
+                    }
+                }
+                Node::Group(subgroup) => {
+                    if let Some(entry) = Self::find_entry_by_title(subgroup, title) {
+                        return Some(entry);
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    /// Find or create entry by path for writing
+    /// Returns the entry name (title) that was used
+    fn find_or_create_entry(
+        group: &mut Group,
+        path: &[&str],
+        value: &str,
+        field: &str,
+    ) -> Result<String> {
+        if path.is_empty() {
+            return Err(FnoxError::Provider(
+                "Empty path for KeePass entry".to_string(),
+            ));
+        }
+
+        if path.len() == 1 {
+            // Create or update entry in this group
+            let entry_name = path[0];
+
+            // Look for existing entry
+            for node in &mut group.children {
+                if let Node::Entry(entry) = node
+                    && entry.get_title() == Some(entry_name)
+                {
+                    // Update existing entry
+                    entry
+                        .fields
+                        .insert(field.to_string(), Value::Unprotected(value.to_string()));
+                    return Ok(entry_name.to_string());
+                }
+            }
+
+            // Create new entry
+            let mut entry = Entry::new();
+            entry.fields.insert(
+                "Title".to_string(),
+                Value::Unprotected(entry_name.to_string()),
+            );
+            entry
+                .fields
+                .insert(field.to_string(), Value::Unprotected(value.to_string()));
+            group.children.push(Node::Entry(entry));
+            Ok(entry_name.to_string())
+        } else {
+            // Navigate to or create subgroup
+            let group_name = path[0];
+
+            // Look for existing group
+            for node in &mut group.children {
+                if let Node::Group(subgroup) = node
+                    && subgroup.name == group_name
+                {
+                    return Self::find_or_create_entry(subgroup, &path[1..], value, field);
+                }
+            }
+
+            // Create new group
+            let mut new_group = Group::new(group_name);
+            let result = Self::find_or_create_entry(&mut new_group, &path[1..], value, field)?;
+            group.children.push(Node::Group(new_group));
+            Ok(result)
+        }
+    }
+}
+
+#[async_trait]
+impl crate::providers::Provider for KeePassProvider {
+    fn capabilities(&self) -> Vec<ProviderCapability> {
+        vec![ProviderCapability::RemoteStorage]
+    }
+
+    async fn get_secret(&self, value: &str, _key_file: Option<&Path>) -> Result<String> {
+        let (entry_path, field) = Self::parse_reference(value);
+
+        tracing::debug!(
+            "Getting KeePass secret '{}' field '{}' from '{}'",
+            entry_path.join("/"),
+            field,
+            self.database_path.display()
+        );
+
+        let db = self.open_database()?;
+
+        let entry = Self::find_entry(&db.root, &entry_path).ok_or_else(|| {
+            FnoxError::Provider(format!(
+                "Entry '{}' not found in KeePass database",
+                entry_path.join("/")
+            ))
+        })?;
+
+        entry.get(field).map(|s| s.to_string()).ok_or_else(|| {
+            FnoxError::Provider(format!(
+                "Field '{}' not found in entry '{}'",
+                field,
+                entry_path.join("/")
+            ))
+        })
+    }
+
+    async fn put_secret(&self, key: &str, value: &str, _key_file: Option<&Path>) -> Result<String> {
+        // Parse the key to determine entry path and field
+        let (entry_path, field) = Self::parse_reference(key);
+
+        tracing::debug!(
+            "Storing KeePass secret '{}' field '{}' in '{}'",
+            entry_path.join("/"),
+            field,
+            self.database_path.display()
+        );
+
+        // Check if database exists; if not, create a new one
+        let mut db = if self.database_path.exists() {
+            self.open_database()?
+        } else {
+            // Create new KDBX4 database
+            tracing::info!(
+                "Creating new KeePass database at '{}'",
+                self.database_path.display()
+            );
+            Database::new(keepass::config::DatabaseConfig::default())
+        };
+
+        // Find or create the entry
+        let entry_name = Self::find_or_create_entry(&mut db.root, &entry_path, value, field)?;
+
+        // Save the database
+        self.save_database(&db)?;
+
+        tracing::debug!(
+            "Successfully stored secret in KeePass entry '{}'",
+            entry_name
+        );
+
+        // Return the reference to store in config
+        Ok(key.to_string())
+    }
+
+    async fn test_connection(&self) -> Result<()> {
+        tracing::debug!(
+            "Testing connection to KeePass database '{}'",
+            self.database_path.display()
+        );
+
+        // Try to open the database
+        self.open_database()?;
+
+        tracing::debug!("KeePass database connection test successful");
+        Ok(())
+    }
+}
+
+/// Environment variable for KeePass password
+static KEEPASS_PASSWORD: LazyLock<Option<String>> = LazyLock::new(|| {
+    std::env::var("FNOX_KEEPASS_PASSWORD")
+        .or_else(|_| std::env::var("KEEPASS_PASSWORD"))
+        .ok()
+});
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_reference_simple() {
+        let (path, field) = KeePassProvider::parse_reference("my-entry");
+        assert_eq!(path, vec!["my-entry"]);
+        assert_eq!(field, "Password");
+    }
+
+    #[test]
+    fn test_parse_reference_with_field() {
+        let (path, field) = KeePassProvider::parse_reference("my-entry/username");
+        assert_eq!(path, vec!["my-entry"]);
+        assert_eq!(field, "UserName");
+
+        let (path, field) = KeePassProvider::parse_reference("my-entry/password");
+        assert_eq!(path, vec!["my-entry"]);
+        assert_eq!(field, "Password");
+
+        let (path, field) = KeePassProvider::parse_reference("my-entry/url");
+        assert_eq!(path, vec!["my-entry"]);
+        assert_eq!(field, "URL");
+
+        let (path, field) = KeePassProvider::parse_reference("my-entry/notes");
+        assert_eq!(path, vec!["my-entry"]);
+        assert_eq!(field, "Notes");
+    }
+
+    #[test]
+    fn test_parse_reference_with_group() {
+        let (path, field) = KeePassProvider::parse_reference("group/my-entry");
+        assert_eq!(path, vec!["group", "my-entry"]);
+        assert_eq!(field, "Password");
+
+        let (path, field) = KeePassProvider::parse_reference("group/subgroup/my-entry");
+        assert_eq!(path, vec!["group", "subgroup", "my-entry"]);
+        assert_eq!(field, "Password");
+    }
+
+    #[test]
+    fn test_parse_reference_with_group_and_field() {
+        let (path, field) = KeePassProvider::parse_reference("group/my-entry/username");
+        assert_eq!(path, vec!["group", "my-entry"]);
+        assert_eq!(field, "UserName");
+
+        let (path, field) = KeePassProvider::parse_reference("group/subgroup/my-entry/password");
+        assert_eq!(path, vec!["group", "subgroup", "my-entry"]);
+        assert_eq!(field, "Password");
+    }
+}

--- a/src/providers/keepass.rs
+++ b/src/providers/keepass.rs
@@ -411,14 +411,13 @@ impl crate::providers::Provider for KeePassProvider {
         self.get_password()?;
 
         // Verify keyfile exists if configured
-        if let Some(keyfile_path) = &self.keyfile_path {
-            if !keyfile_path.exists() {
+        if let Some(keyfile_path) = &self.keyfile_path
+            && !keyfile_path.exists() {
                 return Err(FnoxError::Provider(format!(
                     "KeePass keyfile '{}' does not exist",
                     keyfile_path.display()
                 )));
             }
-        }
 
         // If database exists, verify we can open it
         // If it doesn't exist, that's OK - put_secret will create it

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -14,6 +14,7 @@ pub mod bitwarden;
 pub mod gcp_kms;
 pub mod gcp_sm;
 pub mod infisical;
+pub mod keepass;
 pub mod keychain;
 pub mod onepassword;
 pub mod password_store;
@@ -107,6 +108,15 @@ pub enum ProviderConfig {
         environment: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         path: Option<String>,
+    },
+    #[serde(rename = "keepass")]
+    #[strum(serialize = "keepass")]
+    KeePass {
+        database: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        keyfile: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        password: Option<String>,
     },
     #[serde(rename = "keychain")]
     #[strum(serialize = "keychain")]
@@ -292,6 +302,15 @@ pub fn get_provider(config: &ProviderConfig) -> Result<Box<dyn Provider>> {
             project_id.clone(),
             environment.clone(),
             path.clone(),
+        ))),
+        ProviderConfig::KeePass {
+            database,
+            keyfile,
+            password,
+        } => Ok(Box::new(keepass::KeePassProvider::new(
+            database.clone(),
+            keyfile.clone(),
+            password.clone(),
         ))),
         ProviderConfig::Keychain { service, prefix } => Ok(Box::new(
             keychain::KeychainProvider::new(service.clone(), prefix.clone()),

--- a/test/keepass.bats
+++ b/test/keepass.bats
@@ -382,3 +382,30 @@ EOF
 	assert_success
 	assert_output "fnox-env-value"
 }
+
+@test "fnox set fails when writing to title field" {
+	create_keepass_config
+
+	# Try to set a secret with title field - should fail
+	run "$FNOX_BIN" set TITLE_SECRET "some-title-value" --provider keepass --key-name "my-entry/title"
+	assert_failure
+	assert_output --partial "Cannot write to 'Title' field"
+}
+
+@test "fnox set updates entry in subgroup using just name" {
+	create_keepass_config
+
+	# Create an entry in a subgroup
+	run "$FNOX_BIN" set SUBGROUP_ENTRY "initial-value" --provider keepass --key-name "mygroup/nested-entry"
+	assert_success
+	track_entry_name "mygroup/nested-entry"
+
+	# Update using just the entry name (should find it recursively)
+	run "$FNOX_BIN" set SUBGROUP_ENTRY "updated-value" --provider keepass --key-name "nested-entry"
+	assert_success
+
+	# Verify the update worked (should get updated value)
+	run "$FNOX_BIN" get SUBGROUP_ENTRY
+	assert_success
+	assert_output "updated-value"
+}

--- a/test/keepass.bats
+++ b/test/keepass.bats
@@ -1,0 +1,384 @@
+#!/usr/bin/env bats
+#
+# KeePass Provider Tests
+#
+# These tests verify the KeePass provider integration with fnox.
+#
+# Prerequisites:
+#   - The keepass crate with save_kdbx4 feature (built into fnox)
+#   - Run tests: mise run test:bats -- test/keepass.bats
+#
+# Note: Tests create a temporary KeePass database for isolation.
+#
+
+setup() {
+	load 'test_helper/common_setup'
+	_common_setup
+
+	# Set up test KeePass database path
+	export KEEPASS_DB="$BATS_TEST_TMPDIR/test.kdbx"
+	export KEEPASS_PASSWORD="fnox-test-password"
+
+	# Track secrets for cleanup (entry names)
+	export TEST_ENTRY_NAMES=""
+}
+
+teardown() {
+	# Clean up test database
+	rm -f "$KEEPASS_DB" 2>/dev/null || true
+
+	_common_teardown
+}
+
+# Helper function to create a keepass provider config
+create_keepass_config() {
+	cat >"${FNOX_CONFIG_FILE:-fnox.toml}" <<EOF
+[providers.keepass]
+type = "keepass"
+database = "$KEEPASS_DB"
+
+[secrets]
+EOF
+}
+
+# Helper to track entry names for cleanup
+track_entry_name() {
+	local name="$1"
+	TEST_ENTRY_NAMES="${TEST_ENTRY_NAMES} $name"
+}
+
+@test "fnox set creates new KeePass database and stores secret" {
+	create_keepass_config
+
+	# Set a secret - this should create a new database
+	run "$FNOX_BIN" set MY_SECRET "my-secret-value" --provider keepass
+	assert_success
+	assert_output --partial "Set secret MY_SECRET"
+
+	track_entry_name "MY_SECRET"
+
+	# Verify the config contains only a reference (not the value)
+	run cat "${FNOX_CONFIG_FILE}"
+	assert_success
+	assert_output --partial 'MY_SECRET'
+	assert_output --partial 'provider = "keepass"'
+	assert_output --partial 'value = "MY_SECRET"'
+	refute_output --partial "my-secret-value"
+
+	# Verify the database file was created
+	[ -f "$KEEPASS_DB" ]
+}
+
+@test "fnox get retrieves secret from KeePass database" {
+	create_keepass_config
+
+	# Set a secret
+	run "$FNOX_BIN" set TEST_GET "test-value-123" --provider keepass
+	assert_success
+	track_entry_name "TEST_GET"
+
+	# Get the secret back
+	run "$FNOX_BIN" get TEST_GET
+	assert_success
+	assert_output "test-value-123"
+}
+
+@test "fnox set and get with username field" {
+	create_keepass_config
+
+	# Set a secret with custom key-name that includes field
+	run "$FNOX_BIN" set USER_SECRET "admin@example.com" --provider keepass --key-name "my-entry/username"
+	assert_success
+	track_entry_name "my-entry"
+
+	# Get the username field back
+	run "$FNOX_BIN" get USER_SECRET
+	assert_success
+	assert_output "admin@example.com"
+}
+
+@test "fnox set and get with url field" {
+	create_keepass_config
+
+	# Set a URL
+	run "$FNOX_BIN" set URL_SECRET "https://api.example.com" --provider keepass --key-name "api-entry/url"
+	assert_success
+	track_entry_name "api-entry"
+
+	# Get the URL back
+	run "$FNOX_BIN" get URL_SECRET
+	assert_success
+	assert_output "https://api.example.com"
+}
+
+@test "fnox set and get with notes field" {
+	create_keepass_config
+
+	# Set notes
+	run "$FNOX_BIN" set NOTES_SECRET "This is a test note" --provider keepass --key-name "notes-entry/notes"
+	assert_success
+	track_entry_name "notes-entry"
+
+	# Get the notes back
+	run "$FNOX_BIN" get NOTES_SECRET
+	assert_success
+	assert_output "This is a test note"
+}
+
+@test "fnox get fails with non-existent entry" {
+	create_keepass_config
+
+	# First create the database with at least one entry
+	run "$FNOX_BIN" set EXISTING "existing-value" --provider keepass
+	assert_success
+	track_entry_name "EXISTING"
+
+	# Manually add a reference to a non-existent entry
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
+
+[secrets.NONEXISTENT]
+provider = "keepass"
+value = "does-not-exist"
+EOF
+
+	# Try to get non-existent entry
+	run "$FNOX_BIN" get NONEXISTENT
+	assert_failure
+	assert_output --partial "not found"
+}
+
+@test "fnox set with special characters" {
+	create_keepass_config
+
+	local secret_value='p@ssw0rd!#$%^&*()_+-={}[]|\:";'\''<>?,./~`'
+
+	# Set a secret with special characters
+	run "$FNOX_BIN" set SPECIAL_CHARS "$secret_value" --provider keepass
+	assert_success
+	track_entry_name "SPECIAL_CHARS"
+
+	# Get it back
+	run "$FNOX_BIN" get SPECIAL_CHARS
+	assert_success
+	assert_output "$secret_value"
+}
+
+@test "fnox set updates existing entry" {
+	create_keepass_config
+
+	# Set initial value
+	run "$FNOX_BIN" set UPDATE_TEST "initial-value" --provider keepass
+	assert_success
+	track_entry_name "UPDATE_TEST"
+
+	# Update the value
+	run "$FNOX_BIN" set UPDATE_TEST "updated-value" --provider keepass
+	assert_success
+
+	# Get the updated value
+	run "$FNOX_BIN" get UPDATE_TEST
+	assert_success
+	assert_output "updated-value"
+}
+
+@test "fnox list shows KeePass secrets" {
+	create_keepass_config
+
+	# Set multiple secrets
+	run "$FNOX_BIN" set SECRET1 "value1" --provider keepass --description "First secret"
+	assert_success
+	track_entry_name "SECRET1"
+
+	run "$FNOX_BIN" set SECRET2 "value2" --provider keepass --description "Second secret"
+	assert_success
+	track_entry_name "SECRET2"
+
+	# List secrets
+	run "$FNOX_BIN" list
+	assert_success
+	assert_output --partial "SECRET1"
+	assert_output --partial "SECRET2"
+	assert_output --partial "First secret"
+	assert_output --partial "Second secret"
+}
+
+@test "fnox exec with KeePass secrets" {
+	create_keepass_config
+
+	# Set a secret
+	run "$FNOX_BIN" set EXEC_TEST "exec-value" --provider keepass
+	assert_success
+	track_entry_name "EXEC_TEST"
+
+	# Use it in exec (redirect stderr to filter warnings)
+	run bash -c "'$FNOX_BIN' exec -- bash -c 'echo \$EXEC_TEST' 2>/dev/null"
+	assert_success
+	assert_output "exec-value"
+}
+
+@test "fnox set with description metadata" {
+	create_keepass_config
+
+	# Set secret with description
+	run "$FNOX_BIN" set DESCRIBED "value" --provider keepass --description "Test description"
+	assert_success
+	track_entry_name "DESCRIBED"
+
+	# Verify description in list
+	run "$FNOX_BIN" list
+	assert_success
+	assert_output --partial "DESCRIBED"
+	assert_output --partial "Test description"
+}
+
+@test "fnox get with JSON-like value" {
+	create_keepass_config
+
+	local json_value='{"api_key":"test123","endpoint":"https://api.example.com"}'
+
+	# Set JSON value
+	run "$FNOX_BIN" set JSON_SECRET "$json_value" --provider keepass
+	assert_success
+	track_entry_name "JSON_SECRET"
+
+	# Get it back
+	run "$FNOX_BIN" get JSON_SECRET
+	assert_success
+	assert_output "$json_value"
+}
+
+@test "fnox set reads from stdin" {
+	create_keepass_config
+
+	# Set secret from stdin (using bash -c for stdin pipe)
+	run bash -c "echo 'stdin-value' | '$FNOX_BIN' set STDIN_SECRET --provider keepass"
+	assert_success
+	track_entry_name "STDIN_SECRET"
+
+	# Get it back
+	run "$FNOX_BIN" get STDIN_SECRET
+	assert_success
+	assert_output "stdin-value"
+}
+
+@test "keepass provider with long values" {
+	create_keepass_config
+
+	# Create a long value (4KB)
+	local long_value
+	long_value=$(python3 -c "print('a' * 4096)")
+
+	# Set long value
+	run "$FNOX_BIN" set LONG_SECRET "$long_value" --provider keepass
+	assert_success
+	track_entry_name "LONG_SECRET"
+
+	# Get it back
+	run "$FNOX_BIN" get LONG_SECRET
+	assert_success
+	assert_output "$long_value"
+}
+
+@test "fnox check detects missing KeePass entries" {
+	create_keepass_config
+
+	# First create the database with at least one entry
+	run "$FNOX_BIN" set EXISTING "existing-value" --provider keepass
+	assert_success
+	track_entry_name "EXISTING"
+
+	# Add reference without actually storing in KeePass
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
+
+[secrets.MISSING_SECRET]
+provider = "keepass"
+value = "not-in-keepass"
+if_missing = "error"
+EOF
+
+	# Check should detect the missing secret
+	run "$FNOX_BIN" check
+	assert_failure
+	assert_output --partial "MISSING_SECRET"
+}
+
+@test "fnox set with group path" {
+	create_keepass_config
+
+	# Set a secret with group path
+	run "$FNOX_BIN" set GROUPED_SECRET "grouped-value" --provider keepass --key-name "work/api-key"
+	assert_success
+	track_entry_name "work/api-key"
+
+	# Get it back
+	run "$FNOX_BIN" get GROUPED_SECRET
+	assert_success
+	assert_output "grouped-value"
+}
+
+@test "fnox set with nested group path" {
+	create_keepass_config
+
+	# Set a secret with nested group path
+	run "$FNOX_BIN" set NESTED_SECRET "nested-value" --provider keepass --key-name "company/project/database/password"
+	assert_success
+	track_entry_name "company/project/database"
+
+	# Get it back
+	run "$FNOX_BIN" get NESTED_SECRET
+	assert_success
+	assert_output "nested-value"
+}
+
+@test "fnox fails with wrong password" {
+	create_keepass_config
+
+	# First create the database
+	run "$FNOX_BIN" set CREATE_DB "test" --provider keepass
+	assert_success
+	track_entry_name "CREATE_DB"
+
+	# Change password env var to wrong value
+	export KEEPASS_PASSWORD="wrong-password"
+
+	# Try to get - should fail
+	run "$FNOX_BIN" get CREATE_DB
+	assert_failure
+	assert_output --partial "Failed to open KeePass database"
+}
+
+@test "fnox fails with missing database file for get" {
+	# Create config pointing to non-existent database
+	cat >"${FNOX_CONFIG_FILE:-fnox.toml}" <<EOF
+[providers.keepass]
+type = "keepass"
+database = "$BATS_TEST_TMPDIR/nonexistent.kdbx"
+
+[secrets.MISSING_DB]
+provider = "keepass"
+value = "some-entry"
+EOF
+
+	# Try to get - should fail because database doesn't exist
+	run "$FNOX_BIN" get MISSING_DB
+	assert_failure
+	assert_output --partial "Failed to open KeePass database"
+}
+
+@test "keepass provider respects FNOX_KEEPASS_PASSWORD" {
+	create_keepass_config
+
+	# Use FNOX_KEEPASS_PASSWORD instead of KEEPASS_PASSWORD
+	unset KEEPASS_PASSWORD
+	export FNOX_KEEPASS_PASSWORD="fnox-test-password"
+
+	# Set a secret
+	run "$FNOX_BIN" set FNOX_ENV_TEST "fnox-env-value" --provider keepass
+	assert_success
+	track_entry_name "FNOX_ENV_TEST"
+
+	# Get it back
+	run "$FNOX_BIN" get FNOX_ENV_TEST
+	assert_success
+	assert_output "fnox-env-value"
+}

--- a/test/keepass.bats
+++ b/test/keepass.bats
@@ -409,3 +409,29 @@ EOF
 	assert_success
 	assert_output "updated-value"
 }
+
+@test "fnox set creates parent directories for new database" {
+	# Use a nested path that doesn't exist
+	local nested_db="$BATS_TEST_TMPDIR/nested/dirs/test.kdbx"
+
+	cat >"${FNOX_CONFIG_FILE:-fnox.toml}" <<EOF
+[providers.keepass]
+type = "keepass"
+database = "$nested_db"
+
+[secrets]
+EOF
+
+	# Set a secret - should create parent directories and database
+	run "$FNOX_BIN" set NESTED_DIR_SECRET "nested-value" --provider keepass
+	assert_success
+	assert_output --partial "Set secret NESTED_DIR_SECRET"
+
+	# Verify the database file was created in the nested directory
+	[ -f "$nested_db" ]
+
+	# Verify we can read the secret back
+	run "$FNOX_BIN" get NESTED_DIR_SECRET
+	assert_success
+	assert_output "nested-value"
+}


### PR DESCRIPTION
## Summary

- Adds KeePass provider support using the `keepass-rs` library with KDBX4 save support
- Implements `RemoteStorage` capability for read/write operations to KeePass database files
- Supports password authentication via `FNOX_KEEPASS_PASSWORD` or `KEEPASS_PASSWORD` env vars, or config
- Supports optional keyfile authentication
- Supports both simple entry references (`entry-name`) and full path references (`group/subgroup/entry/field`)
- Auto-creates KDBX4 database if it doesn't exist

Closes #50

## Test plan

- [x] 20 bats integration tests added in `test/keepass.bats`
- [x] 4 unit tests added for reference parsing
- [x] All existing tests pass
- [x] CI workflow updated with `KEEPASS_PASSWORD` env var for test execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a KeePass remote-storage provider with KDBX4 read/write, env/keyfile auth, path-based field access, CLI integration, tests, and CI env setup.
> 
> - **Providers**:
>   - **KeePass** (`src/providers/keepass.rs`): New provider implementing `RemoteStorage` for `.kdbx` files (KDBX4 save), with password from `FNOX_KEEPASS_PASSWORD`/`KEEPASS_PASSWORD` or config, optional keyfile, atomic saves, path/field parsing (e.g., `group/entry/username`).
>   - **Config wiring** (`src/providers/mod.rs`): Added `ProviderConfig::KeePass` and `get_provider` integration.
> - **CLI**:
>   - **Set command** (`src/commands/set.rs`): Integrates KeePass in remote-storage flow; supports `--key-name` for entry/field paths; stores reference key in config.
> - **CI**:
>   - **Workflow** (`.github/workflows/ci.yml`): Exposes `KEEPASS_PASSWORD` for bats tests.
> - **Tests**:
>   - **Integration** (`test/keepass.bats`): Adds comprehensive bats suite for create/get/update, fields, groups, long/special values, missing entries, env var handling, and nested paths.
>   - **Unit** (`src/providers/keepass.rs`): Adds parsing tests for entry/field resolution.
> - **Dependencies**:
>   - Adds `keepass` crate (with `save_kdbx4`) and transitive requirements in `Cargo.toml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit afbbf7bbfac96959e13c09e567d817118289df31. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->