### PR TITLE
chore: exclude CHANGELOG.md from prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 tmp
 CLAUDE.md
+CHANGELOG.md

--- a/hk.pkl
+++ b/hk.pkl
@@ -4,7 +4,7 @@ import "package://github.com/jdx/hk/releases/download/v1.19.0/hk@1.19.0#/Builtin
 local linters = new Mapping<String, Step> {
     ["actionlint"] = Builtins.actionlint
     ["prettier"] = (Builtins.prettier) {
-        exclude = List("CLAUDE.md") // TODO: fix symbolic links with prettier built-in: ([error] Explicitly specified pattern "CLAUDE.md" is a symbolic link.)
+        exclude = List("CLAUDE.md", "CHANGELOG.md") // TODO: fix symbolic links with prettier built-in: ([error] Explicitly specified pattern "CLAUDE.md" is a symbolic link.)
     }
     ["cargo-fmt"] = Builtins.cargo_fmt
     ["cargo-check"] = Builtins.cargo_check


### PR DESCRIPTION
## Summary
- Excludes CHANGELOG.md from prettier in both `hk.pkl` and `.prettierignore`
- Prevents autofix-ci from reformatting the changelog on release PRs, which can cause rebase issues

## Test plan
- [x] Verified `pkl eval hk.pkl` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents release PR changelog auto-formatting by excluding it from Prettier in both config sources.
> 
> - Adds `CHANGELOG.md` to `.prettierignore`
> - Updates `hk.pkl` `prettier` linter `exclude` list to include `CHANGELOG.md`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4da16f6eb748dfe730b82c038cb4bba5228b3e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->