### PR TITLE
docs: disable light mode in documentation site

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -26,7 +26,7 @@ export default defineConfig({
   title: "fnox",
   description: "Fort Knox for your secrets",
   base: "/",
-  appearance: "dark",
+  appearance: "force-dark",
 
   themeConfig: {
     logo: "/logo.svg",


### PR DESCRIPTION
## Summary
- Change VitePress `appearance` from `"dark"` to `"force-dark"`
- `"dark"` sets dark as default but still shows the light/dark toggle
- `"force-dark"` enforces dark mode with no toggle button

## Test plan
- [ ] Verify docs site loads in dark mode
- [ ] Verify no appearance toggle button is shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single configuration change to docs theming; no runtime logic, security, or data-handling impact.
> 
> **Overview**
> Updates the VitePress docs site configuration to **force dark mode** by changing `appearance` from `"dark"` to `"force-dark"`, which removes the light/dark toggle and prevents switching to light mode.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a37304c4da9e6ac75c0744d45c175984d0622f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->