### PR TITLE
refactor: simplify Provider trait by removing key_file parameter

### DIFF
--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -920,11 +920,11 @@
       {
         "name": "age-key-file",
         "usage": "--age-key-file <AGE_KEY_FILE>",
-        "help": "Path to age key file for decryption",
-        "help_first_line": "Path to age key file for decryption",
+        "help": "Path to age key file for decryption (deprecated: use provider config instead)",
+        "help_first_line": "Path to age key file for decryption (deprecated: use provider config instead)",
         "short": [],
         "long": ["age-key-file"],
-        "hide": false,
+        "hide": true,
         "global": true,
         "arg": {
           "name": "AGE_KEY_FILE",

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -22,10 +22,6 @@ Profile to use (default: default, or FNOX_PROFILE env var)
 
 Enable verbose logging
 
-### `--age-key-file <AGE_KEY_FILE>`
-
-Path to age key file for decryption
-
 ### `--if-missing <IF_MISSING>`
 
 What to do if a secret is missing (error, warn, ignore)

--- a/fnox.usage.kdl
+++ b/fnox.usage.kdl
@@ -11,7 +11,7 @@ flag "-P --profile" help="Profile to use (default: default, or FNOX_PROFILE env 
     arg <PROFILE>
 }
 flag "-v --verbose" help="Enable verbose logging" global=#true
-flag --age-key-file help="Path to age key file for decryption" global=#true {
+flag --age-key-file help="Path to age key file for decryption (deprecated: use provider config instead)" hide=#true global=#true {
     arg <AGE_KEY_FILE>
 }
 flag --if-missing help="What to do if a secret is missing (error, warn, ignore)" global=#true {

--- a/src/commands/check.rs
+++ b/src/commands/check.rs
@@ -82,7 +82,6 @@ impl CheckCommand {
                                 &profile,
                                 &name,
                                 &secret_config,
-                                cli.age_key_file.as_deref(),
                             )
                             .await
                             {

--- a/src/commands/ci_redact.rs
+++ b/src/commands/ci_redact.rs
@@ -76,15 +76,7 @@ impl CiRedactCommand {
 
         // Resolve and redact each secret
         for (key, secret_config) in &profile_secrets {
-            match resolve_secret(
-                &config,
-                &profile,
-                key,
-                secret_config,
-                cli.age_key_file.as_deref(),
-            )
-            .await
-            {
+            match resolve_secret(&config, &profile, key, secret_config).await {
                 Ok(Some(value)) => {
                     // Output CI-specific mask command
                     mask_fn(key, &value);

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -30,13 +30,7 @@ impl ExecCommand {
         }
 
         // Resolve secrets using batch resolution for better performance
-        let resolved_secrets = resolve_secrets_batch(
-            &config,
-            &profile,
-            &profile_secrets,
-            cli.age_key_file.as_deref(),
-        )
-        .await?;
+        let resolved_secrets = resolve_secrets_batch(&config, &profile, &profile_secrets).await?;
 
         // Add resolved secrets as environment variables
         for (key, value) in resolved_secrets {

--- a/src/commands/export.rs
+++ b/src/commands/export.rs
@@ -56,13 +56,7 @@ impl ExportCommand {
         let profile_secrets = config.get_secrets(&profile)?;
 
         // Resolve secrets using batch resolution for better performance
-        let resolved_secrets = resolve_secrets_batch(
-            &config,
-            &profile,
-            &profile_secrets,
-            cli.age_key_file.as_deref(),
-        )
-        .await?;
+        let resolved_secrets = resolve_secrets_batch(&config, &profile, &profile_secrets).await?;
 
         // Build secrets map, preserving insertion order
         let mut secrets = IndexMap::new();

--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -31,15 +31,7 @@ impl GetCommand {
                 })?;
 
         // Resolve the secret using centralized resolver
-        match resolve_secret(
-            &config,
-            &profile,
-            &self.key,
-            secret_config,
-            cli.age_key_file.as_deref(),
-        )
-        .await
-        {
+        match resolve_secret(&config, &profile, &self.key, secret_config).await {
             Ok(Some(value)) => {
                 println!("{}", value);
                 Ok(())

--- a/src/commands/hook_env.rs
+++ b/src/commands/hook_env.rs
@@ -180,11 +180,8 @@ async fn load_secrets_from_config() -> Result<HashMap<String, String>> {
         .get_secrets(profile_name)
         .map_err(|e| anyhow::anyhow!("Failed to get secrets: {}", e))?;
 
-    let age_key_file = settings.age_key_file.as_deref();
-
     // Use batch resolution for better performance
-    let resolved = match resolve_secrets_batch(&config, profile_name, &secrets, age_key_file).await
-    {
+    let resolved = match resolve_secrets_batch(&config, profile_name, &secrets).await {
         Ok(r) => r,
         Err(e) => {
             // Log error but don't fail the shell hook

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -169,13 +169,7 @@ impl ImportCommand {
                 // Handle encryption or remote storage based on provider capabilities
                 if is_encryption_provider {
                     // Encrypt the value
-                    match provider
-                        .encrypt(
-                            &value,
-                            cli.age_key_file.as_ref().map(PathBuf::from).as_deref(),
-                        )
-                        .await
-                    {
+                    match provider.encrypt(&value).await {
                         Ok(encrypted) => {
                             secret_config.value = Some(encrypted);
                         }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -200,6 +200,7 @@ impl InitCommand {
                     name,
                     ProviderConfig::AgeEncryption {
                         recipients: vec![recipient],
+                        key_file: None,
                     },
                 ))
             }

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -116,15 +116,7 @@ impl ListCommand {
 
         // Resolve secrets if values are requested
         let resolved_values = if self.values {
-            Some(
-                resolve_secrets_batch(
-                    &config,
-                    &profile,
-                    &profile_secrets,
-                    cli.age_key_file.as_deref(),
-                )
-                .await?,
-            )
+            Some(resolve_secrets_batch(&config, &profile, &profile_secrets).await?)
         } else {
             None
         };

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -45,8 +45,8 @@ pub struct Cli {
     #[arg(short, long, global = true)]
     pub verbose: bool,
 
-    /// Path to age key file for decryption
-    #[arg(long, global = true)]
+    /// Path to age key file for decryption (deprecated: use provider config instead)
+    #[arg(long, global = true, hide = true)]
     pub age_key_file: Option<PathBuf>,
 
     /// What to do if a secret is missing (error, warn, ignore)

--- a/src/commands/provider/add.rs
+++ b/src/commands/provider/add.rs
@@ -72,6 +72,7 @@ impl AddCommand {
             },
             ProviderType::Age => crate::config::ProviderConfig::AgeEncryption {
                 recipients: vec!["age1...".to_string()],
+                key_file: None,
             },
             ProviderType::Infisical => crate::config::ProviderConfig::Infisical {
                 project_id: Some("your-project-id".to_string()),

--- a/src/commands/set.rs
+++ b/src/commands/set.rs
@@ -3,7 +3,6 @@ use crate::config::{Config, IfMissing, ProviderConfig};
 use crate::error::{FnoxError, Result};
 use clap::Args;
 use std::io::{self, Read};
-use std::path::PathBuf;
 
 #[derive(Debug, Args)]
 #[command(visible_aliases = ["s"])]
@@ -112,13 +111,7 @@ impl SetCommand {
                         );
 
                         // Encrypt with the provider
-                        match provider
-                            .encrypt(
-                                value,
-                                cli.age_key_file.as_ref().map(PathBuf::from).as_deref(),
-                            )
-                            .await
-                        {
+                        match provider.encrypt(value).await {
                             Ok(encrypted) => (Some(encrypted), None),
                             Err(e) => {
                                 // Provider doesn't support encryption, store plaintext
@@ -177,7 +170,7 @@ impl SetCommand {
                                     );
 
                                 let key_name = self.key_name.as_deref().unwrap_or(&self.key);
-                                let key = pass_provider.put_secret(key_name, value, None).await?;
+                                let key = pass_provider.put_secret(key_name, value).await?;
 
                                 (None, Some(key))
                             }
@@ -208,8 +201,7 @@ impl SetCommand {
                                     );
 
                                 let key_name = self.key_name.as_deref().unwrap_or(&self.key);
-                                let key =
-                                    keepass_provider.put_secret(key_name, value, None).await?;
+                                let key = keepass_provider.put_secret(key_name, value).await?;
 
                                 (None, Some(key))
                             }

--- a/src/providers/aws_kms.rs
+++ b/src/providers/aws_kms.rs
@@ -3,7 +3,6 @@ use async_trait::async_trait;
 use aws_config::BehaviorVersion;
 use aws_sdk_kms::Client;
 use aws_sdk_kms::primitives::Blob;
-use std::path::Path;
 
 pub struct AwsKmsProvider {
     key_id: String,
@@ -61,12 +60,12 @@ impl crate::providers::Provider for AwsKmsProvider {
         vec![crate::providers::ProviderCapability::Encryption]
     }
 
-    async fn get_secret(&self, value: &str, _key_file: Option<&Path>) -> Result<String> {
+    async fn get_secret(&self, value: &str) -> Result<String> {
         // value contains the base64-encoded encrypted blob
         self.decrypt(value).await
     }
 
-    async fn encrypt(&self, plaintext: &str, _key_file: Option<&Path>) -> Result<String> {
+    async fn encrypt(&self, plaintext: &str) -> Result<String> {
         let client = self.create_client().await?;
 
         let result = client

--- a/src/providers/aws_sm.rs
+++ b/src/providers/aws_sm.rs
@@ -3,7 +3,6 @@ use async_trait::async_trait;
 use aws_config::BehaviorVersion;
 use aws_sdk_secretsmanager::Client;
 use std::collections::HashMap;
-use std::path::Path;
 
 /// Extract the secret name from an AWS Secrets Manager ARN.
 /// ARN format: arn:aws:secretsmanager:region:account:secret:name-SUFFIX
@@ -139,7 +138,7 @@ impl crate::providers::Provider for AwsSecretsManagerProvider {
         vec![crate::providers::ProviderCapability::RemoteStorage]
     }
 
-    async fn get_secret(&self, value: &str, _key_file: Option<&Path>) -> Result<String> {
+    async fn get_secret(&self, value: &str) -> Result<String> {
         let secret_name = self.get_secret_name(value);
         tracing::debug!(
             "Getting secret '{}' from AWS Secrets Manager in region '{}'",
@@ -153,7 +152,6 @@ impl crate::providers::Provider for AwsSecretsManagerProvider {
     async fn get_secrets_batch(
         &self,
         secrets: &[(String, String)],
-        _key_file: Option<&Path>,
     ) -> HashMap<String, Result<String>> {
         tracing::debug!(
             "Getting {} secrets from AWS Secrets Manager using batch API",
@@ -310,7 +308,7 @@ impl crate::providers::Provider for AwsSecretsManagerProvider {
         Ok(())
     }
 
-    async fn put_secret(&self, key: &str, value: &str, _key_file: Option<&Path>) -> Result<String> {
+    async fn put_secret(&self, key: &str, value: &str) -> Result<String> {
         let secret_name = self.get_secret_name(key);
         self.put_secret(&secret_name, value).await?;
         // Return the key name (without prefix) to store in config

--- a/src/providers/azure_kms.rs
+++ b/src/providers/azure_kms.rs
@@ -4,7 +4,6 @@ use azure_core::auth::TokenCredential;
 use azure_identity::{DefaultAzureCredential, TokenCredentialOptions};
 use azure_security_keyvault::KeyClient;
 use azure_security_keyvault::prelude::*;
-use std::path::Path;
 use std::sync::Arc;
 
 pub struct AzureKeyVaultProvider {
@@ -79,12 +78,12 @@ impl crate::providers::Provider for AzureKeyVaultProvider {
         vec![crate::providers::ProviderCapability::Encryption]
     }
 
-    async fn get_secret(&self, value: &str, _key_file: Option<&Path>) -> Result<String> {
+    async fn get_secret(&self, value: &str) -> Result<String> {
         // value contains the base64-encoded encrypted blob
         self.decrypt(value).await
     }
 
-    async fn encrypt(&self, plaintext: &str, _key_file: Option<&Path>) -> Result<String> {
+    async fn encrypt(&self, plaintext: &str) -> Result<String> {
         let client = self.create_client().await?;
 
         // Create encrypt parameters with RSA-OAEP-256 algorithm

--- a/src/providers/azure_sm.rs
+++ b/src/providers/azure_sm.rs
@@ -3,7 +3,6 @@ use async_trait::async_trait;
 use azure_core::auth::TokenCredential;
 use azure_identity::{DefaultAzureCredential, TokenCredentialOptions};
 use azure_security_keyvault::SecretClient;
-use std::path::Path;
 use std::sync::Arc;
 
 pub struct AzureSecretsManagerProvider {
@@ -78,7 +77,7 @@ impl crate::providers::Provider for AzureSecretsManagerProvider {
         vec![crate::providers::ProviderCapability::RemoteStorage]
     }
 
-    async fn get_secret(&self, value: &str, _key_file: Option<&Path>) -> Result<String> {
+    async fn get_secret(&self, value: &str) -> Result<String> {
         let secret_name = self.get_secret_name(value);
         tracing::debug!(
             "Getting secret '{}' from Azure Key Vault '{}'",
@@ -104,7 +103,7 @@ impl crate::providers::Provider for AzureSecretsManagerProvider {
         Ok(())
     }
 
-    async fn put_secret(&self, key: &str, value: &str, _key_file: Option<&Path>) -> Result<String> {
+    async fn put_secret(&self, key: &str, value: &str) -> Result<String> {
         let secret_name = self.get_secret_name(key);
         self.put_secret(&secret_name, value).await?;
         // Return the key name (without prefix) to store in config

--- a/src/providers/bitwarden.rs
+++ b/src/providers/bitwarden.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::process::Command;
-use std::{path::Path, sync::LazyLock};
+use std::sync::LazyLock;
 
 pub struct BitwardenProvider {
     collection: Option<String>,
@@ -206,7 +206,7 @@ impl BitwardenProvider {
 
 #[async_trait]
 impl crate::providers::Provider for BitwardenProvider {
-    async fn get_secret(&self, value: &str, _key_file: Option<&Path>) -> Result<String> {
+    async fn get_secret(&self, value: &str) -> Result<String> {
         tracing::debug!("Getting secret '{}' from Bitwarden", value);
 
         // Parse value as "item/field" or just "item"
@@ -236,7 +236,7 @@ impl crate::providers::Provider for BitwardenProvider {
 }
 
 static BW_SESSION_TOKEN: LazyLock<Option<String>> = LazyLock::new(|| {
-    env::var("FNOX_BW_SESSION_TOKEN")
+    env::var("FNOX_BW_SESSION")
         .or_else(|_| env::var("BW_SESSION"))
         .ok()
 });

--- a/src/providers/gcp_kms.rs
+++ b/src/providers/gcp_kms.rs
@@ -2,7 +2,6 @@ use crate::error::{FnoxError, Result};
 use async_trait::async_trait;
 use google_cloud_kms::client::{Client, ClientConfig};
 use google_cloud_kms::grpc::kms::v1::{DecryptRequest, EncryptRequest, GetCryptoKeyRequest};
-use std::path::Path;
 
 pub struct GcpKmsProvider {
     project: String,
@@ -76,12 +75,12 @@ impl crate::providers::Provider for GcpKmsProvider {
         vec![crate::providers::ProviderCapability::Encryption]
     }
 
-    async fn get_secret(&self, value: &str, _key_file: Option<&Path>) -> Result<String> {
+    async fn get_secret(&self, value: &str) -> Result<String> {
         // value contains the base64-encoded encrypted blob
         self.decrypt(value).await
     }
 
-    async fn encrypt(&self, plaintext: &str, _key_file: Option<&Path>) -> Result<String> {
+    async fn encrypt(&self, plaintext: &str) -> Result<String> {
         let client = self.create_client().await?;
 
         let request = EncryptRequest {

--- a/src/providers/gcp_sm.rs
+++ b/src/providers/gcp_sm.rs
@@ -1,7 +1,6 @@
 use crate::error::{FnoxError, Result};
 use async_trait::async_trait;
 use google_cloud_secretmanager_v1::client::SecretManagerService;
-use std::path::Path;
 
 pub struct GoogleSecretManagerProvider {
     project: String,
@@ -61,7 +60,7 @@ impl crate::providers::Provider for GoogleSecretManagerProvider {
         vec![crate::providers::ProviderCapability::RemoteStorage]
     }
 
-    async fn get_secret(&self, value: &str, _key_file: Option<&Path>) -> Result<String> {
+    async fn get_secret(&self, value: &str) -> Result<String> {
         let client = self.create_client().await?;
         let secret_name = self.build_secret_name(value);
 
@@ -106,7 +105,7 @@ impl crate::providers::Provider for GoogleSecretManagerProvider {
         Ok(())
     }
 
-    async fn put_secret(&self, key: &str, value: &str, _key_file: Option<&Path>) -> Result<String> {
+    async fn put_secret(&self, key: &str, value: &str) -> Result<String> {
         let secret_id = self.get_secret_id(key);
         self.put_secret_value(&secret_id, value).await?;
         // Return the key name (without prefix) to store in config

--- a/src/providers/infisical.rs
+++ b/src/providers/infisical.rs
@@ -2,7 +2,6 @@ use crate::env;
 use crate::error::{FnoxError, Result};
 use async_trait::async_trait;
 use std::collections::HashMap;
-use std::path::Path;
 use std::process::Command;
 use std::sync::{LazyLock, Mutex};
 
@@ -171,7 +170,7 @@ impl InfisicalProvider {
 
 #[async_trait]
 impl crate::providers::Provider for InfisicalProvider {
-    async fn get_secret(&self, value: &str, _key_file: Option<&Path>) -> Result<String> {
+    async fn get_secret(&self, value: &str) -> Result<String> {
         tracing::debug!("Getting secret '{}' from Infisical", value);
 
         // Build the command: infisical secrets get <name> --output json
@@ -252,7 +251,6 @@ impl crate::providers::Provider for InfisicalProvider {
     async fn get_secrets_batch(
         &self,
         secrets: &[(String, String)],
-        _key_file: Option<&Path>,
     ) -> HashMap<String, Result<String>> {
         // If empty or single secret, fall back to individual get
         if secrets.is_empty() {
@@ -260,7 +258,7 @@ impl crate::providers::Provider for InfisicalProvider {
         }
         if secrets.len() == 1 {
             let (key, value) = &secrets[0];
-            let result = self.get_secret(value, _key_file).await;
+            let result = self.get_secret(value).await;
             let mut map = HashMap::new();
             map.insert(key.clone(), result);
             return map;

--- a/src/providers/keepass.rs
+++ b/src/providers/keepass.rs
@@ -335,7 +335,7 @@ impl crate::providers::Provider for KeePassProvider {
         vec![ProviderCapability::RemoteStorage]
     }
 
-    async fn get_secret(&self, value: &str, _key_file: Option<&Path>) -> Result<String> {
+    async fn get_secret(&self, value: &str) -> Result<String> {
         let (entry_path, field) = Self::parse_reference(value);
 
         tracing::debug!(
@@ -363,7 +363,7 @@ impl crate::providers::Provider for KeePassProvider {
         })
     }
 
-    async fn put_secret(&self, key: &str, value: &str, _key_file: Option<&Path>) -> Result<String> {
+    async fn put_secret(&self, key: &str, value: &str) -> Result<String> {
         // Parse the key to determine entry path and field
         let (entry_path, field) = Self::parse_reference(key);
 

--- a/src/providers/keychain.rs
+++ b/src/providers/keychain.rs
@@ -1,7 +1,6 @@
 use crate::error::{FnoxError, Result};
 use async_trait::async_trait;
 use keyring::Entry;
-use std::path::Path;
 
 pub struct KeychainProvider {
     service: String,
@@ -66,7 +65,7 @@ impl crate::providers::Provider for KeychainProvider {
         vec![crate::providers::ProviderCapability::RemoteStorage]
     }
 
-    async fn get_secret(&self, value: &str, _key_file: Option<&Path>) -> Result<String> {
+    async fn get_secret(&self, value: &str) -> Result<String> {
         let entry = self.create_entry(value)?;
         let full_key = self.build_key_name(value);
 
@@ -111,7 +110,7 @@ impl crate::providers::Provider for KeychainProvider {
         Ok(())
     }
 
-    async fn put_secret(&self, key: &str, value: &str, _key_file: Option<&Path>) -> Result<String> {
+    async fn put_secret(&self, key: &str, value: &str) -> Result<String> {
         self.put_secret(key, value).await?;
         // Return the key name to store in config
         Ok(key.to_string())
@@ -132,7 +131,7 @@ mod tests {
         assert!(result.is_ok(), "Failed to set secret: {:?}", result.err());
 
         // Get it back
-        let result = provider.get_secret("test_key", None).await;
+        let result = provider.get_secret("test_key").await;
         assert!(result.is_ok(), "Failed to get secret: {:?}", result.err());
         assert_eq!(result.unwrap(), "test_value");
 

--- a/src/providers/onepassword.rs
+++ b/src/providers/onepassword.rs
@@ -5,7 +5,7 @@ use regex::Regex;
 use std::collections::HashMap;
 use std::io::Write;
 use std::process::{Command, Stdio};
-use std::{path::Path, sync::LazyLock};
+use std::sync::LazyLock;
 
 /// Precompiled regex to remove leading error prefixes from stderr output of `op`.
 /// [ERROR] YYYY/MM/DD HH:MM:SS message
@@ -164,7 +164,7 @@ impl OnePasswordProvider {
 
 #[async_trait]
 impl crate::providers::Provider for OnePasswordProvider {
-    async fn get_secret(&self, value: &str, _key_file: Option<&Path>) -> Result<String> {
+    async fn get_secret(&self, value: &str) -> Result<String> {
         tracing::debug!("Getting secret '{}' from 1Password", value);
 
         let reference = self.value_to_reference(value)?;
@@ -177,7 +177,6 @@ impl crate::providers::Provider for OnePasswordProvider {
     async fn get_secrets_batch(
         &self,
         secrets: &[(String, String)],
-        _key_file: Option<&Path>,
     ) -> HashMap<String, Result<String>> {
         tracing::debug!(
             "Getting {} secrets from 1Password using batch mode",
@@ -187,7 +186,7 @@ impl crate::providers::Provider for OnePasswordProvider {
         // If only one secret, fall back to single get_secret
         if secrets.len() == 1 {
             let (key, value) = &secrets[0];
-            let result = self.get_secret(value, None).await;
+            let result = self.get_secret(value).await;
             let mut map = HashMap::new();
             map.insert(key.clone(), result);
             return map;
@@ -280,7 +279,7 @@ impl crate::providers::Provider for OnePasswordProvider {
                 tracing::warn!("op inject failed, falling back to individual calls: {}", e);
                 for (key, value) in secrets {
                     if !results.contains_key(key) {
-                        let result = self.get_secret(value, None).await;
+                        let result = self.get_secret(value).await;
                         results.insert(key.clone(), result);
                     }
                 }

--- a/src/providers/password_store.rs
+++ b/src/providers/password_store.rs
@@ -1,7 +1,6 @@
 use crate::error::{FnoxError, Result};
 use crate::providers::ProviderCapability;
 use async_trait::async_trait;
-use std::path::Path;
 use std::process::Command;
 use std::sync::LazyLock;
 
@@ -90,7 +89,7 @@ impl crate::providers::Provider for PasswordStoreProvider {
         vec![ProviderCapability::RemoteStorage]
     }
 
-    async fn get_secret(&self, value: &str, _key_file: Option<&Path>) -> Result<String> {
+    async fn get_secret(&self, value: &str) -> Result<String> {
         let secret_path = self.build_secret_path(value);
 
         tracing::debug!("Getting secret '{secret_path}' from password-store");
@@ -99,7 +98,7 @@ impl crate::providers::Provider for PasswordStoreProvider {
         self.execute_pass_command(&["show", &secret_path])
     }
 
-    async fn put_secret(&self, key: &str, value: &str, _key_file: Option<&Path>) -> Result<String> {
+    async fn put_secret(&self, key: &str, value: &str) -> Result<String> {
         let secret_path = self.build_secret_path(key);
 
         tracing::debug!("Storing secret '{secret_path}' in password-store");

--- a/src/providers/plain.rs
+++ b/src/providers/plain.rs
@@ -1,6 +1,5 @@
 use crate::error::Result;
 use async_trait::async_trait;
-use std::path::Path;
 
 /// Plain provider that stores and returns values as-is without encryption.
 ///
@@ -28,12 +27,12 @@ impl crate::providers::Provider for PlainProvider {
         vec![crate::providers::ProviderCapability::Encryption]
     }
 
-    async fn get_secret(&self, value: &str, _key_file: Option<&Path>) -> Result<String> {
+    async fn get_secret(&self, value: &str) -> Result<String> {
         // Simply return the value as-is
         Ok(value.to_string())
     }
 
-    async fn encrypt(&self, value: &str, _key_file: Option<&Path>) -> Result<String> {
+    async fn encrypt(&self, value: &str) -> Result<String> {
         // Plain provider stores values as-is without encryption
         Ok(value.to_string())
     }

--- a/src/providers/vault.rs
+++ b/src/providers/vault.rs
@@ -2,7 +2,7 @@ use crate::env;
 use crate::error::{FnoxError, Result};
 use async_trait::async_trait;
 use std::process::Command;
-use std::{path::Path, sync::LazyLock};
+use std::sync::LazyLock;
 
 pub struct HashiCorpVaultProvider {
     address: String,
@@ -82,7 +82,7 @@ impl crate::providers::Provider for HashiCorpVaultProvider {
         vec![crate::providers::ProviderCapability::RemoteStorage]
     }
 
-    async fn get_secret(&self, value: &str, _key_file: Option<&Path>) -> Result<String> {
+    async fn get_secret(&self, value: &str) -> Result<String> {
         tracing::debug!("Getting secret '{}' from HashiCorp Vault", value);
 
         // Parse value as "secret-name/field" or just "secret-name"
@@ -126,7 +126,7 @@ impl crate::providers::Provider for HashiCorpVaultProvider {
         Ok(())
     }
 
-    async fn put_secret(&self, key: &str, value: &str, _key_file: Option<&Path>) -> Result<String> {
+    async fn put_secret(&self, key: &str, value: &str) -> Result<String> {
         let secret_path = self.get_secret_path(key);
 
         tracing::debug!("Writing secret '{}' to HashiCorp Vault", secret_path);


### PR DESCRIPTION
## Summary

- Remove `key_file` parameter from Provider trait methods - only Age provider used it
- Add `key_file` field to AgeEncryption ProviderConfig for configuration
- Standardize credential priority: native env var > FNOX_ prefixed > config
- Deprecate `--age-key-file` CLI flag (hidden but still functional)

The Age provider now uses this priority for key file:
1. `FNOX_AGE_KEY` env var (inline key content)
2. `key_file` from provider config
3. `--age-key-file` CLI flag (deprecated, hidden from help)
4. Default path `~/.config/fnox/age.txt`

## Test plan

- [x] All cargo tests pass (31 tests)
- [x] All bats tests pass (395 tests)
- [x] Clippy passes with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes `key_file` from Provider methods, adds `key_file` to `age` provider config with clear priority, deprecates `--age-key-file`, and updates all commands/providers and docs accordingly.
> 
> - **Core**:
>   - Simplify `Provider` trait: drop `key_file` param from `get_secret`, `encrypt`, `put_secret`, and batch APIs.
>   - Update `secret_resolver` and all call sites to new signatures.
> - **Providers**:
>   - `age`: add `key_file` to `ProviderConfig`; resolve key priority: `FNOX_AGE_KEY` > config `key_file` > settings (deprecated flag) > default path; refactor to new API.
>   - Update all providers (`aws-kms`, `azure-kms`, `gcp-kms`, `aws-sm`, `azure-sm`, `gcp-sm`, `keychain`, `password-store`, `keepass`, `vault`, `1password`, `bitwarden`, `plain`) to new method signatures; adjust batch methods accordingly.
>   - `bitwarden`: read session token from `FNOX_BW_SESSION` (fallback `BW_SESSION`).
> - **CLI/Commands**:
>   - Deprecate and hide global flag `--age-key-file`; remove its usage across commands (`check`, `get`, `exec`, `export`, `list`, `ci-redact`, `edit`).
>   - Provider templates and init/add flows include `age` `key_file: None`.
> - **Docs/Usage**:
>   - Update `docs/cli/commands.json`, `fnox.usage.kdl`, and generated docs to hide/remove `--age-key-file` help.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3bc7c27a85b20f49465760f3cd73aae074d34951. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->