### PR TITLE
fix: don't thank @jdx in LLM-generated release notes

### DIFF
--- a/mise-tasks/gen-release-notes
+++ b/mise-tasks/gen-release-notes
@@ -47,7 +47,7 @@ After the title line, write the release notes:
 2. Organize into ### sections (Highlights, Bug Fixes, etc.)
 3. Explain WHY changes matter to users
 4. Include PR links and documentation links (https://fnox.jdx.dev/)
-5. Include contributor usernames (@username)
+5. Include contributor usernames (@username). Do not thank @jdx since that is who is writing these notes.
 6. Skip internal changes
 INSTRUCTIONS
 )


### PR DESCRIPTION
## Summary
- Updates gen-release-notes prompt to avoid thanking @jdx for contributions since they are the maintainer writing the notes

## Test plan
- [ ] Verify next release notes don't include "thanks @jdx" type phrases

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines the release notes generation prompt to ensure correct attribution without unnecessary self-thanks.
> 
> - Updates `mise-tasks/gen-release-notes` instructions: keep including contributor usernames but explicitly avoid thanking `@jdx` (the maintainer writing the notes)
> - No behavioral/code logic changes beyond prompt text
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 73227e5c5c254b644e2c5978952412197767f0a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->