### PR TITLE
fix: use positional args in gen-release-notes

### DIFF
--- a/mise-tasks/gen-release-notes
+++ b/mise-tasks/gen-release-notes
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
-#MISE description="Generate rich release notes for GitHub releases using Claude Code"
-#USAGE arg "<version>" help="Version to release (e.g., v1.9.0)"
-#USAGE arg "[prev_version]" help="Previous version for comparison"
 set -euo pipefail
 
-version="${usage_version:-}"
-prev_version="${usage_prev_version:-}"
+# Generate rich release notes for GitHub releases using Claude Code
+# Usage: mise run gen-release-notes <version> [prev_version]
+
+version="${1:-}"
+prev_version="${2:-}"
 
 if [[ -z $version ]]; then
 	echo "Usage: mise run gen-release-notes <version> [prev_version]" >&2
@@ -56,5 +56,11 @@ output=$(
 		--output-format text \
 		--allowedTools "Read,Grep,Glob"
 )
+
+# Validate we got non-empty output
+if [[ -z $output ]]; then
+	echo "Error: Claude returned empty output" >&2
+	exit 1
+fi
 
 echo "$output"


### PR DESCRIPTION
## Summary
The `gen-release-notes` script was using usage spec environment variables (`usage_version`, `usage_prev_version`) which weren't being set correctly in the GitHub Actions environment, causing the LLM generation to fail.

This switches to using `$1` and `$2` positional arguments directly, consistent with how the mise version works.

This fixes the v1.9.0 release where LLM notes failed and it fell back to raw CHANGELOG.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches `mise-tasks/gen-release-notes` to use positional args and hardens execution flow.
> 
> - Use `"$1"`/`"$2"` instead of `usage_version`/`usage_prev_version` for `version` and `prev_version`
> - Update inline usage docs to reflect positional args
> - Add validation to error if Claude returns empty output
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e8495aaf559667eec40d2c8ade0263bbdd53c37. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->