### PR TITLE
docs(config): fix env-specific config example in mise integration guide

### DIFF
--- a/docs/guide/mise-integration.md
+++ b/docs/guide/mise-integration.md
@@ -67,19 +67,32 @@ _.fnox-env = { fnox_bin = "/usr/local/bin/fnox" }
 
 ## Environment-Specific Configuration
 
-Combine with mise's environment system for different profiles per environment:
+Combine with [mise's environment system](https://mise.jdx.dev/configuration/environments.html) for different profiles per environment. Mise uses separate config files for each environment:
+
+**`mise.toml`** (default/dev):
 
 ```toml
 [plugins]
 fnox-env = "https://github.com/jdx/mise-env-fnox"
 
+[tools]
+fnox = "latest"
+
 [env]
 _.fnox-env = { tools = true, profile = "dev" }
+```
 
-[env.production]
+**`mise.production.toml`**:
+
+```toml
+[env]
 _.fnox-env = { tools = true, profile = "production" }
+```
 
-[env.staging]
+**`mise.staging.toml`**:
+
+```toml
+[env]
 _.fnox-env = { tools = true, profile = "staging" }
 ```
 


### PR DESCRIPTION
## Summary
- The mise integration docs incorrectly used `[env.production]` sections within a single `mise.toml`, but mise uses separate `mise.{env}.toml` files for environment-specific configuration
- Updated the example to show the correct pattern with separate files

Fixes #266

## Test plan
- [ ] Verify the docs site renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes that adjust configuration examples; no runtime or security-impacting code paths are modified.
> 
> **Overview**
> Corrects the *Environment-Specific Configuration* section in `docs/guide/mise-integration.md` to align with mise’s environment system by using separate `mise.production.toml` / `mise.staging.toml` files instead of inline `[env.production]` sections.
> 
> Also clarifies the narrative with a link to mise docs and updates the examples to include the `fnox` tool declaration in the default `mise.toml` snippet.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d0d32723b1aa6ca94b19d5735d122219e964373a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->