### PR TITLE
feat: add authentication prompting for expired credentials

### DIFF
--- a/providers/1password.toml
+++ b/providers/1password.toml
@@ -5,6 +5,7 @@ rust_variant = "OnePassword"
 category = "PasswordManager"
 description = "Requires 1Password CLI and service account token"
 default_name = "onepass"
+auth_command = "op signin"
 setup_instructions = """
 Requires: 1Password CLI (op) and a service account token.
 Set token: export OP_SERVICE_ACCOUNT_TOKEN=<token>"""

--- a/providers/aws-kms.toml
+++ b/providers/aws-kms.toml
@@ -5,6 +5,7 @@ rust_variant = "AwsKms"
 category = "CloudKms"
 description = "AWS Key Management Service"
 default_name = "kms"
+auth_command = "aws sso login"
 setup_instructions = """
 Requires AWS credentials and KMS key.
 Configure: aws configure

--- a/providers/aws-ps.toml
+++ b/providers/aws-ps.toml
@@ -5,6 +5,7 @@ rust_variant = "AwsParameterStore"
 category = "CloudSecretsManager"
 description = "AWS Systems Manager Parameter Store"
 default_name = "ps"
+auth_command = "aws sso login"
 setup_instructions = """
 Stores secrets in AWS Parameter Store.
 Requires AWS credentials configured."""

--- a/providers/aws-sm.toml
+++ b/providers/aws-sm.toml
@@ -5,6 +5,7 @@ rust_variant = "AwsSecretsManager"
 category = "CloudSecretsManager"
 description = "AWS Secrets Manager"
 default_name = "sm"
+auth_command = "aws sso login"
 setup_instructions = """
 Stores secrets in AWS Secrets Manager.
 Requires AWS credentials configured."""

--- a/providers/azure-kms.toml
+++ b/providers/azure-kms.toml
@@ -6,6 +6,7 @@ struct_name = "AzureKeyVaultProvider"
 category = "CloudKms"
 description = "Azure Key Vault encryption"
 default_name = "azure-kms"
+auth_command = "az login"
 setup_instructions = """
 Requires Azure credentials and Key Vault.
 Login: az login

--- a/providers/azure-sm.toml
+++ b/providers/azure-sm.toml
@@ -5,6 +5,7 @@ rust_variant = "AzureSecretsManager"
 category = "CloudSecretsManager"
 description = "Azure Key Vault secrets"
 default_name = "azure-sm"
+auth_command = "az login"
 setup_instructions = """
 Stores secrets in Azure Key Vault.
 Requires Azure credentials configured.

--- a/providers/bitwarden.toml
+++ b/providers/bitwarden.toml
@@ -5,6 +5,7 @@ rust_variant = "Bitwarden"
 category = "PasswordManager"
 description = "Requires Bitwarden CLI and session token"
 default_name = "bitwarden"
+auth_command = "bw login"
 setup_instructions = """
 Requires: Bitwarden CLI (bw) and a session token.
 Login: bw login

--- a/providers/gcp-kms.toml
+++ b/providers/gcp-kms.toml
@@ -5,6 +5,7 @@ rust_variant = "GcpKms"
 category = "CloudKms"
 description = "Google Cloud Key Management Service"
 default_name = "gcp-kms"
+auth_command = "gcloud auth application-default login"
 setup_instructions = """
 Requires GCP credentials and KMS keyring.
 Login: gcloud auth application-default login

--- a/providers/gcp-sm.toml
+++ b/providers/gcp-sm.toml
@@ -5,6 +5,7 @@ rust_variant = "GoogleSecretManager"
 category = "CloudSecretsManager"
 description = "Google Cloud Secret Manager"
 default_name = "gcp-sm"
+auth_command = "gcloud auth application-default login"
 setup_instructions = """
 Stores secrets in Google Cloud Secret Manager.
 Requires GCP credentials configured.

--- a/providers/infisical.toml
+++ b/providers/infisical.toml
@@ -5,6 +5,7 @@ rust_variant = "Infisical"
 category = "PasswordManager"
 description = "Cloud secrets manager with E2E encryption"
 default_name = "infisical"
+auth_command = "infisical login"
 setup_instructions = """
 Requires: Infisical CLI and service token.
 Get token from Infisical project settings.

--- a/providers/vault.toml
+++ b/providers/vault.toml
@@ -5,6 +5,7 @@ rust_variant = "HashiCorpVault"
 category = "CloudSecretsManager"
 description = "HashiCorp Vault secrets engine"
 default_name = "vault"
+auth_command = "vault login"
 setup_instructions = """
 Requires HashiCorp Vault server and token.
 Set: export VAULT_ADDR=http://localhost:8200

--- a/src/auth_prompt.rs
+++ b/src/auth_prompt.rs
@@ -1,0 +1,72 @@
+//! Authentication prompt handling for providers.
+//!
+//! When a provider fails due to authentication issues, this module handles
+//! prompting the user to run the appropriate auth command and retrying.
+
+use crate::config::Config;
+use crate::error::{FnoxError, Result};
+use crate::providers::ProviderConfig;
+use demand::Confirm;
+use std::process::Command;
+
+/// Prompts the user to run an auth command and executes it if they agree.
+///
+/// Returns `Ok(true)` if the auth command was run successfully,
+/// `Ok(false)` if the user declined or no auth command is available,
+/// `Err` if the auth command failed.
+pub fn prompt_and_run_auth(
+    config: &Config,
+    provider_config: &ProviderConfig,
+    provider_name: &str,
+    error: &FnoxError,
+) -> Result<bool> {
+    // Check if we should prompt
+    if !config.should_prompt_auth() {
+        return Ok(false);
+    }
+
+    // Get the auth command for this provider
+    let Some(auth_command) = provider_config.default_auth_command() else {
+        return Ok(false);
+    };
+
+    // Show the error and prompt
+    eprintln!(
+        "Authentication failed for provider '{}': {}",
+        provider_name, error
+    );
+
+    let user_confirmed = Confirm::new(format!("Run `{}` to authenticate?", auth_command))
+        .affirmative("Yes")
+        .negative("No")
+        .run()
+        .map_err(|e| FnoxError::Provider(format!("Failed to show prompt: {}", e)))?;
+
+    if !user_confirmed {
+        return Ok(false);
+    }
+
+    // Run the auth command
+    eprintln!("Running: {}", auth_command);
+
+    let status = if cfg!(target_os = "windows") {
+        Command::new("cmd").args(["/C", auth_command]).status()
+    } else {
+        Command::new("sh").args(["-c", auth_command]).status()
+    };
+
+    match status {
+        Ok(exit_status) if exit_status.success() => {
+            eprintln!("Authentication successful, retrying...");
+            Ok(true)
+        }
+        Ok(exit_status) => Err(FnoxError::Provider(format!(
+            "Auth command failed with exit code: {}",
+            exit_status.code().unwrap_or(-1)
+        ))),
+        Err(e) => Err(FnoxError::Provider(format!(
+            "Failed to run auth command: {}",
+            e
+        ))),
+    }
+}

--- a/src/env.rs
+++ b/src/env.rs
@@ -28,6 +28,13 @@ pub static FNOX_PROFILE: LazyLock<Option<String>> = LazyLock::new(|| {
 // Age encryption key configuration
 pub static FNOX_AGE_KEY: LazyLock<Option<String>> = LazyLock::new(|| var("FNOX_AGE_KEY").ok());
 
+// Auth prompt configuration (defaults to true if not set)
+pub static FNOX_PROMPT_AUTH: LazyLock<Option<bool>> = LazyLock::new(|| {
+    var("FNOX_PROMPT_AUTH")
+        .ok()
+        .map(|v| matches!(v.to_lowercase().as_str(), "1" | "true" | "yes"))
+});
+
 // Helper functions for parsing environment variables
 fn var_path(name: &str) -> Option<PathBuf> {
     var(name).map(PathBuf::from).ok()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 // Library interface for fnox
+pub mod auth_prompt;
 pub mod commands;
 pub mod config;
 pub mod env;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
+mod auth_prompt;
 mod commands;
 mod config;
 mod env;


### PR DESCRIPTION
## Summary

- When a provider fails to retrieve a secret (typically due to expired credentials), fnox now prompts users to run the appropriate auth command and retries automatically when running in a TTY
- Adds `auth_command` field to all provider definitions with sensible defaults (e.g., `aws sso login`, `op signin`)
- Adds `prompt_auth` config option and `FNOX_PROMPT_AUTH` env var to disable prompting
- Uses the `demand` crate for interactive prompts

## Behavior

| Context | Result |
|---------|--------|
| TTY + auth fails | Prompts: "Authentication failed. Run `aws sso login`? [Y/n]" |
| Non-TTY + auth fails | No prompt, continues based on `if_missing` |
| TTY + `prompt_auth = false` | No prompt |

## Test plan

- [ ] Test with expired AWS credentials to verify prompt appears
- [ ] Test with `FNOX_PROMPT_AUTH=false` to verify prompt is suppressed
- [ ] Test in non-TTY (piped) environment to verify no prompt
- [ ] Verify existing tests still pass

Closes #181

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces interactive auth prompting with provider-specific defaults and a single retry on failure.
> 
> - Adds `auth_prompt` module and integrates retry flow into secret resolution (single and batch) with `prompt_and_run_auth`
> - Extends provider schema and generator to support `auth_command` and expose `ProviderConfig::default_auth_command()`
> - Updates all provider TOMLs to include default `auth_command` values (AWS, Azure, GCP, 1Password, Bitwarden, Infisical, Vault)
> - Adds `prompt_auth` config option and `FNOX_PROMPT_AUTH` env var; implements `Config::should_prompt_auth()` with TTY detection and merge support
> - Documents behavior and configuration in `CRUSH.md`; wires new module in `lib.rs`/`main.rs`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 65a25dbc2ba2c942c4a388e6d233a6abb865dd69. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->