### PR TITLE
feat: add secret references in provider config

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -220,13 +220,6 @@ When fnox encounters `{ secret = "NAME" }` in a provider config:
 2. **Config secret**: Look up `NAME` in the `[secrets]` section and resolve via its provider
 3. **Error**: If neither is available, return an error
 
-#### Supported Fields
-
-| Provider  | Field      | Description                          |
-| --------- | ---------- | ------------------------------------ |
-| `vault`   | `token`    | HashiCorp Vault authentication token |
-| `keepass` | `password` | KeePass database password            |
-
 #### Bootstrap Providers
 
 Secrets referenced in provider configs must use "bootstrap" providers—providers that don't themselves require secret references:

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -1,8 +1,8 @@
 use crate::commands::Cli;
 use crate::config::Config;
+use crate::config_resolver::ResolutionContext;
 use crate::env;
 use crate::error::Result;
-use crate::providers::get_provider;
 use clap::Args;
 
 #[derive(Debug, Args)]
@@ -94,7 +94,8 @@ impl DoctorCommand {
             println!();
             println!("🔍 Provider Health:");
             for (name, provider_config) in &providers {
-                match get_provider(provider_config) {
+                let mut ctx = ResolutionContext::new(&config, &profile);
+                match provider_config.create_provider(&mut ctx).await {
                     Ok(provider) => {
                         print!("  {}: Testing...", name);
                         match provider.test_connection().await {

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -225,6 +225,15 @@ impl InitCommand {
         let mut fields = HashMap::new();
 
         for field in info.fields {
+            // Skip sensitive fields - they should be configured via env vars or secret refs
+            if field.sensitive {
+                println!(
+                    "  ⚠️  Skipping '{}' - configure via environment variable or secret reference",
+                    field.name
+                );
+                continue;
+            }
+
             let result = Input::new(field.label).placeholder(field.placeholder).run();
 
             match result {

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,7 +1,8 @@
 use crate::commands::Cli;
 use crate::config::{Config, ProviderConfig, SecretConfig};
+use crate::config_resolver::ResolutionContext;
 use crate::error::{FnoxError, Result};
-use crate::providers::{WizardCategory, WizardInfo, get_provider};
+use crate::providers::{WizardCategory, WizardInfo};
 use clap::Args;
 use demand::{Confirm, DemandOption, Input, Select};
 use std::collections::HashMap;
@@ -306,7 +307,11 @@ impl InitCommand {
     async fn test_provider_connection(&self, provider_config: &ProviderConfig) {
         println!("\n🔍 Testing provider connection...");
 
-        match get_provider(provider_config) {
+        // Create a minimal config context for testing
+        // The wizard only uses plain values, so this will work
+        let test_config = Config::new();
+        let mut ctx = ResolutionContext::new(&test_config, "default");
+        match provider_config.create_provider(&mut ctx).await {
             Ok(provider) => match provider.test_connection().await {
                 Ok(()) => {
                     println!("✓ Provider connection successful!\n");

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -34,7 +34,13 @@ pub mod version;
 #[command(help_expected = true)]
 pub struct Cli {
     /// Path to the configuration file (default: fnox.toml, searches parent directories)
-    #[arg(short, long, default_value = "fnox.toml", global = true)]
+    #[arg(
+        short,
+        long,
+        default_value = "fnox.toml",
+        env = "FNOX_CONFIG_FILE",
+        global = true
+    )]
     pub config: PathBuf,
 
     /// Profile to use (default: default, or FNOX_PROFILE env var)

--- a/src/commands/provider/add.rs
+++ b/src/commands/provider/add.rs
@@ -1,6 +1,11 @@
 use crate::commands::Cli;
-use crate::config::Config;
+use crate::config::{Config, ConfigValue, ProviderConfig};
 use crate::error::{FnoxError, Result};
+use crate::providers::{
+    age::AgeConfig, aws_kms::AwsKmsConfig, aws_ps::AwsPsConfig, aws_sm::AwsSmConfig,
+    azure_kms::AzureKmsConfig, azure_sm::AzureSmConfig, gcp_kms::GcpKmsConfig, gcp_sm::GcpSmConfig,
+    infisical::InfisicalConfig, onepassword::OnePasswordConfig, vault::VaultConfig,
+};
 use clap::Args;
 
 use super::ProviderType;
@@ -65,56 +70,56 @@ impl AddCommand {
 
         // Create a template provider config based on type
         let provider_config = match self.provider_type {
-            ProviderType::OnePassword => crate::config::ProviderConfig::OnePassword {
-                vault: Some("default".to_string()),
+            ProviderType::OnePassword => ProviderConfig::OnePassword(OnePasswordConfig {
+                vault: Some(ConfigValue::Plain("default".to_string())),
                 account: None,
-            },
-            ProviderType::Aws => crate::config::ProviderConfig::AwsSecretsManager {
-                region: "us-east-1".to_string(),
+            }),
+            ProviderType::Aws => ProviderConfig::AwsSecretsManager(AwsSmConfig {
+                region: ConfigValue::Plain("us-east-1".to_string()),
                 prefix: None,
-            },
-            ProviderType::Vault => crate::config::ProviderConfig::HashiCorpVault {
-                address: "http://localhost:8200".to_string(),
-                path: Some("secret".to_string()),
+            }),
+            ProviderType::Vault => ProviderConfig::HashiCorpVault(VaultConfig {
+                address: ConfigValue::Plain("http://localhost:8200".to_string()),
+                path: Some(ConfigValue::Plain("secret".to_string())),
                 token: None,
-            },
-            ProviderType::Gcp => crate::config::ProviderConfig::GoogleSecretManager {
-                project: "my-project".to_string(),
+            }),
+            ProviderType::Gcp => ProviderConfig::GoogleSecretManager(GcpSmConfig {
+                project: ConfigValue::Plain("my-project".to_string()),
                 prefix: None,
-            },
-            ProviderType::AwsKms => crate::config::ProviderConfig::AwsKms {
-                region: "us-east-1".to_string(),
-                key_id: "alias/my-key".to_string(),
-            },
-            ProviderType::AwsParameterStore => crate::config::ProviderConfig::AwsParameterStore {
-                region: "us-east-1".to_string(),
-                prefix: Some("/myapp/prod/".to_string()),
-            },
-            ProviderType::AzureKms => crate::config::ProviderConfig::AzureKms {
-                vault_url: "https://my-vault.vault.azure.net/".to_string(),
-                key_name: "my-key".to_string(),
-            },
+            }),
+            ProviderType::AwsKms => ProviderConfig::AwsKms(AwsKmsConfig {
+                region: ConfigValue::Plain("us-east-1".to_string()),
+                key_id: ConfigValue::Plain("alias/my-key".to_string()),
+            }),
+            ProviderType::AwsParameterStore => ProviderConfig::AwsParameterStore(AwsPsConfig {
+                region: ConfigValue::Plain("us-east-1".to_string()),
+                prefix: Some(ConfigValue::Plain("/myapp/prod/".to_string())),
+            }),
+            ProviderType::AzureKms => ProviderConfig::AzureKms(AzureKmsConfig {
+                vault_url: ConfigValue::Plain("https://my-vault.vault.azure.net/".to_string()),
+                key_name: ConfigValue::Plain("my-key".to_string()),
+            }),
             ProviderType::AzureSecretsManager => {
-                crate::config::ProviderConfig::AzureSecretsManager {
-                    vault_url: "https://my-vault.vault.azure.net/".to_string(),
+                ProviderConfig::AzureSecretsManager(AzureSmConfig {
+                    vault_url: ConfigValue::Plain("https://my-vault.vault.azure.net/".to_string()),
                     prefix: None,
-                }
+                })
             }
-            ProviderType::GcpKms => crate::config::ProviderConfig::GcpKms {
-                project: "my-project".to_string(),
-                location: "global".to_string(),
-                keyring: "my-keyring".to_string(),
-                key: "my-key".to_string(),
-            },
-            ProviderType::Age => crate::config::ProviderConfig::AgeEncryption {
-                recipients: vec!["age1...".to_string()],
+            ProviderType::GcpKms => ProviderConfig::GcpKms(GcpKmsConfig {
+                project: ConfigValue::Plain("my-project".to_string()),
+                location: ConfigValue::Plain("global".to_string()),
+                keyring: ConfigValue::Plain("my-keyring".to_string()),
+                key: ConfigValue::Plain("my-key".to_string()),
+            }),
+            ProviderType::Age => ProviderConfig::AgeEncryption(AgeConfig {
+                recipients: vec![ConfigValue::Plain("age1...".to_string())],
                 key_file: None,
-            },
-            ProviderType::Infisical => crate::config::ProviderConfig::Infisical {
-                project_id: Some("your-project-id".to_string()),
-                environment: Some("dev".to_string()),
-                path: Some("/".to_string()),
-            },
+            }),
+            ProviderType::Infisical => ProviderConfig::Infisical(InfisicalConfig {
+                project_id: Some(ConfigValue::Plain("your-project-id".to_string())),
+                environment: Some(ConfigValue::Plain("dev".to_string())),
+                path: Some(ConfigValue::Plain("/".to_string())),
+            }),
         };
 
         config

--- a/src/commands/provider/test.rs
+++ b/src/commands/provider/test.rs
@@ -1,5 +1,6 @@
 use crate::commands::Cli;
 use crate::config::Config;
+use crate::config_resolver::ResolutionContext;
 use crate::error::{FnoxError, Result};
 use clap::Args;
 
@@ -11,16 +12,18 @@ pub struct TestCommand {
 }
 
 impl TestCommand {
-    pub async fn run(&self, _cli: &Cli, config: Config) -> Result<()> {
+    pub async fn run(&self, cli: &Cli, config: Config) -> Result<()> {
+        let profile = Config::get_profile(cli.profile.as_deref());
         tracing::debug!("Testing provider '{}'", self.provider);
 
-        let provider_config = config
-            .providers
+        let providers = config.get_providers(&profile);
+        let provider_config = providers
             .get(&self.provider)
             .ok_or_else(|| FnoxError::Config(format!("Provider '{}' not found", self.provider)))?;
 
-        // Create the provider instance
-        let provider = crate::providers::get_provider(provider_config)?;
+        // Create the provider instance (resolving any secret refs)
+        let mut ctx = ResolutionContext::new(&config, &profile);
+        let provider = provider_config.create_provider(&mut ctx).await?;
 
         // Test the connection
         provider.test_connection().await?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -56,22 +56,6 @@ impl ConfigValue {
     pub fn is_plain(&self) -> bool {
         matches!(self, ConfigValue::Plain(_))
     }
-
-    /// Get the plain value if this is a Plain variant
-    pub fn as_plain(&self) -> Option<&str> {
-        match self {
-            ConfigValue::Plain(s) => Some(s),
-            ConfigValue::SecretRef(_) => None,
-        }
-    }
-
-    /// Get the secret reference if this is a SecretRef variant
-    pub fn as_secret_ref(&self) -> Option<&SecretRef> {
-        match self {
-            ConfigValue::Plain(_) => None,
-            ConfigValue::SecretRef(r) => Some(r),
-        }
-    }
 }
 
 impl From<String> for ConfigValue {

--- a/src/config_resolver.rs
+++ b/src/config_resolver.rs
@@ -1,0 +1,165 @@
+//! Configuration value resolution for provider configs.
+//!
+//! This module handles resolving `ConfigValue` fields in provider configurations,
+//! which may be either plain values or references to secrets.
+
+use crate::config::{Config, ConfigValue, SecretConfig};
+use crate::env;
+use crate::error::{FnoxError, Result};
+use crate::providers::{self, ProviderConfig};
+
+/// Resolve a ConfigValue to a plain string.
+///
+/// Resolution priority:
+/// 1. Plain value - return immediately
+/// 2. Secret reference:
+///    a. Check environment variable with the secret name
+///    b. Look up secret in config and resolve via provider
+///
+/// # Bootstrap Provider Requirement
+///
+/// Secrets used in provider configs must be stored using "bootstrap" providers -
+/// providers that don't have secret references in their own config. This includes:
+/// - `keychain` - uses OS-level authentication
+/// - `age` - uses FNOX_AGE_KEY env var or key file path
+/// - `password-store` - uses GPG
+/// - `plain` - no authentication
+///
+/// If a secret references a non-bootstrap provider, an error is returned.
+pub async fn resolve_config_value(
+    value: &ConfigValue,
+    config: &Config,
+    profile: &str,
+) -> Result<String> {
+    match value {
+        ConfigValue::Plain(s) => Ok(s.clone()),
+        ConfigValue::SecretRef(secret_ref) => {
+            resolve_secret_ref(&secret_ref.secret, config, profile).await
+        }
+    }
+}
+
+/// Resolve an optional ConfigValue.
+pub async fn resolve_config_value_optional(
+    value: &Option<ConfigValue>,
+    config: &Config,
+    profile: &str,
+) -> Result<Option<String>> {
+    match value {
+        Some(v) => Ok(Some(resolve_config_value(v, config, profile).await?)),
+        None => Ok(None),
+    }
+}
+
+/// Resolve a secret reference by name.
+///
+/// Priority:
+/// 1. Environment variable with the secret name
+/// 2. Secret defined in config (resolved via its provider)
+async fn resolve_secret_ref(secret_name: &str, config: &Config, profile: &str) -> Result<String> {
+    // Priority 1: Check environment variable
+    if let Ok(env_value) = env::var(secret_name) {
+        tracing::debug!(
+            "Resolved secret '{}' from environment variable",
+            secret_name
+        );
+        return Ok(env_value);
+    }
+
+    // Priority 2: Look up secret in config
+    let secrets = config.get_secrets(profile)?;
+    let secret_config = secrets.get(secret_name).ok_or_else(|| {
+        FnoxError::Config(format!(
+            "Secret '{}' not found in config or environment. \
+            Provider config secrets must be defined in [secrets] or available as environment variables.",
+            secret_name
+        ))
+    })?;
+
+    // Resolve the secret using its provider (must be a bootstrap provider)
+    resolve_secret_for_provider_config(secret_name, secret_config, config, profile).await
+}
+
+/// Resolve a secret specifically for use in provider config.
+///
+/// This is a restricted version of secret resolution that only works with
+/// bootstrap providers to avoid circular dependencies.
+async fn resolve_secret_for_provider_config(
+    secret_name: &str,
+    secret_config: &SecretConfig,
+    config: &Config,
+    profile: &str,
+) -> Result<String> {
+    // Check if secret has a provider and value
+    let Some(provider_value) = &secret_config.value else {
+        // No provider value - check for default
+        if let Some(default) = &secret_config.default {
+            return Ok(default.clone());
+        }
+        return Err(FnoxError::Config(format!(
+            "Secret '{}' has no value or default configured",
+            secret_name
+        )));
+    };
+
+    // Get the provider name
+    let provider_name = if let Some(ref name) = secret_config.provider {
+        name.clone()
+    } else if let Some(default) = config.get_default_provider(profile)? {
+        default
+    } else {
+        return Err(FnoxError::Config(format!(
+            "Secret '{}' has no provider specified and no default provider configured",
+            secret_name
+        )));
+    };
+
+    // Get the provider config
+    let providers = config.get_providers(profile);
+    let provider_config =
+        providers
+            .get(&provider_name)
+            .ok_or_else(|| FnoxError::ProviderNotConfigured {
+                provider: provider_name.clone(),
+                profile: profile.to_string(),
+                config_path: config.provider_sources.get(&provider_name).cloned(),
+            })?;
+
+    // Ensure this is a bootstrap provider (no secret refs in its config)
+    if has_secret_refs(provider_config) {
+        return Err(FnoxError::Config(format!(
+            "Cannot resolve secret '{}': provider '{}' has secret references in its config. \
+            Secrets used in provider configurations must use bootstrap providers \
+            (keychain, age, password-store, plain) that don't have secret references.",
+            secret_name, provider_name
+        )));
+    }
+
+    // Create the provider using the simple (non-resolving) path
+    let provider = providers::get_provider_simple(provider_config)?;
+
+    // Resolve the secret
+    let value = provider.get_secret(provider_value).await?;
+    tracing::debug!(
+        "Resolved secret '{}' from provider '{}'",
+        secret_name,
+        provider_name
+    );
+    Ok(value)
+}
+
+/// Check if a provider config has any secret references.
+///
+/// Returns true if any field in the config is a ConfigValue::SecretRef.
+pub fn has_secret_refs(config: &ProviderConfig) -> bool {
+    match config {
+        ProviderConfig::HashiCorpVault { token, .. } => {
+            token.as_ref().is_some_and(|t| !t.is_plain())
+        }
+        ProviderConfig::KeePass { password, .. } => {
+            password.as_ref().is_some_and(|p| !p.is_plain())
+        }
+        // All other providers don't have ConfigValue fields
+        _ => false,
+    }
+}

--- a/src/config_resolver.rs
+++ b/src/config_resolver.rs
@@ -6,49 +6,75 @@
 use crate::config::{Config, ConfigValue, SecretConfig};
 use crate::env;
 use crate::error::{FnoxError, Result};
-use crate::providers;
+
+/// Context for resolving secrets with cycle detection.
+///
+/// Tracks the resolution stack to detect and prevent circular secret references.
+pub struct ResolutionContext<'a> {
+    pub config: &'a Config,
+    pub profile: String,
+    resolving: Vec<String>,
+}
+
+impl<'a> ResolutionContext<'a> {
+    pub fn new(config: &'a Config, profile: &str) -> Self {
+        Self {
+            config,
+            profile: profile.to_string(),
+            resolving: Vec::new(),
+        }
+    }
+
+    /// Check if resolving this secret would create a cycle.
+    pub fn would_cycle(&self, secret_name: &str) -> bool {
+        self.resolving.contains(&secret_name.to_string())
+    }
+
+    /// Push a secret onto the resolution stack.
+    pub fn push(&mut self, secret_name: &str) {
+        self.resolving.push(secret_name.to_string());
+    }
+
+    /// Pop a secret from the resolution stack.
+    pub fn pop(&mut self) {
+        self.resolving.pop();
+    }
+
+    /// Get the current resolution stack for error messages.
+    pub fn stack_trace(&self) -> String {
+        self.resolving.join(" → ")
+    }
+}
 
 /// Resolve a ConfigValue to a plain string.
-///
-/// Resolution priority:
-/// 1. Plain value - return immediately
-/// 2. Secret reference:
-///    a. Check environment variable with the secret name
-///    b. Look up secret in config and resolve via provider
-///
-/// # Bootstrap Provider Requirement
-///
-/// Secrets used in provider configs must be stored using "bootstrap" providers -
-/// providers that don't have secret references in their own config. This includes:
-/// - `keychain` - uses OS-level authentication
-/// - `age` - uses FNOX_AGE_KEY env var or key file path
-/// - `password-store` - uses GPG
-/// - `plain` - no authentication
-///
-/// If a secret references a non-bootstrap provider, an error is returned.
-pub async fn resolve_config_value(
-    value: &ConfigValue,
-    config: &Config,
-    profile: &str,
-) -> Result<String> {
+pub async fn resolve(value: &ConfigValue, ctx: &mut ResolutionContext<'_>) -> Result<String> {
     match value {
         ConfigValue::Plain(s) => Ok(s.clone()),
-        ConfigValue::SecretRef(secret_ref) => {
-            resolve_secret_ref(&secret_ref.secret, config, profile).await
-        }
+        ConfigValue::SecretRef(r) => resolve_secret_ref(&r.secret, ctx).await,
     }
 }
 
 /// Resolve an optional ConfigValue.
-pub async fn resolve_config_value_optional(
+pub async fn resolve_opt(
     value: &Option<ConfigValue>,
-    config: &Config,
-    profile: &str,
+    ctx: &mut ResolutionContext<'_>,
 ) -> Result<Option<String>> {
     match value {
-        Some(v) => Ok(Some(resolve_config_value(v, config, profile).await?)),
         None => Ok(None),
+        Some(v) => Ok(Some(resolve(v, ctx).await?)),
     }
+}
+
+/// Resolve a vec of ConfigValues.
+pub async fn resolve_vec(
+    values: &[ConfigValue],
+    ctx: &mut ResolutionContext<'_>,
+) -> Result<Vec<String>> {
+    let mut resolved = Vec::with_capacity(values.len());
+    for v in values {
+        resolved.push(resolve(v, ctx).await?);
+    }
+    Ok(resolved)
 }
 
 /// Resolve a secret reference by name.
@@ -56,8 +82,17 @@ pub async fn resolve_config_value_optional(
 /// Priority:
 /// 1. Environment variable with the secret name
 /// 2. Secret defined in config (resolved via its provider)
-async fn resolve_secret_ref(secret_name: &str, config: &Config, profile: &str) -> Result<String> {
-    // Priority 1: Check environment variable
+async fn resolve_secret_ref(secret_name: &str, ctx: &mut ResolutionContext<'_>) -> Result<String> {
+    // Check for cycle
+    if ctx.would_cycle(secret_name) {
+        return Err(FnoxError::Config(format!(
+            "Circular secret reference detected: {} → {}",
+            ctx.stack_trace(),
+            secret_name
+        )));
+    }
+
+    // Priority 1: Check environment variable (no cycle possible)
     if let Ok(env_value) = env::var(secret_name) {
         tracing::debug!(
             "Resolved secret '{}' from environment variable",
@@ -66,8 +101,24 @@ async fn resolve_secret_ref(secret_name: &str, config: &Config, profile: &str) -
         return Ok(env_value);
     }
 
+    // Push onto stack before resolving
+    ctx.push(secret_name);
+
     // Priority 2: Look up secret in config
-    let secrets = config.get_secrets(profile)?;
+    let result = resolve_secret_from_config(secret_name, ctx).await;
+
+    // Pop from stack
+    ctx.pop();
+
+    result
+}
+
+/// Resolve a secret from config.
+async fn resolve_secret_from_config(
+    secret_name: &str,
+    ctx: &mut ResolutionContext<'_>,
+) -> Result<String> {
+    let secrets = ctx.config.get_secrets(&ctx.profile)?;
     let secret_config = secrets.get(secret_name).ok_or_else(|| {
         FnoxError::Config(format!(
             "Secret '{}' not found in config or environment. \
@@ -76,74 +127,64 @@ async fn resolve_secret_ref(secret_name: &str, config: &Config, profile: &str) -
         ))
     })?;
 
-    // Resolve the secret using its provider (must be a bootstrap provider)
-    resolve_secret_for_provider_config(secret_name, secret_config, config, profile).await
+    resolve_secret_for_provider_config(secret_name, secret_config, ctx).await
 }
 
 /// Resolve a secret specifically for use in provider config.
 ///
-/// This is a restricted version of secret resolution that only works with
-/// bootstrap providers to avoid circular dependencies.
-async fn resolve_secret_for_provider_config(
-    secret_name: &str,
-    secret_config: &SecretConfig,
-    config: &Config,
-    profile: &str,
-) -> Result<String> {
-    // Check if secret has a provider and value
-    let Some(provider_value) = &secret_config.value else {
-        // No provider value - check for default
-        if let Some(default) = &secret_config.default {
-            return Ok(default.clone());
-        }
-        return Err(FnoxError::Config(format!(
-            "Secret '{}' has no value or default configured",
-            secret_name
-        )));
-    };
+/// Uses `Box::pin` for the recursive async call to `create_provider` to satisfy
+/// the compiler's requirement for bounded async recursion.
+fn resolve_secret_for_provider_config<'a>(
+    secret_name: &'a str,
+    secret_config: &'a SecretConfig,
+    ctx: &'a mut ResolutionContext<'_>,
+) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<String>> + Send + 'a>> {
+    Box::pin(async move {
+        // Check if secret has a provider and value
+        let Some(provider_value) = &secret_config.value else {
+            // No provider value - check for default
+            if let Some(default) = &secret_config.default {
+                return Ok(default.clone());
+            }
+            return Err(FnoxError::Config(format!(
+                "Secret '{}' has no value or default configured",
+                secret_name
+            )));
+        };
 
-    // Get the provider name
-    let provider_name = if let Some(ref name) = secret_config.provider {
-        name.clone()
-    } else if let Some(default) = config.get_default_provider(profile)? {
-        default
-    } else {
-        return Err(FnoxError::Config(format!(
-            "Secret '{}' has no provider specified and no default provider configured",
-            secret_name
-        )));
-    };
+        // Get the provider name
+        let provider_name = if let Some(ref name) = secret_config.provider {
+            name.clone()
+        } else if let Some(default) = ctx.config.get_default_provider(&ctx.profile)? {
+            default
+        } else {
+            return Err(FnoxError::Config(format!(
+                "Secret '{}' has no provider specified and no default provider configured",
+                secret_name
+            )));
+        };
 
-    // Get the provider config
-    let providers = config.get_providers(profile);
-    let provider_config =
-        providers
-            .get(&provider_name)
-            .ok_or_else(|| FnoxError::ProviderNotConfigured {
-                provider: provider_name.clone(),
-                profile: profile.to_string(),
-                config_path: config.provider_sources.get(&provider_name).cloned(),
-            })?;
+        // Get the provider config
+        let providers = ctx.config.get_providers(&ctx.profile);
+        let provider_config =
+            providers
+                .get(&provider_name)
+                .ok_or_else(|| FnoxError::ProviderNotConfigured {
+                    provider: provider_name.clone(),
+                    profile: ctx.profile.clone(),
+                    config_path: ctx.config.provider_sources.get(&provider_name).cloned(),
+                })?;
 
-    // Ensure this is a bootstrap provider (no secret refs in its config)
-    if provider_config.has_secret_refs() {
-        return Err(FnoxError::Config(format!(
-            "Cannot resolve secret '{}': provider '{}' has secret references in its config. \
-            Secrets used in provider configurations must use bootstrap providers \
-            (keychain, age, password-store, plain) that don't have secret references.",
-            secret_name, provider_name
-        )));
-    }
+        // Create the provider (this will recursively resolve any secret refs in its config)
+        let provider = provider_config.create_provider(ctx).await?;
 
-    // Create the provider using the simple (non-resolving) path
-    let provider = providers::get_provider_simple(provider_config)?;
-
-    // Resolve the secret
-    let value = provider.get_secret(provider_value).await?;
-    tracing::debug!(
-        "Resolved secret '{}' from provider '{}'",
-        secret_name,
-        provider_name
-    );
-    Ok(value)
+        // Resolve the secret
+        let value = provider.get_secret(provider_value).await?;
+        tracing::debug!(
+            "Resolved secret '{}' from provider '{}'",
+            secret_name,
+            provider_name
+        );
+        Ok(value)
+    })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 // Library interface for fnox
 pub mod commands;
 pub mod config;
+pub mod config_resolver;
 pub mod env;
 pub mod error;
 pub mod hook_env;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 mod commands;
 mod config;
+mod config_resolver;
 mod env;
 mod error;
 mod hook_env;

--- a/src/providers/age.rs
+++ b/src/providers/age.rs
@@ -19,6 +19,7 @@ Generate a key with: age-keygen -o ~/.config/fnox/age.txt",
         label: "Age public key (recipient):",
         placeholder: "age1...",
         required: true,
+        ..WizardField::DEFAULT
     }],
 };
 

--- a/src/providers/aws_kms.rs
+++ b/src/providers/aws_kms.rs
@@ -20,12 +20,14 @@ Requires AWS credentials configured.",
             label: "KMS Key ID (ARN or alias):",
             placeholder: "arn:aws:kms:us-east-1:123456789012:key/...",
             required: true,
+            ..WizardField::DEFAULT
         },
         WizardField {
             name: "region",
             label: "AWS Region:",
             placeholder: "us-east-1",
             required: true,
+            ..WizardField::DEFAULT
         },
     ],
 };

--- a/src/providers/aws_ps.rs
+++ b/src/providers/aws_ps.rs
@@ -21,12 +21,13 @@ Requires AWS credentials configured.",
             label: "AWS Region:",
             placeholder: "us-east-1",
             required: true,
+            ..WizardField::DEFAULT
         },
         WizardField {
             name: "prefix",
             label: "Parameter path prefix (optional):",
             placeholder: "/myapp/prod/",
-            required: false,
+            ..WizardField::DEFAULT
         },
     ],
 };

--- a/src/providers/aws_ps.rs
+++ b/src/providers/aws_ps.rs
@@ -1,8 +1,11 @@
+use crate::config::ConfigValue;
+use crate::config_resolver::{ResolutionContext, resolve, resolve_opt};
 use crate::error::{FnoxError, Result};
-use crate::providers::{WizardCategory, WizardField, WizardInfo};
+use crate::providers::{Provider, WizardCategory, WizardField, WizardInfo};
 use async_trait::async_trait;
 use aws_config::BehaviorVersion;
 use aws_sdk_ssm::Client;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 pub const WIZARD_INFO: WizardInfo = WizardInfo {
@@ -31,6 +34,27 @@ Requires AWS credentials configured.",
         },
     ],
 };
+
+/// Configuration for the AWS Parameter Store provider.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AwsPsConfig {
+    pub region: ConfigValue,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prefix: Option<ConfigValue>,
+}
+
+impl AwsPsConfig {
+    /// Create a provider from this config, resolving any secret references.
+    pub async fn create_provider(
+        &self,
+        ctx: &mut ResolutionContext<'_>,
+    ) -> Result<Box<dyn Provider>> {
+        Ok(Box::new(AwsParameterStoreProvider::new(
+            resolve(&self.region, ctx).await?,
+            resolve_opt(&self.prefix, ctx).await?,
+        )))
+    }
+}
 
 pub struct AwsParameterStoreProvider {
     region: String,

--- a/src/providers/aws_sm.rs
+++ b/src/providers/aws_sm.rs
@@ -20,12 +20,13 @@ Requires AWS credentials configured.",
             label: "AWS Region:",
             placeholder: "us-east-1",
             required: true,
+            ..WizardField::DEFAULT
         },
         WizardField {
             name: "prefix",
             label: "Secret name prefix (optional):",
             placeholder: "fnox/",
-            required: false,
+            ..WizardField::DEFAULT
         },
     ],
 };

--- a/src/providers/azure_kms.rs
+++ b/src/providers/azure_kms.rs
@@ -22,12 +22,14 @@ Requires Azure credentials configured.",
             label: "Key Vault URL:",
             placeholder: "https://my-vault.vault.azure.net/",
             required: true,
+            ..WizardField::DEFAULT
         },
         WizardField {
             name: "key_name",
             label: "Key name:",
             placeholder: "my-key",
             required: true,
+            ..WizardField::DEFAULT
         },
     ],
 };

--- a/src/providers/azure_sm.rs
+++ b/src/providers/azure_sm.rs
@@ -21,12 +21,13 @@ Requires Azure credentials configured.",
             label: "Key Vault URL:",
             placeholder: "https://my-vault.vault.azure.net/",
             required: true,
+            ..WizardField::DEFAULT
         },
         WizardField {
             name: "prefix",
             label: "Secret name prefix (optional):",
             placeholder: "fnox-",
-            required: false,
+            ..WizardField::DEFAULT
         },
     ],
 };

--- a/src/providers/bitwarden.rs
+++ b/src/providers/bitwarden.rs
@@ -20,20 +20,17 @@ Login: bw login && export BW_SESSION=$(bw unlock --raw)",
         WizardField {
             name: "collection",
             label: "Collection ID (optional):",
-            placeholder: "",
-            required: false,
+            ..WizardField::DEFAULT
         },
         WizardField {
             name: "organization_id",
             label: "Organization ID (optional):",
-            placeholder: "",
-            required: false,
+            ..WizardField::DEFAULT
         },
         WizardField {
             name: "profile",
             label: "Bitwarden CLI profile (optional):",
-            placeholder: "",
-            required: false,
+            ..WizardField::DEFAULT
         },
     ],
 };

--- a/src/providers/gcp_kms.rs
+++ b/src/providers/gcp_kms.rs
@@ -19,24 +19,28 @@ Requires GCP credentials configured.",
             label: "GCP Project ID:",
             placeholder: "my-project",
             required: true,
+            ..WizardField::DEFAULT
         },
         WizardField {
             name: "location",
             label: "Location:",
             placeholder: "us-east1",
             required: true,
+            ..WizardField::DEFAULT
         },
         WizardField {
             name: "keyring",
             label: "Keyring name:",
             placeholder: "my-keyring",
             required: true,
+            ..WizardField::DEFAULT
         },
         WizardField {
             name: "key",
             label: "Key name:",
             placeholder: "my-key",
             required: true,
+            ..WizardField::DEFAULT
         },
     ],
 };

--- a/src/providers/gcp_sm.rs
+++ b/src/providers/gcp_sm.rs
@@ -18,12 +18,13 @@ Requires GCP credentials configured.",
             label: "GCP Project ID:",
             placeholder: "my-project",
             required: true,
+            ..WizardField::DEFAULT
         },
         WizardField {
             name: "prefix",
             label: "Secret name prefix (optional):",
             placeholder: "fnox-",
-            required: false,
+            ..WizardField::DEFAULT
         },
     ],
 };

--- a/src/providers/infisical.rs
+++ b/src/providers/infisical.rs
@@ -21,20 +21,19 @@ Set credentials:
         WizardField {
             name: "project_id",
             label: "Project ID (optional if CLI is configured):",
-            placeholder: "",
-            required: false,
+            ..WizardField::DEFAULT
         },
         WizardField {
             name: "environment",
             label: "Environment (optional, default: dev):",
             placeholder: "dev",
-            required: false,
+            ..WizardField::DEFAULT
         },
         WizardField {
             name: "path",
             label: "Secret path (optional, default: /):",
             placeholder: "/",
-            required: false,
+            ..WizardField::DEFAULT
         },
     ],
 };

--- a/src/providers/keepass.rs
+++ b/src/providers/keepass.rs
@@ -24,12 +24,12 @@ Set password via FNOX_KEEPASS_PASSWORD or KEEPASS_PASSWORD env var.",
             label: "Database path:",
             placeholder: "~/.config/fnox/secrets.kdbx",
             required: true,
+            ..WizardField::DEFAULT
         },
         WizardField {
             name: "keyfile",
             label: "Keyfile path (optional, for additional security):",
-            placeholder: "",
-            required: false,
+            ..WizardField::DEFAULT
         },
     ],
 };

--- a/src/providers/keychain.rs
+++ b/src/providers/keychain.rs
@@ -20,12 +20,13 @@ Uses your operating system's secure keychain:
             label: "Service name (namespace for your secrets):",
             placeholder: "fnox",
             required: true,
+            ..WizardField::DEFAULT
         },
         WizardField {
             name: "prefix",
             label: "Secret name prefix (optional):",
             placeholder: "myapp/",
-            required: false,
+            ..WizardField::DEFAULT
         },
     ],
 };

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -85,7 +85,7 @@ impl WizardCategory {
 }
 
 /// A field that the wizard needs to collect
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct WizardField {
     /// Internal field name (e.g., "region")
     pub name: &'static str,
@@ -95,6 +95,27 @@ pub struct WizardField {
     pub placeholder: &'static str,
     /// Whether field must have a value
     pub required: bool,
+    /// Whether field contains sensitive data (like tokens/passwords)
+    /// Sensitive fields should be stored as secret references, not plain values
+    pub sensitive: bool,
+}
+
+impl WizardField {
+    /// Default value for use in const contexts with struct update syntax.
+    /// Example: `WizardField { name: "foo", ..WizardField::DEFAULT }`
+    pub const DEFAULT: Self = Self {
+        name: "",
+        label: "",
+        placeholder: "",
+        required: false,
+        sensitive: false,
+    };
+}
+
+impl Default for WizardField {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
 }
 
 /// Complete wizard metadata for a provider type

--- a/src/providers/onepassword.rs
+++ b/src/providers/onepassword.rs
@@ -21,14 +21,12 @@ Set token: export OP_SERVICE_ACCOUNT_TOKEN=<token>",
         WizardField {
             name: "vault",
             label: "Vault name (optional):",
-            placeholder: "",
-            required: false,
+            ..WizardField::DEFAULT
         },
         WizardField {
             name: "account",
             label: "Account (optional, e.g., my.1password.com):",
-            placeholder: "",
-            required: false,
+            ..WizardField::DEFAULT
         },
     ],
 };

--- a/src/providers/password_store.rs
+++ b/src/providers/password_store.rs
@@ -19,13 +19,12 @@ Initialize with: pass init <gpg-key-id>",
             name: "prefix",
             label: "Secret name prefix (optional):",
             placeholder: "fnox/",
-            required: false,
+            ..WizardField::DEFAULT
         },
         WizardField {
             name: "store_dir",
             label: "Custom store directory (optional):",
-            placeholder: "",
-            required: false,
+            ..WizardField::DEFAULT
         },
     ],
 };

--- a/src/providers/plain.rs
+++ b/src/providers/plain.rs
@@ -1,6 +1,8 @@
+use crate::config_resolver::ResolutionContext;
 use crate::error::Result;
-use crate::providers::{WizardCategory, WizardInfo};
+use crate::providers::{Provider, WizardCategory, WizardInfo};
 use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
 
 pub const WIZARD_INFO: WizardInfo = WizardInfo {
     provider_type: "plain",
@@ -13,6 +15,20 @@ Only use this for non-sensitive values or development.",
     default_name: "plain",
     fields: &[],
 };
+
+/// Configuration for the plain provider.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PlainConfig {}
+
+impl PlainConfig {
+    /// Create a provider from this config, resolving any secret references.
+    pub async fn create_provider(
+        &self,
+        _ctx: &mut ResolutionContext<'_>,
+    ) -> Result<Box<dyn Provider>> {
+        Ok(Box::new(PlainProvider::new()))
+    }
+}
 
 /// Plain provider that stores and returns values as-is without encryption.
 ///

--- a/src/providers/vault.rs
+++ b/src/providers/vault.rs
@@ -20,18 +20,19 @@ Requires Vault address and token.",
             label: "Vault address:",
             placeholder: "https://vault.example.com:8200",
             required: true,
+            ..WizardField::DEFAULT
         },
         WizardField {
             name: "path",
             label: "Vault path prefix (optional):",
             placeholder: "secret/data/fnox",
-            required: false,
+            ..WizardField::DEFAULT
         },
         WizardField {
             name: "token",
             label: "Vault token (optional, can use VAULT_TOKEN env var):",
-            placeholder: "",
-            required: false,
+            sensitive: true,
+            ..WizardField::DEFAULT
         },
     ],
 };

--- a/src/secret_resolver.rs
+++ b/src/secret_resolver.rs
@@ -1,7 +1,7 @@
 use crate::config::{Config, IfMissing, SecretConfig};
 use crate::env;
 use crate::error::{FnoxError, Result};
-use crate::providers::get_provider;
+use crate::providers::get_provider_resolved;
 use crate::settings::Settings;
 use indexmap::IndexMap;
 use std::collections::HashMap; // Used only for internal grouping by provider
@@ -155,8 +155,8 @@ async fn try_resolve_from_provider(
                 config_path: config.provider_sources.get(&provider_name).cloned(),
             })?;
 
-    // Resolve from provider
-    let provider = get_provider(provider_config)?;
+    // Resolve from provider (using get_provider_resolved to handle secret refs in provider config)
+    let provider = get_provider_resolved(provider_config, config, profile).await?;
     let value = provider.get_secret(provider_value).await?;
     Ok(Some(value))
 }
@@ -319,8 +319,8 @@ async fn resolve_provider_batch(
         }
     };
 
-    // Get the provider instance
-    let provider = match get_provider(provider_config) {
+    // Get the provider instance (using get_provider_resolved to handle secret refs in provider config)
+    let provider = match get_provider_resolved(provider_config, config, profile).await {
         Ok(p) => p,
         Err(e) => {
             // Failed to create provider, handle errors for all secrets

--- a/test/config_recursion.bats
+++ b/test/config_recursion.bats
@@ -3,6 +3,10 @@
 setup() {
 	load 'test_helper/common_setup'
 	_common_setup
+
+	# Config recursion tests need fnox to search parent directories,
+	# which requires FNOX_CONFIG_FILE to be unset
+	unset FNOX_CONFIG_FILE
 }
 
 teardown() {

--- a/test/provider_secret_refs.bats
+++ b/test/provider_secret_refs.bats
@@ -1,0 +1,135 @@
+#!/usr/bin/env bats
+
+# Tests for provider config secret references
+# This feature allows provider configs to reference secrets using { secret = "SECRET_NAME" } syntax
+
+setup() {
+	load 'test_helper/common_setup'
+	_common_setup
+}
+
+teardown() {
+	_common_teardown
+}
+
+@test "plain token value in vault provider config works" {
+	cat >"${FNOX_CONFIG_FILE}" <<EOF
+[providers]
+plain = { type = "plain" }
+
+[providers.vault]
+type = "vault"
+address = "https://vault.example.com"
+token = "hvs.test-token"
+
+[secrets]
+TEST = { provider = "plain", value = "test-value" }
+EOF
+
+	run "$FNOX_BIN" get TEST
+	assert_success
+	assert_output "test-value"
+}
+
+@test "secret ref in vault provider config with env var fallback" {
+	# Set up config with secret ref but no secret defined
+	cat >"${FNOX_CONFIG_FILE}" <<EOF
+[providers]
+plain = { type = "plain" }
+
+[providers.vault]
+type = "vault"
+address = "https://vault.example.com"
+token = { secret = "VAULT_TOKEN" }
+
+[secrets]
+TEST = { provider = "plain", value = "test-value" }
+EOF
+
+	# Set the env var that the secret ref should fall back to
+	export VAULT_TOKEN="hvs.from-env"
+
+	run "$FNOX_BIN" get TEST
+	assert_success
+	assert_output "test-value"
+}
+
+@test "secret ref in vault provider config resolved from config" {
+	cat >"${FNOX_CONFIG_FILE}" <<EOF
+[providers]
+plain = { type = "plain" }
+
+[providers.vault]
+type = "vault"
+address = "https://vault.example.com"
+token = { secret = "VAULT_TOKEN" }
+
+[secrets]
+# This is a secret that can bootstrap - using plain provider
+VAULT_TOKEN = { provider = "plain", value = "hvs.from-config" }
+TEST = { provider = "plain", value = "test-value" }
+EOF
+
+	run "$FNOX_BIN" get TEST
+	assert_success
+	assert_output "test-value"
+}
+
+@test "missing secret ref with no env var errors" {
+	cat >"${FNOX_CONFIG_FILE}" <<EOF
+[providers.vault]
+type = "vault"
+address = "https://vault.example.com"
+token = { secret = "NONEXISTENT_SECRET" }
+
+[secrets]
+TEST = { provider = "vault", value = "secret/data/test" }
+EOF
+
+	# Ensure the env var is not set
+	unset NONEXISTENT_SECRET 2>/dev/null || true
+
+	run "$FNOX_BIN" get TEST
+	assert_failure
+	assert_output --partial "not found"
+}
+
+@test "keepass provider with plain password works" {
+	skip "keepass tests require KEEPASS_PASSWORD env var"
+
+	cat >"${FNOX_CONFIG_FILE}" <<EOF
+[providers.keepass]
+type = "keepass"
+database = "/tmp/test.kdbx"
+password = "test-password"
+
+[secrets]
+TEST = { provider = "keepass", value = "test-entry" }
+EOF
+
+	# This would require a real KeePass database to test fully
+	run "$FNOX_BIN" get TEST
+	# Just verify the config parses without error
+}
+
+@test "keepass provider with secret ref password works" {
+	skip "keepass tests require actual database"
+
+	cat >"${FNOX_CONFIG_FILE}" <<EOF
+[providers]
+plain = { type = "plain" }
+
+[providers.keepass]
+type = "keepass"
+database = "/tmp/test.kdbx"
+password = { secret = "KEEPASS_PASSWORD" }
+
+[secrets]
+KEEPASS_PASSWORD = { provider = "plain", value = "test-password" }
+TEST = { provider = "keepass", value = "test-entry" }
+EOF
+
+	# This would require a real KeePass database to test fully
+	run "$FNOX_BIN" get TEST
+	# Just verify the config parses without error
+}

--- a/test/provider_secret_refs.bats
+++ b/test/provider_secret_refs.bats
@@ -133,3 +133,124 @@ EOF
 	run "$FNOX_BIN" get TEST
 	# Just verify the config parses without error
 }
+
+@test "fnox edit preserves secret refs in provider config" {
+	# Set up config with secret ref in vault provider
+	cat >"${FNOX_CONFIG_FILE}" <<EOF
+root = true
+
+[providers]
+plain = { type = "plain" }
+
+[providers.vault]
+type = "vault"
+address = "https://vault.example.com"
+token = { secret = "VAULT_TOKEN" }
+
+[secrets]
+VAULT_TOKEN = { provider = "plain", value = "hvs.from-config" }
+TEST = { provider = "plain", value = "test-value" }
+EOF
+
+	# Verify initial state
+	run "$FNOX_BIN" get TEST
+	assert_success
+	assert_output "test-value"
+
+	# Create an editor script that modifies the TEST secret value
+	cat >"${BATS_TEST_TMPDIR}/test-editor.py" <<'EDITOR_SCRIPT'
+#!/usr/bin/env python3
+import sys
+import re
+
+with open(sys.argv[1], 'r') as f:
+    content = f.read()
+
+# Change TEST value (flexible pattern to handle spacing variations)
+content = re.sub(
+    r'TEST\s*=\s*\{\s*provider\s*=\s*"plain",\s*value\s*=\s*"[^"]*"\s*\}',
+    r'TEST= { provider = "plain", value = "modified-value" }',
+    content
+)
+
+with open(sys.argv[1], 'w') as f:
+    f.write(content)
+EDITOR_SCRIPT
+	chmod +x "${BATS_TEST_TMPDIR}/test-editor.py"
+
+	export EDITOR="${BATS_TEST_TMPDIR}/test-editor.py"
+
+	# Run edit command
+	run "$FNOX_BIN" edit
+	assert_success
+
+	# Verify the secret was modified
+	run "$FNOX_BIN" get TEST
+	assert_success
+	assert_output "modified-value"
+
+	# Verify the secret ref in vault provider config was preserved
+	run grep 'token = { secret = "VAULT_TOKEN" }' "${FNOX_CONFIG_FILE}"
+	assert_success
+}
+
+@test "fnox edit can add secret ref to provider config" {
+	# Set up config with plain token in vault provider
+	cat >"${FNOX_CONFIG_FILE}" <<EOF
+root = true
+
+[providers]
+plain = { type = "plain" }
+
+[providers.vault]
+type = "vault"
+address = "https://vault.example.com"
+token = "hvs.plain-token"
+
+[secrets]
+TEST = { provider = "plain", value = "test-value" }
+EOF
+
+	# Create an editor script that converts plain token to secret ref
+	cat >"${BATS_TEST_TMPDIR}/test-editor.py" <<'EDITOR_SCRIPT'
+#!/usr/bin/env python3
+import sys
+import re
+
+with open(sys.argv[1], 'r') as f:
+    content = f.read()
+
+# Add VAULT_TOKEN secret
+content = re.sub(
+    r'(\[secrets\]\n)',
+    r'\1VAULT_TOKEN= { provider = "plain", value = "hvs.secret-token" }\n',
+    content
+)
+
+# Change vault token from plain to secret ref
+content = re.sub(
+    r'token = "hvs\.plain-token"',
+    r'token = { secret = "VAULT_TOKEN" }',
+    content
+)
+
+with open(sys.argv[1], 'w') as f:
+    f.write(content)
+EDITOR_SCRIPT
+	chmod +x "${BATS_TEST_TMPDIR}/test-editor.py"
+
+	export EDITOR="${BATS_TEST_TMPDIR}/test-editor.py"
+
+	# Run edit command
+	run "$FNOX_BIN" edit
+	assert_success
+
+	# Verify the VAULT_TOKEN secret was added
+	run "$FNOX_BIN" get VAULT_TOKEN
+	assert_success
+	assert_output "hvs.secret-token"
+
+	# Verify the secret ref in vault provider config was persisted
+	run grep 'token = { secret = "VAULT_TOKEN" }' "${FNOX_CONFIG_FILE}"
+	assert_success
+}

--- a/test/test_helper/common_setup.bash
+++ b/test/test_helper/common_setup.bash
@@ -71,13 +71,16 @@ _common_setup() {
 
 	# Set up test environment variables
 	export HOME="$TEST_TEMP_DIR"
-	export FNOX_CONFIG_FILE="$TEST_TEMP_DIR/fnox.toml"
+
+	# Set FNOX_CONFIG_FILE to relative path - this makes fnox look for config
+	# in the current directory. Tests that need config recursion should unset this.
+	export FNOX_CONFIG_FILE="fnox.toml"
 
 	# Clear hook-env session state to ensure clean test environment
 	unset __FNOX_SESSION
 
-	# Ensure no existing config
-	rm -f "$FNOX_CONFIG_FILE"
+	# Ensure no existing config in test directory
+	rm -f fnox.toml
 }
 
 _common_teardown() {


### PR DESCRIPTION
## Summary

- Allow provider config fields to securely reference secrets using `{ secret = "SECRET_NAME" }` syntax
- Enables storing sensitive provider configuration (like tokens) encrypted or in external secret stores
- Supports `HashiCorpVault::token` and `KeePass::password` fields

### Example

```toml
[providers]
keychain = { type = "keychain", service = "fnox" }

[providers.vault]
type = "vault"
address = "https://vault.example.com"
token = { secret = "VAULT_TOKEN" }

[secrets]
VAULT_TOKEN = { provider = "keychain", value = "vault-token" }
MY_APP_SECRET = { provider = "vault", value = "secret/data/myapp" }
```

### Resolution Behavior

When a provider config field has `{ secret = "NAME" }`:
1. First checks environment variable `NAME`
2. If not found, looks up secret `NAME` in config and resolves via its provider
3. Errors if neither is available

### Bootstrap Providers

Secrets in provider configs must use bootstrap providers that don't themselves have secret refs:
- `keychain` - Uses OS-level authentication
- `age` - Uses `FNOX_AGE_KEY` env var
- `password-store` - Uses GPG
- `plain` - No authentication

## Test plan

- [x] Unit tests for ConfigValue serde (deserialize plain, deserialize secret ref, serialize)
- [x] Unit tests for provider config parsing with secret refs
- [x] Integration tests for provider secret refs (test/provider_secret_refs.bats)
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `{ secret = "NAME" }` support in provider configs with a cycle-safe resolver, refactors providers to typed configs with runtime resolution, and updates commands/docs/tests accordingly.
> 
> - **Core/config**:
>   - Introduce `ConfigValue` (`Plain` | `SecretRef`) and `SecretRef` for provider fields; add serde + unit tests.
>   - Add `config_resolver` with `ResolutionContext` to resolve secret refs (env → config secret via provider) with cycle detection.
>   - Refactor `ProviderConfig` to typed structs per provider and add `create_provider(...)`; remove `get_provider`.
>   - Add `ProviderConfig::capabilities()` (type-based, non-resolving).
> - **Commands**:
>   - Update `doctor`, `edit`, `import`, `init`, `provider test`, `set` to use `ResolutionContext` + `ProviderConfig::create_provider()` and capabilities.
>   - Init wizard: support sensitive fields and secret-ref prompts (`@secret:NAME`).
>   - CLI: `--config` reads from `FNOX_CONFIG_FILE`.
> - **Providers**:
>   - All providers accept `ConfigValue` fields and implement `create_provider()`; unify `put_secret` behavior; add/adjust wizard field metadata.
> - **Docs**:
>   - Add KeePass docs.
>   - Document “Provider Secret References” syntax, resolution order, bootstrap providers, and examples.
> - **Tests**:
>   - Add `test/provider_secret_refs.bats`; update recursion tests to unset `FNOX_CONFIG_FILE`; add unit tests for `ConfigValue` serialize/deserialize.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf3320e2300d270030e30e043bc343f1cc54a728. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->