### PR TITLE
docs: clarify fix type is for CLI bugs only

### DIFF
--- a/CRUSH.md
+++ b/CRUSH.md
@@ -9,13 +9,13 @@ All commit messages and PR titles MUST follow conventional commit format:
 **Types:**
 
 - `feat:` - New features
-- `fix:` - Bug fixes
+- `fix:` - Bug fixes that affect the CLI behavior (not CI, docs, or infrastructure)
 - `refactor:` - Code refactoring
 - `docs:` - Documentation changes
 - `style:` - Code style/formatting (no logic changes)
 - `perf:` - Performance improvements
 - `test:` - Testing changes
-- `chore:` - Maintenance tasks, releases, dependency updates
+- `chore:` - Maintenance tasks, releases, dependency updates, CI/infrastructure changes
 - `security:` - Security-related changes
 
 **Scopes:**


### PR DESCRIPTION
## Summary
- Clarify that `fix:` type is for bug fixes that affect CLI behavior (not CI, docs, or infrastructure)
- Clarify that `chore:` includes CI/infrastructure changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates conventional commit guidelines in `CRUSH.md`.
> 
> - Refines `fix:` to mean bugs that affect CLI behavior (excludes CI/docs/infrastructure)
> - Expands `chore:` to include CI/infrastructure changes in addition to maintenance/release/deps
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4930722f4d5794f72c01f41dca2419a5c3d2b96f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->