### PR TITLE
chore: add creative titles to GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,11 +107,17 @@ jobs:
             if [[ -s /tmp/release-raw.txt ]]; then
               # Strip any preamble before the "# vX.X.X -" line
               sed -n '/^# v[0-9]/,$p' /tmp/release-raw.txt > /tmp/release-full.txt
-              # Extract title from first line (format: "# vX.X.X - Creative Title")
-              RELEASE_TITLE="$(head -1 /tmp/release-full.txt | sed 's/^# //')"
-              echo "$RELEASE_TITLE" > /tmp/release-title.txt
-              # Body is everything after the first line
-              tail -n +2 /tmp/release-full.txt > release-notes.md
+              if [[ -s /tmp/release-full.txt ]]; then
+                # Extract title from first line (format: "# vX.X.X - Creative Title")
+                RELEASE_TITLE="$(head -1 /tmp/release-full.txt | sed 's/^# //')"
+                echo "$RELEASE_TITLE" > /tmp/release-title.txt
+                # Body is everything after the first line
+                tail -n +2 /tmp/release-full.txt > release-notes.md
+              else
+                echo "LLM output missing expected format, falling back to CHANGELOG.md"
+                awk '/^## \[/{if(found) exit; found=1} found{print}' CHANGELOG.md > release-notes.md
+                echo "$TAG_NAME" > /tmp/release-title.txt
+              fi
             fi
           else
             echo "ANTHROPIC_API_KEY not set, using CHANGELOG.md"
@@ -139,7 +145,8 @@ jobs:
           else
             TAG_NAME="${{ github.ref_name }}"
           fi
-          RELEASE_TITLE="$(cat /tmp/release-title.txt 2>/dev/null || echo "$TAG_NAME")"
+          RELEASE_TITLE="$(cat /tmp/release-title.txt 2>/dev/null)"
+          RELEASE_TITLE="${RELEASE_TITLE:-$TAG_NAME}"
           gh release create "$TAG_NAME" \
             --title "$RELEASE_TITLE" \
             --notes-file release-notes.md \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,15 +97,28 @@ jobs:
           fi
           PREV_TAG="$(git describe --tags --abbrev=0 "$TAG_NAME^" 2>/dev/null || echo "")"
           # Generate rich release notes using LLM
+          # Output format: "# vX.X.X - Creative Title" followed by release notes
           if [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
-            mise run gen-release-notes "$TAG_NAME" "$PREV_TAG" > release-notes.md || {
+            mise run gen-release-notes "$TAG_NAME" "$PREV_TAG" > /tmp/release-raw.txt || {
               echo "LLM generation failed, falling back to CHANGELOG.md"
               awk '/^## \[/{if(found) exit; found=1} found{print}' CHANGELOG.md > release-notes.md
+              echo "$TAG_NAME" > /tmp/release-title.txt
             }
+            if [[ -s /tmp/release-raw.txt ]]; then
+              # Strip any preamble before the "# vX.X.X -" line
+              sed -n '/^# v[0-9]/,$p' /tmp/release-raw.txt > /tmp/release-full.txt
+              # Extract title from first line (format: "# vX.X.X - Creative Title")
+              RELEASE_TITLE="$(head -1 /tmp/release-full.txt | sed 's/^# //')"
+              echo "$RELEASE_TITLE" > /tmp/release-title.txt
+              # Body is everything after the first line
+              tail -n +2 /tmp/release-full.txt > release-notes.md
+            fi
           else
             echo "ANTHROPIC_API_KEY not set, using CHANGELOG.md"
             awk '/^## \[/{if(found) exit; found=1} found{print}' CHANGELOG.md > release-notes.md
+            echo "$TAG_NAME" > /tmp/release-title.txt
           fi
+          echo "Release title: $(cat /tmp/release-title.txt)"
           cat release-notes.md
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -126,7 +139,8 @@ jobs:
           else
             TAG_NAME="${{ github.ref_name }}"
           fi
+          RELEASE_TITLE="$(cat /tmp/release-title.txt 2>/dev/null || echo "$TAG_NAME")"
           gh release create "$TAG_NAME" \
-            --title "$TAG_NAME" \
+            --title "$RELEASE_TITLE" \
             --notes-file release-notes.md \
             release-assets/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,12 +99,8 @@ jobs:
           # Generate rich release notes using LLM
           # Output format: "# vX.X.X - Creative Title" followed by release notes
           if [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
-            mise run gen-release-notes "$TAG_NAME" "$PREV_TAG" > /tmp/release-raw.txt || {
-              echo "LLM generation failed, falling back to CHANGELOG.md"
-              awk '/^## \[/{if(found) exit; found=1} found{print}' CHANGELOG.md > release-notes.md
-              echo "$TAG_NAME" > /tmp/release-title.txt
-            }
-            if [[ -s /tmp/release-raw.txt ]]; then
+            # Only process output if command succeeds - prevents partial output from overwriting fallback
+            if mise run gen-release-notes "$TAG_NAME" "$PREV_TAG" > /tmp/release-raw.txt 2>&1; then
               # Strip any preamble before the "# vX.X.X -" line
               sed -n '/^# v[0-9]/,$p' /tmp/release-raw.txt > /tmp/release-full.txt
               if [[ -s /tmp/release-full.txt ]]; then
@@ -113,11 +109,13 @@ jobs:
                 echo "$RELEASE_TITLE" > /tmp/release-title.txt
                 # Body is everything after the first line
                 tail -n +2 /tmp/release-full.txt > release-notes.md
-              else
-                echo "LLM output missing expected format, falling back to CHANGELOG.md"
-                awk '/^## \[/{if(found) exit; found=1} found{print}' CHANGELOG.md > release-notes.md
-                echo "$TAG_NAME" > /tmp/release-title.txt
               fi
+            fi
+            # Fallback if LLM generation failed or output was invalid
+            if [[ ! -s release-notes.md ]]; then
+              echo "LLM release notes failed, falling back to CHANGELOG.md"
+              awk '/^## \[/{if(found) exit; found=1} found{print}' CHANGELOG.md > release-notes.md
+              echo "$TAG_NAME" > /tmp/release-title.txt
             fi
           else
             echo "ANTHROPIC_API_KEY not set, using CHANGELOG.md"

--- a/mise-tasks/gen-release-notes
+++ b/mise-tasks/gen-release-notes
@@ -34,17 +34,21 @@ prompt=$(
 	printf '%s\n' "Here is the raw changelog from git-cliff:"
 	printf '%s\n' "$changelog"
 	printf '\n'
-	cat <<'INSTRUCTIONS'
-Write user-friendly release notes:
+	cat <<INSTRUCTIONS
+Write user-friendly release notes with a creative title.
 
+FORMAT - Your output MUST start with this exact line format:
+# $version - <Creative Title>
+
+Where <Creative Title> is 2-6 words capturing the theme of the release (e.g., "Secrets Stay Secret", "Provider Paradise", "Better Error Messages").
+
+After the title line, write the release notes:
 1. Start with 1-2 paragraphs summarizing key changes
 2. Organize into ### sections (Highlights, Bug Fixes, etc.)
 3. Explain WHY changes matter to users
 4. Include PR links and documentation links (https://fnox.jdx.dev/)
 5. Include contributor usernames (@username)
 6. Skip internal changes
-
-Output ONLY the release notes, no preamble.
 INSTRUCTIONS
 )
 


### PR DESCRIPTION
## Summary

- Updates `gen-release-notes` to output format `# vX.X.X - Creative Title`
- Updates release workflow to extract the title and use it for the GitHub release
- Any preamble before the `# v` line is stripped for robustness

Example release title: `v1.11.0 - Secrets Stay Secret`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves release automation to generate and apply creative-titled release notes reliably.
> 
> - **Workflow (`release.yml`)**: Parses LLM output, strips any preamble, extracts `"# vX.X.X - <Title>"` header to a temp title file, writes the body to `release-notes.md`, and falls back to `CHANGELOG.md` and tag-only title if generation/format is invalid. Uses the parsed title for `gh release create` and logs it for visibility.
> - **Generator (`mise-tasks/gen-release-notes`)**: Tightens prompt to enforce the exact header format `"# $version - <Creative Title>"` and structured sections; allows `$version` interpolation and expects creative titles, enabling the workflow to reliably parse title/body.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit babe7a5a234b0daab299731921e4d19b3836db51. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->