### PR TITLE
feat: add JSON secrets

### DIFF
--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -496,6 +496,10 @@
             }
           ]
         },
+        "json_path": {
+          "description": "JSON path to extract from the secret value (supports dot notation: \"nested.key\")\nWhen set, the secret value is parsed as JSON and the specified path is extracted.",
+          "type": ["string", "null"]
+        },
         "provider": {
           "description": "Provider to fetch from (age, aws-kms, 1password, aws, etc.)",
           "anyOf": [

--- a/src/config.rs
+++ b/src/config.rs
@@ -111,6 +111,10 @@ pub struct SecretConfig {
     /// Write secret to a temporary file and set env var to the file path instead of the secret value
     #[serde(default, skip_serializing_if = "is_false")]
     pub as_file: bool,
+    /// JSON path to extract from the secret value (supports dot notation: "nested.key")
+    /// When set, the secret value is parsed as JSON and the specified path is extracted.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub json_path: Option<String>,
 
     /// Path to the config file where this secret was defined (not serialized)
     #[serde(skip)]
@@ -1193,6 +1197,7 @@ impl SecretConfig {
             provider: None,
             value: None,
             as_file: false,
+            json_path: None,
             source_path: None,
         }
     }
@@ -1206,6 +1211,9 @@ impl SecretConfig {
         }
         if let Some(value) = self.value() {
             inline.insert("value", toml_edit::Value::from(value));
+        }
+        if let Some(ref json_path) = self.json_path {
+            inline.insert("json_path", toml_edit::Value::from(json_path.as_str()));
         }
         if let Some(ref description) = self.description {
             inline.insert("description", toml_edit::Value::from(description.as_str()));

--- a/src/secret_resolver.rs
+++ b/src/secret_resolver.rs
@@ -66,7 +66,7 @@ fn split_key_path(key: &str) -> Vec<String> {
 fn apply_post_processing(value: String, secret_config: &SecretConfig) -> Result<String> {
     if let Some(ref json_path) = secret_config.json_path {
         if json_path.is_empty() {
-            return Err(FnoxError::Config("json_path must not be empty".to_string()).into());
+            return Err(FnoxError::Config("json_path must not be empty".to_string()));
         }
         extract_json_path(&value, json_path)
     } else {

--- a/src/secret_resolver.rs
+++ b/src/secret_resolver.rs
@@ -10,6 +10,70 @@ use indexmap::IndexMap;
 use miette::SourceSpan;
 use std::collections::{HashMap, HashSet};
 
+/// Extract a value from JSON using dot notation (e.g., "nested.path")
+/// Supports escaped dots: "foo\.bar" accesses the literal key "foo.bar"
+fn extract_json_path(json_str: &str, path: &str) -> Result<String> {
+    let value: serde_json::Value = serde_json::from_str(json_str)
+        .map_err(|e| FnoxError::Config(format!("Failed to parse JSON secret: {}", e)))?;
+
+    let mut current = &value;
+    for part in split_key_path(path) {
+        current = current.get(&part).ok_or_else(|| {
+            FnoxError::Config(format!("JSON path '{}' not found in secret", path))
+        })?;
+    }
+
+    match current {
+        serde_json::Value::String(s) => Ok(s.clone()),
+        serde_json::Value::Null => Ok("null".to_string()),
+        other => Ok(other.to_string()), // Numbers, bools, arrays, objects
+    }
+}
+
+/// Split a key path on unescaped dots, unescaping `\.` to `.` in each part.
+/// Examples:
+///   "foo.bar" -> ["foo", "bar"]
+///   "foo\.bar" -> ["foo.bar"]
+///   "a.b\.c.d" -> ["a", "b.c", "d"]
+///   "foo\\\.bar" -> ["foo\.bar"] (escaped backslash + escaped dot)
+fn split_key_path(key: &str) -> Vec<String> {
+    let mut parts = Vec::new();
+    let mut current = String::new();
+    let mut chars = key.chars();
+
+    while let Some(c) = chars.next() {
+        if c == '\\' {
+            // Escape the next character.
+            if let Some(next_char) = chars.next() {
+                current.push(next_char);
+            } else {
+                // A trailing backslash is treated as a literal backslash.
+                current.push('\\');
+            }
+        } else if c == '.' {
+            parts.push(std::mem::take(&mut current));
+        } else {
+            current.push(c);
+        }
+    }
+
+    parts.push(current);
+    parts
+}
+
+/// Apply post-processing to a secret value based on SecretConfig settings.
+/// When json_path is set, extracts the specified path from a JSON value.
+fn apply_post_processing(value: String, secret_config: &SecretConfig) -> Result<String> {
+    if let Some(ref json_path) = secret_config.json_path {
+        if json_path.is_empty() {
+            return Err(FnoxError::Config("json_path must not be empty".to_string()).into());
+        }
+        extract_json_path(&value, json_path)
+    } else {
+        Ok(value)
+    }
+}
+
 /// Creates a ProviderNotConfigured error, using source spans when available for better error display.
 fn create_provider_not_configured_error(
     provider_name: &str,
@@ -47,7 +111,7 @@ fn create_provider_not_configured_error(
 
 /// Resolves the if_missing behavior using the complete priority chain:
 /// 1. CLI flag (--if-missing) via Settings
-/// 2. Environment variable (FNOX_IF_MISSING) via Settings  
+/// 2. Environment variable (FNOX_IF_MISSING) via Settings
 /// 3. Secret-level if_missing
 /// 4. Top-level config if_missing
 /// 5. Base default environment variable (FNOX_IF_MISSING_DEFAULT) via Settings
@@ -134,27 +198,34 @@ pub fn handle_provider_error(
 /// 3. Environment variable
 ///
 /// The raw `value` field is NEVER used directly - it's only used as input to providers.
+/// Post-processing (e.g., JSON path extraction) is applied to all sources consistently.
 pub async fn resolve_secret(
     config: &Config,
     profile: &str,
     key: &str,
     secret_config: &SecretConfig,
 ) -> Result<Option<String>> {
-    // Priority 1: Provider (if specified and has a value)
-    if let Some(value) = try_resolve_from_provider(config, profile, secret_config).await? {
-        return Ok(Some(value));
-    }
+    // Try to get a value from any source (provider, default, or env var)
+    let value_to_process =
+        // Priority 1: Provider (if specified and has a value)
+        if let Some(value) = try_resolve_from_provider(config, profile, secret_config).await? {
+            Some(value)
+        // Priority 2: Default value
+        } else if let Some(default) = &secret_config.default {
+            tracing::debug!("Using default value for secret '{}'", key);
+            Some(default.clone())
+        // Priority 3: Environment variable
+        } else if let Ok(env_value) = env::var(key) {
+            tracing::debug!("Found secret '{}' in current environment", key);
+            Some(env_value)
+        } else {
+            None
+        };
 
-    // Priority 2: Default value
-    if let Some(default) = &secret_config.default {
-        tracing::debug!("Using default value for secret '{}'", key);
-        return Ok(Some(default.clone()));
-    }
-
-    // Priority 3: Environment variable
-    if let Ok(env_value) = env::var(key) {
-        tracing::debug!("Found secret '{}' in current environment", key);
-        return Ok(Some(env_value));
+    // Apply post-processing to whatever value we found (e.g., JSON path extraction)
+    if let Some(value) = value_to_process {
+        let processed = apply_post_processing(value, secret_config)?;
+        return Ok(Some(processed));
     }
 
     // No value found - handle based on if_missing with priority chain
@@ -502,20 +573,11 @@ async fn resolve_level(
     }
 
     // Resolve no-provider secrets in parallel
-    let no_provider_results: Vec<_> = stream::iter(level_no_provider)
+    let no_provider_results: Vec<Result<_>> = stream::iter(level_no_provider)
         .map(|key| async move {
             let secret_config = &secrets[&key];
-            match resolve_secret(config, profile, &key, secret_config).await {
-                Ok(value) => Ok((key, value)),
-                Err(e) => {
-                    let if_missing = resolve_if_missing_behavior(secret_config, config);
-                    if let Some(error) = handle_provider_error(&key, e, if_missing, true) {
-                        Err(error)
-                    } else {
-                        Ok((key, None))
-                    }
-                }
-            }
+            let value = resolve_secret(config, profile, &key, secret_config).await?;
+            Ok((key, value))
         })
         .buffer_unordered(10)
         .collect()
@@ -686,7 +748,17 @@ fn process_batch_results(
         let secret_config = &secrets[&key];
         match result {
             Ok(value) => {
-                results.insert(key, Some(value));
+                // Apply post-processing (e.g., JSON path extraction)
+                match apply_post_processing(value, secret_config) {
+                    Ok(processed) => {
+                        results.insert(key, Some(processed));
+                    }
+                    Err(e) => {
+                        // Post-processing errors (invalid JSON, missing key) are config/data errors,
+                        // not "missing secret" — always fail hard regardless of if_missing.
+                        return Err(e);
+                    }
+                }
             }
             Err(e) => {
                 let if_missing = resolve_if_missing_behavior(secret_config, config);
@@ -848,5 +920,44 @@ mod tests {
         assert_eq!(levels[0], vec!["OP_SERVICE_ACCOUNT_TOKEN", "PLAIN_VAR"]);
         // Level 1: 1Password secrets that depend on the token
         assert_eq!(levels[1], vec!["DB_PASSWORD", "TUNNEL_TOKEN"]);
+    }
+
+    #[test]
+    fn test_split_key_path_simple() {
+        assert_eq!(split_key_path("foo"), vec!["foo"]);
+        assert_eq!(split_key_path("foo.bar"), vec!["foo", "bar"]);
+        assert_eq!(split_key_path("a.b.c"), vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn test_split_key_path_escaped_dot() {
+        // Single escaped dot
+        assert_eq!(split_key_path(r"foo\.bar"), vec!["foo.bar"]);
+        // Escaped dot in the middle of a path
+        assert_eq!(split_key_path(r"a.b\.c.d"), vec!["a", "b.c", "d"]);
+        // Multiple escaped dots
+        assert_eq!(split_key_path(r"foo\.bar\.baz"), vec!["foo.bar.baz"]);
+    }
+
+    #[test]
+    fn test_split_key_path_escaped_backslash() {
+        // Escaped backslash followed by dot (literal backslash + path separator)
+        assert_eq!(split_key_path(r"foo\\.bar"), vec!["foo\\", "bar"]);
+        // Escaped backslash followed by escaped dot
+        assert_eq!(split_key_path(r"foo\\\.bar"), vec!["foo\\.bar"]);
+    }
+
+    #[test]
+    fn test_split_key_path_edge_cases() {
+        // Empty string
+        assert_eq!(split_key_path(""), vec![""]);
+        // Just a dot
+        assert_eq!(split_key_path("."), vec!["", ""]);
+        // Trailing dot
+        assert_eq!(split_key_path("foo."), vec!["foo", ""]);
+        // Leading dot
+        assert_eq!(split_key_path(".foo"), vec!["", "foo"]);
+        // Backslash at end (kept as-is)
+        assert_eq!(split_key_path(r"foo\"), vec!["foo\\"]);
     }
 }

--- a/test/json_secrets.bats
+++ b/test/json_secrets.bats
@@ -1,0 +1,294 @@
+#!/usr/bin/env bats
+
+setup() {
+	load 'test_helper/common_setup'
+	_common_setup
+}
+
+teardown() {
+	_common_teardown
+}
+
+@test "get: extracts JSON path from plain secret" {
+	cat >fnox.toml <<EOF
+root = true
+
+[providers.plain]
+type = "plain"
+
+[secrets]
+MY_SECRET = { provider = "plain", value = '{"username":"admin","password":"secret123"}', json_path = "username" }
+EOF
+
+	run "$FNOX_BIN" get MY_SECRET
+	assert_success
+	assert_output "admin"
+}
+
+@test "get: extracts nested JSON path with dot notation from plain secret" {
+	cat >fnox.toml <<EOF
+root = true
+
+[providers.plain]
+type = "plain"
+
+[secrets]
+MY_SECRET = { provider = "plain", value = '{"database":{"host":"localhost","port":5432},"api":{"key":"abc123"}}', json_path = "database.host" }
+EOF
+
+	run "$FNOX_BIN" get MY_SECRET
+	assert_success
+	assert_output "localhost"
+}
+
+@test "get: fails with clear error for invalid JSON" {
+	cat >fnox.toml <<EOF
+root = true
+
+[providers.plain]
+type = "plain"
+
+[secrets]
+MY_SECRET = { provider = "plain", value = "not valid json", json_path = "foo" }
+EOF
+
+	run "$FNOX_BIN" get MY_SECRET
+	assert_failure
+	assert_output --partial "Failed to parse JSON secret"
+}
+
+@test "get: fails with clear error when key not found in JSON" {
+	cat >fnox.toml <<EOF
+root = true
+
+[providers.plain]
+type = "plain"
+
+[secrets]
+MY_SECRET = { provider = "plain", value = '{"foo":"bar"}', json_path = "missing" }
+EOF
+
+	run "$FNOX_BIN" get MY_SECRET
+	assert_failure
+	assert_output --partial "JSON path 'missing' not found"
+}
+
+@test "get: handles JSON null values" {
+	cat >fnox.toml <<EOF
+root = true
+
+[providers.plain]
+type = "plain"
+
+[secrets]
+MY_SECRET = { provider = "plain", value = '{"value":null}', json_path = "value" }
+EOF
+
+	run "$FNOX_BIN" get MY_SECRET
+	assert_success
+	assert_output "null"
+}
+
+@test "get: handles JSON boolean values" {
+	cat >fnox.toml <<EOF
+root = true
+
+[providers.plain]
+type = "plain"
+
+[secrets]
+ENABLED = { provider = "plain", value = '{"enabled":true}', json_path = "enabled" }
+DISABLED = { provider = "plain", value = '{"disabled":false}', json_path = "disabled" }
+EOF
+
+	run "$FNOX_BIN" get ENABLED
+	assert_success
+	assert_output "true"
+
+	run "$FNOX_BIN" get DISABLED
+	assert_success
+	assert_output "false"
+}
+
+@test "exec: resolves JSON secrets in batch" {
+	cat >fnox.toml <<EOF
+root = true
+
+[providers.plain]
+type = "plain"
+
+[secrets]
+DB_USER = { provider = "plain", value = '{"user":"admin","pass":"secret"}', json_path = "user" }
+DB_PASS = { provider = "plain", value = '{"user":"admin","pass":"secret"}', json_path = "pass" }
+EOF
+
+	run "$FNOX_BIN" exec -- sh -c 'echo "$DB_USER:$DB_PASS"'
+	assert_success
+	assert_output "admin:secret"
+}
+
+@test "exec: json_path with as_file writes extracted value to temp file" {
+	cat >fnox.toml <<EOF
+root = true
+
+[providers.plain]
+type = "plain"
+
+[secrets]
+DB_PASS = { provider = "plain", value = '{"user":"admin","pass":"secret"}', json_path = "pass", as_file = true }
+EOF
+
+	run "$FNOX_BIN" exec -- sh -c 'cat "$DB_PASS"'
+	assert_success
+	assert_output "secret"
+}
+
+@test "get: fails with clear error for empty json_path" {
+	cat >fnox.toml <<EOF
+root = true
+
+[providers.plain]
+type = "plain"
+
+[secrets]
+MY_SECRET = { provider = "plain", value = '{"foo":"bar"}', json_path = "" }
+EOF
+
+	run "$FNOX_BIN" get MY_SECRET
+	assert_failure
+	assert_output --partial "json_path must not be empty"
+}
+
+@test "get: without json_path returns raw value" {
+	cat >fnox.toml <<EOF
+root = true
+
+[providers.plain]
+type = "plain"
+
+[secrets]
+MY_SECRET = { provider = "plain", value = '{"foo":"bar"}' }
+EOF
+
+	run "$FNOX_BIN" get MY_SECRET
+	assert_success
+	assert_output '{"foo":"bar"}'
+}
+
+@test "get: extracts JSON path containing literal dot using escape" {
+	cat >fnox.toml <<EOF
+root = true
+
+[providers.plain]
+type = "plain"
+
+[secrets]
+MY_SECRET = { provider = "plain", value = '{"foo.bar":"value1","nested":{"key":"value2"}}', json_path = 'foo\.bar' }
+EOF
+
+	run "$FNOX_BIN" get MY_SECRET
+	assert_success
+	assert_output "value1"
+}
+
+@test "get: mixed escaped and unescaped dots in key path" {
+	cat >fnox.toml <<EOF
+root = true
+
+[providers.plain]
+type = "plain"
+
+[secrets]
+MY_SECRET = { provider = "plain", value = '{"a":{"b.c":{"d":"found"}}}', json_path = 'a.b\.c.d' }
+EOF
+
+	run "$FNOX_BIN" get MY_SECRET
+	assert_success
+	assert_output "found"
+}
+
+@test "get: extracts JSON path from default value" {
+	cat >fnox.toml <<EOF
+root = true
+
+[providers.plain]
+type = "plain"
+
+[secrets]
+MY_SECRET = { default = '{"user":"admin","pass":"secret"}', json_path = "user" }
+EOF
+
+	run "$FNOX_BIN" get MY_SECRET
+	assert_success
+	assert_output "admin"
+}
+
+# resolve_secret applies json_path to all three value sources (provider, default, env var).
+# This test exercises the env var fallback path to ensure post-processing works there too.
+@test "get: extracts JSON path from environment variable" {
+	cat >fnox.toml <<EOF
+root = true
+
+[providers.plain]
+type = "plain"
+
+[secrets]
+MY_SECRET = { json_path = "host" }
+EOF
+
+	MY_SECRET='{"host":"localhost","port":5432}' run "$FNOX_BIN" get MY_SECRET
+	assert_success
+	assert_output "localhost"
+}
+
+@test "get: extracts JSON path from age-encrypted secret" {
+	# Skip if age not installed
+	if ! command -v age-keygen >/dev/null 2>&1; then
+		skip "age-keygen not installed"
+	fi
+
+	# Generate age key
+	local keygen_output
+	keygen_output=$(age-keygen -o key.txt 2>&1)
+	local public_key
+	public_key=$(echo "$keygen_output" | grep "^Public key:" | cut -d' ' -f3)
+	local private_key
+	private_key=$(grep "^AGE-SECRET-KEY" key.txt)
+
+	# Store config header for reuse
+	local config_header
+	config_header=$(
+		cat <<EOF
+root = true
+
+[providers.age]
+type = "age"
+recipients = ["$public_key"]
+
+[secrets]
+EOF
+	)
+
+	# Create config for fnox set
+	cat >fnox.toml <<EOF
+${config_header}
+EOF
+
+	# Set the encrypted JSON secret using fnox set
+	export FNOX_AGE_KEY=$private_key
+	run "$FNOX_BIN" set JSON_SECRET '{"username":"admin","password":"secret123"}'
+	assert_success
+
+	# Extract encrypted value, rewrite config with json_path
+	local encrypted_value
+	encrypted_value=$(grep -o 'value = "[^"]*"' fnox.toml | grep -o '"[^"]*"')
+	cat >fnox.toml <<EOF
+${config_header}
+JSON_SECRET = { provider = "age", value = ${encrypted_value}, json_path = "username" }
+EOF
+
+	# Should be able to extract the username
+	run "$FNOX_BIN" get JSON_SECRET
+	assert_success
+	assert_output "admin"
+}


### PR DESCRIPTION
This is picking up the idea presented in discussion #138: being able to directly use json secrets, as is commonly done in AWS Secrets Manager.

While the workaround with `jq` currently described in the docs allows _getting_ individual values, actually exporting values as env vars using `fnox x` (or the mise integration) doesn't work.

I was not looking into the auto-expansion (since there's quite a bit of ambiguity in some things there), but rather specifying individual keys.

This basically introduces a `json_path` secret parameter that triggers treating the secret as json and accessing the path.

`json_path` currently cannot be used with `fnox set`, but needs to be set up directly in the config file.