### PR TITLE
docs: add mise integration guide

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -52,6 +52,7 @@ export default defineConfig({
         text: "Features",
         items: [
           { text: "Shell Integration", link: "/guide/shell-integration" },
+          { text: "Mise Integration", link: "/guide/mise-integration" },
           { text: "TUI Dashboard", link: "/guide/tui" },
           { text: "Profiles", link: "/guide/profiles" },
           { text: "Hierarchical Config", link: "/guide/hierarchical-config" },

--- a/docs/guide/mise-integration.md
+++ b/docs/guide/mise-integration.md
@@ -1,0 +1,156 @@
+# Mise Integration
+
+fnox integrates with [mise](https://mise.jdx.dev) through the `jdx/mise-env-fnox` env plugin, allowing you to automatically load secrets into your development environment.
+
+## Installation
+
+Add the plugin to your project's `mise.toml`:
+
+```toml
+[plugins]
+fnox-env = "https://github.com/jdx/mise-env-fnox"
+
+[env]
+_.fnox-env = {}
+```
+
+## How It Works
+
+When mise activates your environment, the fnox plugin:
+
+1. Searches for `fnox.toml` in the current directory and parent directories
+2. Resolves secrets using your configured providers
+3. Exports the secrets as environment variables
+4. Watches `fnox.toml` for changes to invalidate the cache
+
+## Configuration Options
+
+| Option     | Description         | Default   |
+| ---------- | ------------------- | --------- |
+| `profile`  | fnox profile to use | `default` |
+| `fnox_bin` | Path to fnox binary | `fnox`    |
+
+### Examples
+
+```toml
+[plugins]
+fnox-env = "https://github.com/jdx/mise-env-fnox"
+
+[env]
+# Use default profile
+_.fnox-env = {}
+```
+
+```toml
+[plugins]
+fnox-env = "https://github.com/jdx/mise-env-fnox"
+
+[env]
+# Use production profile
+_.fnox-env = { profile = "production" }
+```
+
+```toml
+[plugins]
+fnox-env = "https://github.com/jdx/mise-env-fnox"
+
+[env]
+# Custom fnox binary path
+_.fnox-env = { fnox_bin = "/usr/local/bin/fnox" }
+```
+
+## Environment-Specific Configuration
+
+Combine with mise's environment system for different profiles per environment:
+
+```toml
+[plugins]
+fnox-env = "https://github.com/jdx/mise-env-fnox"
+
+[env]
+_.fnox-env = { profile = "dev" }
+
+[env.production]
+_.fnox-env = { profile = "production" }
+
+[env.staging]
+_.fnox-env = { profile = "staging" }
+```
+
+Then activate different environments:
+
+```bash
+# Development (default)
+mise env
+
+# Production
+MISE_ENV=production mise env
+
+# Staging
+MISE_ENV=staging mise env
+```
+
+## Caching
+
+The fnox plugin supports mise's environment caching (when `MISE_ENV_CACHE=1`). Secrets are:
+
+- Cached encrypted on disk for fast subsequent loads
+- Automatically refreshed when `fnox.toml` changes
+- Scoped to your shell session for security
+
+To enable caching:
+
+```bash
+export MISE_ENV_CACHE=1
+```
+
+## Comparison with Shell Integration
+
+| Feature                   | Shell Integration | Mise Integration     |
+| ------------------------- | ----------------- | -------------------- |
+| Automatic loading on `cd` | Yes               | Yes (via mise)       |
+| Works without mise        | Yes               | No                   |
+| Caching                   | No                | Yes (with env cache) |
+| Task integration          | No                | Yes                  |
+| Tool version management   | No                | Yes                  |
+
+Use shell integration if you want fnox-only secret loading. Use mise integration if you're already using mise for tool/environment management.
+
+## Troubleshooting
+
+### Secrets not loading
+
+1. Ensure `fnox.toml` exists in your project:
+
+   ```bash
+   ls fnox.toml
+   ```
+
+2. Test fnox directly:
+
+   ```bash
+   fnox export --format json
+   ```
+
+3. Check mise is loading the plugin:
+   ```bash
+   mise env
+   ```
+
+### Cache not invalidating
+
+If secrets aren't updating after changes to `fnox.toml`:
+
+```bash
+# Clear mise's env cache
+mise cache clear
+
+# Or use fresh flag
+mise exec --fresh-env -- your-command
+```
+
+## Next Steps
+
+- [Shell Integration](/guide/shell-integration) - Alternative direct shell integration
+- [Profiles](/guide/profiles) - Managing multiple environments
+- [Hierarchical Config](/guide/hierarchical-config) - Organizing secrets across directories


### PR DESCRIPTION
## Summary
- Add documentation for using jdx/mise-env-fnox plugin with mise
- Covers installation, configuration options, environment-specific configs, caching, and troubleshooting
- Added to sidebar under Features section

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces documentation for integrating fnox with Mise via the `jdx/mise-env-fnox` plugin and surfaces it in the docs navigation.
> 
> - New page `docs/guide/mise-integration.md` covering installation, how it works, configuration options (e.g., `profile`, `fnox_bin`), environment-specific configs, caching, troubleshooting, and comparison with shell integration
> - Updates `docs/.vitepress/config.mjs` to add "Mise Integration" under the **Features** sidebar section
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a0911948fd1959da537ff8e6cb100a01bca8466. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->