### PR TITLE
fix(release): make release notes editorialization non-blocking

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,7 @@ jobs:
       - name: Install Claude Code CLI
         run: npm install -g @anthropic-ai/claude-code
       - name: Generate release notes
+        continue-on-error: true
         run: |
           if [[ -n "${{ inputs.version }}" ]]; then
             TAG_NAME="v${{ inputs.version }}"
@@ -96,20 +97,14 @@ jobs:
             TAG_NAME="${{ github.ref_name }}"
           fi
           PREV_TAG="$(git describe --tags --abbrev=0 "$TAG_NAME^" 2>/dev/null || echo "")"
+
           # Generate rich release notes using LLM
-          # Output format: "# vX.X.X - Creative Title" followed by release notes
           if [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
-            # Only process output if command succeeds - prevents partial output from overwriting fallback
-            if mise run gen-release-notes "$TAG_NAME" "$PREV_TAG" > /tmp/release-raw.txt 2>&1; then
-              # Strip any preamble before the "# vX.X.X -" line
-              sed -n '/^# v[0-9]/,$p' /tmp/release-raw.txt > /tmp/release-full.txt
-              if [[ -s /tmp/release-full.txt ]]; then
-                # Extract title from first line (format: "# vX.X.X - Creative Title")
-                RELEASE_TITLE="$(head -1 /tmp/release-full.txt | sed 's/^# //')"
-                echo "$RELEASE_TITLE" > /tmp/release-title.txt
-                # Body is everything after the first line
-                tail -n +2 /tmp/release-full.txt > release-notes.md
-              fi
+            OUTPUT_DIR=$(mktemp -d)
+            if mise run gen-release-notes "$TAG_NAME" "$OUTPUT_DIR" "$PREV_TAG"; then
+              RELEASE_TITLE="$(cat "$OUTPUT_DIR/title")"
+              cp "$OUTPUT_DIR/notes" release-notes.md
+              echo "$RELEASE_TITLE" > /tmp/release-title.txt
             fi
             # Fallback if LLM generation failed or output was invalid
             if [[ ! -s release-notes.md ]]; then

--- a/mise-tasks/gen-release-notes
+++ b/mise-tasks/gen-release-notes
@@ -19,7 +19,7 @@ else
 fi
 
 if [[ -z $changelog ]]; then
-	echo "Error: No changes found for release"
+	echo "Error: No changes found for release" >&2
 	exit 1
 fi
 
@@ -58,10 +58,10 @@ INSTRUCTIONS
 )
 
 # Use Claude Code to generate the release notes
-echo "Generating release notes with Claude..."
-echo "Version: $version"
-echo "Previous version: ${prev_version:-none}"
-echo "Changelog length: ${#changelog} chars"
+echo "Generating release notes with Claude..." >&2
+echo "Version: $version" >&2
+echo "Previous version: ${prev_version:-none}" >&2
+echo "Changelog length: ${#changelog} chars" >&2
 
 if ! output=$(
 	printf '%s' "$prompt" | claude -p \
@@ -70,32 +70,32 @@ if ! output=$(
 		--output-format text \
 		--allowedTools "Read,Grep,Glob"
 ); then
-	echo "Error: Claude CLI failed"
+	echo "Error: Claude CLI failed" >&2
 	exit 1
 fi
 
 # Validate we got non-empty output
 if [[ -z $output ]]; then
-	echo "Error: Claude returned empty output"
+	echo "Error: Claude returned empty output" >&2
 	exit 1
 fi
 
 # Strip any preamble before the "# vX.X.X -" line
-output=$(echo "$output" | sed -n '/^# v[0-9]/,$p')
+output=$(printf '%s\n' "$output" | sed -n '/^# v[0-9]/,$p')
 
 if [[ -z $output ]]; then
-	echo "Error: No '# vX.X.X -' line found in Claude output"
+	echo "Error: No '# vX.X.X -' line found in Claude output" >&2
 	exit 1
 fi
 
-echo "Raw output:"
-echo "$output"
+echo "Raw output:" >&2
+printf '%s\n' "$output" >&2
 
 # Extract title from first line (format: "# vX.X.X - Creative Title")
-title=$(echo "$output" | head -1 | sed 's/^# //')
-body=$(echo "$output" | tail -n +2)
+title=$(printf '%s\n' "$output" | head -1 | sed 's/^# //')
+body=$(printf '%s\n' "$output" | tail -n +2)
 
 # Write parsed results to output directory
-echo "$title" >"$output_dir/title"
-echo "$body" >"$output_dir/notes"
+printf '%s\n' "$title" >"$output_dir/title"
+printf '%s\n' "$body" >"$output_dir/notes"
 echo "Wrote title and notes to $output_dir"

--- a/mise-tasks/gen-release-notes
+++ b/mise-tasks/gen-release-notes
@@ -1,19 +1,17 @@
 #!/usr/bin/env bash
+#MISE description="Generate editorialized release notes with Claude Code"
+#USAGE arg "<version>" help="Git tag/version to generate notes for"
+#USAGE arg "<output_dir>" help="Directory to write title and notes files"
+#USAGE arg "[prev_version]" help="Previous version"
 set -euo pipefail
 
-# Generate rich release notes for GitHub releases using Claude Code
-# Usage: mise run gen-release-notes <version> [prev_version]
+version="${usage_version}"
+output_dir="${usage_output_dir}"
+prev_version="${usage_prev_version:-}"
 
-version="${1:-}"
-prev_version="${2:-}"
-
-if [[ -z $version ]]; then
-	echo "Usage: mise run gen-release-notes <version> [prev_version]" >&2
-	exit 1
-fi
+mkdir -p "$output_dir"
 
 # Get the git-cliff changelog for context
-# Use the tag range if prev_version provided, otherwise unreleased
 if [[ -n $prev_version ]]; then
 	changelog=$(git cliff --strip all "${prev_version}..${version}" 2>/dev/null || echo "")
 else
@@ -21,13 +19,9 @@ else
 fi
 
 if [[ -z $changelog ]]; then
-	echo "Error: No changes found for release" >&2
+	echo "Error: No changes found for release"
 	exit 1
 fi
-
-output_file=$(mktemp /tmp/release-notes-XXXXXX.md)
-stderr_file=$(mktemp)
-trap 'rm -f "$stderr_file" "$output_file"' EXIT
 
 # Build prompt safely using printf to avoid command substitution on backticks in changelog
 prompt=$(
@@ -60,38 +54,48 @@ After the title line, write the release notes:
 4. Include PR links and documentation links (https://fnox.jdx.dev/)
 5. Include contributor usernames (@username). Do not thank @jdx since that is who is writing these notes.
 6. Skip internal changes
-
-Write your output to the file: ${output_file}
-Do not output anything else — just write to the file.
 INSTRUCTIONS
 )
 
 # Use Claude Code to generate the release notes
-# Claude writes to a temp file via the Write tool to avoid formatting artifacts from stdout
-echo "Generating release notes with Claude..." >&2
-echo "Version: $version" >&2
-echo "Previous version: ${prev_version:-none}" >&2
-echo "Changelog length: ${#changelog} chars" >&2
+echo "Generating release notes with Claude..."
+echo "Version: $version"
+echo "Previous version: ${prev_version:-none}"
+echo "Changelog length: ${#changelog} chars"
 
-if ! printf '%s' "$prompt" | claude -p \
-	--model claude-opus-4-6 \
-	--permission-mode bypassPermissions \
-	--allowedTools "Read,Grep,Glob,Write($output_file)" >/dev/null 2>"$stderr_file"; then
-	echo "Error: Claude CLI failed" >&2
-	if [[ -s $stderr_file ]]; then
-		cat "$stderr_file" >&2
-	else
-		echo "(no stderr output from Claude CLI)" >&2
-	fi
+if ! output=$(
+	printf '%s' "$prompt" | claude -p \
+		--model claude-opus-4-6 \
+		--permission-mode bypassPermissions \
+		--output-format text \
+		--allowedTools "Read,Grep,Glob"
+); then
+	echo "Error: Claude CLI failed"
 	exit 1
 fi
 
-# Validate the output file was created and is non-empty
-if [[ ! -s $output_file ]]; then
-	echo "Error: Claude did not write release notes to $output_file" >&2
-	cat "$stderr_file" >&2
+# Validate we got non-empty output
+if [[ -z $output ]]; then
+	echo "Error: Claude returned empty output"
 	exit 1
 fi
 
-output=$(cat "$output_file")
+# Strip any preamble before the "# vX.X.X -" line
+output=$(echo "$output" | sed -n '/^# v[0-9]/,$p')
+
+if [[ -z $output ]]; then
+	echo "Error: No '# vX.X.X -' line found in Claude output"
+	exit 1
+fi
+
+echo "Raw output:"
 echo "$output"
+
+# Extract title from first line (format: "# vX.X.X - Creative Title")
+title=$(echo "$output" | head -1 | sed 's/^# //')
+body=$(echo "$output" | tail -n +2)
+
+# Write parsed results to output directory
+echo "$title" >"$output_dir/title"
+echo "$body" >"$output_dir/notes"
+echo "Wrote title and notes to $output_dir"


### PR DESCRIPTION
## Summary
- Script writes parsed title/notes to an output directory instead of stdout for better CI log visibility
- Claude's stdout/stderr flows through naturally instead of being suppressed
- Add `continue-on-error` so failures don't block releases

## Test plan
- [ ] Trigger a release and verify the editorialize step logs are visible
- [ ] If Claude produces bad output, the release still succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change: adjusts the release workflow and a helper script, with the main impact being potentially degraded release-note content if Claude output parsing fails (it falls back to `CHANGELOG.md`).
> 
> **Overview**
> Makes LLM-based release note generation **best-effort** by marking the GitHub Actions “Generate release notes” step as `continue-on-error` and keeping the release creation unblocked via fallback to `CHANGELOG.md`.
> 
> Refactors `mise-tasks/gen-release-notes` to take an explicit `output_dir`, capture Claude output from stdout (instead of using the `Write` tool), validate/strip preamble to the `# vX.Y.Z - …` header, and write parsed `title` and `notes` files that the workflow then consumes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 04643abc5244dc258cd4e48fd80a696a5edaadee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->