### PR TITLE
docs(shell): remove incorrect `cd .` reload instructions

### DIFF
--- a/docs/guide/profiles.md
+++ b/docs/guide/profiles.md
@@ -58,7 +58,7 @@ export FNOX_PROFILE=production
 cd my-app  # Loads production secrets
 
 export FNOX_PROFILE=staging
-cd .       # Reloads with staging secrets
+# fnox detects the change on the next prompt automatically
 ```
 
 ## Profile Inheritance

--- a/docs/guide/shell-integration.md
+++ b/docs/guide/shell-integration.md
@@ -70,7 +70,7 @@ cd my-app
 
 # Switch to staging
 export FNOX_PROFILE=staging
-cd .  # Reload secrets
+# fnox detects the change on the next prompt automatically
 # fnox: -3 +3 DATABASE_URL, API_KEY, JWT_SECRET (from staging profile)
 ```
 
@@ -95,13 +95,9 @@ When you `cd services/api/`, fnox loads:
 
 ## Manual Reload
 
-Force a reload without changing directories:
+fnox's shell hook runs on every prompt and automatically detects changes to config files and environment variables like `FNOX_PROFILE`. In most cases, no manual reload is needed.
 
-```bash
-cd .
-```
-
-Or temporarily disable and re-enable:
+To force a full reload, temporarily disable and re-enable:
 
 ```bash
 # Disable


### PR DESCRIPTION
## Summary

- Remove `cd .` from docs as a way to reload secrets — it doesn't work since the directory doesn't actually change
- The shell hook runs on every prompt (`precmd`/`PROMPT_COMMAND`/`fish_prompt`) and auto-detects changes to config files and env vars like `FNOX_PROFILE`, so no manual reload is needed
- Update "Manual Reload" section to explain auto-detection and only show the disable/re-enable approach for forcing a full reload

Reported in #241.

## Test plan

- [ ] Verify docs render correctly on the site

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only change that corrects guidance around profile switching/reloading; no runtime behavior is modified.
> 
> **Overview**
> Updates docs to remove the incorrect `cd .` “reload” step when switching `FNOX_PROFILE`, clarifying that the shell hook auto-detects profile/env/config changes on the next prompt.
> 
> Rewrites the *Manual Reload* section in `shell-integration.md` to emphasize that manual reload is usually unnecessary, and documents the supported force-reload approach by temporarily running `fnox deactivate` and re-activating the hook.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 145fec943cdf0d63947cbb413521fdff43268800. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->