### PR TITLE
feat: preserve source error chains for JSON/YAML errors

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -395,25 +395,31 @@ pub enum FnoxError {
     // ========================================================================
     // JSON/YAML Errors
     // ========================================================================
-    #[error("JSON error: {0}")]
+    #[error("JSON error")]
     #[diagnostic(code(fnox::json::error))]
-    Json(String),
+    Json {
+        #[source]
+        source: serde_json::Error,
+    },
 
-    #[error("YAML error: {0}")]
+    #[error("YAML error")]
     #[diagnostic(code(fnox::yaml::error))]
-    Yaml(String),
+    Yaml {
+        #[source]
+        source: serde_yaml::Error,
+    },
 }
 
 // Implement conversions for common error types
 impl From<serde_json::Error> for FnoxError {
-    fn from(err: serde_json::Error) -> Self {
-        FnoxError::Json(err.to_string())
+    fn from(source: serde_json::Error) -> Self {
+        FnoxError::Json { source }
     }
 }
 
 impl From<serde_yaml::Error> for FnoxError {
-    fn from(err: serde_yaml::Error) -> Self {
-        FnoxError::Yaml(err.to_string())
+    fn from(source: serde_yaml::Error) -> Self {
+        FnoxError::Yaml { source }
     }
 }
 


### PR DESCRIPTION
## Summary
- Change `Json` and `Yaml` error variants to use `#[source]` chains instead of converting errors to strings
- Preserves the original `serde_json::Error` and `serde_yaml::Error` for better debugging

### Before:
```rust
Json(String)  // loses the underlying serde_json::Error
Yaml(String)  // loses the underlying serde_yaml::Error
```

### After:
```rust
Json { #[source] source: serde_json::Error }  // preserves error chain
Yaml { #[source] source: serde_yaml::Error }  // preserves error chain
```

### Benefits:
- Proper error chaining visible with `RUST_BACKTRACE` or miette's `--causes` flag
- Better debugging experience when parsing fails
- Consistent with other `FnoxError` variants that use `#[source]`
- Error messages now show the full error chain instead of just a string

## Test plan
- [x] Build succeeds
- [x] All 41 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Preserves underlying serde error chains for parsing failures.
> 
> - Replace `Json(String)`/`Yaml(String)` with struct variants carrying `#[source] serde_json::Error` and `serde_yaml::Error`
> - Update `From<serde_json::Error>` and `From<serde_yaml::Error>` to construct the new variants
> - Simplify messages to `"JSON error"` / `"YAML error"` for clearer chained diagnostics
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ad8113ee6ed87e9ab0976fbe84ebb75eb8a9e77. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->