### PR TITLE
chore: add tone calibration to release notes prompt

### DIFF
--- a/mise-tasks/gen-release-notes
+++ b/mise-tasks/gen-release-notes
@@ -41,9 +41,16 @@ FORMAT - Your output MUST start with this exact line format:
 # $version - <Creative Title>
 
 Where <Creative Title> is 2-6 words capturing the theme of the release (e.g., "Secrets Stay Secret", "Provider Paradise", "Better Error Messages").
+For smaller or less impactful releases, keep the title understated and modest.
+
+TONE CALIBRATION:
+- Match the tone and length to the actual significance of the changes
+- If the release is mostly small bug fixes or minor tweaks, be upfront about that—a sentence or two of summary is fine, don't write multiple paragraphs inflating the importance
+- Reserve enthusiastic, detailed write-ups for releases with genuinely significant features or changes
+- It's okay to say "This is a smaller release focused on bug fixes" when that's the case
 
 After the title line, write the release notes:
-1. Start with 1-2 paragraphs summarizing key changes
+1. Start with a summary proportional to the significance of the changes
 2. Organize into ### sections (Highlights, Bug Fixes, etc.)
 3. Explain WHY changes matter to users
 4. Include PR links and documentation links (https://fnox.jdx.dev/)


### PR DESCRIPTION
## Summary
- Add tone calibration instructions to the release notes LLM prompt so it matches tone and length to the actual significance of changes
- Add title guideline for smaller releases to keep titles understated
- Change summary instruction from fixed "1-2 paragraphs" to "proportional to significance"

## Test plan
- [x] Prompt-only change, no code logic affected
- [ ] Verify next release notes generation produces appropriately-toned output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-text-only change to release note generation instructions; no runtime logic or data handling is modified.
> 
> **Overview**
> Updates `mise-tasks/gen-release-notes` to refine the release-notes prompt with **tone calibration** guidance so the LLM matches title enthusiasm and write-up length to the significance of the changelog.
> 
> Replaces the fixed “1–2 paragraph” intro requirement with a summary that’s explicitly *proportional to the change size*, and nudges smaller releases toward more modest creative titles.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f84d7018bd1a37f276a66fb14b85e173e22714ff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->