### PR TITLE
feat: use #[related] for validation errors to show all issues at once

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1969,6 +1969,7 @@ dependencies = [
  "miette",
  "miniz_oxide",
  "openssl-sys",
+ "pluralizer",
  "proc-macro2",
  "quote",
  "ratatui",
@@ -4092,6 +4093,16 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "pluralizer"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b3eba432a00a1f6c16f39147847a870e94e2e9b992759b503e330efec778cbe"
+dependencies = [
+ "once_cell",
+ "regex",
+]
 
 [[package]]
 name = "png"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ keepass = { version = "0.8", features = ["save_kdbx4"] }
 keyring = { version = "3", features = ["apple-native", "windows-native", "sync-secret-service"] }
 # Required for rustls crypto provider (used by GCP SDKs)
 rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs", "std"] }
+pluralizer = "0.5.0"
 
 # Linux-specific dependencies for cross-compilation
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/src/config.rs
+++ b/src/config.rs
@@ -749,9 +749,15 @@ impl Config {
         secret: &SecretConfig,
         profile: &str,
     ) -> Option<crate::error::ValidationIssue> {
-        if !secret.value.as_ref().is_some_and(|v| v.is_empty()) {
-            return None;
+        // Early return if value is not an empty string
+        let Some(value) = secret.value.as_deref() else {
+            return None; // No value specified - not an issue
+        };
+        if !value.is_empty() {
+            return None; // Non-empty value - not an issue
         }
+
+        // At this point, value is an empty string
         // Allow empty values for plain provider (empty string is a valid secret value)
         if self.is_plain_provider(secret.provider.as_deref(), profile) {
             return None;

--- a/src/config.rs
+++ b/src/config.rs
@@ -795,6 +795,16 @@ impl Config {
         for (profile_name, profile_config) in &self.profiles {
             let providers = self.get_providers(profile_name);
 
+            // Check for profile secrets with empty values (likely a mistake)
+            for (key, secret) in &profile_config.secrets {
+                if secret.value.as_ref().is_some_and(|v| v.is_empty()) {
+                    issues.push(ValidationIssue::new(format!(
+                        "Secret '{}' in profile '{}' has an empty value",
+                        key, profile_name
+                    )));
+                }
+            }
+
             // Each profile must have at least one provider (inherited or its own), unless root=true
             if providers.is_empty() && !self.root {
                 issues.push(ValidationIssue::with_help(

--- a/src/error.rs
+++ b/src/error.rs
@@ -85,7 +85,7 @@ pub enum FnoxError {
 
     /// Configuration validation failed with one or more issues.
     /// Uses #[related] to display all validation issues together.
-    #[error("Configuration validation failed ({} issue{})", issues.len(), if issues.len() == 1 { "" } else { "s" })]
+    #[error("Configuration validation failed ({})", pluralizer::pluralize("issue", issues.len() as isize, true))]
     #[diagnostic(
         code(fnox::config::validation_failed),
         help("Fix the issues above in your fnox.toml file"),

--- a/src/error.rs
+++ b/src/error.rs
@@ -85,7 +85,7 @@ pub enum FnoxError {
 
     /// Configuration validation failed with one or more issues.
     /// Uses #[related] to display all validation issues together.
-    #[error("Configuration validation failed ({})", pluralizer::pluralize("issue", issues.len() as isize, true))]
+    #[error("Configuration validation failed ({})", pluralizer::pluralize("issue", std::cmp::min(issues.len(), isize::MAX as usize) as isize, true))]
     #[diagnostic(
         code(fnox::config::validation_failed),
         help("Fix the issues above in your fnox.toml file"),

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,6 +14,7 @@ pub struct ValidationIssue {
 }
 
 impl ValidationIssue {
+    #[allow(dead_code)]
     pub fn new(message: impl Into<String>) -> Self {
         Self {
             message: message.into(),


### PR DESCRIPTION
## Summary
Instead of returning early on the first validation error, the `validate()` method now collects all validation issues and displays them together using miette's `#[related]` attribute.

## Changes
- Add `ValidationIssue` struct that implements `Diagnostic` for individual issues
- Update `ConfigValidationFailed` to use `#[related]` with `Vec<ValidationIssue>`
- Modify `validate()` to collect all issues before returning an error
- Each validation issue includes a helpful message with fix suggestions

## Example Output
When multiple validation issues are found:
```
Error: Configuration validation failed (2 issues)

Error: Default provider 'nonexistent' not found in configuration
  help: Add [providers.nonexistent] to your config or remove the default_provider setting

Error: Profile 'prod' has no providers configured
  help: Add [profiles.prod.providers.<name>] or inherit from top-level providers
```

## Benefits
- Users see all configuration problems at once instead of fixing one at a time
- Each issue includes contextual help for how to fix it
- Better UX when setting up complex configurations

## Test plan
- [x] `mise run build` succeeds
- [x] `mise run test:cargo` passes all 41 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves configuration validation UX by aggregating issues and adding targeted checks.
> 
> - `validate()` now accumulates issues and returns `FnoxError::ConfigValidationFailed` with `#[related]` instead of failing fast
> - Introduces `ValidationIssue` (Diagnostic) and updates `ConfigValidationFailed` to carry `Vec<ValidationIssue>` with a pluralized header via `pluralizer`
> - Adds detection of empty secret values (skipped for `plain` provider) using `check_empty_value()` and `is_plain_provider()`
> - Refines validation messages/help text; adds `pluralizer` to `Cargo.toml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2e86e77f8101678633f35db2ff3c0e5b65b62259. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->