### PR TITLE
feat: add JSON schema for fnox.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1976,6 +1976,7 @@ dependencies = [
  "reqwest",
  "rmp-serde",
  "rustls 0.23.36",
+ "schemars 1.2.0",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -4826,9 +4827,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54e910108742c57a770f492731f99be216a52fadd361b06c8fb59d74ccc267d2"
 dependencies = [
  "dyn-clone",
+ "indexmap 2.13.0",
  "ref-cast",
+ "schemars_derive",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4908ad288c5035a8eb12cfdf0d49270def0a268ee162b75eeee0f85d155a7c45"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
 ]
 
 [[package]]
@@ -4971,6 +4986,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ miette = { version = "7", features = ["fancy"] }
 miniz_oxide = "0.8"
 regex = "1"
 rmp-serde = "1"
+schemars = { version = "1", features = ["indexmap2"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"

--- a/build/generate_providers.rs
+++ b/build/generate_providers.rs
@@ -220,6 +220,7 @@ fn generate_provider_config(
 
     // Note: Use super::super:: because this is included inside mod generated { mod providers_config { ... } }
     let output = quote! {
+        use schemars::JsonSchema;
         use serde::{Deserialize, Serialize};
         use strum::AsRefStr;
         use super::super::secret_ref::{OptionStringOrSecretRef, StringOrSecretRef};
@@ -233,7 +234,7 @@ fn generate_provider_config(
             backend.as_ref().is_none_or(|b| *b == BitwardenBackend::Bw)
         }
 
-        #[derive(Debug, Clone, Serialize, Deserialize, AsRefStr)]
+        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, AsRefStr)]
         #[serde(tag = "type")]
         #[serde(deny_unknown_fields)]
         pub enum ProviderConfig {

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -195,7 +195,7 @@
                 "choices": ["env", "json", "yaml", "toml"]
               }
             },
-            "default": "env"
+            "default": ["env"]
           },
           {
             "name": "output",
@@ -292,7 +292,7 @@
             "required": false,
             "double_dash": "Optional",
             "hide": false,
-            "default": "env",
+            "default": ["env"],
             "choices": {
               "choices": ["env", "json", "yaml", "toml"]
             }
@@ -738,7 +738,7 @@
               "double_dash": "Optional",
               "hide": false
             },
-            "default": "."
+            "default": ["."]
           },
           {
             "name": "ignore",
@@ -773,6 +773,20 @@
         "hide": false,
         "help": "Scan repository for potential secrets",
         "name": "scan",
+        "aliases": [],
+        "hidden_aliases": [],
+        "examples": []
+      },
+      "schema": {
+        "full_cmd": ["schema"],
+        "usage": "schema",
+        "subcommands": {},
+        "args": [],
+        "flags": [],
+        "mounts": [],
+        "hide": true,
+        "help": "Generate JSON Schema for fnox configuration",
+        "name": "schema",
         "aliases": [],
         "hidden_aliases": [],
         "examples": []
@@ -970,7 +984,7 @@
           "double_dash": "Optional",
           "hide": false
         },
-        "default": "fnox.toml"
+        "default": ["fnox.toml"]
       },
       {
         "name": "profile",

--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -110,6 +110,37 @@
         {
           "type": "object",
           "properties": {
+            "gpg_opts": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "prefix": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "store_dir": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "password-store"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "plain"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type"]
+        },
+        {
+          "type": "object",
+          "properties": {
             "database": {
               "$ref": "#/$defs/StringOrSecretRef"
             },
@@ -146,54 +177,6 @@
           },
           "additionalProperties": false,
           "required": ["type", "recipients"]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "type": "string",
-              "const": "plain"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["type"]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "gpg_opts": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "prefix": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "store_dir": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "type": {
-              "type": "string",
-              "const": "password-store"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["type"]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "account": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "type": {
-              "type": "string",
-              "const": "1password"
-            },
-            "vault": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["type"]
         },
         {
           "type": "object",
@@ -271,6 +254,40 @@
         {
           "type": "object",
           "properties": {
+            "account": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "1password"
+            },
+            "vault": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "key_name": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "azure-kms"
+            },
+            "vault_url": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type", "vault_url", "key_name"]
+        },
+        {
+          "type": "object",
+          "properties": {
             "key_id": {
               "$ref": "#/$defs/StringOrSecretRef"
             },
@@ -311,19 +328,19 @@
         {
           "type": "object",
           "properties": {
-            "key_name": {
+            "prefix": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "region": {
               "$ref": "#/$defs/StringOrSecretRef"
             },
             "type": {
               "type": "string",
-              "const": "azure-kms"
-            },
-            "vault_url": {
-              "$ref": "#/$defs/StringOrSecretRef"
+              "const": "aws-sm"
             }
           },
           "additionalProperties": false,
-          "required": ["type", "vault_url", "key_name"]
+          "required": ["type", "region"]
         },
         {
           "type": "object",
@@ -341,40 +358,6 @@
           },
           "additionalProperties": false,
           "required": ["type", "vault_url"]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "prefix": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "region": {
-              "$ref": "#/$defs/StringOrSecretRef"
-            },
-            "type": {
-              "type": "string",
-              "const": "aws-ps"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["type", "region"]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "prefix": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "region": {
-              "$ref": "#/$defs/StringOrSecretRef"
-            },
-            "type": {
-              "type": "string",
-              "const": "aws-sm"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["type", "region"]
         },
         {
           "type": "object",
@@ -412,6 +395,23 @@
           },
           "additionalProperties": false,
           "required": ["type", "project"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "prefix": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "region": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "aws-ps"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type", "region"]
         },
         {
           "type": "object",

--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -1,0 +1,517 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://fnox.jdx.dev/schema.json",
+  "title": "fnox Configuration",
+  "description": "Configuration schema for fnox.toml files",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "import": {
+      "type": "array",
+      "description": "Import paths to other config files",
+      "items": {
+        "type": "string"
+      }
+    },
+    "root": {
+      "type": "boolean",
+      "description": "Root configuration - stops recursion at this level",
+      "default": false
+    },
+    "providers": {
+      "type": "object",
+      "description": "Provider configurations",
+      "additionalProperties": {
+        "$ref": "#/$defs/providerConfig"
+      }
+    },
+    "default_provider": {
+      "type": "string",
+      "description": "Default provider name"
+    },
+    "secrets": {
+      "type": "object",
+      "description": "Secret configurations",
+      "additionalProperties": {
+        "$ref": "#/$defs/secretConfig"
+      }
+    },
+    "profiles": {
+      "type": "object",
+      "description": "Named profiles for environment-specific configuration",
+      "additionalProperties": {
+        "$ref": "#/$defs/profileConfig"
+      }
+    },
+    "age_key_file": {
+      "type": "string",
+      "description": "Age encryption key file path"
+    },
+    "if_missing": {
+      "$ref": "#/$defs/ifMissing",
+      "description": "Default if_missing behavior for all secrets"
+    },
+    "prompt_auth": {
+      "type": "boolean",
+      "description": "Whether to prompt for authentication when provider auth fails (default: true in TTY)"
+    }
+  },
+  "$defs": {
+    "ifMissing": {
+      "type": "string",
+      "enum": ["error", "warn", "ignore"],
+      "description": "Behavior when a secret cannot be resolved"
+    },
+    "stringOrSecretRef": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "required": ["secret"],
+          "additionalProperties": false,
+          "properties": {
+            "secret": {
+              "type": "string",
+              "description": "Name of the secret to reference"
+            }
+          }
+        }
+      ],
+      "description": "Either a literal string or a reference to a secret"
+    },
+    "secretConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Description of the secret"
+        },
+        "if_missing": {
+          "$ref": "#/$defs/ifMissing",
+          "description": "What to do if the secret is missing"
+        },
+        "default": {
+          "type": "string",
+          "description": "Default value to use if provider fails"
+        },
+        "provider": {
+          "type": "string",
+          "description": "Provider to fetch from"
+        },
+        "value": {
+          "type": "string",
+          "description": "Value for the provider (secret name, encrypted blob, etc.)"
+        }
+      }
+    },
+    "profileConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "providers": {
+          "type": "object",
+          "description": "Provider configurations for this profile",
+          "additionalProperties": {
+            "$ref": "#/$defs/providerConfig"
+          }
+        },
+        "default_provider": {
+          "type": "string",
+          "description": "Default provider name for this profile"
+        },
+        "secrets": {
+          "type": "object",
+          "description": "Secrets for this profile",
+          "additionalProperties": {
+            "$ref": "#/$defs/secretConfig"
+          }
+        }
+      }
+    },
+    "providerConfig": {
+      "oneOf": [
+        { "$ref": "#/$defs/providers/plain" },
+        { "$ref": "#/$defs/providers/age" },
+        { "$ref": "#/$defs/providers/onePassword" },
+        { "$ref": "#/$defs/providers/awsKms" },
+        { "$ref": "#/$defs/providers/awsPs" },
+        { "$ref": "#/$defs/providers/awsSm" },
+        { "$ref": "#/$defs/providers/azureKms" },
+        { "$ref": "#/$defs/providers/azureSm" },
+        { "$ref": "#/$defs/providers/bitwarden" },
+        { "$ref": "#/$defs/providers/gcpKms" },
+        { "$ref": "#/$defs/providers/gcpSm" },
+        { "$ref": "#/$defs/providers/infisical" },
+        { "$ref": "#/$defs/providers/keepass" },
+        { "$ref": "#/$defs/providers/keychain" },
+        { "$ref": "#/$defs/providers/passwordStore" },
+        { "$ref": "#/$defs/providers/passwordstate" },
+        { "$ref": "#/$defs/providers/vault" }
+      ]
+    },
+    "providers": {
+      "plain": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["type"],
+        "properties": {
+          "type": {
+            "const": "plain"
+          }
+        },
+        "description": "Plain text provider - no encryption"
+      },
+      "age": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["type"],
+        "properties": {
+          "type": {
+            "const": "age"
+          },
+          "recipients": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Age public keys (recipients) for encryption"
+          },
+          "key_file": {
+            "type": "string",
+            "description": "Path to age key file"
+          }
+        },
+        "description": "Age encryption provider"
+      },
+      "onePassword": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["type"],
+        "properties": {
+          "type": {
+            "const": "1password"
+          },
+          "vault": {
+            "$ref": "#/$defs/stringOrSecretRef",
+            "description": "Vault name"
+          },
+          "account": {
+            "$ref": "#/$defs/stringOrSecretRef",
+            "description": "Account (e.g., my.1password.com)"
+          }
+        },
+        "description": "1Password provider"
+      },
+      "awsKms": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["type", "key_id", "region"],
+        "properties": {
+          "type": {
+            "const": "aws-kms"
+          },
+          "key_id": {
+            "$ref": "#/$defs/stringOrSecretRef",
+            "description": "KMS key ID or alias"
+          },
+          "region": {
+            "$ref": "#/$defs/stringOrSecretRef",
+            "description": "AWS region"
+          }
+        },
+        "description": "AWS KMS encryption provider"
+      },
+      "awsPs": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["type", "region"],
+        "properties": {
+          "type": {
+            "const": "aws-ps"
+          },
+          "region": {
+            "$ref": "#/$defs/stringOrSecretRef",
+            "description": "AWS region"
+          },
+          "prefix": {
+            "$ref": "#/$defs/stringOrSecretRef",
+            "description": "Parameter path prefix"
+          }
+        },
+        "description": "AWS Parameter Store provider"
+      },
+      "awsSm": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["type", "region"],
+        "properties": {
+          "type": {
+            "const": "aws-sm"
+          },
+          "region": {
+            "$ref": "#/$defs/stringOrSecretRef",
+            "description": "AWS region"
+          },
+          "prefix": {
+            "$ref": "#/$defs/stringOrSecretRef",
+            "description": "Secret name prefix"
+          }
+        },
+        "description": "AWS Secrets Manager provider"
+      },
+      "azureKms": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["type", "vault_url", "key_name"],
+        "properties": {
+          "type": {
+            "const": "azure-kms"
+          },
+          "vault_url": {
+            "$ref": "#/$defs/stringOrSecretRef",
+            "description": "Azure Key Vault URL"
+          },
+          "key_name": {
+            "$ref": "#/$defs/stringOrSecretRef",
+            "description": "Key name"
+          }
+        },
+        "description": "Azure Key Vault KMS provider"
+      },
+      "azureSm": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["type", "vault_url"],
+        "properties": {
+          "type": {
+            "const": "azure-sm"
+          },
+          "vault_url": {
+            "$ref": "#/$defs/stringOrSecretRef",
+            "description": "Azure Key Vault URL"
+          },
+          "prefix": {
+            "$ref": "#/$defs/stringOrSecretRef",
+            "description": "Secret name prefix"
+          }
+        },
+        "description": "Azure Key Vault Secrets provider"
+      },
+      "bitwarden": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["type"],
+        "properties": {
+          "type": {
+            "const": "bitwarden"
+          },
+          "collection": {
+            "$ref": "#/$defs/stringOrSecretRef",
+            "description": "Collection ID"
+          },
+          "organization_id": {
+            "$ref": "#/$defs/stringOrSecretRef",
+            "description": "Organization ID"
+          },
+          "profile": {
+            "$ref": "#/$defs/stringOrSecretRef",
+            "description": "Profile name"
+          },
+          "backend": {
+            "type": "string",
+            "enum": ["cli", "sdk"],
+            "description": "Bitwarden backend to use"
+          }
+        },
+        "description": "Bitwarden provider"
+      },
+      "gcpKms": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["type", "project", "location", "keyring", "key"],
+        "properties": {
+          "type": {
+            "const": "gcp-kms"
+          },
+          "project": {
+            "$ref": "#/$defs/stringOrSecretRef",
+            "description": "GCP project ID"
+          },
+          "location": {
+            "$ref": "#/$defs/stringOrSecretRef",
+            "description": "Location (e.g., global, us-east1)"
+          },
+          "keyring": {
+            "$ref": "#/$defs/stringOrSecretRef",
+            "description": "Key ring name"
+          },
+          "key": {
+            "$ref": "#/$defs/stringOrSecretRef",
+            "description": "Key name"
+          }
+        },
+        "description": "GCP KMS encryption provider"
+      },
+      "gcpSm": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["type", "project"],
+        "properties": {
+          "type": {
+            "const": "gcp-sm"
+          },
+          "project": {
+            "$ref": "#/$defs/stringOrSecretRef",
+            "description": "GCP project ID"
+          },
+          "prefix": {
+            "$ref": "#/$defs/stringOrSecretRef",
+            "description": "Secret name prefix"
+          }
+        },
+        "description": "GCP Secret Manager provider"
+      },
+      "infisical": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["type"],
+        "properties": {
+          "type": {
+            "const": "infisical"
+          },
+          "project_id": {
+            "$ref": "#/$defs/stringOrSecretRef",
+            "description": "Infisical project ID"
+          },
+          "environment": {
+            "$ref": "#/$defs/stringOrSecretRef",
+            "description": "Environment (e.g., dev, staging, prod)"
+          },
+          "path": {
+            "$ref": "#/$defs/stringOrSecretRef",
+            "description": "Secrets path"
+          }
+        },
+        "description": "Infisical provider"
+      },
+      "keepass": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["type", "database"],
+        "properties": {
+          "type": {
+            "const": "keepass"
+          },
+          "database": {
+            "$ref": "#/$defs/stringOrSecretRef",
+            "description": "Path to KeePass database file (.kdbx)"
+          },
+          "keyfile": {
+            "$ref": "#/$defs/stringOrSecretRef",
+            "description": "Path to key file"
+          },
+          "password": {
+            "$ref": "#/$defs/stringOrSecretRef",
+            "description": "Database password (use env var instead)"
+          }
+        },
+        "description": "KeePass provider"
+      },
+      "keychain": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["type", "service"],
+        "properties": {
+          "type": {
+            "const": "keychain"
+          },
+          "service": {
+            "$ref": "#/$defs/stringOrSecretRef",
+            "description": "Service name"
+          },
+          "prefix": {
+            "$ref": "#/$defs/stringOrSecretRef",
+            "description": "Secret name prefix"
+          }
+        },
+        "description": "OS Keychain provider (macOS/Windows/Linux)"
+      },
+      "passwordStore": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["type"],
+        "properties": {
+          "type": {
+            "const": "password-store"
+          },
+          "prefix": {
+            "$ref": "#/$defs/stringOrSecretRef",
+            "description": "Secret name prefix"
+          },
+          "store_dir": {
+            "$ref": "#/$defs/stringOrSecretRef",
+            "description": "Password store directory"
+          },
+          "gpg_opts": {
+            "$ref": "#/$defs/stringOrSecretRef",
+            "description": "GPG options"
+          }
+        },
+        "description": "Password-store (pass) provider"
+      },
+      "passwordstate": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["type", "base_url", "password_list_id"],
+        "properties": {
+          "type": {
+            "const": "passwordstate"
+          },
+          "base_url": {
+            "$ref": "#/$defs/stringOrSecretRef",
+            "description": "Passwordstate server URL"
+          },
+          "api_key": {
+            "$ref": "#/$defs/stringOrSecretRef",
+            "description": "API key for the password list"
+          },
+          "password_list_id": {
+            "$ref": "#/$defs/stringOrSecretRef",
+            "description": "Password list ID"
+          },
+          "verify_ssl": {
+            "$ref": "#/$defs/stringOrSecretRef",
+            "description": "Verify SSL certificates"
+          }
+        },
+        "description": "Passwordstate provider"
+      },
+      "vault": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["type", "address"],
+        "properties": {
+          "type": {
+            "const": "vault"
+          },
+          "address": {
+            "$ref": "#/$defs/stringOrSecretRef",
+            "description": "Vault server address"
+          },
+          "path": {
+            "$ref": "#/$defs/stringOrSecretRef",
+            "description": "Secrets path"
+          },
+          "token": {
+            "$ref": "#/$defs/stringOrSecretRef",
+            "description": "Vault token"
+          }
+        },
+        "description": "HashiCorp Vault provider"
+      }
+    }
+  }
+}

--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -322,8 +322,8 @@
           },
           "backend": {
             "type": "string",
-            "enum": ["cli", "sdk"],
-            "description": "Bitwarden backend to use"
+            "enum": ["bw", "rbw"],
+            "description": "Bitwarden backend to use (bw = official CLI, rbw = unofficial Rust client)"
           }
         },
         "description": "Bitwarden provider"

--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -180,7 +180,7 @@
             "description": "Age public keys (recipients) for encryption"
           },
           "key_file": {
-            "type": "string",
+            "$ref": "#/$defs/stringOrSecretRef",
             "description": "Path to age key file"
           }
         },

--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -1,517 +1,488 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://fnox.jdx.dev/schema.json",
-  "title": "fnox Configuration",
-  "description": "Configuration schema for fnox.toml files",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Config",
   "type": "object",
-  "additionalProperties": false,
   "properties": {
+    "age_key_file": {
+      "description": "Age encryption key file path (optional, can also be set via env var or CLI flag)",
+      "type": ["string", "null"]
+    },
+    "default_provider": {
+      "description": "Default provider name for default profile",
+      "type": ["string", "null"]
+    },
+    "if_missing": {
+      "description": "Default if_missing behavior for all secrets in this config",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/IfMissing"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "import": {
-      "type": "array",
       "description": "Import paths to other config files",
+      "type": "array",
       "items": {
         "type": "string"
       }
     },
-    "root": {
-      "type": "boolean",
-      "description": "Root configuration - stops recursion at this level",
-      "default": false
-    },
-    "providers": {
-      "type": "object",
-      "description": "Provider configurations",
-      "additionalProperties": {
-        "$ref": "#/$defs/providerConfig"
-      }
-    },
-    "default_provider": {
-      "type": "string",
-      "description": "Default provider name"
-    },
-    "secrets": {
-      "type": "object",
-      "description": "Secret configurations",
-      "additionalProperties": {
-        "$ref": "#/$defs/secretConfig"
-      }
-    },
     "profiles": {
+      "description": "Named profiles",
       "type": "object",
-      "description": "Named profiles for environment-specific configuration",
       "additionalProperties": {
-        "$ref": "#/$defs/profileConfig"
+        "$ref": "#/$defs/ProfileConfig"
       }
-    },
-    "age_key_file": {
-      "type": "string",
-      "description": "Age encryption key file path"
-    },
-    "if_missing": {
-      "$ref": "#/$defs/ifMissing",
-      "description": "Default if_missing behavior for all secrets"
     },
     "prompt_auth": {
-      "type": "boolean",
-      "description": "Whether to prompt for authentication when provider auth fails (default: true in TTY)"
+      "description": "Whether to prompt for authentication when provider auth fails (default: true in TTY)",
+      "type": ["boolean", "null"]
+    },
+    "providers": {
+      "description": "Provider configurations (for default profile)",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/ProviderConfig"
+      }
+    },
+    "root": {
+      "description": "Root configuration - stops recursion at this level",
+      "type": "boolean"
+    },
+    "secrets": {
+      "description": "Default profile secrets (top level)",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/SecretConfig"
+      }
     }
   },
+  "additionalProperties": false,
   "$defs": {
-    "ifMissing": {
+    "BitwardenBackend": {
       "type": "string",
-      "enum": ["error", "warn", "ignore"],
-      "description": "Behavior when a secret cannot be resolved"
+      "enum": ["bw", "rbw"]
     },
-    "stringOrSecretRef": {
+    "IfMissing": {
+      "type": "string",
+      "enum": ["error", "warn", "ignore"]
+    },
+    "OptionStringOrSecretRef": {
+      "description": "An optional value that can be a literal string, a secret reference, or absent.\n\nIn TOML, this deserializes from:\n- Field absent: `None`\n- `field = \"literal-value\"`: `Some(Literal(\"literal-value\"))`\n- `field = { secret = \"SECRET_NAME\" }`: `Some(SecretRef { secret: \"SECRET_NAME\" })`",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/StringOrSecretRef"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "ProfileConfig": {
+      "description": "Configuration for a profile",
+      "type": "object",
+      "properties": {
+        "default_provider": {
+          "description": "Default provider name for this profile",
+          "type": ["string", "null"]
+        },
+        "providers": {
+          "description": "Provider configurations for this profile",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/ProviderConfig"
+          }
+        },
+        "secrets": {
+          "description": "Secrets for this profile",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/SecretConfig"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "ProviderConfig": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "database": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            },
+            "keyfile": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "password": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "keepass"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type", "database"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "key_file": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "recipients": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "type": {
+              "type": "string",
+              "const": "age"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type", "recipients"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "plain"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "gpg_opts": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "prefix": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "store_dir": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "password-store"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "account": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "1password"
+            },
+            "vault": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "api_key": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "base_url": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            },
+            "password_list_id": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "passwordstate"
+            },
+            "verify_ssl": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type", "base_url", "password_list_id"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "backend": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BitwardenBackend"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "collection": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "organization_id": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "profile": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "bitwarden"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "environment": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "path": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "project_id": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "infisical"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "key_id": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            },
+            "region": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "aws-kms"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type", "key_id", "region"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "key": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            },
+            "keyring": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            },
+            "location": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            },
+            "project": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "gcp-kms"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type", "project", "location", "keyring", "key"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "key_name": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "azure-kms"
+            },
+            "vault_url": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type", "vault_url", "key_name"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "prefix": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "azure-sm"
+            },
+            "vault_url": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type", "vault_url"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "prefix": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "region": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "aws-ps"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type", "region"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "prefix": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "region": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "aws-sm"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type", "region"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "address": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            },
+            "path": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "token": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "vault"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type", "address"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "prefix": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "project": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "gcp-sm"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type", "project"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "prefix": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "service": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "keychain"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type", "service"]
+        }
+      ]
+    },
+    "SecretConfig": {
+      "description": "Configuration for a single secret",
+      "type": "object",
+      "properties": {
+        "default": {
+          "description": "Default value to use if provider fails or secret is not found",
+          "type": ["string", "null"]
+        },
+        "description": {
+          "description": "Description of the secret",
+          "type": ["string", "null"]
+        },
+        "if_missing": {
+          "description": "What to do if the secret is missing (error, warn, or ignore)",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/IfMissing"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "provider": {
+          "description": "Provider to fetch from (age, aws-kms, 1password, aws, etc.)",
+          "type": ["string", "null"]
+        },
+        "value": {
+          "description": "Value for the provider (secret name, encrypted blob, etc.)",
+          "type": ["string", "null"]
+        }
+      },
+      "additionalProperties": false
+    },
+    "StringOrSecretRef": {
+      "description": "Either a literal string or a reference to a secret",
       "oneOf": [
         {
           "type": "string"
         },
         {
           "type": "object",
-          "required": ["secret"],
-          "additionalProperties": false,
           "properties": {
             "secret": {
-              "type": "string",
-              "description": "Name of the secret to reference"
-            }
-          }
-        }
-      ],
-      "description": "Either a literal string or a reference to a secret"
-    },
-    "secretConfig": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "description": {
-          "type": "string",
-          "description": "Description of the secret"
-        },
-        "if_missing": {
-          "$ref": "#/$defs/ifMissing",
-          "description": "What to do if the secret is missing"
-        },
-        "default": {
-          "type": "string",
-          "description": "Default value to use if provider fails"
-        },
-        "provider": {
-          "type": "string",
-          "description": "Provider to fetch from"
-        },
-        "value": {
-          "type": "string",
-          "description": "Value for the provider (secret name, encrypted blob, etc.)"
-        }
-      }
-    },
-    "profileConfig": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "providers": {
-          "type": "object",
-          "description": "Provider configurations for this profile",
-          "additionalProperties": {
-            "$ref": "#/$defs/providerConfig"
-          }
-        },
-        "default_provider": {
-          "type": "string",
-          "description": "Default provider name for this profile"
-        },
-        "secrets": {
-          "type": "object",
-          "description": "Secrets for this profile",
-          "additionalProperties": {
-            "$ref": "#/$defs/secretConfig"
-          }
-        }
-      }
-    },
-    "providerConfig": {
-      "oneOf": [
-        { "$ref": "#/$defs/providers/plain" },
-        { "$ref": "#/$defs/providers/age" },
-        { "$ref": "#/$defs/providers/onePassword" },
-        { "$ref": "#/$defs/providers/awsKms" },
-        { "$ref": "#/$defs/providers/awsPs" },
-        { "$ref": "#/$defs/providers/awsSm" },
-        { "$ref": "#/$defs/providers/azureKms" },
-        { "$ref": "#/$defs/providers/azureSm" },
-        { "$ref": "#/$defs/providers/bitwarden" },
-        { "$ref": "#/$defs/providers/gcpKms" },
-        { "$ref": "#/$defs/providers/gcpSm" },
-        { "$ref": "#/$defs/providers/infisical" },
-        { "$ref": "#/$defs/providers/keepass" },
-        { "$ref": "#/$defs/providers/keychain" },
-        { "$ref": "#/$defs/providers/passwordStore" },
-        { "$ref": "#/$defs/providers/passwordstate" },
-        { "$ref": "#/$defs/providers/vault" }
-      ]
-    },
-    "providers": {
-      "plain": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": ["type"],
-        "properties": {
-          "type": {
-            "const": "plain"
-          }
-        },
-        "description": "Plain text provider - no encryption"
-      },
-      "age": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": ["type"],
-        "properties": {
-          "type": {
-            "const": "age"
-          },
-          "recipients": {
-            "type": "array",
-            "items": {
               "type": "string"
-            },
-            "description": "Age public keys (recipients) for encryption"
+            }
           },
-          "key_file": {
-            "$ref": "#/$defs/stringOrSecretRef",
-            "description": "Path to age key file"
-          }
-        },
-        "description": "Age encryption provider"
-      },
-      "onePassword": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": ["type"],
-        "properties": {
-          "type": {
-            "const": "1password"
-          },
-          "vault": {
-            "$ref": "#/$defs/stringOrSecretRef",
-            "description": "Vault name"
-          },
-          "account": {
-            "$ref": "#/$defs/stringOrSecretRef",
-            "description": "Account (e.g., my.1password.com)"
-          }
-        },
-        "description": "1Password provider"
-      },
-      "awsKms": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": ["type", "key_id", "region"],
-        "properties": {
-          "type": {
-            "const": "aws-kms"
-          },
-          "key_id": {
-            "$ref": "#/$defs/stringOrSecretRef",
-            "description": "KMS key ID or alias"
-          },
-          "region": {
-            "$ref": "#/$defs/stringOrSecretRef",
-            "description": "AWS region"
-          }
-        },
-        "description": "AWS KMS encryption provider"
-      },
-      "awsPs": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": ["type", "region"],
-        "properties": {
-          "type": {
-            "const": "aws-ps"
-          },
-          "region": {
-            "$ref": "#/$defs/stringOrSecretRef",
-            "description": "AWS region"
-          },
-          "prefix": {
-            "$ref": "#/$defs/stringOrSecretRef",
-            "description": "Parameter path prefix"
-          }
-        },
-        "description": "AWS Parameter Store provider"
-      },
-      "awsSm": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": ["type", "region"],
-        "properties": {
-          "type": {
-            "const": "aws-sm"
-          },
-          "region": {
-            "$ref": "#/$defs/stringOrSecretRef",
-            "description": "AWS region"
-          },
-          "prefix": {
-            "$ref": "#/$defs/stringOrSecretRef",
-            "description": "Secret name prefix"
-          }
-        },
-        "description": "AWS Secrets Manager provider"
-      },
-      "azureKms": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": ["type", "vault_url", "key_name"],
-        "properties": {
-          "type": {
-            "const": "azure-kms"
-          },
-          "vault_url": {
-            "$ref": "#/$defs/stringOrSecretRef",
-            "description": "Azure Key Vault URL"
-          },
-          "key_name": {
-            "$ref": "#/$defs/stringOrSecretRef",
-            "description": "Key name"
-          }
-        },
-        "description": "Azure Key Vault KMS provider"
-      },
-      "azureSm": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": ["type", "vault_url"],
-        "properties": {
-          "type": {
-            "const": "azure-sm"
-          },
-          "vault_url": {
-            "$ref": "#/$defs/stringOrSecretRef",
-            "description": "Azure Key Vault URL"
-          },
-          "prefix": {
-            "$ref": "#/$defs/stringOrSecretRef",
-            "description": "Secret name prefix"
-          }
-        },
-        "description": "Azure Key Vault Secrets provider"
-      },
-      "bitwarden": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": ["type"],
-        "properties": {
-          "type": {
-            "const": "bitwarden"
-          },
-          "collection": {
-            "$ref": "#/$defs/stringOrSecretRef",
-            "description": "Collection ID"
-          },
-          "organization_id": {
-            "$ref": "#/$defs/stringOrSecretRef",
-            "description": "Organization ID"
-          },
-          "profile": {
-            "$ref": "#/$defs/stringOrSecretRef",
-            "description": "Profile name"
-          },
-          "backend": {
-            "type": "string",
-            "enum": ["bw", "rbw"],
-            "description": "Bitwarden backend to use (bw = official CLI, rbw = unofficial Rust client)"
-          }
-        },
-        "description": "Bitwarden provider"
-      },
-      "gcpKms": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": ["type", "project", "location", "keyring", "key"],
-        "properties": {
-          "type": {
-            "const": "gcp-kms"
-          },
-          "project": {
-            "$ref": "#/$defs/stringOrSecretRef",
-            "description": "GCP project ID"
-          },
-          "location": {
-            "$ref": "#/$defs/stringOrSecretRef",
-            "description": "Location (e.g., global, us-east1)"
-          },
-          "keyring": {
-            "$ref": "#/$defs/stringOrSecretRef",
-            "description": "Key ring name"
-          },
-          "key": {
-            "$ref": "#/$defs/stringOrSecretRef",
-            "description": "Key name"
-          }
-        },
-        "description": "GCP KMS encryption provider"
-      },
-      "gcpSm": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": ["type", "project"],
-        "properties": {
-          "type": {
-            "const": "gcp-sm"
-          },
-          "project": {
-            "$ref": "#/$defs/stringOrSecretRef",
-            "description": "GCP project ID"
-          },
-          "prefix": {
-            "$ref": "#/$defs/stringOrSecretRef",
-            "description": "Secret name prefix"
-          }
-        },
-        "description": "GCP Secret Manager provider"
-      },
-      "infisical": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": ["type"],
-        "properties": {
-          "type": {
-            "const": "infisical"
-          },
-          "project_id": {
-            "$ref": "#/$defs/stringOrSecretRef",
-            "description": "Infisical project ID"
-          },
-          "environment": {
-            "$ref": "#/$defs/stringOrSecretRef",
-            "description": "Environment (e.g., dev, staging, prod)"
-          },
-          "path": {
-            "$ref": "#/$defs/stringOrSecretRef",
-            "description": "Secrets path"
-          }
-        },
-        "description": "Infisical provider"
-      },
-      "keepass": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": ["type", "database"],
-        "properties": {
-          "type": {
-            "const": "keepass"
-          },
-          "database": {
-            "$ref": "#/$defs/stringOrSecretRef",
-            "description": "Path to KeePass database file (.kdbx)"
-          },
-          "keyfile": {
-            "$ref": "#/$defs/stringOrSecretRef",
-            "description": "Path to key file"
-          },
-          "password": {
-            "$ref": "#/$defs/stringOrSecretRef",
-            "description": "Database password (use env var instead)"
-          }
-        },
-        "description": "KeePass provider"
-      },
-      "keychain": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": ["type", "service"],
-        "properties": {
-          "type": {
-            "const": "keychain"
-          },
-          "service": {
-            "$ref": "#/$defs/stringOrSecretRef",
-            "description": "Service name"
-          },
-          "prefix": {
-            "$ref": "#/$defs/stringOrSecretRef",
-            "description": "Secret name prefix"
-          }
-        },
-        "description": "OS Keychain provider (macOS/Windows/Linux)"
-      },
-      "passwordStore": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": ["type"],
-        "properties": {
-          "type": {
-            "const": "password-store"
-          },
-          "prefix": {
-            "$ref": "#/$defs/stringOrSecretRef",
-            "description": "Secret name prefix"
-          },
-          "store_dir": {
-            "$ref": "#/$defs/stringOrSecretRef",
-            "description": "Password store directory"
-          },
-          "gpg_opts": {
-            "$ref": "#/$defs/stringOrSecretRef",
-            "description": "GPG options"
-          }
-        },
-        "description": "Password-store (pass) provider"
-      },
-      "passwordstate": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": ["type", "base_url", "password_list_id"],
-        "properties": {
-          "type": {
-            "const": "passwordstate"
-          },
-          "base_url": {
-            "$ref": "#/$defs/stringOrSecretRef",
-            "description": "Passwordstate server URL"
-          },
-          "api_key": {
-            "$ref": "#/$defs/stringOrSecretRef",
-            "description": "API key for the password list"
-          },
-          "password_list_id": {
-            "$ref": "#/$defs/stringOrSecretRef",
-            "description": "Password list ID"
-          },
-          "verify_ssl": {
-            "$ref": "#/$defs/stringOrSecretRef",
-            "description": "Verify SSL certificates"
-          }
-        },
-        "description": "Passwordstate provider"
-      },
-      "vault": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": ["type", "address"],
-        "properties": {
-          "type": {
-            "const": "vault"
-          },
-          "address": {
-            "$ref": "#/$defs/stringOrSecretRef",
-            "description": "Vault server address"
-          },
-          "path": {
-            "$ref": "#/$defs/stringOrSecretRef",
-            "description": "Secrets path"
-          },
-          "token": {
-            "$ref": "#/$defs/stringOrSecretRef",
-            "description": "Vault token"
-          }
-        },
-        "description": "HashiCorp Vault provider"
-      }
+          "additionalProperties": false,
+          "required": ["secret"]
+        }
+      ]
     }
   }
 }

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -2,6 +2,27 @@
 
 Complete reference for the `fnox.toml` configuration file.
 
+## JSON Schema
+
+A JSON Schema is available for IDE autocompletion and validation:
+
+```
+https://fnox.jdx.dev/schema.json
+```
+
+### Editor Setup
+
+**VS Code** with [Even Better TOML](https://marketplace.visualstudio.com/items?itemName=tamasfe.even-better-toml):
+
+```toml
+#:schema https://fnox.jdx.dev/schema.json
+
+[providers]
+age = { type = "age", recipients = ["age1..."] }
+```
+
+**JetBrains IDEs**: Add the schema URL in Settings > Languages & Frameworks > Schemas and DTDs > JSON Schema Mappings.
+
 ## File Location
 
 fnox looks for configuration files in this order (lowest to highest priority):

--- a/fnox.usage.kdl
+++ b/fnox.usage.kdl
@@ -134,6 +134,7 @@ cmd scan help="Scan repository for potential secrets" {
     }
     flag "-q --quiet" help="Show only files with potential secrets"
 }
+cmd schema hide=#true help="Generate JSON Schema for fnox configuration"
 cmd set help="Set a secret value" {
     alias s
     flag "-d --description" help="Description of the secret" {

--- a/mise.toml
+++ b/mise.toml
@@ -65,6 +65,15 @@ depends = ["build", "test", "lint"]
 description = "Render documentation from usage"
 depends = ["render:*"]
 
+[tasks."render:schema"]
+description = "Generate JSON Schema for fnox configuration"
+depends = ["build"]
+run = [
+  "fnox schema > docs/public/schema.json",
+  "prettier --write docs/public/schema.json",
+  "git add docs/public/schema.json",
+]
+
 [tasks."render:usage"]
 description = "Generate CLI documentation from usage"
 depends = ["build"]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -23,6 +23,7 @@ pub mod profiles;
 pub mod provider;
 pub mod remove;
 pub mod scan;
+pub mod schema;
 pub mod set;
 pub mod tui;
 pub mod usage;
@@ -120,6 +121,10 @@ pub enum Commands {
     /// Scan repository for potential secrets
     Scan(scan::ScanCommand),
 
+    /// Generate JSON Schema for fnox configuration
+    #[command(hide = true)]
+    Schema(schema::SchemaCommand),
+
     /// Set a secret value
     Set(set::SetCommand),
 
@@ -140,6 +145,7 @@ impl Commands {
             Commands::Version(cmd) => cmd.run(cli).await,
             Commands::Init(cmd) => cmd.run(cli).await,
             Commands::Completion(cmd) => cmd.run(cli).await,
+            Commands::Schema(cmd) => cmd.run(cli).await,
             Commands::Usage(cmd) => cmd.run(cli).await,
             Commands::Activate(cmd) => cmd
                 .run()

--- a/src/commands/schema.rs
+++ b/src/commands/schema.rs
@@ -1,0 +1,16 @@
+use crate::commands::Cli;
+use crate::config::Config;
+use crate::error::Result;
+
+#[derive(clap::Args)]
+#[command(hide = true)]
+pub struct SchemaCommand {}
+
+impl SchemaCommand {
+    pub async fn run(&self, _cli: &Cli) -> Result<()> {
+        let schema = schemars::schema_for!(Config);
+        let json = serde_json::to_string_pretty(&schema)?;
+        println!("{json}");
+        Ok(())
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,6 +2,7 @@ use crate::env;
 use crate::error::{FnoxError, Result};
 use clap::ValueEnum;
 use indexmap::IndexMap;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
@@ -11,7 +12,7 @@ use strum::VariantNames;
 // Re-export ProviderConfig from providers module
 pub use crate::providers::ProviderConfig;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct Config {
     /// Import paths to other config files
@@ -60,7 +61,7 @@ pub struct Config {
 }
 
 /// Configuration for a single secret
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct SecretConfig {
     /// Description of the secret
@@ -89,7 +90,7 @@ pub struct SecretConfig {
 }
 
 /// Configuration for a profile
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct ProfileConfig {
     /// Provider configurations for this profile
@@ -113,7 +114,9 @@ pub struct ProfileConfig {
     pub secret_sources: HashMap<String, PathBuf>,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, ValueEnum, VariantNames)]
+#[derive(
+    Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq, ValueEnum, VariantNames,
+)]
 #[serde(rename_all = "lowercase")]
 pub enum IfMissing {
     Error,

--- a/src/providers/bitwarden.rs
+++ b/src/providers/bitwarden.rs
@@ -1,6 +1,7 @@
 use crate::env;
 use crate::error::{FnoxError, Result};
 use async_trait::async_trait;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::process::Command;
@@ -13,7 +14,7 @@ pub struct BitwardenProvider {
     backend: BitwardenBackend,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum BitwardenBackend {
     Bw,


### PR DESCRIPTION
## Summary
- Add comprehensive JSON schema at `docs/public/schema.json`
- Supports all 17 provider types with their configuration fields
- Includes `StringOrSecretRef` support for fields that can be literals or secret references
- Document schema usage in configuration reference with editor setup instructions

## Test plan
- [x] Schema validates against sample fnox.toml files
- [x] VS Code with Even Better TOML provides autocompletion using schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds first-class JSON Schema support and tooling for `fnox.toml`.
> 
> - Introduces `schemars`; derives `JsonSchema` for `Config`, `SecretConfig`, `ProfileConfig`, `IfMissing`, `BitwardenBackend`, generated `ProviderConfig`, and secret ref types (`StringOrSecretRef`, `OptionStringOrSecretRef`)
> - New hidden `schema` CLI subcommand outputs the schema; adds `render:schema` task to generate and commit `docs/public/schema.json`
> - Updates docs with schema URL and editor setup; refreshes CLI specs (`fnox.usage.kdl`, `docs/cli/commands.json`) including default value representations and the `schema` command
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b234c4ff8efefe867a1293e6742f2dc7fcbb95b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->