### PR TITLE
refactor: convert miette::miette!() to FnoxError in encrypt.rs and list.rs

### DIFF
--- a/src/commands/encrypt.rs
+++ b/src/commands/encrypt.rs
@@ -45,16 +45,22 @@ impl EncryptCommand {
         tracing::debug!("Encrypting for {} recipients", recipients.len());
 
         // Create encryptor
-        let encryptor = AgeEncryptor::new(recipients)
-            .map_err(|e| miette::miette!("Failed to create encryptor: {}", e))?;
+        let encryptor = AgeEncryptor::new(recipients).map_err(|e| {
+            FnoxError::AgeEncryptionFailed {
+                details: format!("Failed to create encryptor: {}", e),
+            }
+        })?;
 
         // Serialize secrets to JSON
         let secrets_json = serde_json::to_string(&config.secrets)?;
         let plaintext = secrets_json.as_bytes();
 
         // Encrypt the data
-        let ciphertext = encryptor.encrypt(plaintext).await
-            .map_err(|e| miette::miette!("Encryption failed: {}", e))?;
+        let ciphertext = encryptor.encrypt(plaintext).await.map_err(|e| {
+            FnoxError::AgeEncryptionFailed {
+                details: e.to_string(),
+            }
+        })?;
 
         // Base64 encode the ciphertext
         use base64::Engine;

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -92,9 +92,7 @@ impl ListCommand {
         tracing::debug!("Listing secrets in profile '{}'", profile);
 
         // Get the profile secrets
-        let profile_secrets = config
-            .get_secrets(&profile)
-            .map_err(|e| miette::miette!(e))?;
+        let profile_secrets = config.get_secrets(&profile)?;
 
         if profile_secrets.is_empty() {
             if !self.complete {


### PR DESCRIPTION
## Summary
- Convert 2 `miette::miette!()` calls in `encrypt.rs` to `FnoxError::AgeEncryptionFailed` for better structured error diagnostics
- Remove unnecessary `.map_err(|e| miette::miette!(e))` wrapper in `list.rs` since `get_secrets()` already returns `Result<_, FnoxError>`

## Test plan
- [x] `mise run build` succeeds
- [x] `mise run test:cargo` passes all 41 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Refactor error handling for encryption and listing**
> 
> - In `encrypt.rs`, map `AgeEncryptor::new` and `encrypt(...).await` errors to `FnoxError::AgeEncryptionFailed` with `details` instead of using `miette::miette!()`
> - In `list.rs`, remove unnecessary `.map_err(|e| miette::miette!(e))` around `config.get_secrets(&profile)` since it already returns `Result<_, FnoxError>`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22121a8d168cbd59c0124d1aacf2f70e48288c6e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->