### PR TITLE
test: Add missing skip logic to aws_parameter_store.bats

### DIFF
--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -194,7 +194,8 @@
               "choices": {
                 "choices": ["env", "json", "yaml", "toml"]
               }
-            }
+            },
+            "default": "env"
           },
           {
             "name": "output",
@@ -735,7 +736,8 @@
               "required": true,
               "double_dash": "Optional",
               "hide": false
-            }
+            },
+            "default": "."
           },
           {
             "name": "ignore",
@@ -952,7 +954,8 @@
           "required": true,
           "double_dash": "Optional",
           "hide": false
-        }
+        },
+        "default": "fnox.toml"
       },
       {
         "name": "profile",

--- a/docs/cli/export.md
+++ b/docs/cli/export.md
@@ -20,6 +20,8 @@ Export format
 - `yaml`
 - `toml`
 
+**Default:** `env`
+
 ### `-o --output <OUTPUT>`
 
 Output file (default: stdout)

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -14,6 +14,8 @@
 
 Path to the configuration file (default: fnox.toml, searches parent directories)
 
+**Default:** `fnox.toml`
+
 ### `-P --profile <PROFILE>`
 
 Profile to use (default: default, or FNOX_PROFILE env var)

--- a/docs/cli/scan.md
+++ b/docs/cli/scan.md
@@ -12,6 +12,8 @@ Scan repository for potential secrets
 
 Directory to scan (default: current directory)
 
+**Default:** `.`
+
 ### `-i --ignore… <IGNORE>`
 
 Skip files matching this pattern (can be used multiple times)

--- a/fnox.usage.kdl
+++ b/fnox.usage.kdl
@@ -4,7 +4,7 @@ bin fnox
 version "1.7.0"
 about "A flexible secret management tool by @jdx"
 usage "Usage: fnox [OPTIONS] <COMMAND>"
-flag "-c --config" help="Path to the configuration file (default: fnox.toml, searches parent directories)" global=#true {
+flag "-c --config" help="Path to the configuration file (default: fnox.toml, searches parent directories)" global=#true default=fnox.toml {
     arg <CONFIG>
 }
 flag "-P --profile" help="Profile to use (default: default, or FNOX_PROFILE env var)" global=#true {
@@ -43,7 +43,7 @@ cmd exec help="Execute a command with secrets as environment variables" {
 }
 cmd export help="Export secrets in various formats" {
     alias ex
-    flag "-f --format" help="Export format" {
+    flag "-f --format" help="Export format" default=env {
         arg <FORMAT> {
             choices env json yaml toml
         }
@@ -126,7 +126,7 @@ cmd remove help="Remove a secret" {
     arg <KEY> help="Secret key to remove"
 }
 cmd scan help="Scan repository for potential secrets" {
-    flag "-d --dir" help="Directory to scan (default: current directory)" {
+    flag "-d --dir" help="Directory to scan (default: current directory)" default=. {
         arg <DIR>
     }
     flag "-i --ignore" help="Skip files matching this pattern (can be used multiple times)" var=#true {

--- a/test/aws_parameter_store.bats
+++ b/test/aws_parameter_store.bats
@@ -16,6 +16,17 @@ setup() {
 	load 'test_helper/common_setup'
 	_common_setup
 
+	# Check if AWS credentials are available
+	# (mise run test:bats automatically loads secrets via fnox exec)
+	if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
+		skip "AWS credentials not available. Ensure AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are configured."
+	fi
+
+	# Check if aws CLI is installed
+	if ! command -v aws >/dev/null 2>&1; then
+		skip "AWS CLI not installed. Install with: brew install awscli"
+	fi
+
 	# Set the region
 	export PS_REGION="us-east-1"
 }


### PR DESCRIPTION
Fixes the CI failures on forked PRs (like #141).

## Problem
The `aws_parameter_store.bats` test was missing the credential check that other AWS tests have. Without this check, the test would fail on forked PRs where AWS credentials aren't available instead of skipping gracefully.

## Solution
Added the same skip logic that `aws_kms.bats` and `aws_secrets_manager.bats` already have:

```bash
# Check if AWS credentials are available
if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
    skip "AWS credentials not available..."
fi

# Check if aws CLI is installed
if ! command -v aws >/dev/null 2>&1; then
    skip "AWS CLI not installed..."
fi
```

Now the test will skip gracefully when credentials aren't available.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add skip guards in `test/aws_parameter_store.bats` to bypass tests when AWS credentials are absent or the `aws` CLI is not installed.
> 
> - **Tests**:
>   - Update `test/aws_parameter_store.bats` setup to skip when `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` are missing or `aws` CLI is not installed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5bf8a70b5f83066c034f027ef1a969651be8e00e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->