### PR TITLE
feat(1password): add token field supporting secret references

### DIFF
--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -110,37 +110,6 @@
         {
           "type": "object",
           "properties": {
-            "gpg_opts": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "prefix": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "store_dir": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "type": {
-              "type": "string",
-              "const": "password-store"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["type"]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "type": "string",
-              "const": "plain"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["type"]
-        },
-        {
-          "type": "object",
-          "properties": {
             "database": {
               "$ref": "#/$defs/StringOrSecretRef"
             },
@@ -177,6 +146,57 @@
           },
           "additionalProperties": false,
           "required": ["type", "recipients"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "plain"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "gpg_opts": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "prefix": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "store_dir": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "password-store"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "account": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "token": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "1password"
+            },
+            "vault": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type"]
         },
         {
           "type": "object",
@@ -254,40 +274,6 @@
         {
           "type": "object",
           "properties": {
-            "account": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "type": {
-              "type": "string",
-              "const": "1password"
-            },
-            "vault": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["type"]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "key_name": {
-              "$ref": "#/$defs/StringOrSecretRef"
-            },
-            "type": {
-              "type": "string",
-              "const": "azure-kms"
-            },
-            "vault_url": {
-              "$ref": "#/$defs/StringOrSecretRef"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["type", "vault_url", "key_name"]
-        },
-        {
-          "type": "object",
-          "properties": {
             "key_id": {
               "$ref": "#/$defs/StringOrSecretRef"
             },
@@ -328,19 +314,19 @@
         {
           "type": "object",
           "properties": {
-            "prefix": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "region": {
+            "key_name": {
               "$ref": "#/$defs/StringOrSecretRef"
             },
             "type": {
               "type": "string",
-              "const": "aws-sm"
+              "const": "azure-kms"
+            },
+            "vault_url": {
+              "$ref": "#/$defs/StringOrSecretRef"
             }
           },
           "additionalProperties": false,
-          "required": ["type", "region"]
+          "required": ["type", "vault_url", "key_name"]
         },
         {
           "type": "object",
@@ -358,6 +344,40 @@
           },
           "additionalProperties": false,
           "required": ["type", "vault_url"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "prefix": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "region": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "aws-ps"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type", "region"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "prefix": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "region": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "aws-sm"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type", "region"]
         },
         {
           "type": "object",
@@ -395,23 +415,6 @@
           },
           "additionalProperties": false,
           "required": ["type", "project"]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "prefix": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "region": {
-              "$ref": "#/$defs/StringOrSecretRef"
-            },
-            "type": {
-              "type": "string",
-              "const": "aws-ps"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["type", "region"]
         },
         {
           "type": "object",

--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -110,6 +110,37 @@
         {
           "type": "object",
           "properties": {
+            "gpg_opts": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "prefix": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "store_dir": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "password-store"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "plain"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type"]
+        },
+        {
+          "type": "object",
+          "properties": {
             "database": {
               "$ref": "#/$defs/StringOrSecretRef"
             },
@@ -146,57 +177,6 @@
           },
           "additionalProperties": false,
           "required": ["type", "recipients"]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "type": "string",
-              "const": "plain"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["type"]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "gpg_opts": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "prefix": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "store_dir": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "type": {
-              "type": "string",
-              "const": "password-store"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["type"]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "account": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "token": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "type": {
-              "type": "string",
-              "const": "1password"
-            },
-            "vault": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["type"]
         },
         {
           "type": "object",
@@ -274,6 +254,43 @@
         {
           "type": "object",
           "properties": {
+            "account": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "token": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "1password"
+            },
+            "vault": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "key_name": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "azure-kms"
+            },
+            "vault_url": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type", "vault_url", "key_name"]
+        },
+        {
+          "type": "object",
+          "properties": {
             "key_id": {
               "$ref": "#/$defs/StringOrSecretRef"
             },
@@ -314,19 +331,19 @@
         {
           "type": "object",
           "properties": {
-            "key_name": {
+            "prefix": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "region": {
               "$ref": "#/$defs/StringOrSecretRef"
             },
             "type": {
               "type": "string",
-              "const": "azure-kms"
-            },
-            "vault_url": {
-              "$ref": "#/$defs/StringOrSecretRef"
+              "const": "aws-sm"
             }
           },
           "additionalProperties": false,
-          "required": ["type", "vault_url", "key_name"]
+          "required": ["type", "region"]
         },
         {
           "type": "object",
@@ -344,40 +361,6 @@
           },
           "additionalProperties": false,
           "required": ["type", "vault_url"]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "prefix": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "region": {
-              "$ref": "#/$defs/StringOrSecretRef"
-            },
-            "type": {
-              "type": "string",
-              "const": "aws-ps"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["type", "region"]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "prefix": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "region": {
-              "$ref": "#/$defs/StringOrSecretRef"
-            },
-            "type": {
-              "type": "string",
-              "const": "aws-sm"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["type", "region"]
         },
         {
           "type": "object",
@@ -415,6 +398,23 @@
           },
           "additionalProperties": false,
           "required": ["type", "project"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "prefix": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "region": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "aws-ps"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type", "region"]
         },
         {
           "type": "object",

--- a/providers/1password.toml
+++ b/providers/1password.toml
@@ -8,7 +8,8 @@ default_name = "onepass"
 auth_command = "op signin"
 setup_instructions = """
 Requires: 1Password CLI (op) and a service account token.
-Set token: export OP_SERVICE_ACCOUNT_TOKEN=<token>"""
+Set token via env: export OP_SERVICE_ACCOUNT_TOKEN=<token>
+Or use a secret reference: token = { secret = "OP_TOKEN" }"""
 
 [fields.vault]
 type = "optional"
@@ -21,3 +22,9 @@ type = "optional"
 placeholder = ""
 label = "Account (optional, e.g., my.1password.com):"
 wizard = true
+
+[fields.token]
+type = "optional"
+placeholder = ""
+label = "Service account token (optional, can reference another secret):"
+wizard = false

--- a/src/commands/provider/add.rs
+++ b/src/commands/provider/add.rs
@@ -69,6 +69,7 @@ impl AddCommand {
             ProviderType::OnePassword => crate::config::ProviderConfig::OnePassword {
                 vault: OptionStringOrSecretRef::literal("default"),
                 account: OptionStringOrSecretRef::none(),
+                token: OptionStringOrSecretRef::none(),
             },
             ProviderType::Aws => crate::config::ProviderConfig::AwsSecretsManager {
                 region: StringOrSecretRef::from("us-east-1"),


### PR DESCRIPTION
## Summary

- Adds a `token` field to the 1Password provider configuration
- The token field supports secret references (e.g., `{ secret = "OP_TOKEN" }`)
- Enables bootstrapping workflows where the 1Password service account token is stored in another provider (like keychain) and resolved before 1Password secrets are accessed

## Example Usage

```toml
[providers]
keychain = { type = "keychain", service = "fnox" }
onepass = { type = "1password", vault = "development", token = { secret = "OP_TOKEN" } }

[secrets]
OP_TOKEN = { provider = "keychain", value = "op-service-token" }
OPENAI_API_KEY = { provider = "onepass", value = "OPENAI_API_KEY" }
```

With this configuration:
1. fnox resolves `OP_TOKEN` from keychain first
2. The resolved token is used to authenticate with 1Password
3. `OPENAI_API_KEY` is then fetched from 1Password

## Test plan

- [x] Cargo tests pass
- [x] Schema regenerated with new token field
- [ ] Manual testing with keychain + 1Password setup

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces an optional `token` field for the 1Password provider and wires it into authentication.
> 
> - Extends `ProviderConfig` schema to include `token` for `"1password"` and updates `providers/1password.toml` (setup instructions and UI field) to document env/secret-ref usage
> - Updates `provider add` template to include `token = None`
> - Modifies `OnePasswordProvider` to accept `token`, adds `get_token()` to prefer configured token over env, and uses it for all `op` and `op inject` calls
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51341e0c63bf65bbad2eb07be988f7bc0fad461c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->