### PR TITLE
docs(set): add security guidance for secret value argument

### DIFF
--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -849,8 +849,9 @@
           {
             "name": "VALUE",
             "usage": "[VALUE]",
-            "help": "Secret value (reads from stdin if not provided)",
-            "help_first_line": "Secret value (reads from stdin if not provided)",
+            "help": "Secret value to store",
+            "help_long": "Secret value to store.\n\nIf omitted: reads from stdin when piped (`echo \"x\" | fnox set KEY`), or prompts interactively with hidden input.\n\nPassing secrets as arguments exposes them in shell history and `ps` output. For sensitive values, prefer stdin or the interactive prompt.",
+            "help_first_line": "Secret value to store",
             "required": false,
             "double_dash": "Optional",
             "hide": false

--- a/docs/cli/set.md
+++ b/docs/cli/set.md
@@ -15,7 +15,11 @@ Secret key (environment variable name)
 
 ### `[VALUE]`
 
-Secret value (reads from stdin if not provided)
+Secret value to store.
+
+If omitted: reads from stdin when piped (`echo "x" | fnox set KEY`), or prompts interactively with hidden input.
+
+Passing secrets as arguments exposes them in shell history and `ps` output. For sensitive values, prefer stdin or the interactive prompt.
 
 ## Flags
 

--- a/fnox.usage.kdl
+++ b/fnox.usage.kdl
@@ -161,7 +161,7 @@ cmd set help="Set a secret value" {
         }
     }
     arg <KEY> help="Secret key (environment variable name)"
-    arg "[VALUE]" help="Secret value (reads from stdin if not provided)" required=#false
+    arg "[VALUE]" help="Secret value to store" help_long="Secret value to store.\n\nIf omitted: reads from stdin when piped (`echo \"x\" | fnox set KEY`), or prompts interactively with hidden input.\n\nPassing secrets as arguments exposes them in shell history and `ps` output. For sensitive values, prefer stdin or the interactive prompt." required=#false
 }
 cmd tui help="Interactive TUI dashboard for managing secrets"
 cmd usage hide=#true help="Generate usage specification"

--- a/src/commands/set.rs
+++ b/src/commands/set.rs
@@ -10,7 +10,13 @@ pub struct SetCommand {
     /// Secret key (environment variable name)
     pub key: String,
 
-    /// Secret value (reads from stdin if not provided)
+    /// Secret value to store.
+    ///
+    /// If omitted: reads from stdin when piped (`echo "x" | fnox set KEY`),
+    /// or prompts interactively with hidden input.
+    ///
+    /// Passing secrets as arguments exposes them in shell history and `ps` output.
+    /// For sensitive values, prefer stdin or the interactive prompt.
     pub value: Option<String>,
 
     /// Description of the secret


### PR DESCRIPTION
## Summary

- Expand the help text for the `VALUE` argument in `fnox set` to warn about security implications of passing secrets as CLI arguments
- Document safer alternatives: stdin piping and interactive prompt with hidden input

The help now reads:
```
[VALUE]
    Secret value to store.
    
    If omitted: reads from stdin when piped (`echo "x" | fnox set KEY`),
    or prompts interactively with hidden input.
    
    Passing secrets as arguments exposes them in shell history and `ps`
    output. For sensitive values, prefer stdin or the interactive prompt.
```

Closes #228

## Test plan

- [x] `cargo test` passes
- [x] `fnox set --help` displays the updated help text

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Improve `fnox set` help text for `VALUE`**
> 
> - Clarifies input behavior: reads from stdin when piped or prompts interactively with hidden input if omitted
> - Adds security warning about exposing secrets via CLI args (shell history and `ps`)
> - No functional code changes; update is limited to documentation strings in `src/commands/set.rs`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a747c370d7ec0a6fd24de3cdc6257906375a08d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->