### PR TITLE
chore: release v1.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,24 @@
 # Changelog
 
-## [1.12.0](https://github.com/jdx/fnox/compare/v1.11.0..v1.12.0) - 2026-02-08
+## [1.12.1](https://github.com/jdx/fnox/compare/v1.12.0..v1.12.1) - 2026-02-10
+
+### 🐛 Bug Fixes
+
+- load global config in shell integration hook-env by [@jdx](https://github.com/jdx) in [#262](https://github.com/jdx/fnox/pull/262)
+
+### 📚 Documentation
+
+- condense CLAUDE.md from 1159 to 96 lines by [@jdx](https://github.com/jdx) in [#260](https://github.com/jdx/fnox/pull/260)
+
+### 🛡️ Security
+
+- disable light mode in documentation site by [@jdx](https://github.com/jdx) in [#261](https://github.com/jdx/fnox/pull/261)
+
+### 📦️ Dependency Updates
+
+- lock file maintenance by [@renovate[bot]](https://github.com/renovate[bot]) in [#257](https://github.com/jdx/fnox/pull/257)
+
+## [1.12.0](https://github.com/jdx/fnox/compare/v1.11.0..v1.12.0) - 2026-02-09
 
 ### 🚀 Features
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1956,7 +1956,7 @@ dependencies = [
 
 [[package]]
 name = "fnox"
-version = "1.12.0"
+version = "1.12.1"
 dependencies = [
  "age",
  "anyhow",
@@ -3410,9 +3410,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.181"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "459427e2af2b9c839b132acb702a1c654d95e10f8c326bfc2ad11310e458b1c5"
 
 [[package]]
 name = "libdbus-sys"
@@ -5601,12 +5601,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.24.0"
+version = "3.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.3",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fnox"
-version = "1.12.0"
+version = "1.12.1"
 edition = "2024"
 authors = ["@jdx"]
 description = "A flexible secret management tool supporting multiple providers and encryption methods"

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -1144,7 +1144,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.12.0",
+  "version": "1.12.1",
   "usage": "Usage: fnox [OPTIONS] <COMMAND>",
   "complete": {
     "key": {

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -4,7 +4,7 @@
 
 **Usage**: `fnox [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.12.0
+**Version**: 1.12.1
 
 - **Usage**: `fnox [FLAGS] <SUBCOMMAND>`
 

--- a/fnox.usage.kdl
+++ b/fnox.usage.kdl
@@ -1,7 +1,7 @@
 min_usage_version "1.3"
 name fnox
 bin fnox
-version "1.12.0"
+version "1.12.1"
 about "A flexible secret management tool by @jdx"
 usage "Usage: fnox [OPTIONS] <COMMAND>"
 flag "-c --config" help="Path to the configuration file (default: fnox.toml, searches parent directories)" global=#true default=fnox.toml {


### PR DESCRIPTION
### 🐛 Bug Fixes

- load global config in shell integration hook-env by [@jdx](https://github.com/jdx) in [#262](https://github.com/jdx/fnox/pull/262)

### 📚 Documentation

- condense CLAUDE.md from 1159 to 96 lines by [@jdx](https://github.com/jdx) in [#260](https://github.com/jdx/fnox/pull/260)

### 🛡️ Security

- disable light mode in documentation site by [@jdx](https://github.com/jdx) in [#261](https://github.com/jdx/fnox/pull/261)

### 📦️ Dependency Updates

- lock file maintenance by [@renovate[bot]](https://github.com/renovate[bot]) in [#257](https://github.com/jdx/fnox/pull/257)