### PR TITLE
feat: add LLM-generated editorialized release notes

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -34,7 +34,10 @@ jobs:
         with:
           experimental: true
       - run: mise trust --all
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code
       - run: mise run release-plz
         env:
           GITHUB_TOKEN: ${{ secrets.FNOX_GH_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,8 +86,11 @@ jobs:
         with:
           experimental: true
       - run: mise trust --all
-      - name: Generate release notes
-        run: git cliff --latest > release-notes.md && cat release-notes.md
+      - name: Extract release notes from CHANGELOG
+        run: |
+          # Extract the latest release section from CHANGELOG.md (includes LLM summary if available)
+          awk '/^## \[/{if(found) exit; found=1} found{print}' CHANGELOG.md > release-notes.md
+          cat release-notes.md
       - name: Download all artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,11 +86,28 @@ jobs:
         with:
           experimental: true
       - run: mise trust --all
-      - name: Extract release notes from CHANGELOG
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code
+      - name: Generate release notes
         run: |
-          # Extract the latest release section from CHANGELOG.md (includes LLM summary if available)
-          awk '/^## \[/{if(found) exit; found=1} found{print}' CHANGELOG.md > release-notes.md
+          TAG_NAME="${{ github.ref_name }}"
+          if [ -z "$TAG_NAME" ]; then
+            TAG_NAME="v${{ inputs.version }}"
+          fi
+          PREV_TAG="$(git describe --tags --abbrev=0 "$TAG_NAME^" 2>/dev/null || echo "")"
+          # Generate rich release notes using LLM
+          if [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
+            mise run gen-release-notes "$TAG_NAME" "$PREV_TAG" > release-notes.md || {
+              echo "LLM generation failed, falling back to CHANGELOG.md"
+              awk '/^## \[/{if(found) exit; found=1} found{print}' CHANGELOG.md > release-notes.md
+            }
+          else
+            echo "ANTHROPIC_API_KEY not set, using CHANGELOG.md"
+            awk '/^## \[/{if(found) exit; found=1} found{print}' CHANGELOG.md > release-notes.md
+          fi
           cat release-notes.md
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       - name: Download all artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,9 +90,10 @@ jobs:
         run: npm install -g @anthropic-ai/claude-code
       - name: Generate release notes
         run: |
-          TAG_NAME="${{ github.ref_name }}"
-          if [ -z "$TAG_NAME" ]; then
+          if [[ -n "${{ inputs.version }}" ]]; then
             TAG_NAME="v${{ inputs.version }}"
+          else
+            TAG_NAME="${{ github.ref_name }}"
           fi
           PREV_TAG="$(git describe --tags --abbrev=0 "$TAG_NAME^" 2>/dev/null || echo "")"
           # Generate rich release notes using LLM
@@ -120,9 +121,10 @@ jobs:
           ls -la release-assets/
       - name: Create release with all assets
         run: |
-          TAG_NAME="${{ github.ref_name }}"
-          if [ -z "$TAG_NAME" ]; then
+          if [[ -n "${{ inputs.version }}" ]]; then
             TAG_NAME="v${{ inputs.version }}"
+          else
+            TAG_NAME="${{ github.ref_name }}"
           fi
           gh release create "$TAG_NAME" \
             --title "$TAG_NAME" \

--- a/mise-tasks/gen-release-notes
+++ b/mise-tasks/gen-release-notes
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#MISE description="Generate concise changelog entry using Claude Code"
+#MISE description="Generate rich release notes for GitHub releases using Claude Code"
 #USAGE arg "<version>" help="Version to release (e.g., v1.9.0)"
 #USAGE arg "[prev_version]" help="Previous version for comparison"
 set -euo pipefail
@@ -8,15 +8,20 @@ version="${usage_version:-}"
 prev_version="${usage_prev_version:-}"
 
 if [[ -z $version ]]; then
-	echo "Usage: mise run gen-release-summary <version> [prev_version]" >&2
+	echo "Usage: mise run gen-release-notes <version> [prev_version]" >&2
 	exit 1
 fi
 
 # Get the git-cliff changelog for context
-changelog=$(git cliff --unreleased --strip all 2>/dev/null || echo "")
+# Use the tag range if prev_version provided, otherwise unreleased
+if [[ -n $prev_version ]]; then
+	changelog=$(git cliff --strip all "${prev_version}..${version}" 2>/dev/null || echo "")
+else
+	changelog=$(git cliff --unreleased --strip all 2>/dev/null || echo "")
+fi
 
 if [[ -z $changelog ]]; then
-	echo "Error: No unreleased changes found" >&2
+	echo "Error: No changes found for release" >&2
 	exit 1
 fi
 
@@ -30,23 +35,20 @@ prompt=$(
 	printf '%s\n' "$changelog"
 	printf '\n'
 	cat <<'INSTRUCTIONS'
-Write a brief changelog entry:
+Write user-friendly release notes:
 
-1. One short paragraph (2-3 sentences) summarizing the release
-2. Categorized bullet points (### Features, ### Bug Fixes, etc.)
-3. One line per change, no explanations
-4. Skip minor/internal changes
-5. Include PR links for significant changes
-6. Include contributor usernames (@username)
-7. Link to relevant documentation at https://fnox.jdx.dev/ where applicable
+1. Start with 1-2 paragraphs summarizing key changes
+2. Organize into ### sections (Highlights, Bug Fixes, etc.)
+3. Explain WHY changes matter to users
+4. Include PR links and documentation links (https://fnox.jdx.dev/)
+5. Include contributor usernames (@username)
+6. Skip internal changes
 
-IMPORTANT: Use only ### for section headers. NEVER use "## [" as this pattern is reserved for version headers.
-
-Output ONLY the brief changelog, no preamble.
+Output ONLY the release notes, no preamble.
 INSTRUCTIONS
 )
 
-# Use Claude Code to generate the changelog entry
+# Use Claude Code to generate the release notes
 # Sandboxed: only read-only tools allowed (no Bash, Edit, Write)
 output=$(
 	printf '%s' "$prompt" | claude -p \
@@ -54,11 +56,5 @@ output=$(
 		--output-format text \
 		--allowedTools "Read,Grep,Glob"
 )
-
-# Validate output doesn't contain patterns that would corrupt changelog processing
-if echo "$output" | grep -qE '^## \['; then
-	echo "Error: LLM output contains '## [' pattern which would corrupt changelog processing" >&2
-	exit 1
-fi
 
 echo "$output"

--- a/mise-tasks/gen-release-summary
+++ b/mise-tasks/gen-release-summary
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#MISE description="Generate editorialized release notes using Claude Code"
+#USAGE arg "<version>" help="Version to release (e.g., v1.9.0)"
+#USAGE arg "[prev_version]" help="Previous version for comparison"
+set -euo pipefail
+
+version="${usage_version:-}"
+prev_version="${usage_prev_version:-}"
+
+if [[ -z $version ]]; then
+	echo "Usage: mise run gen-release-summary <version> [prev_version]" >&2
+	exit 1
+fi
+
+# Get the git-cliff changelog for context
+changelog=$(git cliff --unreleased --strip all 2>/dev/null || echo "")
+
+if [[ -z $changelog ]]; then
+	echo "Error: No unreleased changes found" >&2
+	exit 1
+fi
+
+# Use Claude Code to editorialize the release notes
+# Sandboxed: only read-only tools allowed (no Bash, Edit, Write)
+output=$(
+	claude -p \
+		--model claude-sonnet-4-20250514 \
+		--output-format text \
+		--allowedTools "Read,Grep,Glob" \
+		<<EOF
+You are writing release notes for fnox version ${version}${prev_version:+ (previous version: ${prev_version})}.
+
+fnox is a secrets management CLI that encrypts and manages secrets in config files, supporting multiple providers (1Password, AWS, Azure, GCP, Bitwarden, etc.).
+
+Here is the raw changelog from git-cliff:
+${changelog}
+
+Rewrite this into user-friendly release notes. The format should be:
+
+1. Start with 1-2 paragraphs summarizing the most important changes
+2. Then organize into sections using ### headers (e.g., "### Highlights", "### Bug Fixes")
+3. Write in clear, user-focused language (not developer commit messages)
+4. Explain WHY changes matter to users, not just what changed
+5. Group related changes together logically
+6. Skip minor/internal changes that don't affect users
+7. Include contributor attribution where appropriate (@username)
+
+IMPORTANT: Use only ### for section headers. NEVER use "## [" as this pattern is reserved for version headers and will corrupt changelog processing.
+
+Keep the tone professional but approachable. Focus on what users care about.
+
+Output ONLY the editorialized release notes, no preamble.
+EOF
+)
+
+# Validate output doesn't contain patterns that would corrupt changelog processing
+if echo "$output" | grep -qE '^## \['; then
+	echo "Error: LLM output contains '## [' pattern which would corrupt changelog processing" >&2
+	exit 1
+fi
+
+echo "$output"

--- a/mise-tasks/gen-release-summary
+++ b/mise-tasks/gen-release-summary
@@ -20,21 +20,16 @@ if [[ -z $changelog ]]; then
 	exit 1
 fi
 
-# Use Claude Code to editorialize the release notes
-# Sandboxed: only read-only tools allowed (no Bash, Edit, Write)
-output=$(
-	claude -p \
-		--model claude-sonnet-4-20250514 \
-		--output-format text \
-		--allowedTools "Read,Grep,Glob" \
-		<<EOF
-You are writing release notes for fnox version ${version}${prev_version:+ (previous version: ${prev_version})}.
-
-fnox is a secrets management CLI that encrypts and manages secrets in config files, supporting multiple providers (1Password, AWS, Azure, GCP, Bitwarden, etc.).
-
-Here is the raw changelog from git-cliff:
-${changelog}
-
+# Build prompt safely using printf to avoid command substitution on backticks in changelog
+prompt=$(
+	printf '%s\n' "You are writing release notes for fnox version ${version}${prev_version:+ (previous version: ${prev_version})}."
+	printf '\n'
+	printf '%s\n' "fnox is a secrets management CLI that encrypts and manages secrets in config files, supporting multiple providers (1Password, AWS, Azure, GCP, Bitwarden, etc.)."
+	printf '\n'
+	printf '%s\n' "Here is the raw changelog from git-cliff:"
+	printf '%s\n' "$changelog"
+	printf '\n'
+	cat <<'INSTRUCTIONS'
 Rewrite this into user-friendly release notes. The format should be:
 
 1. Start with 1-2 paragraphs summarizing the most important changes
@@ -44,13 +39,24 @@ Rewrite this into user-friendly release notes. The format should be:
 5. Group related changes together logically
 6. Skip minor/internal changes that don't affect users
 7. Include contributor attribution where appropriate (@username)
+8. Include links to PRs (e.g., [#123](https://github.com/jdx/fnox/pull/123)) for significant changes
+9. Where applicable, link to relevant documentation at https://fnox.jdx.dev/
 
 IMPORTANT: Use only ### for section headers. NEVER use "## [" as this pattern is reserved for version headers and will corrupt changelog processing.
 
 Keep the tone professional but approachable. Focus on what users care about.
 
 Output ONLY the editorialized release notes, no preamble.
-EOF
+INSTRUCTIONS
+)
+
+# Use Claude Code to editorialize the release notes
+# Sandboxed: only read-only tools allowed (no Bash, Edit, Write)
+output=$(
+	printf '%s' "$prompt" | claude -p \
+		--model claude-sonnet-4-20250514 \
+		--output-format text \
+		--allowedTools "Read,Grep,Glob"
 )
 
 # Validate output doesn't contain patterns that would corrupt changelog processing

--- a/mise-tasks/release-plz
+++ b/mise-tasks/release-plz
@@ -17,11 +17,10 @@ if [ -z "$released_versions" ] || ! echo "$released_versions" | grep -q "^v$cur_
 fi
 
 version="$(git cliff --bumped-version)"
-changelog="$(git cliff --bump --unreleased --strip all)"
 
 if [ "$DRY_RUN" -ne 0 ]; then
   echo "version: $version"
-  echo "changelog: $changelog"
+  echo "changelog: $(git cliff --bump --unreleased --strip all)"
   exit 0
 fi
 
@@ -31,13 +30,64 @@ if [ "$version" = "v$cur_version" ]; then
   exit 0
 fi
 
-git cliff --bump -o CHANGELOG.md
 cargo set-version --package fnox "${version#v}"
 
 git config user.name mise-en-dev
 git config user.email 123107610+mise-en-dev@users.noreply.github.com
 cargo update
 mise run render ::: lint-fix
+
+# Generate editorialized release notes using LLM (if available)
+echo "Generating editorialized release notes..."
+prev_tag="$(git describe --tags --abbrev=0 2>/dev/null || echo "")"
+EDITORIALIZED_NOTES=""
+if command -v claude >/dev/null 2>&1 && [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
+  EDITORIALIZED_NOTES="$(mise run gen-release-summary "$version" "$prev_tag" 2>/dev/null || echo "")"
+fi
+
+# Validate we got non-empty release notes, fall back to raw changelog
+if [[ -z $EDITORIALIZED_NOTES ]]; then
+  echo "LLM generation unavailable or failed, using raw changelog"
+  EDITORIALIZED_NOTES="$(git cliff --bump --unreleased --strip all)"
+fi
+
+# Create the release header with appropriate URL format
+RELEASE_DATE="$(date +%Y-%m-%d)"
+if [[ -n $prev_tag ]]; then
+  RELEASE_HEADER="## [${version#v}](https://github.com/jdx/fnox/compare/$prev_tag..$version) - $RELEASE_DATE"
+else
+  # No previous tag - link to the tag directly instead of a compare URL
+  RELEASE_HEADER="## [${version#v}](https://github.com/jdx/fnox/releases/tag/$version) - $RELEASE_DATE"
+fi
+
+# Insert the new release before the first existing release section (## [)
+# This handles any CHANGELOG format as long as releases start with ## [
+# Use ENVIRON for notes to avoid awk interpreting backslash escape sequences
+export RELEASE_HEADER EDITORIALIZED_NOTES
+awk_exit_code=0
+awk '
+  /^## \[/ && !inserted {
+    # Insert new release before the first existing release
+    print ENVIRON["RELEASE_HEADER"]
+    print ""
+    print ENVIRON["EDITORIALIZED_NOTES"]
+    print ""
+    inserted = 1
+  }
+  { print }
+  END {
+    # Signal whether insertion happened via exit code
+    exit (inserted ? 0 : 1)
+  }
+' CHANGELOG.md >CHANGELOG.md.tmp || awk_exit_code=$?
+
+if [[ $awk_exit_code -ne 0 ]]; then
+  echo "Error: Failed to insert release notes into CHANGELOG.md (no existing release section found)" >&2
+  rm -f CHANGELOG.md.tmp
+  exit 1
+fi
+mv CHANGELOG.md.tmp CHANGELOG.md
+echo "Editorialized release notes added to CHANGELOG.md"
 
 git add \
   Cargo.* \
@@ -50,7 +100,7 @@ git commit -m "chore: release $version"
 git push origin release --force
 
 # Try to create PR, if it already exists then edit it
-if ! gh pr create --title "chore: release $version" --body "$changelog"; then
+if ! gh pr create --title "chore: release $version" --body "$EDITORIALIZED_NOTES"; then
   echo "Failed to create PR, attempting to update existing PR"
-  gh pr edit release --title "chore: release $version" --body "$changelog" || true
+  gh pr edit release --title "chore: release $version" --body "$EDITORIALIZED_NOTES" || true
 fi

--- a/mise-tasks/release-plz
+++ b/mise-tasks/release-plz
@@ -51,6 +51,12 @@ if [[ -z $EDITORIALIZED_NOTES ]]; then
   EDITORIALIZED_NOTES="$(git cliff --bump --unreleased --strip all)"
 fi
 
+# Validate notes don't contain patterns that would corrupt changelog processing
+if echo "$EDITORIALIZED_NOTES" | grep -qE '^## \['; then
+  echo "Error: Release notes contain '## [' pattern which would corrupt changelog processing" >&2
+  exit 1
+fi
+
 # Create the release header with appropriate URL format
 RELEASE_DATE="$(date +%Y-%m-%d)"
 if [[ -n $prev_tag ]]; then


### PR DESCRIPTION
## Summary

Adds Claude Code CLI integration to generate user-friendly editorialized release notes.

### Changes

- **New script** `mise-tasks/gen-release-summary`: Generates editorialized release notes from git-cliff output using Claude Code (sandboxed with read-only tools)
- **Updated `mise-tasks/release-plz`**: Uses editorialized notes for CHANGELOG.md
- **Updated `.github/workflows/release.yml`**: Extracts notes from CHANGELOG.md for GitHub releases
- **Validation**: Rejects LLM output containing "## [" pattern to prevent changelog corruption

### How it works

1. During release-plz, the script generates editorialized release notes using Claude Code
2. The editorialized content is inserted into CHANGELOG.md
3. GitHub releases extract the same content from CHANGELOG.md (single source of truth)

### Security

The Claude Code agent is sandboxed with `--allowedTools "Read,Grep,Glob"` to prevent any file modifications or command execution.

### Requirements

- `ANTHROPIC_API_KEY` secret must be configured

## Test plan

- [ ] Verify `mise run gen-release-summary` produces well-formatted output locally
- [ ] Test with a release cycle to confirm CHANGELOG.md and GitHub release have correct content

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds LLM-generated release notes to automate and standardize release documentation.
> 
> - **Workflows**: Install `@anthropic-ai/claude-code` in `release-plz.yml` and `release.yml`; pass `ANTHROPIC_API_KEY`; `release.yml` now generates notes via LLM with fallback to `CHANGELOG.md`.
> - **New tasks**: `mise-tasks/gen-release-notes` (rich release notes) and `mise-tasks/gen-release-summary` (concise changelog) using Claude Code in read-only sandbox.
> - **Release script updates**: `mise-tasks/release-plz` generates editorialized notes, validates against corrupting patterns, inserts a properly linked header and notes into `CHANGELOG.md`, and uses them as PR body; falls back to raw `git-cliff` output if LLM unavailable.
> - **Safety**: Rejects outputs containing `## [` and confines agent to read-only tools.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a7e9a3fddcb7dc03126a4c73256c1e8e3a506289. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->