### PR TITLE
fix: preserve TOML comments in `fnox set`

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -518,6 +518,9 @@ impl Config {
     /// Always saves to the default_target (local config file), creating a local
     /// override if the secret exists in a parent config. This aligns with the
     /// hierarchical config model where child configs override parent configs.
+    ///
+    /// This method preserves comments and formatting in the TOML file by
+    /// directly manipulating the document AST rather than re-serializing.
     pub fn save_secret_to_source(
         &self,
         secret_name: &str,
@@ -525,61 +528,58 @@ impl Config {
         profile: &str,
         default_target: &Path,
     ) -> Result<()> {
-        // Always save to the local config file (default_target)
-        // If a secret exists in a parent config, this creates a local override
-        // rather than modifying the parent - matching user expectations for
-        // hierarchical configs (fixes #104, #121)
+        use toml_edit::{DocumentMut, Item, Value};
+
         let target_file = default_target.to_path_buf();
 
-        // Load the target file (or create new config if it doesn't exist)
-        let mut target_config = if target_file.exists() {
-            Self::load_single(&target_file)?
+        // Load existing document or create new one (preserves comments)
+        let mut doc = if target_file.exists() {
+            let content =
+                fs::read_to_string(&target_file).map_err(|source| FnoxError::ConfigReadFailed {
+                    path: target_file.clone(),
+                    source,
+                })?;
+            content
+                .parse::<DocumentMut>()
+                .map_err(|e| FnoxError::Config(format!("Failed to parse TOML: {}", e)))?
         } else {
-            Self::new()
+            DocumentMut::new()
         };
 
-        // Update the secret in the appropriate location
-        if profile == "default" {
-            target_config
-                .secrets
-                .insert(secret_name.to_string(), secret_config.clone());
+        // Get or create the secrets table
+        let secrets_table = if profile == "default" {
+            if doc.get("secrets").is_none() {
+                doc["secrets"] = Item::Table(toml_edit::Table::new());
+            }
+            doc["secrets"].as_table_mut().unwrap()
         } else {
-            target_config
-                .profiles
-                .entry(profile.to_string())
-                .or_default()
-                .secrets
-                .insert(secret_name.to_string(), secret_config.clone());
-        }
+            if doc.get("profiles").is_none() {
+                doc["profiles"] = Item::Table(toml_edit::Table::new());
+            }
+            let profiles = doc["profiles"].as_table_mut().unwrap();
+            if profiles.get(profile).is_none() {
+                profiles[profile] = Item::Table(toml_edit::Table::new());
+            }
+            let profile_table = profiles[profile].as_table_mut().unwrap();
+            if profile_table.get("secrets").is_none() {
+                profile_table["secrets"] = Item::Table(toml_edit::Table::new());
+            }
+            profile_table["secrets"].as_table_mut().unwrap()
+        };
 
-        // Save back to the target file
-        target_config.save(&target_file)?;
-        Ok(())
-    }
+        // Update/insert the secret as inline table
+        let inline = secret_config.to_inline_table();
+        secrets_table[secret_name] = Item::Value(Value::InlineTable(inline));
 
-    /// Load a single config file without recursion or merging
-    fn load_single(path: &Path) -> Result<Self> {
-        let content = fs::read_to_string(path).map_err(|source| FnoxError::ConfigReadFailed {
-            path: path.to_path_buf(),
-            source,
+        // Write back (preserves all comments and formatting)
+        fs::write(&target_file, doc.to_string()).map_err(|source| {
+            FnoxError::ConfigWriteFailed {
+                path: target_file,
+                source,
+            }
         })?;
 
-        let mut config: Self = toml_edit::de::from_str(&content)?;
-
-        // Store the source path for all secrets in this file
-        let source_path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
-
-        for secret in config.secrets.values_mut() {
-            secret.source_path = Some(source_path.clone());
-        }
-
-        for profile in config.profiles.values_mut() {
-            for secret in profile.secrets.values_mut() {
-                secret.source_path = Some(source_path.clone());
-            }
-        }
-
-        Ok(config)
+        Ok(())
     }
 
     /// Create a new default configuration
@@ -1044,6 +1044,35 @@ impl SecretConfig {
             value: None,
             source_path: None,
         }
+    }
+
+    /// Convert this secret config to a TOML inline table for saving
+    pub fn to_inline_table(&self) -> toml_edit::InlineTable {
+        let mut inline = toml_edit::InlineTable::new();
+
+        if let Some(provider) = self.provider() {
+            inline.insert("provider", toml_edit::Value::from(provider));
+        }
+        if let Some(value) = self.value() {
+            inline.insert("value", toml_edit::Value::from(value));
+        }
+        if let Some(ref description) = self.description {
+            inline.insert("description", toml_edit::Value::from(description.as_str()));
+        }
+        if let Some(ref default) = self.default {
+            inline.insert("default", toml_edit::Value::from(default.as_str()));
+        }
+        if let Some(if_missing) = self.if_missing {
+            let if_missing_str = match if_missing {
+                IfMissing::Error => "error",
+                IfMissing::Warn => "warn",
+                IfMissing::Ignore => "ignore",
+            };
+            inline.insert("if_missing", toml_edit::Value::from(if_missing_str));
+        }
+
+        inline.fmt();
+        inline
     }
 
     /// Check if this secret has any value (provider, value, or default)

--- a/src/config.rs
+++ b/src/config.rs
@@ -571,6 +571,11 @@ impl Config {
         let inline = secret_config.to_inline_table();
         secrets_table[secret_name] = Item::Value(Value::InlineTable(inline));
 
+        // Remove trailing space from key to match format: KEY= { ... } instead of KEY = { ... }
+        if let Some(mut key) = secrets_table.key_mut(secret_name) {
+            key.leaf_decor_mut().set_suffix("");
+        }
+
         // Write back (preserves all comments and formatting)
         fs::write(&target_file, doc.to_string()).map_err(|source| {
             FnoxError::ConfigWriteFailed {


### PR DESCRIPTION
## Summary

- Fixes `fnox set` destroying TOML comments when updating config files
- Changes `save_secret_to_source()` to directly manipulate the TOML document AST instead of re-serializing the config struct
- Adds `to_inline_table()` method to `SecretConfig` for clean AST manipulation
- Adds tests for comment preservation

Fixes #135

## Test plan

- [x] Run `mise run test:bats -- test/toml-formatting.bats` - all 5 tests pass
- [x] Run `mise run test:cargo` - all 57 tests pass
- [x] Manual test with commented config file confirms comments preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures `fnox set` updates do not strip TOML comments/formatting and keeps secrets as inline tables.
> 
> - Update `save_secret_to_source` to manipulate `toml_edit::DocumentMut` directly, creating/updating `secrets` or `profiles.<name>.secrets` and writing values as inline tables without re-serializing
> - Add `SecretConfig::to_inline_table()` to generate inline-table values consistently
> - Write back via `doc.to_string()` to retain all existing comments and layout
> - Extend `test/toml-formatting.bats` with tests verifying comment preservation for new and updated secrets
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5440f6aa20f10aa69152f677755951f4d185cc18. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->