### PR TITLE
chore: add mise.local.toml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ age.txt
 
 # Local configuration overrides (user-specific, should not be committed)
 fnox.local.toml
+mise.local.toml
 
 # VitePress
 node_modules/


### PR DESCRIPTION
## Summary
- Add `mise.local.toml` to `.gitignore` so developers can set local mise environment overrides without committing them
- Useful for setting `SKIP_KEYCHAIN_TESTS=1` on headless environments where OS keychain isn't accessible

## Test plan
- [ ] Verify `mise.local.toml` is ignored by git
- [ ] Verify `SKIP_KEYCHAIN_TESTS=1` in `mise.local.toml` causes keychain bats tests to skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates `.gitignore` and does not affect runtime code paths or production behavior.
> 
> **Overview**
> Ignores `mise.local.toml` in `.gitignore` so developers can keep local mise configuration/environment overrides out of version control.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 10c84418936bf6029b18b0ebc224a16dd9a71dc3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->