### PR TITLE
fix: update claude CLI model and add bypassPermissions

### DIFF
--- a/.github/workflows/test-claude.yml
+++ b/.github/workflows/test-claude.yml
@@ -1,0 +1,39 @@
+name: test-claude
+
+on:
+  workflow_dispatch:
+
+env:
+  ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+
+jobs:
+  test-claude:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code
+      - name: Test Claude CLI
+        run: |
+          echo "Testing Claude Code CLI with Opus 4.5..."
+          echo "Claude version: $(claude --version)"
+
+          # Simple test: ask Claude to summarize what this repo does
+          # Uses only Read tool, with bypassPermissions for CI
+          output=$(claude -p \
+            --model claude-opus-4-5-20251101 \
+            --permission-mode bypassPermissions \
+            --output-format text \
+            --allowedTools "Read,Grep,Glob" \
+            "Read the README.md and Cargo.toml files and write a one-sentence summary of what this project does.")
+
+          echo "Claude output:"
+          echo "$output"
+
+          # Verify we got non-empty output
+          if [[ -z "$output" ]]; then
+            echo "ERROR: Claude returned empty output"
+            exit 1
+          fi
+
+          echo "Test passed!"

--- a/mise-tasks/gen-release-notes
+++ b/mise-tasks/gen-release-notes
@@ -61,12 +61,17 @@ trap 'rm -f "$stderr_file"' EXIT
 
 if ! output=$(
 	printf '%s' "$prompt" | claude -p \
-		--model claude-opus-4-20250514 \
+		--model claude-opus-4-5-20251101 \
+		--permission-mode bypassPermissions \
 		--output-format text \
 		--allowedTools "Read,Grep,Glob" 2>"$stderr_file"
 ); then
 	echo "Error: Claude CLI failed" >&2
-	cat "$stderr_file" >&2
+	if [[ -s $stderr_file ]]; then
+		cat "$stderr_file" >&2
+	else
+		echo "(no stderr output from Claude CLI)" >&2
+	fi
 	exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Use `claude-opus-4-5-20251101` model (Opus 4.5) per [Claude Code docs](https://code.claude.com/docs/en/github-actions)
- Add `--permission-mode bypassPermissions` for automated CI/CD execution

This should fix the LLM release notes generation that was failing silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Update release notes generation**
> 
> - Switches `mise-tasks/gen-release-notes` to `--model claude-opus-4-5-20251101` and adds `--permission-mode bypassPermissions` with read-only tools
> - Improves failure diagnostics by printing captured stderr only when present; validates non-empty output
> 
> **New CI workflow**
> 
> - Adds `.github/workflows/test-claude.yml` to install and run Claude Code CLI against repo files using Opus 4.5 with bypassPermissions
> - Verifies CLI returns non-empty output; uses `ANTHROPIC_API_KEY` secret
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1127663845a678ddea7d467232c0bce2feaa67a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->