### PR TITLE
chore: release v1.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.9.1](https://github.com/jdx/fnox/compare/v1.9.0..v1.9.1) - 2026-01-19
+
+### 🐛 Bug Fixes
+
+- use positional args in gen-release-notes by [@jdx](https://github.com/jdx) in [#187](https://github.com/jdx/fnox/pull/187)
+
 ## [1.9.0](https://github.com/jdx/fnox/compare/v1.8.0..v1.9.0) - 2026-01-19
 
 ### 🚀 Features
@@ -197,7 +203,7 @@
 
 ### 🚜 Refactor
 
-- remove unused env_diff module and \_\_FNOX_DIFF by [@jdx](https://github.com/jdx) in [#70](https://github.com/jdx/fnox/pull/70)
+- remove unused env_diff module and __FNOX_DIFF by [@jdx](https://github.com/jdx) in [#70](https://github.com/jdx/fnox/pull/70)
 
 ### ⚡ Performance
 
@@ -205,7 +211,7 @@
 
 ### 🛡️ Security
 
-- **(security)** store only hashes in \_\_FNOX_SESSION instead of plaintext secrets by [@jdx](https://github.com/jdx) in [#71](https://github.com/jdx/fnox/pull/71)
+- **(security)** store only hashes in __FNOX_SESSION instead of plaintext secrets by [@jdx](https://github.com/jdx) in [#71](https://github.com/jdx/fnox/pull/71)
 
 ## [1.2.3](https://github.com/jdx/fnox/compare/v1.2.2..v1.2.3) - 2025-11-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -203,7 +203,7 @@
 
 ### 🚜 Refactor
 
-- remove unused env_diff module and __FNOX_DIFF by [@jdx](https://github.com/jdx) in [#70](https://github.com/jdx/fnox/pull/70)
+- remove unused env_diff module and \_\_FNOX_DIFF by [@jdx](https://github.com/jdx) in [#70](https://github.com/jdx/fnox/pull/70)
 
 ### ⚡ Performance
 
@@ -211,7 +211,7 @@
 
 ### 🛡️ Security
 
-- **(security)** store only hashes in __FNOX_SESSION instead of plaintext secrets by [@jdx](https://github.com/jdx) in [#71](https://github.com/jdx/fnox/pull/71)
+- **(security)** store only hashes in \_\_FNOX_SESSION instead of plaintext secrets by [@jdx](https://github.com/jdx) in [#71](https://github.com/jdx/fnox/pull/71)
 
 ## [1.2.3](https://github.com/jdx/fnox/compare/v1.2.2..v1.2.3) - 2025-11-01
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1745,7 +1745,7 @@ dependencies = [
 
 [[package]]
 name = "fnox"
-version = "1.9.0"
+version = "1.9.1"
 dependencies = [
  "age",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fnox"
-version = "1.9.0"
+version = "1.9.1"
 edition = "2024"
 authors = ["@jdx"]
 description = "A flexible secret management tool supporting multiple providers and encryption methods"

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -1040,7 +1040,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.9.0",
+  "version": "1.9.1",
   "usage": "Usage: fnox [OPTIONS] <COMMAND>",
   "complete": {
     "key": {

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -4,7 +4,7 @@
 
 **Usage**: `fnox [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.9.0
+**Version**: 1.9.1
 
 - **Usage**: `fnox [FLAGS] <SUBCOMMAND>`
 

--- a/fnox.usage.kdl
+++ b/fnox.usage.kdl
@@ -1,7 +1,7 @@
 min_usage_version "1.3"
 name fnox
 bin fnox
-version "1.9.0"
+version "1.9.1"
 about "A flexible secret management tool by @jdx"
 usage "Usage: fnox [OPTIONS] <COMMAND>"
 flag "-c --config" help="Path to the configuration file (default: fnox.toml, searches parent directories)" global=#true default=fnox.toml {


### PR DESCRIPTION
## [1.9.1](https://github.com/jdx/fnox/compare/v1.9.0..v1.9.1) - 2026-01-19

### 🐛 Bug Fixes

- use positional args in gen-release-notes by [@jdx](https://github.com/jdx) in [#187](https://github.com/jdx/fnox/pull/187)