### PR TITLE
chore: release v1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,66 @@
 # Changelog
 
+## [1.10.0](https://github.com/jdx/fnox/compare/v1.9.2..v1.10.0) - 2026-01-25
+
+### 🚀 Features
+
+- **(1password)** add token field supporting secret references by [@jdx](https://github.com/jdx) in [#200](https://github.com/jdx/fnox/pull/200)
+- **(vault)** add namespace option by [@pierrop](https://github.com/pierrop) in [#220](https://github.com/jdx/fnox/pull/220)
+- add JSON schema for fnox.toml by [@jdx](https://github.com/jdx) in [#196](https://github.com/jdx/fnox/pull/196)
+- add --all flag to provider test command by [@jdx](https://github.com/jdx) in [#202](https://github.com/jdx/fnox/pull/202)
+- add documentation URLs to error diagnostics by [@jdx](https://github.com/jdx) in [#212](https://github.com/jdx/fnox/pull/212)
+- preserve source error chains for JSON/YAML errors by [@jdx](https://github.com/jdx) in [#214](https://github.com/jdx/fnox/pull/214)
+- use structured error variants instead of generic Config/Provider by [@jdx](https://github.com/jdx) in [#213](https://github.com/jdx/fnox/pull/213)
+- add "Did you mean?" suggestions for typos by [@jdx](https://github.com/jdx) in [#204](https://github.com/jdx/fnox/pull/204)
+- add --dry-run flag to data-modifying commands by [@jdx](https://github.com/jdx) in [#201](https://github.com/jdx/fnox/pull/201)
+- Support fnox.toml (and variants) dotfiles. by [@dharrigan](https://github.com/dharrigan) in [#141](https://github.com/jdx/fnox/pull/141)
+- add source code spans for better error reporting by [@jdx](https://github.com/jdx) in [#205](https://github.com/jdx/fnox/pull/205)
+- use #[related] for validation errors to show all issues at once by [@jdx](https://github.com/jdx) in [#211](https://github.com/jdx/fnox/pull/211)
+- add source code span tracking for default_provider errors by [@jdx](https://github.com/jdx) in [#209](https://github.com/jdx/fnox/pull/209)
+- add source code span tracking for SecretConfig.value by [@jdx](https://github.com/jdx) in [#210](https://github.com/jdx/fnox/pull/210)
+- improve miette error handling with structured provider errors and URLs by [@jdx](https://github.com/jdx) in [#216](https://github.com/jdx/fnox/pull/216)
+
+### 🐛 Bug Fixes
+
+- update claude CLI model and add bypassPermissions by [@jdx](https://github.com/jdx) in [#194](https://github.com/jdx/fnox/pull/194)
+- update claude CLI model and add bypassPermissions by [@jdx](https://github.com/jdx) in [#195](https://github.com/jdx/fnox/pull/195)
+- preserve TOML comments in `fnox set` by [@jdx](https://github.com/jdx) in [#223](https://github.com/jdx/fnox/pull/223)
+
+### 🚜 Refactor
+
+- convert miette::miette!() to FnoxError in encrypt.rs and list.rs by [@jdx](https://github.com/jdx) in [#208](https://github.com/jdx/fnox/pull/208)
+- use structured errors in remove and export commands by [@jdx](https://github.com/jdx) in [#206](https://github.com/jdx/fnox/pull/206)
+- use structured errors in import command by [@jdx](https://github.com/jdx) in [#207](https://github.com/jdx/fnox/pull/207)
+
+### 📚 Documentation
+
+- add comprehensive TUI dashboard guide by [@jdx](https://github.com/jdx) in [#203](https://github.com/jdx/fnox/pull/203)
+- add mise integration guide by [@jdx](https://github.com/jdx) in [#215](https://github.com/jdx/fnox/pull/215)
+
+### ⚡ Performance
+
+- reduce KMS API calls in CI tests by [@jdx](https://github.com/jdx) in [#217](https://github.com/jdx/fnox/pull/217)
+
+### 🛡️ Security
+
+- add Black Ops One font branding to docs by [@jdx](https://github.com/jdx) in [#198](https://github.com/jdx/fnox/pull/198)
+
+### 📦️ Dependency Updates
+
+- lock file maintenance by [@renovate[bot]](https://github.com/renovate[bot]) in [#197](https://github.com/jdx/fnox/pull/197)
+- update jdx/mise-action digest to 6d1e696 by [@renovate[bot]](https://github.com/renovate[bot]) in [#218](https://github.com/jdx/fnox/pull/218)
+- update rust crate proc-macro2 to v1.0.106 by [@renovate[bot]](https://github.com/renovate[bot]) in [#219](https://github.com/jdx/fnox/pull/219)
+
+### New Contributors
+
+- @pierrop made their first contribution in [#220](https://github.com/jdx/fnox/pull/220)
+- @dharrigan made their first contribution in [#141](https://github.com/jdx/fnox/pull/141)
+
 ## [1.9.2](https://github.com/jdx/fnox/compare/v1.9.1..v1.9.2) - 2026-01-19
+
+### 🚀 Features
+
+- add interactive TUI dashboard using ratatui by [@jdx](https://github.com/jdx) in [#188](https://github.com/jdx/fnox/pull/188)
 
 ### 🐛 Bug Fixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,9 +351,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.15.3"
+version = "1.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e84ce723ab67259cfeb9877c6a639ee9eb7a27b28123abd71db7f0d5d0cc9d86"
+checksum = "7b7b6141e96a8c160799cc2d5adecd5cbbe5054cb8c7c4af53da0f83bb7ad256"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -361,9 +361,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a442ece363113bd4bd4c8b18977a7798dd4d3c3383f34fb61936960e8f4ad8"
+checksum = "5c34dda4df7017c8db52132f0f8a2e0f8161649d15723ed63fc00c82d0f2081a"
 dependencies = [
  "cc",
  "cmake",
@@ -1072,9 +1072,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.53"
+version = "1.2.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755d2fce177175ffca841e9a06afdb2c4ab0f593d53b4dee48147dfaade85932"
+checksum = "6354c81bbfd62d9cfa9cb3c773c2b7b2a3a482d569de977fd0e961f6e7c00583"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1932,7 +1932,7 @@ dependencies = [
 
 [[package]]
 name = "fnox"
-version = "1.9.2"
+version = "1.10.0"
 dependencies = [
  "age",
  "anyhow",
@@ -2868,7 +2868,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.6.2",
  "tokio",
  "tower-service",
  "tracing",
@@ -3353,9 +3353,9 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -3613,9 +3613,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-integer"
@@ -3792,9 +3792,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-probe"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f50d9b3dabb09ecd771ad0aa242ca6894994c130308ca3d7684634df8037391"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-src"
@@ -4266,7 +4266,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.36",
- "socket2 0.6.1",
+ "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4303,16 +4303,16 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.1",
+ "socket2 0.6.2",
  "tracing",
  "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.43"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
@@ -4735,7 +4735,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
- "openssl-probe 0.2.0",
+ "openssl-probe 0.2.1",
  "rustls-pki-types",
  "schannel",
  "security-framework 3.5.1",
@@ -5271,9 +5271,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
@@ -5579,9 +5579,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.45"
+version = "0.3.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+checksum = "9da98b7d9b7dad93488a84b8248efc35352b0b2657397d4167e7ad67e5d535e5"
 dependencies = [
  "deranged",
  "itoa",
@@ -5595,15 +5595,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.25"
+version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
+checksum = "78cc610bac2dcee56805c99642447d4c5dbde4d01f752ffea0199aee1f601dc4"
 dependencies = [
  "num-conv",
  "time-core",
@@ -5647,7 +5647,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.1",
+ "socket2 0.6.2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -6162,9 +6162,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
+checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
 dependencies = [
  "getrandom 0.3.4",
  "js-sys",
@@ -6816,9 +6816,9 @@ checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "xx"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704f7d8fce796d9206ab2f0a04a0c59c54394105b838b236d6687e8eef721440"
+checksum = "b2df0028c106b318c37108eaa6930ee85c73e0ad03e2d54dfe7fea44975c1259"
 dependencies = [
  "duct",
  "filetime",
@@ -6950,9 +6950,9 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f63c051f4fe3c1509da62131a678643c5b6fbdc9273b2b79d4378ebda003d2"
+checksum = "dfcd145825aace48cff44a8844de64bf75feec3080e0aa5cdbde72961ae51a65"
 
 [[package]]
 name = "zune-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fnox"
-version = "1.9.2"
+version = "1.10.0"
 edition = "2024"
 authors = ["@jdx"]
 description = "A flexible secret management tool supporting multiple providers and encryption methods"

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -1119,7 +1119,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.9.2",
+  "version": "1.10.0",
   "usage": "Usage: fnox [OPTIONS] <COMMAND>",
   "complete": {
     "key": {

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -4,7 +4,7 @@
 
 **Usage**: `fnox [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.9.2
+**Version**: 1.10.0
 
 - **Usage**: `fnox [FLAGS] <SUBCOMMAND>`
 

--- a/fnox.usage.kdl
+++ b/fnox.usage.kdl
@@ -1,7 +1,7 @@
 min_usage_version "1.3"
 name fnox
 bin fnox
-version "1.9.2"
+version "1.10.0"
 about "A flexible secret management tool by @jdx"
 usage "Usage: fnox [OPTIONS] <COMMAND>"
 flag "-c --config" help="Path to the configuration file (default: fnox.toml, searches parent directories)" global=#true default=fnox.toml {


### PR DESCRIPTION
### 🚀 Features

- **(1password)** add token field supporting secret references by [@jdx](https://github.com/jdx) in [#200](https://github.com/jdx/fnox/pull/200)
- **(vault)** add namespace option by [@pierrop](https://github.com/pierrop) in [#220](https://github.com/jdx/fnox/pull/220)
- add JSON schema for fnox.toml by [@jdx](https://github.com/jdx) in [#196](https://github.com/jdx/fnox/pull/196)
- add --all flag to provider test command by [@jdx](https://github.com/jdx) in [#202](https://github.com/jdx/fnox/pull/202)
- add documentation URLs to error diagnostics by [@jdx](https://github.com/jdx) in [#212](https://github.com/jdx/fnox/pull/212)
- preserve source error chains for JSON/YAML errors by [@jdx](https://github.com/jdx) in [#214](https://github.com/jdx/fnox/pull/214)
- use structured error variants instead of generic Config/Provider by [@jdx](https://github.com/jdx) in [#213](https://github.com/jdx/fnox/pull/213)
- add "Did you mean?" suggestions for typos by [@jdx](https://github.com/jdx) in [#204](https://github.com/jdx/fnox/pull/204)
- add --dry-run flag to data-modifying commands by [@jdx](https://github.com/jdx) in [#201](https://github.com/jdx/fnox/pull/201)
- Support fnox.toml (and variants) dotfiles. by [@dharrigan](https://github.com/dharrigan) in [#141](https://github.com/jdx/fnox/pull/141)
- add source code spans for better error reporting by [@jdx](https://github.com/jdx) in [#205](https://github.com/jdx/fnox/pull/205)
- use #[related] for validation errors to show all issues at once by [@jdx](https://github.com/jdx) in [#211](https://github.com/jdx/fnox/pull/211)
- add source code span tracking for default_provider errors by [@jdx](https://github.com/jdx) in [#209](https://github.com/jdx/fnox/pull/209)
- add source code span tracking for SecretConfig.value by [@jdx](https://github.com/jdx) in [#210](https://github.com/jdx/fnox/pull/210)
- improve miette error handling with structured provider errors and URLs by [@jdx](https://github.com/jdx) in [#216](https://github.com/jdx/fnox/pull/216)

### 🐛 Bug Fixes

- update claude CLI model and add bypassPermissions by [@jdx](https://github.com/jdx) in [#194](https://github.com/jdx/fnox/pull/194)
- update claude CLI model and add bypassPermissions by [@jdx](https://github.com/jdx) in [#195](https://github.com/jdx/fnox/pull/195)
- preserve TOML comments in `fnox set` by [@jdx](https://github.com/jdx) in [#223](https://github.com/jdx/fnox/pull/223)

### 🚜 Refactor

- convert miette::miette!() to FnoxError in encrypt.rs and list.rs by [@jdx](https://github.com/jdx) in [#208](https://github.com/jdx/fnox/pull/208)
- use structured errors in remove and export commands by [@jdx](https://github.com/jdx) in [#206](https://github.com/jdx/fnox/pull/206)
- use structured errors in import command by [@jdx](https://github.com/jdx) in [#207](https://github.com/jdx/fnox/pull/207)

### 📚 Documentation

- add comprehensive TUI dashboard guide by [@jdx](https://github.com/jdx) in [#203](https://github.com/jdx/fnox/pull/203)
- add mise integration guide by [@jdx](https://github.com/jdx) in [#215](https://github.com/jdx/fnox/pull/215)

### ⚡ Performance

- reduce KMS API calls in CI tests by [@jdx](https://github.com/jdx) in [#217](https://github.com/jdx/fnox/pull/217)

### 🛡️ Security

- add Black Ops One font branding to docs by [@jdx](https://github.com/jdx) in [#198](https://github.com/jdx/fnox/pull/198)

### 📦️ Dependency Updates

- lock file maintenance by [@renovate[bot]](https://github.com/renovate[bot]) in [#197](https://github.com/jdx/fnox/pull/197)
- update jdx/mise-action digest to 6d1e696 by [@renovate[bot]](https://github.com/renovate[bot]) in [#218](https://github.com/jdx/fnox/pull/218)
- update rust crate proc-macro2 to v1.0.106 by [@renovate[bot]](https://github.com/renovate[bot]) in [#219](https://github.com/jdx/fnox/pull/219)

### New Contributors

- @pierrop made their first contribution in [#220](https://github.com/jdx/fnox/pull/220)
- @dharrigan made their first contribution in [#141](https://github.com/jdx/fnox/pull/141)