### PR TITLE
feat: add Black Ops One font branding to docs

### DIFF
--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -2,6 +2,7 @@
  * Customize default theme styling by overriding CSS variables:
  * https://github.com/vuejs/vitepress/blob/main/src/client/theme-default/styles/vars.css
  */
+@import url('https://fonts.googleapis.com/css2?family=Black+Ops+One&display=swap');
 
 /**
  * Colors - Fort Knox theme (dark blue/gold)
@@ -143,4 +144,17 @@
   border-bottom: 1px solid rgba(212, 175, 55, 0.1);
   background: rgba(10, 14, 26, 0.8);
   backdrop-filter: blur(8px);
+}
+
+/* Black Ops One branding */
+.VPNavBarTitle .title {
+  font-family: 'Black Ops One', cursive;
+  font-size: 1.5rem;
+  color: var(--vp-c-brand-1) !important;
+}
+
+.VPHero .name {
+  font-family: 'Black Ops One', cursive !important;
+  font-size: 4rem !important;
+  font-weight: 400 !important;
 }

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -2,7 +2,7 @@
  * Customize default theme styling by overriding CSS variables:
  * https://github.com/vuejs/vitepress/blob/main/src/client/theme-default/styles/vars.css
  */
-@import url('https://fonts.googleapis.com/css2?family=Black+Ops+One&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=Black+Ops+One&display=swap");
 
 /**
  * Colors - Fort Knox theme (dark blue/gold)
@@ -148,13 +148,13 @@
 
 /* Black Ops One branding */
 .VPNavBarTitle .title {
-  font-family: 'Black Ops One', cursive;
+  font-family: "Black Ops One", cursive;
   font-size: 1.5rem;
   color: var(--vp-c-brand-1) !important;
 }
 
 .VPHero .name {
-  font-family: 'Black Ops One', cursive !important;
+  font-family: "Black Ops One", cursive !important;
   font-size: 4rem !important;
   font-weight: 400 !important;
 }


### PR DESCRIPTION
## Summary
- Add Black Ops One font for hero title and navbar
- Matches fnox's security/tactical theme with gold accents
- Similar styling approach to usage (VT323) and pitchfork (Creepster) docs

## Test plan
- [ ] Verify dev server shows Black Ops One font on homepage title
- [ ] Verify navbar shows Black Ops One font
- [ ] Check mobile responsiveness

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces branded typography to docs.
> 
> - Imports Google font `Black Ops One` in `docs/.vitepress/theme/style.css`
> - Applies font to ` .VPNavBarTitle .title` and ` .VPHero .name`, adjusting size/weight for each
> - Keeps existing Fort Knox color/theme variables and navbar styling intact
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 033d403d51f9180aa11548ead003989925351157. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->