### PR TITLE
fix(config): preserve TOML comments in import and remove

### DIFF
--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -3,6 +3,7 @@ use crate::config::Config;
 use crate::error::{FnoxError, Result};
 use clap::{Args, ValueEnum};
 use console;
+use indexmap::IndexMap;
 use miette::{NamedSource, SourceSpan};
 use regex::Regex;
 use std::io::{self, Read};
@@ -204,48 +205,41 @@ impl ImportCommand {
             cli.config.clone()
         };
 
-        // Load only the target config file (not merged) for modification
-        let mut target_config = if target_path.exists() {
-            Config::load(&target_path)?
-        } else {
-            Config::new()
-        };
+        // Build the secrets to import (encrypt each value)
+        let mut import_secrets = IndexMap::new();
+        let total_secrets = secrets.len();
 
-        // Process and encrypt/store each secret into the target config
-        {
-            let profile_secrets = target_config.get_secrets_mut(&profile);
-            let total_secrets = secrets.len();
+        for (key, value) in secrets {
+            let mut secret_config = crate::config::SecretConfig::default();
 
-            for (key, value) in secrets {
-                let secret_config = profile_secrets.entry(key.clone()).or_default();
+            // Set the provider
+            secret_config.set_provider(Some(self.provider.clone()));
 
-                // Set the provider
-                secret_config.set_provider(Some(self.provider.clone()));
-
-                // Encrypt the value (provider already validated as encryption provider)
-                match provider.encrypt(&value).await {
-                    Ok(encrypted) => {
-                        secret_config.set_value(Some(encrypted));
-                    }
-                    Err(e) => {
-                        return Err(FnoxError::ImportEncryptionFailed {
-                            key: key.clone(),
-                            provider: self.provider.clone(),
-                            details: e.to_string(),
-                        });
-                    }
+            // Encrypt the value (provider already validated as encryption provider)
+            match provider.encrypt(&value).await {
+                Ok(encrypted) => {
+                    secret_config.set_value(Some(encrypted));
+                }
+                Err(e) => {
+                    return Err(FnoxError::ImportEncryptionFailed {
+                        key: key.clone(),
+                        provider: self.provider.clone(),
+                        details: e.to_string(),
+                    });
                 }
             }
 
-            let global_suffix = if self.global { " (global)" } else { "" };
-            println!(
-                "✓ Imported {} secrets into profile '{}' using provider '{}'{}",
-                total_secrets, profile, self.provider, global_suffix
-            );
+            import_secrets.insert(key, secret_config);
         }
 
-        // Save only the target config
-        target_config.save(&target_path)?;
+        // Save secrets directly to the TOML document, preserving comments
+        Config::save_secrets_to_source(&import_secrets, &profile, &target_path)?;
+
+        let global_suffix = if self.global { " (global)" } else { "" };
+        println!(
+            "✓ Imported {} secrets into profile '{}' using provider '{}'{}",
+            total_secrets, profile, self.provider, global_suffix
+        );
 
         Ok(())
     }

--- a/src/commands/remove.rs
+++ b/src/commands/remove.rs
@@ -40,49 +40,48 @@ impl RemoveCommand {
             });
         }
 
-        let mut config = Config::load(&target_path)?;
+        // Check the secret exists before attempting removal
+        let config = Config::load(&target_path)?;
+        let profile_secrets = config.get_secrets(&profile)?;
 
-        // Get the profile secrets
-        let profile_secrets = config.get_secrets_mut(&profile);
-
-        if profile_secrets.contains_key(&self.key) {
-            if self.dry_run {
-                let dry_run_label = console::style("[dry-run]").yellow().bold();
-                let styled_key = console::style(&self.key).cyan();
-                let styled_profile = console::style(&profile).magenta();
-                let styled_path = console::style(target_path.display()).dim();
-                let global_suffix = if self.global { " (global)" } else { "" };
-                if profile == "default" {
-                    println!(
-                        "{dry_run_label} Would remove secret {styled_key}{global_suffix} from {styled_path}"
-                    );
-                } else {
-                    println!(
-                        "{dry_run_label} Would remove secret {styled_key} from profile {styled_profile}{global_suffix} from {styled_path}"
-                    );
-                }
-            } else {
-                profile_secrets.shift_remove(&self.key);
-                config.save(&target_path)?;
-                let check = console::style("✓").green();
-                let styled_key = console::style(&self.key).cyan();
-                let styled_profile = console::style(&profile).magenta();
-                let global_suffix = if self.global { " (global)" } else { "" };
-                if profile == "default" {
-                    println!("{check} Removed secret {styled_key}{global_suffix}");
-                } else {
-                    println!(
-                        "{check} Removed secret {styled_key} from profile {styled_profile}{global_suffix}"
-                    );
-                }
-            }
-        } else {
+        if !profile_secrets.contains_key(&self.key) {
             return Err(FnoxError::SecretNotFound {
                 key: self.key.clone(),
                 profile: profile.to_string(),
                 config_path: Some(target_path),
                 suggestion: None,
             });
+        }
+
+        if self.dry_run {
+            let dry_run_label = console::style("[dry-run]").yellow().bold();
+            let styled_key = console::style(&self.key).cyan();
+            let styled_profile = console::style(&profile).magenta();
+            let styled_path = console::style(target_path.display()).dim();
+            let global_suffix = if self.global { " (global)" } else { "" };
+            if profile == "default" {
+                println!(
+                    "{dry_run_label} Would remove secret {styled_key}{global_suffix} from {styled_path}"
+                );
+            } else {
+                println!(
+                    "{dry_run_label} Would remove secret {styled_key} from profile {styled_profile}{global_suffix} from {styled_path}"
+                );
+            }
+        } else {
+            // Remove secret directly from the TOML document, preserving comments
+            Config::remove_secret_from_source(&self.key, &profile, &target_path)?;
+            let check = console::style("✓").green();
+            let styled_key = console::style(&self.key).cyan();
+            let styled_profile = console::style(&profile).magenta();
+            let global_suffix = if self.global { " (global)" } else { "" };
+            if profile == "default" {
+                println!("{check} Removed secret {styled_key}{global_suffix}");
+            } else {
+                println!(
+                    "{check} Removed secret {styled_key} from profile {styled_profile}{global_suffix}"
+                );
+            }
         }
 
         Ok(())

--- a/src/commands/remove.rs
+++ b/src/commands/remove.rs
@@ -70,7 +70,15 @@ impl RemoveCommand {
             }
         } else {
             // Remove secret directly from the TOML document, preserving comments
-            Config::remove_secret_from_source(&self.key, &profile, &target_path)?;
+            let removed = Config::remove_secret_from_source(&self.key, &profile, &target_path)?;
+            if !removed {
+                return Err(FnoxError::SecretNotFound {
+                    key: self.key.clone(),
+                    profile: profile.to_string(),
+                    config_path: Some(target_path),
+                    suggestion: None,
+                });
+            }
             let check = console::style("✓").green();
             let styled_key = console::style(&self.key).cyan();
             let styled_profile = console::style(&profile).magenta();

--- a/src/config.rs
+++ b/src/config.rs
@@ -592,6 +592,119 @@ impl Config {
         Ok(())
     }
 
+    /// Remove a single secret from a config file, preserving comments and formatting.
+    ///
+    /// This method directly manipulates the TOML document AST rather than
+    /// re-serializing, so all comments, whitespace, and formatting are preserved.
+    pub fn remove_secret_from_source(
+        secret_name: &str,
+        profile: &str,
+        target_file: &Path,
+    ) -> Result<bool> {
+        use toml_edit::DocumentMut;
+
+        let content =
+            fs::read_to_string(target_file).map_err(|source| FnoxError::ConfigReadFailed {
+                path: target_file.to_path_buf(),
+                source,
+            })?;
+        let mut doc = content
+            .parse::<DocumentMut>()
+            .map_err(|e| FnoxError::Config(format!("Failed to parse TOML: {}", e)))?;
+
+        // Navigate to the secrets table
+        let removed = if profile == "default" {
+            doc.get_mut("secrets")
+                .and_then(|s| s.as_table_mut())
+                .map(|t| t.remove(secret_name).is_some())
+                .unwrap_or(false)
+        } else {
+            doc.get_mut("profiles")
+                .and_then(|p| p.as_table_mut())
+                .and_then(|p| p.get_mut(profile))
+                .and_then(|p| p.as_table_mut())
+                .and_then(|p| p.get_mut("secrets"))
+                .and_then(|s| s.as_table_mut())
+                .map(|t| t.remove(secret_name).is_some())
+                .unwrap_or(false)
+        };
+
+        if removed {
+            fs::write(target_file, doc.to_string()).map_err(|source| {
+                FnoxError::ConfigWriteFailed {
+                    path: target_file.to_path_buf(),
+                    source,
+                }
+            })?;
+        }
+
+        Ok(removed)
+    }
+
+    /// Save multiple secrets to a config file, preserving comments and formatting.
+    ///
+    /// This is the batch equivalent of `save_secret_to_source`, used by `fnox import`.
+    pub fn save_secrets_to_source(
+        secrets: &IndexMap<String, SecretConfig>,
+        profile: &str,
+        target_file: &Path,
+    ) -> Result<()> {
+        use toml_edit::{DocumentMut, Item, Value};
+
+        // Load existing document or create new one (preserves comments)
+        let mut doc = if target_file.exists() {
+            let content =
+                fs::read_to_string(target_file).map_err(|source| FnoxError::ConfigReadFailed {
+                    path: target_file.to_path_buf(),
+                    source,
+                })?;
+            content
+                .parse::<DocumentMut>()
+                .map_err(|e| FnoxError::Config(format!("Failed to parse TOML: {}", e)))?
+        } else {
+            DocumentMut::new()
+        };
+
+        // Get or create the secrets table
+        let secrets_table = if profile == "default" {
+            if doc.get("secrets").is_none() {
+                doc["secrets"] = Item::Table(toml_edit::Table::new());
+            }
+            doc["secrets"].as_table_mut().unwrap()
+        } else {
+            if doc.get("profiles").is_none() {
+                doc["profiles"] = Item::Table(toml_edit::Table::new());
+            }
+            let profiles = doc["profiles"].as_table_mut().unwrap();
+            if profiles.get(profile).is_none() {
+                profiles[profile] = Item::Table(toml_edit::Table::new());
+            }
+            let profile_table = profiles[profile].as_table_mut().unwrap();
+            if profile_table.get("secrets").is_none() {
+                profile_table["secrets"] = Item::Table(toml_edit::Table::new());
+            }
+            profile_table["secrets"].as_table_mut().unwrap()
+        };
+
+        // Insert each secret as an inline table
+        for (name, config) in secrets {
+            let inline = config.to_inline_table();
+            secrets_table[name.as_str()] = Item::Value(Value::InlineTable(inline));
+
+            if let Some(mut key) = secrets_table.key_mut(name.as_str()) {
+                key.leaf_decor_mut().set_suffix("");
+            }
+        }
+
+        // Write back (preserves all comments and formatting)
+        fs::write(target_file, doc.to_string()).map_err(|source| FnoxError::ConfigWriteFailed {
+            path: target_file.to_path_buf(),
+            source,
+        })?;
+
+        Ok(())
+    }
+
     /// Create a new default configuration
     pub fn new() -> Self {
         Self {

--- a/src/config.rs
+++ b/src/config.rs
@@ -544,9 +544,13 @@ impl Config {
                     path: target_file.clone(),
                     source,
                 })?;
-            content
-                .parse::<DocumentMut>()
-                .map_err(|e| FnoxError::Config(format!("Failed to parse TOML: {}", e)))?
+            content.parse::<DocumentMut>().map_err(|e| {
+                FnoxError::Config(format!(
+                    "Failed to parse TOML in {}: {}",
+                    target_file.display(),
+                    e
+                ))
+            })?
         } else {
             DocumentMut::new()
         };
@@ -608,9 +612,13 @@ impl Config {
                 path: target_file.to_path_buf(),
                 source,
             })?;
-        let mut doc = content
-            .parse::<DocumentMut>()
-            .map_err(|e| FnoxError::Config(format!("Failed to parse TOML: {}", e)))?;
+        let mut doc = content.parse::<DocumentMut>().map_err(|e| {
+            FnoxError::Config(format!(
+                "Failed to parse TOML in {}: {}",
+                target_file.display(),
+                e
+            ))
+        })?;
 
         // Navigate to the secrets table
         let removed = if profile == "default" {
@@ -658,9 +666,13 @@ impl Config {
                     path: target_file.to_path_buf(),
                     source,
                 })?;
-            content
-                .parse::<DocumentMut>()
-                .map_err(|e| FnoxError::Config(format!("Failed to parse TOML: {}", e)))?
+            content.parse::<DocumentMut>().map_err(|e| {
+                FnoxError::Config(format!(
+                    "Failed to parse TOML in {}: {}",
+                    target_file.display(),
+                    e
+                ))
+            })?
         } else {
             DocumentMut::new()
         };

--- a/test/comment-preservation.bats
+++ b/test/comment-preservation.bats
@@ -1,0 +1,173 @@
+#!/usr/bin/env bats
+
+load 'test_helper/common_setup'
+
+# Test that fnox import and fnox remove preserve TOML comments
+
+setup() {
+	_common_setup
+}
+
+teardown() {
+	_common_teardown
+}
+
+# Helper function to setup age provider with comments in config
+setup_age_with_comments() {
+	if ! command -v age-keygen >/dev/null 2>&1; then
+		skip "age-keygen not installed"
+	fi
+
+	# Generate age key
+	local keygen_output
+	keygen_output=$(age-keygen -o key.txt 2>&1)
+	local public_key
+	public_key=$(echo "$keygen_output" | grep "^Public key:" | cut -d' ' -f3)
+
+	# Create config with comments throughout
+	cat >fnox.toml <<EOF
+# Main configuration file for the project
+root = true
+
+# Age encryption provider
+[providers.age]
+type = "age"
+recipients = ["$public_key"]
+
+# Application secrets
+[secrets]
+# Database connection string
+DB_URL= { provider = "age", value = "plaintext-db-url" }
+# API key for external service
+API_KEY= { provider = "age", value = "plaintext-api-key" }
+# End of secrets section
+EOF
+}
+
+@test "fnox remove preserves comments in fnox.toml" {
+	setup_age_with_comments
+
+	# Remove one secret
+	assert_fnox_success remove API_KEY
+
+	# Verify all comments are preserved
+	run cat fnox.toml
+	assert_output --partial "# Main configuration file for the project"
+	assert_output --partial "# Age encryption provider"
+	assert_output --partial "# Application secrets"
+	assert_output --partial "# Database connection string"
+	assert_output --partial "# End of secrets section"
+
+	# Verify the removed secret is gone
+	refute_output --partial "API_KEY"
+
+	# Verify the remaining secret is still there
+	assert_output --partial "DB_URL"
+}
+
+@test "fnox remove preserves comments when removing last secret" {
+	setup_age_with_comments
+
+	# Remove both secrets
+	assert_fnox_success remove DB_URL
+	assert_fnox_success remove API_KEY
+
+	# Verify comments are still preserved
+	run cat fnox.toml
+	assert_output --partial "# Main configuration file for the project"
+	assert_output --partial "# Age encryption provider"
+	assert_output --partial "# Application secrets"
+}
+
+@test "fnox import preserves existing comments in fnox.toml" {
+	setup_age_with_comments
+
+	# Create a .env file with new secrets to import
+	cat >.env <<EOF
+NEW_SECRET=new-secret-value
+ANOTHER_SECRET=another-value
+EOF
+
+	# Import new secrets
+	assert_fnox_success import -i .env --provider age --force
+
+	# Verify all original comments are preserved
+	run cat fnox.toml
+	assert_output --partial "# Main configuration file for the project"
+	assert_output --partial "# Age encryption provider"
+	assert_output --partial "# Application secrets"
+	assert_output --partial "# Database connection string"
+	assert_output --partial "# API key for external service"
+	assert_output --partial "# End of secrets section"
+
+	# Verify new secrets were added
+	assert_output --partial "NEW_SECRET"
+	assert_output --partial "ANOTHER_SECRET"
+
+	# Verify existing secrets are still there
+	assert_output --partial "DB_URL"
+	assert_output --partial "API_KEY"
+}
+
+@test "fnox import preserves comments when config file has no existing secrets" {
+	if ! command -v age-keygen >/dev/null 2>&1; then
+		skip "age-keygen not installed"
+	fi
+
+	local keygen_output
+	keygen_output=$(age-keygen -o key.txt 2>&1)
+	local public_key
+	public_key=$(echo "$keygen_output" | grep "^Public key:" | cut -d' ' -f3)
+
+	# Create config with comments but no secrets section
+	cat >fnox.toml <<EOF
+# Project config
+root = true
+
+# Encryption provider
+[providers.age]
+type = "age"
+recipients = ["$public_key"]
+EOF
+
+	cat >.env <<EOF
+MY_SECRET=my-value
+EOF
+
+	assert_fnox_success import -i .env --provider age --force
+
+	# Verify comments preserved
+	run cat fnox.toml
+	assert_output --partial "# Project config"
+	assert_output --partial "# Encryption provider"
+	assert_output --partial "MY_SECRET"
+}
+
+@test "fnox import followed by remove preserves comments" {
+	setup_age_with_comments
+
+	# Import a new secret
+	cat >.env <<EOF
+TEMP_SECRET=temp-value
+EOF
+	assert_fnox_success import -i .env --provider age --force
+
+	# Then remove it
+	assert_fnox_success remove TEMP_SECRET
+
+	# All original comments should still be there
+	run cat fnox.toml
+	assert_output --partial "# Main configuration file for the project"
+	assert_output --partial "# Age encryption provider"
+	assert_output --partial "# Application secrets"
+	assert_output --partial "# Database connection string"
+	assert_output --partial "# API key for external service"
+	assert_output --partial "# End of secrets section"
+
+	# Original secrets should still be there
+	assert_output --partial "DB_URL"
+	assert_output --partial "API_KEY"
+
+	# Temp secret should be gone
+	refute_output --partial "TEMP_SECRET"
+}


### PR DESCRIPTION
## Summary

Fixes #135

- `fnox import` and `fnox remove` were using `Config::save()` which re-serializes from the Rust struct, destroying all TOML comments and custom formatting
- Both commands now use `DocumentMut`-based methods that surgically modify only the relevant entries, preserving all comments, whitespace, and formatting
- Adds `Config::remove_secret_from_source()` and `Config::save_secrets_to_source()` following the same pattern as the existing `save_secret_to_source()` (used by `fnox set`)

All commands that modify `fnox.toml` now preserve comments:
| Command | Status |
|---------|--------|
| `fnox set` | Already preserved (since #223) |
| `fnox edit` | Already preserved |
| `fnox import` | **Fixed in this PR** |
| `fnox remove` | **Fixed in this PR** |

## Test plan

- [x] New `test/comment-preservation.bats` with 5 tests covering:
  - `fnox remove` preserves comments
  - `fnox remove` preserves comments when removing last secret
  - `fnox import` preserves existing comments
  - `fnox import` preserves comments with no existing secrets section
  - `fnox import` followed by `fnox remove` preserves comments
- [x] All existing `test/import.bats` tests pass (18/18)
- [x] All existing `test/toml-formatting.bats` tests pass (5/5)
- [x] `cargo test` passes (67/68 — 1 pre-existing keychain test failure unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `fnox import` and `fnox remove` write to config files by editing the TOML AST instead of re-serializing, which could impact correctness of updates/removals or produce unexpected TOML if edge cases are missed. Scope is limited to config mutation paths and is covered by new comment-preservation tests.
> 
> **Overview**
> **Preserves `fnox.toml` comments/formatting when modifying secrets.** `fnox import` now encrypts values then writes secrets via a new `Config::save_secrets_to_source` TOML-AST update path (instead of `Config::save()`), while preserving existing secret metadata on re-import.
> 
> `fnox remove` now validates existence up front and deletes secrets via new `Config::remove_secret_from_source`, updating the file in-place without destroying comments.
> 
> Adds `test/comment-preservation.bats` to assert comment retention across import/remove scenarios (including last-secret removal and files without an existing `[secrets]` section).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b65b3aaeccc0061405b1e845c3a49ced64dc161c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->