### PR TITLE
feat: use structured error variants instead of generic Config/Provider

### DIFF
--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -1,6 +1,6 @@
 use crate::commands::Cli;
 use crate::config::Config;
-use crate::error::Result;
+use crate::error::{FnoxError, Result};
 use clap::{Args, ValueEnum};
 use regex::Regex;
 use std::io::{self, Read};
@@ -261,7 +261,7 @@ impl ImportCommand {
             let mut input = String::new();
             io::stdin()
                 .read_to_string(&mut input)
-                .map_err(|e| miette::miette!("Failed to read from stdin: {}", e))?;
+                .map_err(|source| FnoxError::StdinReadFailed { source })?;
             Ok(input)
         }
     }

--- a/src/commands/set.rs
+++ b/src/commands/set.rs
@@ -64,7 +64,7 @@ impl SetCommand {
             let mut buffer = String::new();
             io::stdin()
                 .read_to_string(&mut buffer)
-                .map_err(|e| FnoxError::Config(format!("Failed to read from stdin: {}", e)))?;
+                .map_err(|source| FnoxError::StdinReadFailed { source })?;
             Some(buffer.trim().to_string())
         } else {
             // Interactive terminal - prompt for value

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,7 +16,6 @@ pub enum FnoxError {
     )]
     ConfigFileNotFound { path: std::path::PathBuf },
 
-    #[allow(dead_code)]
     #[error("Failed to read configuration file: {}", path.display())]
     #[diagnostic(
         code(fnox::config::read_failed),
@@ -28,7 +27,6 @@ pub enum FnoxError {
         source: std::io::Error,
     },
 
-    #[allow(dead_code)]
     #[error("Failed to write configuration file: {}", path.display())]
     #[diagnostic(
         code(fnox::config::write_failed),
@@ -364,7 +362,6 @@ pub enum FnoxError {
     // ========================================================================
     // Input/Output Errors
     // ========================================================================
-    #[allow(dead_code)]
     #[error("Failed to read from stdin")]
     #[diagnostic(code(fnox::io::stdin_read_failed))]
     StdinReadFailed {


### PR DESCRIPTION
## Summary
- Replace generic `FnoxError::Config(format!("..."))` with structured error variants
- Three previously dead_code error variants are now used

### Changes:
| Generic Error | Structured Variant | Benefit |
|--------------|-------------------|---------|
| `Config("Failed to read config file: ...")` | `ConfigReadFailed { path, source }` | Includes file path + I/O error source |
| `Config("Failed to write config file: ...")` | `ConfigWriteFailed { path, source }` | Includes file path + I/O error source |
| `Config("Failed to read from stdin: ...")` | `StdinReadFailed { source }` | Proper I/O error source chain |

### Benefits:
- Specific error codes (e.g., `fnox::config::read_failed`)
- Proper `#[source]` chains for error context
- More helpful diagnostic messages
- Removed 3 `#[allow(dead_code)]` attributes

## Test plan
- [x] Build succeeds
- [x] All 41 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves error diagnostics by using structured error variants with path and source chaining.
> 
> - Replace generic `FnoxError::Config("...read...")`/`("...write...")` with `ConfigReadFailed { path, source }` and `ConfigWriteFailed { path, source }` in `edit.rs` and `config.rs`
> - Use `StdinReadFailed { source }` for stdin reads in `import.rs` and `set.rs`
> - Leverage `From<toml_edit::de::Error>`/`ser::Error` conversions (e.g., remove manual parse mapping in `load_single`), keeping consistent error typing
> - Tidy `error.rs`: activate structured variants (remove dead_code allows) and keep generic fallbacks for compatibility
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1fa2ff0a33de351eac989d67011f438d877fdce5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->