### PR TITLE
fix: gen-release-notes improvements

### DIFF
--- a/mise-tasks/gen-release-notes
+++ b/mise-tasks/gen-release-notes
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
-#MISE description="Generate rich release notes for GitHub releases using Claude Code"
-#USAGE arg "<version>" help="Version to release (e.g., v1.9.0)"
-#USAGE arg "[prev_version]" help="Previous version for comparison"
 set -euo pipefail
 
-version="${usage_version:-}"
-prev_version="${usage_prev_version:-}"
+# Generate rich release notes for GitHub releases using Claude Code
+# Usage: mise run gen-release-notes <version> [prev_version]
+
+version="${1:-}"
+prev_version="${2:-}"
 
 if [[ -z $version ]]; then
 	echo "Usage: mise run gen-release-notes <version> [prev_version]" >&2
@@ -56,5 +56,11 @@ output=$(
 		--output-format text \
 		--allowedTools "Read,Grep,Glob"
 )
+
+# Validate we got non-empty output
+if [[ -z $output ]]; then
+	echo "Error: Claude returned empty output" >&2
+	exit 1
+fi
 
 echo "$output"

--- a/mise-tasks/gen-release-notes
+++ b/mise-tasks/gen-release-notes
@@ -55,21 +55,26 @@ echo "Version: $version" >&2
 echo "Previous version: ${prev_version:-none}" >&2
 echo "Changelog length: ${#changelog} chars" >&2
 
+# Capture stderr separately to avoid polluting output
+stderr_file=$(mktemp)
+trap 'rm -f "$stderr_file"' EXIT
+
 if ! output=$(
 	printf '%s' "$prompt" | claude -p \
 		--model claude-opus-4-20250514 \
 		--output-format text \
-		--allowedTools "Read,Grep,Glob" 2>&1
+		--allowedTools "Read,Grep,Glob" 2>"$stderr_file"
 ); then
 	echo "Error: Claude CLI failed" >&2
-	echo "Output: $output" >&2
+	cat "$stderr_file" >&2
 	exit 1
 fi
 
-# Fall back to raw changelog if Claude returns empty output
+# Validate we got non-empty output
 if [[ -z $output ]]; then
-	echo "Warning: Claude returned empty output, falling back to raw changelog" >&2
-	output="$changelog"
+	echo "Error: Claude returned empty output" >&2
+	cat "$stderr_file" >&2
+	exit 1
 fi
 
 echo "$output"

--- a/mise-tasks/gen-release-notes
+++ b/mise-tasks/gen-release-notes
@@ -57,10 +57,10 @@ output=$(
 		--allowedTools "Read,Grep,Glob"
 )
 
-# Validate we got non-empty output
+# Fall back to raw changelog if Claude returns empty output
 if [[ -z $output ]]; then
-	echo "Error: Claude returned empty output" >&2
-	exit 1
+	echo "Warning: Claude returned empty output, falling back to raw changelog" >&2
+	output="$changelog"
 fi
 
 echo "$output"

--- a/mise-tasks/gen-release-notes
+++ b/mise-tasks/gen-release-notes
@@ -50,12 +50,21 @@ INSTRUCTIONS
 
 # Use Claude Code to generate the release notes
 # Sandboxed: only read-only tools allowed (no Bash, Edit, Write)
-output=$(
+echo "Generating release notes with Claude..." >&2
+echo "Version: $version" >&2
+echo "Previous version: ${prev_version:-none}" >&2
+echo "Changelog length: ${#changelog} chars" >&2
+
+if ! output=$(
 	printf '%s' "$prompt" | claude -p \
 		--model claude-opus-4-20250514 \
 		--output-format text \
-		--allowedTools "Read,Grep,Glob"
-)
+		--allowedTools "Read,Grep,Glob" 2>&1
+); then
+	echo "Error: Claude CLI failed" >&2
+	echo "Output: $output" >&2
+	exit 1
+fi
 
 # Fall back to raw changelog if Claude returns empty output
 if [[ -z $output ]]; then

--- a/mise-tasks/release-plz
+++ b/mise-tasks/release-plz
@@ -41,7 +41,8 @@ mise run render ::: lint-fix
 git cliff --bump -o CHANGELOG.md
 
 # Get the unreleased notes for PR body
-PR_BODY="$(git cliff --bump --unreleased --strip all)"
+# Strip version header since PR title already has version
+PR_BODY="$(git cliff --bump --unreleased --strip all | tail -n +3)"
 
 git add \
   Cargo.* \

--- a/mise-tasks/release-plz
+++ b/mise-tasks/release-plz
@@ -20,7 +20,7 @@ version="$(git cliff --bumped-version)"
 
 if [ "$DRY_RUN" -ne 0 ]; then
   echo "version: $version"
-  echo "changelog: $(git cliff --bump --unreleased --strip all)"
+  echo "changelog: $(git cliff --bump --unreleased --strip all | tail -n +3)"
   exit 0
 fi
 


### PR DESCRIPTION
## Summary
- Use positional args (`$1`, `$2`) instead of usage spec environment variables in `gen-release-notes` - the env vars weren't being set correctly in GitHub Actions
- Add validation for empty Claude output to ensure fallback to CHANGELOG.md works
- Strip version header from PR body since PR title already has version

These fixes address issues discovered after the v1.9.0 release where LLM generation failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens release automation and cleans PR body formatting.
> 
> - `gen-release-notes`: add debug logging to stderr, capture Claude CLI stderr via a temp file, handle CLI failures explicitly, and validate non-empty model output before emitting
> - `release-plz`: strip the version header from unreleased changelog output (`tail -n +3`) for both dry-run display and PR body
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70c799d863832ed91a69f78a52278ab43ad25f08. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->