### PR TITLE
feat(vault): add namespace option

### DIFF
--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -382,6 +382,9 @@
             "address": {
               "$ref": "#/$defs/StringOrSecretRef"
             },
+            "namespace": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
             "path": {
               "$ref": "#/$defs/OptionStringOrSecretRef"
             },

--- a/providers/vault.toml
+++ b/providers/vault.toml
@@ -28,3 +28,9 @@ type = "optional"
 placeholder = ""
 label = "Token (optional, uses env var if not set):"
 wizard = true
+
+[fields.namespace]
+type = "optional"
+placeholder = ""
+label = "Namespace (optional, uses env var if not set):"
+wizard = true

--- a/src/commands/provider/add.rs
+++ b/src/commands/provider/add.rs
@@ -79,6 +79,7 @@ impl AddCommand {
                 address: StringOrSecretRef::from("http://localhost:8200"),
                 path: OptionStringOrSecretRef::literal("secret"),
                 token: OptionStringOrSecretRef::none(),
+                namespace: OptionStringOrSecretRef::none(),
             },
             ProviderType::Gcp => crate::config::ProviderConfig::GoogleSecretManager {
                 project: StringOrSecretRef::from("my-project"),

--- a/src/providers/vault.rs
+++ b/src/providers/vault.rs
@@ -12,7 +12,12 @@ pub struct HashiCorpVaultProvider {
 }
 
 impl HashiCorpVaultProvider {
-    pub fn new(address: String, path: Option<String>, token: Option<String>, namespace: Option<String>) -> Self {
+    pub fn new(
+        address: String,
+        path: Option<String>,
+        token: Option<String>,
+        namespace: Option<String>,
+    ) -> Self {
         Self {
             address,
             path,

--- a/src/providers/vault.rs
+++ b/src/providers/vault.rs
@@ -8,14 +8,16 @@ pub struct HashiCorpVaultProvider {
     address: String,
     path: Option<String>,
     token: Option<String>,
+    namespace: Option<String>,
 }
 
 impl HashiCorpVaultProvider {
-    pub fn new(address: String, path: Option<String>, token: Option<String>) -> Self {
+    pub fn new(address: String, path: Option<String>, token: Option<String>, namespace: Option<String>) -> Self {
         Self {
             address,
             path,
             token,
+            namespace,
         }
     }
 
@@ -34,6 +36,12 @@ impl HashiCorpVaultProvider {
 
         // Set VAULT_ADDR from provider config
         cmd.env("VAULT_ADDR", &self.address);
+
+        // Set VAULT_NAMESPACE if provided
+        if let Some(namespace) = &self.namespace {
+            tracing::debug!("Setting VAULT_NAMESPACE to '{}'", namespace);
+            cmd.env("VAULT_NAMESPACE", namespace);
+        }
 
         // Set VAULT_TOKEN from provider config or environment
         let token = self


### PR DESCRIPTION
# Add Vault Namespace Support
This PR adds support for HashiCorp Vault namespaces, enabling users to configure and use Vault namespaces when retrieving secrets.

## Changes
- **Provider Configuration**: Added a new optional namespace field to the Vault provider configuration in vault.toml
- **Provider Implementation**: Updated HashiCorpVaultProvider to accept and store the namespace parameter
- **Environment Variable**: When a namespace is configured, the provider now sets the `VAULT_NAMESPACE` environment variable for Vault CLI commands
- **Wizard Support**: Added namespace field to the interactive provider setup wizard with appropriate prompt
- **Default Configuration**: Updated the provider add command to include namespace in the default Vault configuration

## Usage
Users can now configure a Vault namespace in their fnox.toml

The namespace will be automatically applied when the Vault CLI is invoked to retrieve secrets.

## Backward Compatibility

This change is fully backward compatible, the namespace field is optional and existing configurations will continue to work without modification.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Vault namespace support end-to-end while remaining backward compatible.
> 
> - Schema: Adds optional `namespace` to `ProviderConfig` for `vault` in `docs/public/schema.json`
> - Wizard/UI: Adds `namespace` field to `providers/vault.toml`
> - Defaults: Includes `namespace` in `provider add` Vault template (`src/commands/provider/add.rs`)
> - Provider: Extends `HashiCorpVaultProvider` to accept `namespace` and export `VAULT_NAMESPACE` when invoking the Vault CLI (`src/providers/vault.rs`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 07c7eac544ff5cf83349c179c4a901adeafb3663. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->