### PR TITLE
fix(exec): resolve secrets in dependency order using Kahn's algorithm

### DIFF
--- a/src/providers/age.rs
+++ b/src/providers/age.rs
@@ -4,6 +4,10 @@ use async_trait::async_trait;
 use std::io::Read;
 use std::path::PathBuf;
 
+pub fn env_dependencies() -> &'static [&'static str] {
+    &[]
+}
+
 pub struct AgeEncryptionProvider {
     recipients: Vec<String>,
     key_file: Option<PathBuf>,

--- a/src/providers/aws_kms.rs
+++ b/src/providers/aws_kms.rs
@@ -4,6 +4,10 @@ use aws_config::BehaviorVersion;
 use aws_sdk_kms::Client;
 use aws_sdk_kms::primitives::Blob;
 
+pub fn env_dependencies() -> &'static [&'static str] {
+    &[]
+}
+
 const URL: &str = "https://fnox.jdx.dev/providers/aws-kms";
 
 /// Convert AWS SDK errors to structured FnoxError with appropriate hints

--- a/src/providers/aws_ps.rs
+++ b/src/providers/aws_ps.rs
@@ -4,6 +4,10 @@ use aws_config::BehaviorVersion;
 use aws_sdk_ssm::Client;
 use std::collections::HashMap;
 
+pub fn env_dependencies() -> &'static [&'static str] {
+    &[]
+}
+
 const URL: &str = "https://fnox.jdx.dev/providers/aws-ps";
 
 /// Convert AWS SDK errors to structured FnoxError with appropriate hints

--- a/src/providers/aws_sm.rs
+++ b/src/providers/aws_sm.rs
@@ -4,6 +4,10 @@ use aws_config::BehaviorVersion;
 use aws_sdk_secretsmanager::Client;
 use std::collections::HashMap;
 
+pub fn env_dependencies() -> &'static [&'static str] {
+    &[]
+}
+
 /// Convert AWS SDK errors to structured FnoxError with appropriate hints
 fn aws_error_to_fnox<E, R>(
     err: &aws_sdk_secretsmanager::error::SdkError<E, R>,

--- a/src/providers/azure_kms.rs
+++ b/src/providers/azure_kms.rs
@@ -6,6 +6,10 @@ use azure_security_keyvault_keys::{
     models::{EncryptionAlgorithm, KeyOperationParameters},
 };
 
+pub fn env_dependencies() -> &'static [&'static str] {
+    &[]
+}
+
 const URL: &str = "https://fnox.jdx.dev/providers/azure-kms";
 
 pub struct AzureKeyVaultProvider {

--- a/src/providers/azure_sm.rs
+++ b/src/providers/azure_sm.rs
@@ -3,6 +3,10 @@ use async_trait::async_trait;
 use azure_identity::DeveloperToolsCredential;
 use azure_security_keyvault_secrets::{SecretClient, models::SetSecretParameters};
 
+pub fn env_dependencies() -> &'static [&'static str] {
+    &[]
+}
+
 const URL: &str = "https://fnox.jdx.dev/providers/azure-sm";
 
 pub struct AzureSecretsManagerProvider {

--- a/src/providers/bitwarden.rs
+++ b/src/providers/bitwarden.rs
@@ -5,7 +5,6 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::process::Command;
-use std::sync::LazyLock;
 
 pub struct BitwardenProvider {
     collection: Option<String>,
@@ -90,7 +89,8 @@ impl BitwardenProvider {
         }
 
         // Check if session token is available
-        let token = if let Some(token) = &*BW_SESSION_TOKEN {
+        let session_token = bw_session_token();
+        let token = if let Some(token) = &session_token {
             tracing::debug!(
                 "Found BW_SESSION token in environment (length: {})",
                 token.len()
@@ -280,8 +280,12 @@ impl crate::providers::Provider for BitwardenProvider {
     }
 }
 
-static BW_SESSION_TOKEN: LazyLock<Option<String>> = LazyLock::new(|| {
+pub fn env_dependencies() -> &'static [&'static str] {
+    &["BW_SESSION", "FNOX_BW_SESSION"]
+}
+
+fn bw_session_token() -> Option<String> {
     env::var("FNOX_BW_SESSION")
         .or_else(|_| env::var("BW_SESSION"))
         .ok()
-});
+}

--- a/src/providers/gcp_kms.rs
+++ b/src/providers/gcp_kms.rs
@@ -3,6 +3,10 @@ use async_trait::async_trait;
 use google_cloud_kms::client::{Client, ClientConfig};
 use google_cloud_kms::grpc::kms::v1::{DecryptRequest, EncryptRequest, GetCryptoKeyRequest};
 
+pub fn env_dependencies() -> &'static [&'static str] {
+    &[]
+}
+
 const URL: &str = "https://fnox.jdx.dev/providers/gcp-kms";
 
 pub struct GcpKmsProvider {

--- a/src/providers/gcp_sm.rs
+++ b/src/providers/gcp_sm.rs
@@ -2,6 +2,10 @@ use crate::error::{FnoxError, Result};
 use async_trait::async_trait;
 use google_cloud_secretmanager_v1::client::SecretManagerService;
 
+pub fn env_dependencies() -> &'static [&'static str] {
+    &[]
+}
+
 const URL: &str = "https://fnox.jdx.dev/providers/gcp-sm";
 
 pub struct GoogleSecretManagerProvider {

--- a/src/providers/infisical.rs
+++ b/src/providers/infisical.rs
@@ -27,35 +27,27 @@ impl InfisicalProvider {
     /// Get authentication token - either from environment or by logging in with client credentials
     fn get_auth_token(&self) -> Result<String> {
         // Check if we already have a token
-        if let Some(token) = &*INFISICAL_TOKEN {
+        if let Some(token) = infisical_token() {
             tracing::debug!("Using INFISICAL_TOKEN from environment");
-            return Ok(token.clone());
+            return Ok(token);
         }
 
         // Check if we have client credentials to obtain a token
-        let client_id =
-            INFISICAL_CLIENT_ID
-                .as_ref()
-                .ok_or_else(|| {
-                    FnoxError::ProviderAuthFailed {
-                provider: "Infisical".to_string(),
-                details: "Authentication not found".to_string(),
-                hint:
-                    "Set INFISICAL_TOKEN, or both INFISICAL_CLIENT_ID and INFISICAL_CLIENT_SECRET"
-                        .to_string(),
-                url: "https://fnox.jdx.dev/providers/infisical".to_string(),
-            }
-                })?;
+        let client_id = infisical_client_id().ok_or_else(|| FnoxError::ProviderAuthFailed {
+            provider: "Infisical".to_string(),
+            details: "Authentication not found".to_string(),
+            hint: "Set INFISICAL_TOKEN, or both INFISICAL_CLIENT_ID and INFISICAL_CLIENT_SECRET"
+                .to_string(),
+            url: "https://fnox.jdx.dev/providers/infisical".to_string(),
+        })?;
 
         let client_secret =
-            INFISICAL_CLIENT_SECRET
-                .as_ref()
-                .ok_or_else(|| FnoxError::ProviderAuthFailed {
-                    provider: "Infisical".to_string(),
-                    details: "Client secret not found".to_string(),
-                    hint: "Set INFISICAL_CLIENT_SECRET or FNOX_INFISICAL_CLIENT_SECRET".to_string(),
-                    url: "https://fnox.jdx.dev/providers/infisical".to_string(),
-                })?;
+            infisical_client_secret().ok_or_else(|| FnoxError::ProviderAuthFailed {
+                provider: "Infisical".to_string(),
+                details: "Client secret not found".to_string(),
+                hint: "Set INFISICAL_CLIENT_SECRET or FNOX_INFISICAL_CLIENT_SECRET".to_string(),
+                url: "https://fnox.jdx.dev/providers/infisical".to_string(),
+            })?;
 
         // Acquire lock for the entire check-and-login operation to prevent race condition
         // where multiple threads might all see no cached token and perform expensive login operations
@@ -76,16 +68,16 @@ impl InfisicalProvider {
             "--method",
             "universal-auth",
             "--client-id",
-            client_id,
+            &client_id,
             "--client-secret",
-            client_secret,
+            &client_secret,
             "--plain",
             "--silent",
         ]);
 
         // Add custom domain if specified, stripping /api suffix if present
         // The CLI's --domain flag expects base URL (some commands append /api automatically)
-        if let Some(api_url) = &*INFISICAL_API_URL {
+        if let Some(api_url) = infisical_api_url() {
             let base_url = api_url.trim_end_matches("/api").trim_end_matches('/');
             cmd.arg("--domain");
             cmd.arg(base_url);
@@ -159,7 +151,7 @@ impl InfisicalProvider {
 
         // Add custom domain if specified, stripping /api suffix if present
         // The CLI's --domain flag expects base URL (some commands append /api automatically)
-        if let Some(api_url) = &*INFISICAL_API_URL {
+        if let Some(api_url) = infisical_api_url() {
             let base_url = api_url.trim_end_matches("/api").trim_end_matches('/');
             cmd.arg("--domain");
             cmd.arg(base_url);
@@ -432,29 +424,40 @@ impl crate::providers::Provider for InfisicalProvider {
     }
 }
 
-static INFISICAL_TOKEN: LazyLock<Option<String>> = LazyLock::new(|| {
+pub fn env_dependencies() -> &'static [&'static str] {
+    &[
+        "INFISICAL_TOKEN",
+        "FNOX_INFISICAL_TOKEN",
+        "INFISICAL_CLIENT_ID",
+        "FNOX_INFISICAL_CLIENT_ID",
+        "INFISICAL_CLIENT_SECRET",
+        "FNOX_INFISICAL_CLIENT_SECRET",
+    ]
+}
+
+fn infisical_token() -> Option<String> {
     env::var("FNOX_INFISICAL_TOKEN")
         .or_else(|_| env::var("INFISICAL_TOKEN"))
         .ok()
-});
+}
 
-static INFISICAL_CLIENT_ID: LazyLock<Option<String>> = LazyLock::new(|| {
+fn infisical_client_id() -> Option<String> {
     env::var("FNOX_INFISICAL_CLIENT_ID")
         .or_else(|_| env::var("INFISICAL_CLIENT_ID"))
         .ok()
-});
+}
 
-static INFISICAL_CLIENT_SECRET: LazyLock<Option<String>> = LazyLock::new(|| {
+fn infisical_client_secret() -> Option<String> {
     env::var("FNOX_INFISICAL_CLIENT_SECRET")
         .or_else(|_| env::var("INFISICAL_CLIENT_SECRET"))
         .ok()
-});
+}
 
-static INFISICAL_API_URL: LazyLock<Option<String>> = LazyLock::new(|| {
+fn infisical_api_url() -> Option<String> {
     env::var("FNOX_INFISICAL_API_URL")
         .or_else(|_| env::var("INFISICAL_API_URL"))
         .ok()
-});
+}
 
 // Cache login token to avoid repeated login calls
 static CACHED_LOGIN_TOKEN: LazyLock<Mutex<Option<String>>> = LazyLock::new(|| Mutex::new(None));

--- a/src/providers/infisical.rs
+++ b/src/providers/infisical.rs
@@ -432,6 +432,8 @@ pub fn env_dependencies() -> &'static [&'static str] {
         "FNOX_INFISICAL_CLIENT_ID",
         "INFISICAL_CLIENT_SECRET",
         "FNOX_INFISICAL_CLIENT_SECRET",
+        "INFISICAL_API_URL",
+        "FNOX_INFISICAL_API_URL",
     ]
 }
 

--- a/src/providers/keychain.rs
+++ b/src/providers/keychain.rs
@@ -2,6 +2,10 @@ use crate::error::{FnoxError, Result};
 use async_trait::async_trait;
 use keyring::Entry;
 
+pub fn env_dependencies() -> &'static [&'static str] {
+    &[]
+}
+
 pub struct KeychainProvider {
     service: String,
     prefix: Option<String>,

--- a/src/providers/onepassword.rs
+++ b/src/providers/onepassword.rs
@@ -29,7 +29,10 @@ impl OnePasswordProvider {
 
     /// Get the service account token, preferring the configured token over environment variable.
     fn get_token(&self) -> Option<String> {
-        self.token.clone().or_else(op_service_account_token)
+        self.token
+            .as_ref()
+            .cloned()
+            .or_else(op_service_account_token)
     }
 
     /// Convert a value to an op:// reference

--- a/src/providers/onepassword.rs
+++ b/src/providers/onepassword.rs
@@ -28,10 +28,8 @@ impl OnePasswordProvider {
     }
 
     /// Get the service account token, preferring the configured token over environment variable.
-    fn get_token(&self) -> Option<&str> {
-        self.token
-            .as_deref()
-            .or_else(|| OP_SERVICE_ACCOUNT_TOKEN.as_deref())
+    fn get_token(&self) -> Option<String> {
+        self.token.clone().or_else(op_service_account_token)
     }
 
     /// Convert a value to an op:// reference
@@ -399,8 +397,12 @@ impl crate::providers::Provider for OnePasswordProvider {
     }
 }
 
-static OP_SERVICE_ACCOUNT_TOKEN: LazyLock<Option<String>> = LazyLock::new(|| {
+pub fn env_dependencies() -> &'static [&'static str] {
+    &["OP_SERVICE_ACCOUNT_TOKEN", "FNOX_OP_SERVICE_ACCOUNT_TOKEN"]
+}
+
+fn op_service_account_token() -> Option<String> {
     env::var("FNOX_OP_SERVICE_ACCOUNT_TOKEN")
         .or_else(|_| env::var("OP_SERVICE_ACCOUNT_TOKEN"))
         .ok()
-});
+}

--- a/src/providers/passwordstate.rs
+++ b/src/providers/passwordstate.rs
@@ -3,14 +3,16 @@ use crate::error::{FnoxError, Result};
 use async_trait::async_trait;
 use serde::Deserialize;
 use std::collections::HashMap;
-use std::sync::LazyLock;
+pub fn env_dependencies() -> &'static [&'static str] {
+    &["PASSWORDSTATE_API_KEY", "FNOX_PASSWORDSTATE_API_KEY"]
+}
 
-/// Environment variable fallback for API key
-static PASSWORDSTATE_API_KEY: LazyLock<Option<String>> = LazyLock::new(|| {
+/// Read API key from environment
+fn passwordstate_api_key() -> Option<String> {
     env::var("FNOX_PASSWORDSTATE_API_KEY")
         .or_else(|_| env::var("PASSWORDSTATE_API_KEY"))
         .ok()
-});
+}
 
 /// Password entry returned from Passwordstate API
 #[derive(Debug, Deserialize)]
@@ -45,9 +47,7 @@ impl PasswordstateProvider {
         password_list_id: String,
         verify_ssl: Option<String>,
     ) -> Self {
-        let api_key = api_key
-            .or_else(|| PASSWORDSTATE_API_KEY.clone())
-            .unwrap_or_default();
+        let api_key = api_key.or_else(passwordstate_api_key).unwrap_or_default();
 
         let verify_ssl = verify_ssl
             .map(|v| v.to_lowercase() != "false")

--- a/src/providers/plain.rs
+++ b/src/providers/plain.rs
@@ -1,6 +1,10 @@
 use crate::error::Result;
 use async_trait::async_trait;
 
+pub fn env_dependencies() -> &'static [&'static str] {
+    &[]
+}
+
 /// Plain provider that stores and returns values as-is without encryption.
 ///
 /// This provider is useful for:

--- a/src/secret_resolver.rs
+++ b/src/secret_resolver.rs
@@ -8,7 +8,7 @@ use crate::source_registry;
 use crate::suggest::{find_similar, format_suggestions};
 use indexmap::IndexMap;
 use miette::SourceSpan;
-use std::collections::HashMap; // Used only for internal grouping by provider
+use std::collections::HashMap;
 
 /// Creates a ProviderNotConfigured error, using source spans when available for better error display.
 fn create_provider_not_configured_error(
@@ -280,8 +280,12 @@ fn handle_missing_secret(
 
 /// Resolves multiple secrets efficiently using batch operations when possible.
 ///
-/// This groups secrets by provider and uses `get_secrets_batch` to minimize
-/// external API calls. Providers are processed in parallel for maximum efficiency.
+/// Secrets are resolved in dependency order using Kahn's algorithm. If a provider
+/// declares env var dependencies (e.g., 1Password needs `OP_SERVICE_ACCOUNT_TOKEN`),
+/// and another secret provides that env var (e.g., an age-encrypted secret named
+/// `OP_SERVICE_ACCOUNT_TOKEN`), the dependency is resolved first. Between resolution
+/// levels, resolved values are set as environment variables so subsequent providers
+/// can read them.
 ///
 /// Returns an error immediately if any secret with `if_missing = "error"` fails to resolve.
 pub async fn resolve_secrets_batch(
@@ -289,77 +293,137 @@ pub async fn resolve_secrets_batch(
     profile: &str,
     secrets: &IndexMap<String, SecretConfig>,
 ) -> Result<IndexMap<String, Option<String>>> {
-    use futures::stream::{self, StreamExt};
+    use std::collections::HashSet;
 
-    // Group secrets by provider
-    let mut by_provider: HashMap<String, Vec<(String, String)>> = HashMap::new();
+    // Classify each secret: provider-backed vs no-provider
+    let mut secret_provider: HashMap<String, (String, String)> = HashMap::new(); // key -> (provider_name, provider_value)
     let mut no_provider = Vec::new();
 
+    let providers = config.get_providers(profile);
+
     for (key, secret_config) in secrets {
-        // Check if we can resolve from provider
         if let Some(provider_value) = secret_config.value() {
-            // Determine which provider to use
             let provider_name = if let Some(provider_name) = secret_config.provider() {
                 provider_name.to_string()
             } else if let Ok(Some(default_provider)) = config.get_default_provider(profile) {
                 default_provider
             } else {
-                // No provider, fall back to individual resolution
                 no_provider.push(key.clone());
                 continue;
             };
 
-            by_provider
-                .entry(provider_name)
-                .or_default()
-                .push((key.clone(), provider_value.to_string()));
+            secret_provider.insert(key.clone(), (provider_name, provider_value.to_string()));
         } else {
-            // No value for provider, use individual resolution
             no_provider.push(key.clone());
         }
     }
 
-    // Resolve secrets grouped by provider in parallel
-    let provider_results: Vec<_> = stream::iter(by_provider)
-        .map(|(provider_name, provider_secrets)| async move {
-            resolve_provider_batch(config, profile, secrets, &provider_name, provider_secrets).await
-        })
-        .buffer_unordered(10)
-        .collect()
-        .await;
+    // Build dependency graph using Kahn's algorithm.
+    // A secret S depends on secret D if S's provider declares an env var dependency
+    // that matches D's key name (case-sensitive).
+    let secret_keys: HashSet<&str> = secrets.keys().map(|k| k.as_str()).collect();
+    let mut in_degree: HashMap<String, usize> = HashMap::new();
+    let mut dependents: HashMap<String, Vec<String>> = HashMap::new(); // dep -> secrets that depend on it
 
-    // Combine results from all providers into a temporary HashMap, failing fast on errors
-    let mut temp_results = HashMap::new();
-    for provider_result in provider_results {
-        temp_results.extend(provider_result?);
+    for (key, (provider_name, _)) in &secret_provider {
+        let env_deps = if let Some(pc) = providers.get(provider_name) {
+            pc.env_dependencies()
+        } else {
+            &[]
+        };
+
+        let mut degree = 0usize;
+        for dep_env in env_deps {
+            if secret_keys.contains(dep_env) && *dep_env != key.as_str() {
+                degree += 1;
+                dependents
+                    .entry(dep_env.to_string())
+                    .or_default()
+                    .push(key.clone());
+            }
+        }
+        in_degree.insert(key.clone(), degree);
     }
 
-    // Resolve secrets that couldn't be batched using individual resolution in parallel
-    let no_provider_results: Vec<_> = stream::iter(no_provider)
-        .map(|key| async move {
-            let secret_config = &secrets[&key];
-            match resolve_secret(config, profile, &key, secret_config).await {
-                Ok(value) => Ok((key, value)),
-                Err(e) => {
-                    let if_missing = resolve_if_missing_behavior(secret_config, config);
-                    if let Some(error) = handle_provider_error(&key, e, if_missing, true) {
-                        // Error should fail fast - return the error
-                        Err(error)
-                    } else {
-                        // Warn or ignore - continue with None
-                        Ok((key, None))
+    // Also include no_provider secrets with in_degree 0 (they have no deps)
+    for key in &no_provider {
+        in_degree.insert(key.clone(), 0);
+    }
+
+    // Kahn's algorithm: resolve in levels
+    let mut temp_results: HashMap<String, Option<String>> = HashMap::new();
+    let mut remaining: HashSet<String> = in_degree.keys().cloned().collect();
+
+    loop {
+        // Collect all secrets with in_degree 0
+        let ready: Vec<String> = remaining
+            .iter()
+            .filter(|k| in_degree.get(*k).copied().unwrap_or(0) == 0)
+            .cloned()
+            .collect();
+
+        if ready.is_empty() {
+            break;
+        }
+
+        // Remove ready secrets from remaining
+        for k in &ready {
+            remaining.remove(k);
+        }
+
+        // Resolve this level
+        let level_results = resolve_level(
+            config,
+            profile,
+            secrets,
+            &secret_provider,
+            &no_provider,
+            &ready,
+        )
+        .await?;
+
+        // Set resolved env vars so next level's providers can see them
+        for (key, value) in &level_results {
+            if let Some(val) = value {
+                // SAFETY: We're single-threaded here (between await points) and no other
+                // thread is reading these env vars concurrently at this point.
+                unsafe {
+                    std::env::set_var(key, val);
+                }
+            }
+        }
+
+        // Decrement in-degrees for dependents
+        for key in &ready {
+            if let Some(deps) = dependents.get(key) {
+                for dep in deps {
+                    if let Some(d) = in_degree.get_mut(dep) {
+                        *d = d.saturating_sub(1);
                     }
                 }
             }
-        })
-        .buffer_unordered(10)
-        .collect()
-        .await;
+        }
 
-    // Add no-provider results to temporary HashMap, failing fast on errors
-    for result in no_provider_results {
-        let (key, value) = result?;
-        temp_results.insert(key, value);
+        temp_results.extend(level_results);
+    }
+
+    // Handle any remaining secrets (cycles) - resolve best-effort
+    if !remaining.is_empty() {
+        tracing::warn!(
+            "Detected dependency cycle among secrets: {:?}. Resolving best-effort.",
+            remaining
+        );
+        let cycle_keys: Vec<String> = remaining.into_iter().collect();
+        let level_results = resolve_level(
+            config,
+            profile,
+            secrets,
+            &secret_provider,
+            &no_provider,
+            &cycle_keys,
+        )
+        .await?;
+        temp_results.extend(level_results);
     }
 
     // Build final results in the original order from the input secrets IndexMap
@@ -371,6 +435,75 @@ pub async fn resolve_secrets_batch(
     }
 
     Ok(results)
+}
+
+/// Resolve a single level of secrets (all can be resolved in parallel).
+async fn resolve_level(
+    config: &Config,
+    profile: &str,
+    secrets: &IndexMap<String, SecretConfig>,
+    secret_provider: &HashMap<String, (String, String)>,
+    no_provider: &[String],
+    ready: &[String],
+) -> Result<HashMap<String, Option<String>>> {
+    use futures::stream::{self, StreamExt};
+
+    // Split ready keys into provider-backed and no-provider
+    let mut by_provider: HashMap<String, Vec<(String, String)>> = HashMap::new();
+    let mut level_no_provider = Vec::new();
+
+    for key in ready {
+        if let Some((provider_name, provider_value)) = secret_provider.get(key) {
+            by_provider
+                .entry(provider_name.clone())
+                .or_default()
+                .push((key.clone(), provider_value.clone()));
+        } else if no_provider.contains(key) {
+            level_no_provider.push(key.clone());
+        }
+    }
+
+    let mut temp_results = HashMap::new();
+
+    // Resolve provider-backed secrets in parallel by provider
+    let provider_results: Vec<_> = stream::iter(by_provider)
+        .map(|(provider_name, provider_secrets)| async move {
+            resolve_provider_batch(config, profile, secrets, &provider_name, provider_secrets).await
+        })
+        .buffer_unordered(10)
+        .collect()
+        .await;
+
+    for provider_result in provider_results {
+        temp_results.extend(provider_result?);
+    }
+
+    // Resolve no-provider secrets in parallel
+    let no_provider_results: Vec<_> = stream::iter(level_no_provider)
+        .map(|key| async move {
+            let secret_config = &secrets[&key];
+            match resolve_secret(config, profile, &key, secret_config).await {
+                Ok(value) => Ok((key, value)),
+                Err(e) => {
+                    let if_missing = resolve_if_missing_behavior(secret_config, config);
+                    if let Some(error) = handle_provider_error(&key, e, if_missing, true) {
+                        Err(error)
+                    } else {
+                        Ok((key, None))
+                    }
+                }
+            }
+        })
+        .buffer_unordered(10)
+        .collect()
+        .await;
+
+    for result in no_provider_results {
+        let (key, value) = result?;
+        temp_results.insert(key, value);
+    }
+
+    Ok(temp_results)
 }
 
 /// Resolve all secrets for a single provider using batch operations

--- a/src/secret_resolver.rs
+++ b/src/secret_resolver.rs
@@ -385,8 +385,9 @@ pub async fn resolve_secrets_batch(
         // Set resolved env vars so next level's providers can see them
         for (key, value) in &level_results {
             if let Some(val) = value {
-                // SAFETY: We're single-threaded here (between await points) and no other
-                // thread is reading these env vars concurrently at this point.
+                // SAFETY: set_var is unsafe in Rust 2024 edition. No other thread
+                // reads these specific env vars concurrently — provider functions
+                // that consume them only run in subsequent levels after this point.
                 unsafe {
                     std::env::set_var(key, val);
                 }

--- a/src/secret_resolver.rs
+++ b/src/secret_resolver.rs
@@ -9,6 +9,10 @@ use crate::suggest::{find_similar, format_suggestions};
 use indexmap::IndexMap;
 use miette::SourceSpan;
 use std::collections::HashMap;
+use std::sync::Mutex;
+
+/// Mutex to serialize access to std::env::set_var, which is unsafe in Rust 2024 edition.
+static ENV_MUTEX: Mutex<()> = Mutex::new(());
 
 /// Creates a ProviderNotConfigured error, using source spans when available for better error display.
 fn create_provider_not_configured_error(
@@ -383,13 +387,15 @@ pub async fn resolve_secrets_batch(
         .await?;
 
         // Set resolved env vars so next level's providers can see them
-        for (key, value) in &level_results {
-            if let Some(val) = value {
-                // SAFETY: set_var is unsafe in Rust 2024 edition. No other thread
-                // reads these specific env vars concurrently — provider functions
-                // that consume them only run in subsequent levels after this point.
-                unsafe {
-                    std::env::set_var(key, val);
+        {
+            let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+            for (key, value) in &level_results {
+                if let Some(val) = value {
+                    // SAFETY: set_var is unsafe in Rust 2024 edition. Access is
+                    // serialized via ENV_MUTEX.
+                    unsafe {
+                        std::env::set_var(key, val);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Fixes cross-provider secret dependency ordering (e.g., age-encrypted `OP_SERVICE_ACCOUNT_TOKEN` needed by 1Password provider)
- Each provider declares its env var dependencies via `env_dependencies()`
- Replaces `LazyLock` statics with plain functions so providers read env vars fresh (not cached at first access)
- Uses Kahn's algorithm in `resolve_secrets_batch` to resolve secrets in topological levels, calling `set_var` between levels

Fixes https://github.com/jdx/fnox/discussions/232

## Test plan
- [x] `mise run build` passes
- [x] `mise run test:cargo` passes (56/57, pre-existing keychain skip in headless env)
- [ ] Verify with age-encrypted `OP_SERVICE_ACCOUNT_TOKEN` + 1Password provider secrets
- [ ] Verify no regression when there are no cross-provider dependencies (fast path: single level)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core secret-resolution batching and process environment mutation, which can affect ordering, parallelism, and provider auth flows. Main risk is behavioral/regression risk rather than security.
> 
> **Overview**
> **Dependency-ordered secret resolution:** `resolve_secrets_batch` now builds a dependency graph (Kahn’s algorithm) so secrets that *provide* env vars are resolved before providers that *consume* them, and resolved values are `env::set_var`’d between levels.
> 
> **Provider env dependency metadata:** provider modules add `env_dependencies()` (non-empty for `1password`, `bitwarden`, `infisical`, `keepass`, `password-store`, `vault`, `passwordstate`; empty elsewhere), and the codegen in `build/generate_providers.rs` generates `ProviderConfig::env_dependencies()` by importing provider modules.
> 
> **Fresh env reads + safe env writes:** several providers replace `LazyLock`-cached env lookups with functions so env changes during execution are observed, and `src/env.rs` adds a mutex-guarded `set_var` wrapper to safely serialize `std::env::set_var` (Rust 2024).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 33367956101912a7dd485c18fa51566b8a7ab838. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->