### PR TITLE
feat: aws-ps batch concurrency, aws-kms 10 -> 100 concurrency

### DIFF
--- a/src/providers/aws_kms.rs
+++ b/src/providers/aws_kms.rs
@@ -183,4 +183,13 @@ impl crate::providers::Provider for AwsKmsProvider {
 
         Ok(())
     }
+
+    async fn get_secrets_batch(
+        &self,
+        secrets: &[(String, String)],
+    ) -> std::collections::HashMap<String, Result<String>> {
+        // AWS KMS has a rate limit allowance of 10000+ TPS by default.
+        // 10 -> 100 should generally not cause issues.
+        crate::providers::get_secrets_concurrent(self, secrets, 100).await
+    }
 }


### PR DESCRIPTION
This PR:
- adds concurrency on top of the AWS Parameter Store `get_secret_batch` impl. Previously, batches of size 10 would be run in serial. Now, there can be up to 10 concurrent batches of 10 running.
  - the original batching logic is identical, just moved to a `fetch_batch` fn
- increases the concurrency for aws-kms decrypts to 100 instead of 10 (this should plenty healthy for almost all organizations, given the default rate limit of 10000 TPS)

### Performance results

```bash
### aws-kms, 43 secrets

# Before
fnox list -V  0.11s user 0.03s system 3% cpu 3.709 total

# After
fnox-dev list -V  0.09s user 0.04s system 13% cpu 0.972 total

### aws-ps, 43 secrets

# Before
fnox -P ps list -V  0.04s user 0.01s system 2% cpu 2.242 total

# After
fnox-dev -P ps list -V  0.04s user 0.01s system 3% cpu 1.140 total
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces configurable concurrent secret fetching and applies it to AWS providers for faster resolution.
> 
> - Add `get_secrets_concurrent` helper and use it in the default `Provider::get_secrets_batch` implementation
> - `aws_ps`: refactor batch logic into `fetch_batch` and run up to 10 batches of 10 concurrently using `buffer_unordered(10)`
> - `aws_kms`: override `get_secrets_batch` to fetch with concurrency `100` (was `10`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17bc0b69efccc59e06445e86a26c387380404ccc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->