### PR TITLE
fix(release): write release notes to file instead of capturing stdout

### DIFF
--- a/mise-tasks/gen-release-notes
+++ b/mise-tasks/gen-release-notes
@@ -56,27 +56,29 @@ After the title line, write the release notes:
 4. Include PR links and documentation links (https://fnox.jdx.dev/)
 5. Include contributor usernames (@username). Do not thank @jdx since that is who is writing these notes.
 6. Skip internal changes
+
+Write your output to the file: /tmp/release-notes-output.md
+Do not output anything else — just write to the file.
 INSTRUCTIONS
 )
 
 # Use Claude Code to generate the release notes
-# Sandboxed: only read-only tools allowed (no Bash, Edit, Write)
+# Claude writes to a temp file via the Write tool to avoid formatting artifacts from stdout
 echo "Generating release notes with Claude..." >&2
 echo "Version: $version" >&2
 echo "Previous version: ${prev_version:-none}" >&2
 echo "Changelog length: ${#changelog} chars" >&2
 
-# Capture stderr separately to avoid polluting output
-stderr_file=$(mktemp)
-trap 'rm -f "$stderr_file"' EXIT
+output_file="/tmp/release-notes-output.md"
+rm -f "$output_file"
 
-if ! output=$(
-	printf '%s' "$prompt" | claude -p \
-		--model claude-opus-4-5-20251101 \
-		--permission-mode bypassPermissions \
-		--output-format text \
-		--allowedTools "Read,Grep,Glob" 2>"$stderr_file"
-); then
+stderr_file=$(mktemp)
+trap 'rm -f "$stderr_file" "$output_file"' EXIT
+
+if ! printf '%s' "$prompt" | claude -p \
+	--model claude-opus-4-6 \
+	--permission-mode bypassPermissions \
+	--allowedTools "Read,Grep,Glob,Write($output_file)" 2>"$stderr_file"; then
 	echo "Error: Claude CLI failed" >&2
 	if [[ -s $stderr_file ]]; then
 		cat "$stderr_file" >&2
@@ -86,11 +88,12 @@ if ! output=$(
 	exit 1
 fi
 
-# Validate we got non-empty output
-if [[ -z $output ]]; then
-	echo "Error: Claude returned empty output" >&2
+# Validate the output file was created and is non-empty
+if [[ ! -s $output_file ]]; then
+	echo "Error: Claude did not write release notes to $output_file" >&2
 	cat "$stderr_file" >&2
 	exit 1
 fi
 
+output=$(cat "$output_file")
 echo "$output"

--- a/mise-tasks/gen-release-notes
+++ b/mise-tasks/gen-release-notes
@@ -25,6 +25,10 @@ if [[ -z $changelog ]]; then
 	exit 1
 fi
 
+output_file=$(mktemp /tmp/release-notes-XXXXXX.md)
+stderr_file=$(mktemp)
+trap 'rm -f "$stderr_file" "$output_file"' EXIT
+
 # Build prompt safely using printf to avoid command substitution on backticks in changelog
 prompt=$(
 	printf '%s\n' "You are writing release notes for fnox version ${version}${prev_version:+ (previous version: ${prev_version})}."
@@ -57,7 +61,7 @@ After the title line, write the release notes:
 5. Include contributor usernames (@username). Do not thank @jdx since that is who is writing these notes.
 6. Skip internal changes
 
-Write your output to the file: /tmp/release-notes-output.md
+Write your output to the file: ${output_file}
 Do not output anything else — just write to the file.
 INSTRUCTIONS
 )
@@ -69,16 +73,10 @@ echo "Version: $version" >&2
 echo "Previous version: ${prev_version:-none}" >&2
 echo "Changelog length: ${#changelog} chars" >&2
 
-output_file="/tmp/release-notes-output.md"
-rm -f "$output_file"
-
-stderr_file=$(mktemp)
-trap 'rm -f "$stderr_file" "$output_file"' EXIT
-
 if ! printf '%s' "$prompt" | claude -p \
 	--model claude-opus-4-6 \
 	--permission-mode bypassPermissions \
-	--allowedTools "Read,Grep,Glob,Write($output_file)" 2>"$stderr_file"; then
+	--allowedTools "Read,Grep,Glob,Write($output_file)" >/dev/null 2>"$stderr_file"; then
 	echo "Error: Claude CLI failed" >&2
 	if [[ -s $stderr_file ]]; then
 		cat "$stderr_file" >&2


### PR DESCRIPTION
## Summary
- Use Claude's `Write` tool to write release notes to a temp file instead of capturing raw stdout with `--output-format text`, eliminating formatting artifacts
- Scope the `Write` tool to only `/tmp/release-notes-output.md` using path restriction
- Upgrade model from `claude-opus-4-5` to `claude-opus-4-6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk shell-script change that only affects the release-notes generation task; main risk is the Claude CLI Write-tool path/permission behavior causing missing output in CI or local runs.
> 
> **Overview**
> Updates `mise-tasks/gen-release-notes` to have Claude write release notes to a temporary markdown file via the `Write($output_file)` tool instead of capturing stdout, then prints the file contents.
> 
> Adds temp file lifecycle/cleanup and validates the output file is non-empty, and bumps the Claude model to `claude-opus-4-6` while simplifying stderr handling to keep stdout clean.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c90666c6e657e08c2575bcc73bc85aec4b04b46. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->