### PR TITLE
chore: release v1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,55 @@
 # Changelog
 
+## [1.8.0](https://github.com/jdx/fnox/compare/v1.7.0..v1.8.0) - 2026-01-17
+
+### 🚀 Features
+
+- add passwordstate provider by [@davidolrik](https://github.com/davidolrik) in [#147](https://github.com/jdx/fnox/pull/147)
+- aws-ps batch concurrency, aws-kms 10 -> 100 concurrency by [@johnpyp](https://github.com/johnpyp) in [#180](https://github.com/jdx/fnox/pull/180)
+
+### 🐛 Bug Fixes
+
+- resolve clippy unused_assignments warnings in error.rs by [@jdx](https://github.com/jdx) in [#174](https://github.com/jdx/fnox/pull/174)
+- improve AWS SDK error messages and enable SSO support by [@daghoidahl](https://github.com/daghoidahl) in [#173](https://github.com/jdx/fnox/pull/173)
+
+### 📚 Documentation
+
+- add AWS Parameter store to sidebar and provider lists by [@johnpyp](https://github.com/johnpyp) in [#178](https://github.com/jdx/fnox/pull/178)
+
+### 🧪 Testing
+
+- Add missing skip logic to aws_parameter_store.bats by [@jdx](https://github.com/jdx) in [#145](https://github.com/jdx/fnox/pull/145)
+
+### 🛡️ Security
+
+- **(deps)** update azure-sdk-for-rust monorepo to 0.30 by [@renovate[bot]](https://github.com/renovate[bot]) in [#144](https://github.com/jdx/fnox/pull/144)
+
+### 📦️ Dependency Updates
+
+- pin dependencies by [@renovate[bot]](https://github.com/renovate[bot]) in [#133](https://github.com/jdx/fnox/pull/133)
+- update rust crate demand to v1.8.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#134](https://github.com/jdx/fnox/pull/134)
+- lock file maintenance by [@renovate[bot]](https://github.com/renovate[bot]) in [#137](https://github.com/jdx/fnox/pull/137)
+- update rust crate usage-lib to v2.9.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#143](https://github.com/jdx/fnox/pull/143)
+- update rust crate age to v0.11.2 by [@renovate[bot]](https://github.com/renovate[bot]) in [#149](https://github.com/jdx/fnox/pull/149)
+- update aws-sdk-rust monorepo to v1.8.12 by [@renovate[bot]](https://github.com/renovate[bot]) in [#148](https://github.com/jdx/fnox/pull/148)
+- update rust crate gcp_auth to v0.12.5 by [@renovate[bot]](https://github.com/renovate[bot]) in [#151](https://github.com/jdx/fnox/pull/151)
+- update rust crate dbus to v0.9.10 by [@renovate[bot]](https://github.com/renovate[bot]) in [#150](https://github.com/jdx/fnox/pull/150)
+- update rust crate google-cloud-secretmanager-v1 to v1.2.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#153](https://github.com/jdx/fnox/pull/153)
+- update rust crate reqwest to v0.12.25 by [@renovate[bot]](https://github.com/renovate[bot]) in [#152](https://github.com/jdx/fnox/pull/152)
+- lock file maintenance by [@renovate[bot]](https://github.com/renovate[bot]) in [#154](https://github.com/jdx/fnox/pull/154)
+- update dependency vue to v3.5.26 by [@renovate[bot]](https://github.com/renovate[bot]) in [#156](https://github.com/jdx/fnox/pull/156)
+- update rust crate console to v0.16.2 by [@renovate[bot]](https://github.com/renovate[bot]) in [#157](https://github.com/jdx/fnox/pull/157)
+- lock file maintenance by [@renovate[bot]](https://github.com/renovate[bot]) in [#162](https://github.com/jdx/fnox/pull/162)
+- update rust crate arc-swap to v1.8.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#167](https://github.com/jdx/fnox/pull/167)
+- update rust crate chrono to v0.4.43 by [@renovate[bot]](https://github.com/renovate[bot]) in [#176](https://github.com/jdx/fnox/pull/176)
+- update aws-sdk-rust monorepo to v1.98.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#177](https://github.com/jdx/fnox/pull/177)
+
+### New Contributors
+
+- @johnpyp made their first contribution in [#180](https://github.com/jdx/fnox/pull/180)
+- @daghoidahl made their first contribution in [#173](https://github.com/jdx/fnox/pull/173)
+- @davidolrik made their first contribution in [#147](https://github.com/jdx/fnox/pull/147)
+
 ## [1.7.0](https://github.com/jdx/fnox/compare/v1.6.1..v1.7.0) - 2025-11-27
 
 ### 🚀 Features
@@ -8,6 +58,7 @@
 - add KeePass provider support by [@jdx](https://github.com/jdx) in [#123](https://github.com/jdx/fnox/pull/123)
 - add AWS Parameter Store provider support by [@jdx](https://github.com/jdx) in [#126](https://github.com/jdx/fnox/pull/126)
 - support global config file for machine-wide secrets by [@jdx](https://github.com/jdx) in [#128](https://github.com/jdx/fnox/pull/128)
+- add secret references in provider configuration by [@jdx](https://github.com/jdx) in [#131](https://github.com/jdx/fnox/pull/131)
 
 ### 🐛 Bug Fixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,9 +325,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.15.2"
+version = "1.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a88aab2464f1f25453baa7a07c84c5b7684e274054ba06817f382357f77a288"
+checksum = "e84ce723ab67259cfeb9877c6a639ee9eb7a27b28123abd71db7f0d5d0cc9d86"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -335,9 +335,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.35.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45afffdee1e7c9126814751f88dddc747f41d91da16c9551a0f1e8a11e788a1"
+checksum = "43a442ece363113bd4bd4c8b18977a7798dd4d3c3383f34fb61936960e8f4ad8"
 dependencies = [
  "cc",
  "cmake",
@@ -417,15 +417,16 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-signin"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c084bd63941916e1348cb8d9e05ac2e49bdd40a380e9167702683184c6c6be53"
+checksum = "b63973994865f8904a3fb1c58b044f94283590612ef4625ea39726ce406c2add"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http",
  "aws-smithy-json",
+ "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -462,15 +463,16 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.91.0"
+version = "1.92.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ee6402a36f27b52fe67661c6732d684b2635152b676aa2babbfb5204f99115d"
+checksum = "b7d63bd2bdeeb49aa3f9b00c15e18583503b778b2e792fc06284d54e7d5b6566"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http",
  "aws-smithy-json",
+ "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -484,15 +486,16 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.93.0"
+version = "1.94.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45a7f750bbd170ee3677671ad782d90b894548f4e4ae168302c57ec9de5cb3e"
+checksum = "532d93574bf731f311bafb761366f9ece345a0416dbcc273d81d6d1a1205239b"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http",
  "aws-smithy-json",
+ "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -506,15 +509,16 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.95.0"
+version = "1.96.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55542378e419558e6b1f398ca70adb0b2088077e79ad9f14eb09441f2f7b2164"
+checksum = "357e9a029c7524db6a0099cd77fbd5da165540339e7296cca603531bc783b56c"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http",
  "aws-smithy-json",
+ "aws-smithy-observability",
  "aws-smithy-query",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -1015,9 +1019,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.52"
+version = "1.2.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd4932aefd12402b36c60956a4fe0035421f544799057659ff86f923657aada3"
+checksum = "755d2fce177175ffca841e9a06afdb2c4ab0f593d53b4dee48147dfaade85932"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1491,7 +1495,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1613,7 +1617,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1682,9 +1686,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f449e6c6c08c865631d4890cfacf252b3d396c9bcc83adb6623cdb02a8336c41"
+checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
 
 [[package]]
 name = "flate2"
@@ -1742,7 +1746,7 @@ dependencies = [
 
 [[package]]
 name = "fnox"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "age",
  "anyhow",
@@ -2717,7 +2721,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -2966,9 +2970,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.83"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
+checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -3253,7 +3257,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3458,7 +3462,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3882,7 +3886,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.1",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4206,9 +4210,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
@@ -4241,7 +4245,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4267,7 +4271,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.8",
+ "rustls-webpki 0.103.9",
  "subtle",
  "zeroize",
 ]
@@ -4295,9 +4299,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "web-time",
  "zeroize",
@@ -4315,9 +4319,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.8"
+version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -4920,7 +4924,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5689,18 +5693,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.106"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
+checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5711,11 +5715,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.56"
+version = "0.4.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
+checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
 dependencies = [
  "cfg-if",
+ "futures-util",
  "js-sys",
  "once_cell",
  "wasm-bindgen",
@@ -5724,9 +5729,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.106"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
+checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5734,9 +5739,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.106"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
+checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5747,9 +5752,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.106"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
+checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
 ]
@@ -5769,9 +5774,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.83"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
+checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5845,7 +5850,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5861,7 +5866,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
  "windows-collections",
- "windows-core",
+ "windows-core 0.61.2",
  "windows-future",
  "windows-link 0.1.3",
  "windows-numerics",
@@ -5873,7 +5878,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -5885,8 +5890,21 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link 0.1.3",
- "windows-result",
- "windows-strings",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -5895,7 +5913,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
  "windows-link 0.1.3",
  "windows-threading",
 ]
@@ -5940,7 +5958,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
  "windows-link 0.1.3",
 ]
 
@@ -5954,12 +5972,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -6162,9 +6198,9 @@ checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.46.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fnox"
-version = "1.7.0"
+version = "1.8.0"
 edition = "2024"
 authors = ["@jdx"]
 description = "A flexible secret management tool supporting multiple providers and encryption methods"

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -1040,7 +1040,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.7.0",
+  "version": "1.8.0",
   "usage": "Usage: fnox [OPTIONS] <COMMAND>",
   "complete": {
     "key": {

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -4,7 +4,7 @@
 
 **Usage**: `fnox [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.7.0
+**Version**: 1.8.0
 
 - **Usage**: `fnox [FLAGS] <SUBCOMMAND>`
 

--- a/fnox.usage.kdl
+++ b/fnox.usage.kdl
@@ -1,7 +1,7 @@
 min_usage_version "1.3"
 name fnox
 bin fnox
-version "1.7.0"
+version "1.8.0"
 about "A flexible secret management tool by @jdx"
 usage "Usage: fnox [OPTIONS] <COMMAND>"
 flag "-c --config" help="Path to the configuration file (default: fnox.toml, searches parent directories)" global=#true default=fnox.toml {


### PR DESCRIPTION
## [1.8.0](https://github.com/jdx/fnox/compare/v1.7.0..v1.8.0) - 2026-01-17

### 🚀 Features

- add passwordstate provider by [@davidolrik](https://github.com/davidolrik) in [#147](https://github.com/jdx/fnox/pull/147)
- aws-ps batch concurrency, aws-kms 10 -> 100 concurrency by [@johnpyp](https://github.com/johnpyp) in [#180](https://github.com/jdx/fnox/pull/180)

### 🐛 Bug Fixes

- resolve clippy unused_assignments warnings in error.rs by [@jdx](https://github.com/jdx) in [#174](https://github.com/jdx/fnox/pull/174)
- improve AWS SDK error messages and enable SSO support by [@daghoidahl](https://github.com/daghoidahl) in [#173](https://github.com/jdx/fnox/pull/173)

### 📚 Documentation

- add AWS Parameter store to sidebar and provider lists by [@johnpyp](https://github.com/johnpyp) in [#178](https://github.com/jdx/fnox/pull/178)

### 🧪 Testing

- Add missing skip logic to aws_parameter_store.bats by [@jdx](https://github.com/jdx) in [#145](https://github.com/jdx/fnox/pull/145)

### 🛡️ Security

- **(deps)** update azure-sdk-for-rust monorepo to 0.30 by [@renovate[bot]](https://github.com/renovate[bot]) in [#144](https://github.com/jdx/fnox/pull/144)

### 📦️ Dependency Updates

- pin dependencies by [@renovate[bot]](https://github.com/renovate[bot]) in [#133](https://github.com/jdx/fnox/pull/133)
- update rust crate demand to v1.8.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#134](https://github.com/jdx/fnox/pull/134)
- lock file maintenance by [@renovate[bot]](https://github.com/renovate[bot]) in [#137](https://github.com/jdx/fnox/pull/137)
- update rust crate usage-lib to v2.9.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#143](https://github.com/jdx/fnox/pull/143)
- update rust crate age to v0.11.2 by [@renovate[bot]](https://github.com/renovate[bot]) in [#149](https://github.com/jdx/fnox/pull/149)
- update aws-sdk-rust monorepo to v1.8.12 by [@renovate[bot]](https://github.com/renovate[bot]) in [#148](https://github.com/jdx/fnox/pull/148)
- update rust crate gcp_auth to v0.12.5 by [@renovate[bot]](https://github.com/renovate[bot]) in [#151](https://github.com/jdx/fnox/pull/151)
- update rust crate dbus to v0.9.10 by [@renovate[bot]](https://github.com/renovate[bot]) in [#150](https://github.com/jdx/fnox/pull/150)
- update rust crate google-cloud-secretmanager-v1 to v1.2.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#153](https://github.com/jdx/fnox/pull/153)
- update rust crate reqwest to v0.12.25 by [@renovate[bot]](https://github.com/renovate[bot]) in [#152](https://github.com/jdx/fnox/pull/152)
- lock file maintenance by [@renovate[bot]](https://github.com/renovate[bot]) in [#154](https://github.com/jdx/fnox/pull/154)
- update dependency vue to v3.5.26 by [@renovate[bot]](https://github.com/renovate[bot]) in [#156](https://github.com/jdx/fnox/pull/156)
- update rust crate console to v0.16.2 by [@renovate[bot]](https://github.com/renovate[bot]) in [#157](https://github.com/jdx/fnox/pull/157)
- lock file maintenance by [@renovate[bot]](https://github.com/renovate[bot]) in [#162](https://github.com/jdx/fnox/pull/162)
- update rust crate arc-swap to v1.8.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#167](https://github.com/jdx/fnox/pull/167)
- update rust crate chrono to v0.4.43 by [@renovate[bot]](https://github.com/renovate[bot]) in [#176](https://github.com/jdx/fnox/pull/176)
- update aws-sdk-rust monorepo to v1.98.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#177](https://github.com/jdx/fnox/pull/177)

### New Contributors

- @johnpyp made their first contribution in [#180](https://github.com/jdx/fnox/pull/180)
- @daghoidahl made their first contribution in [#173](https://github.com/jdx/fnox/pull/173)
- @davidolrik made their first contribution in [#147](https://github.com/jdx/fnox/pull/147)