### PR TITLE
feat: add a `--no-defaults` CLI flag

### DIFF
--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -1070,16 +1070,6 @@
         }
       },
       {
-        "name": "no-defaults",
-        "usage": "--no-defaults",
-        "help": "Do not merge top-level secrets into the selected profile",
-        "help_first_line": "Do not merge top-level secrets into the selected profile",
-        "short": [],
-        "long": ["no-defaults"],
-        "hide": false,
-        "global": true
-      },
-      {
         "name": "verbose",
         "usage": "-v --verbose",
         "help": "Enable verbose logging",
@@ -1130,6 +1120,16 @@
         "help_first_line": "Disable colored output",
         "short": [],
         "long": ["no-color"],
+        "hide": false,
+        "global": true
+      },
+      {
+        "name": "no-defaults",
+        "usage": "--no-defaults",
+        "help": "Do not merge top-level secrets into the selected profile",
+        "help_first_line": "Do not merge top-level secrets into the selected profile",
+        "short": [],
+        "long": ["no-defaults"],
         "hide": false,
         "global": true
       }

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -1070,6 +1070,16 @@
         }
       },
       {
+        "name": "no-defaults",
+        "usage": "--no-defaults",
+        "help": "Do not merge top-level secrets into the selected profile",
+        "help_first_line": "Do not merge top-level secrets into the selected profile",
+        "short": [],
+        "long": ["no-defaults"],
+        "hide": false,
+        "global": true
+      },
+      {
         "name": "verbose",
         "usage": "-v --verbose",
         "help": "Enable verbose logging",

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -20,6 +20,10 @@ Path to the configuration file (default: fnox.toml, searches parent directories)
 
 Profile to use (default: default, or FNOX_PROFILE env var)
 
+### `--no-defaults`
+
+Do not merge top-level secrets into the selected profile
+
 ### `-v --verbose`
 
 Enable verbose logging

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -20,10 +20,6 @@ Path to the configuration file (default: fnox.toml, searches parent directories)
 
 Profile to use (default: default, or FNOX_PROFILE env var)
 
-### `--no-defaults`
-
-Do not merge top-level secrets into the selected profile
-
 ### `-v --verbose`
 
 Enable verbose logging
@@ -35,6 +31,10 @@ What to do if a secret is missing (error, warn, ignore)
 ### `--no-color`
 
 Disable colored output
+
+### `--no-defaults`
+
+Do not merge top-level secrets into the selected profile
 
 ## Subcommands
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -326,6 +326,14 @@ DATABASE_URL = { provider = "aws", value = "prod-db" }  # Overrides top-level DA
 # Inherits LOG_LEVEL="info" from top-level
 ```
 
+You can disable this merge behavior at runtime:
+
+```bash
+fnox exec --profile production --no-defaults -- ./deploy.sh
+```
+
+With `--no-defaults`, only `[profiles.<name>.secrets]` are used for the selected profile.
+
 ## Complete Example
 
 ```toml

--- a/docs/reference/environment.md
+++ b/docs/reference/environment.md
@@ -23,6 +23,15 @@ fnox get DATABASE_URL
 fnox exec -- ./deploy.sh
 ```
 
+### `FNOX_NO_DEFAULTS`
+
+When set to `true`, do not merge top-level secrets into the selected profile.
+
+```bash
+export FNOX_NO_DEFAULTS=true
+fnox exec --profile production -- ./deploy.sh
+```
+
 ### `FNOX_CONFIG_DIR`
 
 Configuration directory path.

--- a/fnox.usage.kdl
+++ b/fnox.usage.kdl
@@ -10,7 +10,6 @@ flag "-c --config" help="Path to the configuration file (default: fnox.toml, sea
 flag "-P --profile" help="Profile to use (default: default, or FNOX_PROFILE env var)" global=#true {
     arg <PROFILE>
 }
-flag --no-defaults help="Do not merge top-level secrets into the selected profile" global=#true
 flag "-v --verbose" help="Enable verbose logging" global=#true
 flag --age-key-file help="Path to age key file for decryption (deprecated: use provider config instead)" hide=#true global=#true {
     arg <AGE_KEY_FILE>
@@ -19,6 +18,7 @@ flag --if-missing help="What to do if a secret is missing (error, warn, ignore)"
     arg <IF_MISSING>
 }
 flag --no-color help="Disable colored output" global=#true
+flag --no-defaults help="Do not merge top-level secrets into the selected profile" global=#true
 cmd activate help="Output shell activation code to enable automatic secret loading" {
     flag --no-hook-env help="Don't automatically invoke hook-env (for testing)"
     arg "[SHELL]" help="Shell to generate activation code for (bash, zsh, fish)" required=#false

--- a/fnox.usage.kdl
+++ b/fnox.usage.kdl
@@ -10,6 +10,7 @@ flag "-c --config" help="Path to the configuration file (default: fnox.toml, sea
 flag "-P --profile" help="Profile to use (default: default, or FNOX_PROFILE env var)" global=#true {
     arg <PROFILE>
 }
+flag --no-defaults help="Do not merge top-level secrets into the selected profile" global=#true
 flag "-v --verbose" help="Enable verbose logging" global=#true
 flag --age-key-file help="Path to age key file for decryption (deprecated: use provider config instead)" hide=#true global=#true {
     arg <AGE_KEY_FILE>

--- a/settings.toml
+++ b/settings.toml
@@ -50,6 +50,23 @@ examples = [
 ]
 since = "0.1.0"
 
+[no_defaults]
+type = "bool"
+default = "false"
+sources.cli = ["--no-defaults"]
+sources.env = ["FNOX_NO_DEFAULTS"]
+docs = """
+When a non-default profile is selected, do not merge top-level [secrets] into
+the profile. Only [profiles.<name>.secrets] will be used.
+
+Priority (highest to lowest): CLI > Environment > Default
+"""
+examples = [
+  "fnox exec --profile dev --no-defaults -- ./my-app",
+  "FNOX_NO_DEFAULTS=true fnox exec --profile dev -- ./my-app",
+]
+since = "1.12.0"
+
 [shell_integration_output]
 type = "string"
 default = "\"normal\""

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -60,6 +60,10 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub no_color: bool,
 
+    /// Do not merge top-level secrets into the selected profile
+    #[arg(long, global = true)]
+    pub no_defaults: bool,
+
     #[command(subcommand)]
     pub command: Commands,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1278,4 +1278,49 @@ mod tests {
             "Empty profile name should not appear"
         );
     }
+
+    #[test]
+    fn test_no_defaults_profile_only_secrets() {
+        crate::settings::Settings::reset_for_tests();
+        crate::settings::Settings::set_cli_snapshot(crate::settings::CliSnapshot {
+            age_key_file: None,
+            profile: Some("prod".to_string()),
+            if_missing: None,
+            no_defaults: true,
+        });
+
+        let mut config = Config::new();
+        config
+            .secrets
+            .insert("DEFAULT_ONLY".to_string(), SecretConfig::new());
+
+        let mut prod_profile = ProfileConfig::new();
+        prod_profile
+            .secrets
+            .insert("PROD_ONLY".to_string(), SecretConfig::new());
+        config.profiles.insert("prod".to_string(), prod_profile);
+
+        let secrets = config.get_secrets("prod").unwrap();
+        assert!(secrets.contains_key("PROD_ONLY"));
+        assert!(!secrets.contains_key("DEFAULT_ONLY"));
+    }
+
+    #[test]
+    fn test_no_defaults_profile_without_section_is_empty() {
+        crate::settings::Settings::reset_for_tests();
+        crate::settings::Settings::set_cli_snapshot(crate::settings::CliSnapshot {
+            age_key_file: None,
+            profile: Some("prod".to_string()),
+            if_missing: None,
+            no_defaults: true,
+        });
+
+        let mut config = Config::new();
+        config
+            .secrets
+            .insert("DEFAULT_ONLY".to_string(), SecretConfig::new());
+
+        let secrets = config.get_secrets("prod").unwrap();
+        assert!(secrets.is_empty());
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 use crate::env;
-use crate::settings::Settings;
 use crate::error::{FnoxError, Result};
+use crate::settings::Settings;
 use crate::source_registry;
 use crate::spanned::SpannedValue;
 use clap::ValueEnum;
@@ -653,27 +653,25 @@ impl Config {
     pub fn get_secrets(&self, profile: &str) -> Result<IndexMap<String, SecretConfig>> {
         if profile == "default" {
             Ok(self.secrets.clone())
-        } else {
-            if Settings::get().no_defaults {
-                // Profile-only mode: do not merge top-level secrets.
-                if let Some(profile_config) = self.profiles.get(profile) {
-                    Ok(profile_config.secrets.clone())
-                } else {
-                    Ok(IndexMap::new())
-                }
+        } else if Settings::get().no_defaults {
+            // Profile-only mode: do not merge top-level secrets.
+            if let Some(profile_config) = self.profiles.get(profile) {
+                Ok(profile_config.secrets.clone())
             } else {
-                // Start with top-level secrets as base
-                let mut secrets = self.secrets.clone();
-
-                // Get profile-specific secrets and merge/override (if profile exists)
-                if let Some(profile_config) = self.profiles.get(profile) {
-                    // Profile-specific secrets override top-level ones
-                    secrets.extend(profile_config.secrets.clone());
-                }
-                // If profile doesn't exist in [profiles], that's OK - just use top-level secrets
-                // This allows fnox.$FNOX_PROFILE.toml to work without requiring [profiles.xxx]
-                Ok(secrets)
+                Ok(IndexMap::new())
             }
+        } else {
+            // Start with top-level secrets as base
+            let mut secrets = self.secrets.clone();
+
+            // Get profile-specific secrets and merge/override (if profile exists)
+            if let Some(profile_config) = self.profiles.get(profile) {
+                // Profile-specific secrets override top-level ones
+                secrets.extend(profile_config.secrets.clone());
+            }
+            // If profile doesn't exist in [profiles], that's OK - just use top-level secrets
+            // This allows fnox.$FNOX_PROFILE.toml to work without requiring [profiles.xxx]
+            Ok(secrets)
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,7 @@ async fn main() -> miette::Result<()> {
         age_key_file: cli.age_key_file.clone(),
         profile: cli.profile.clone(),
         if_missing: cli.if_missing.clone(),
+        no_defaults: cli.no_defaults,
     });
 
     // Handle --no-color flag

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -44,6 +44,7 @@ pub struct CliSnapshot {
     pub age_key_file: Option<std::path::PathBuf>,
     pub profile: Option<String>,
     pub if_missing: Option<String>,
+    pub no_defaults: bool,
 }
 
 static CLI_SNAPSHOT: LazyLock<Mutex<Option<CliSnapshot>>> = LazyLock::new(|| Mutex::new(None));
@@ -154,6 +155,10 @@ impl Settings {
             if let Some(if_missing) = snapshot.if_missing {
                 map.insert("if_missing", SettingValue::OptionString(Some(if_missing)));
             }
+
+            if snapshot.no_defaults {
+                map.insert("no_defaults", SettingValue::Bool(true));
+            }
         }
 
         map
@@ -214,6 +219,7 @@ mod tests {
         let settings = GeneratedSettings::default();
         assert_eq!(settings.profile, "default");
         assert_eq!(settings.age_key_file, None);
+        assert_eq!(settings.no_defaults, false);
     }
 
     #[test]
@@ -221,6 +227,7 @@ mod tests {
         let defaults = GeneratedSettings {
             age_key_file: None,
             profile: "default".to_string(),
+            no_defaults: false,
             shell_integration_output: "normal".to_string(),
             if_missing: None,
             if_missing_default: None,
@@ -252,6 +259,7 @@ mod tests {
         let defaults = GeneratedSettings {
             age_key_file: None,
             profile: "default".to_string(),
+            no_defaults: false,
             shell_integration_output: "normal".to_string(),
             if_missing: None,
             if_missing_default: None,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -208,6 +208,13 @@ impl Settings {
 
         serde_json::from_value(val).unwrap_or_else(|_| defaults.clone())
     }
+
+    #[cfg(test)]
+    pub fn reset_for_tests() {
+        GLOBAL_SETTINGS.store(Arc::new(GeneratedSettings::default()));
+        *INITIALIZED.lock().unwrap() = false;
+        *CLI_SNAPSHOT.lock().unwrap() = None;
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
Add a `--no-defaults` flag (and `FNOX_NO_DEFAULTS` env var) to allow profile-only secrets injection.

## Motivating Example
I've had a play around with running OpenClaw in a lazy OS level sandbox using [nono](https://github.com/lukehinds/nono).

As a part of that, I wanted to execute it using a profile with only the relevant env vars needed for openclaw to work, and none of the other top level/default secrets.

e.g.
```toml
# fnox.toml
[secrets]
GH_TOKEN = { provider = "keychain", value = "gh-token" }
OPENROUTER_API_KEY = { provider = "keychain", value = "openrouter-api-key" }

[profiles.openclaw.secrets]
TELEGRAM_BOT_TOKEN = { provider = "keychain", value = "telegram-bot-token" }
OPENAI_API_KEY = { provider = "keychain", value = "openai-api-key" }
```

If I run:
```bash
fnox exec --profile openclaw -- nono run --profile openclaw -- openclaw gateway
```
openclaw's process still gets access to the top level `GH_TOKEN` and `OPENROUTER_API_KEY`.

With this change, I can instead do:
```bash
fnox exec --profile openclaw --no-defaults -- nono run --profile openclaw -- openclaw gateway
```

which will only injects the secrets defined in the openclaw profile.


## AI Disclosure
This PR was 100% generated using OpenAI Codex. I've reviewed it myself to the best of my ability, although I'm not a Rust developer so a sanity check would be appreciated.