### PR TITLE
docs: add AWS Parameter store to sidebar and provider lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ eval "$(fnox activate bash)"  # or zsh, fish
 fnox lets you store secrets in two ways:
 
 1. **Encrypted in git** - Using age, AWS KMS, Azure KMS, or GCP KMS
-2. **Remote in cloud** - Using AWS Secrets Manager, Azure Key Vault, GCP Secret Manager, 1Password, Bitwarden, Infisical, or HashiCorp Vault
+2. **Remote in cloud** - Using AWS Secrets Manager, AWS Parameter Store, Azure Key Vault, GCP Secret Manager, 1Password, Bitwarden, Infisical, or HashiCorp Vault
 
 Your `fnox.toml` config file either contains encrypted secrets or references to remote secrets. Use `fnox exec` to run commands with secrets loaded, or enable shell integration to auto-load secrets when you `cd` into a directory.
 
@@ -85,6 +85,7 @@ Your `fnox.toml` config file either contains encrypted secrets or references to 
 
 - [Age Encryption](https://fnox.jdx.dev/providers/age) - Simple, free, works with SSH keys
 - [AWS Secrets Manager](https://fnox.jdx.dev/providers/aws-sm) - Centralized AWS secret management
+- [AWS Parameter Store](https://fnox.jdx.dev/providers/aws-ps) - Simple, cost-effective AWS secret storage
 - [1Password](https://fnox.jdx.dev/providers/1password) - Integrate with 1Password CLI
 - [Bitwarden](https://fnox.jdx.dev/providers/bitwarden) - Open source password manager
 

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -85,6 +85,7 @@ export default defineConfig({
             text: "Cloud Secret Storage",
             collapsed: true,
             items: [
+              { text: "AWS Parameter Store", link: "/providers/aws-ps" },
               { text: "AWS Secrets Manager", link: "/providers/aws-sm" },
               { text: "Azure Key Vault Secrets", link: "/providers/azure-sm" },
               { text: "GCP Secret Manager", link: "/providers/gcp-sm" },

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ features:
     details: Store encrypted secrets in version control with age, AWS KMS, Azure KMS, or GCP KMS.
   - icon: ☁️
     title: Cloud Secret Storage
-    details: Reference secrets stored in AWS Secrets Manager, Azure Key Vault, GCP Secret Manager, or Vault.
+    details: Reference secrets stored in AWS Secrets Manager, AWS Parameter Store, Azure Key Vault, GCP Secret Manager, or Vault.
   - icon: 🔄
     title: Shell Integration
     details: Automatically load secrets when you cd into a directory with a fnox.toml file.
@@ -86,6 +86,7 @@ API_KEY = { default = "dev-key-12345" }  # ← plain default value for local dev
 
 ### ☁️ Cloud Secret Storage (remote, centralized)
 
+- **aws-ps** - AWS Parameter Store
 - **aws-sm** - AWS Secrets Manager
 - **azure-sm** - Azure Key Vault Secrets
 - **gcp-sm** - Google Cloud Secret Manager

--- a/docs/providers/overview.md
+++ b/docs/providers/overview.md
@@ -86,6 +86,7 @@ DATABASE_URL = { provider = "aws", value = "database-url" }
 Choose a provider and get started:
 
 - [Age Encryption](/providers/age) - Simple, free, works with SSH keys
-- [AWS Secrets Manager](/providers/aws-sm) - For AWS production workloads
+- [AWS Parameter Store](/providers/aws-ps) - Simple, cost-effective AWS secret storage
+- [AWS Secrets Manager](/providers/aws-sm) - For AWS production workloads with rotation
 - [1Password](/providers/1password) - Leverage existing 1Password setup
 - [Complete Example](/guide/real-world-example) - See providers in action


### PR DESCRIPTION
This PR adds AWS Parameter Store to the docs sidebar/index lists so that it's a discoverable option.

I was pleasantly surprised to realize it was in here after looking through the code, as it's a much cheaper/faster option compared to SM when rotation isn't needed, and in fact even faster than AWS KMS git encrypted secrets when the number of secrets is ~40+.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Highlights AWS Parameter Store as a first-class provider option throughout the docs.
> 
> - Adds `aws-ps` to Cloud Secret Storage lists in `README.md`, `docs/index.md`, and providers `overview.md` (including Next Steps)
> - Updates feature text to mention AWS Parameter Store alongside AWS Secrets Manager
> - Adds "AWS Parameter Store" link to the VitePress sidebar in `docs/.vitepress/config.mjs`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a92f7200f84e7f8898aa568f6f27c56d9055e5f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->