### PR TITLE
feat: Add AWS Profile support for AWS PS and Secrets Manager in provider config

### DIFF
--- a/docs/providers/aws-ps.md
+++ b/docs/providers/aws-ps.md
@@ -124,8 +124,19 @@ If running on EC2, ECS, Lambda, or other AWS services:
 
 ```toml
 [providers]
-ps = { type = "aws-ps", region = "us-east-1", prefix = "/myapp/prod/" }  # prefix is optional
+ps = { type = "aws-ps", region = "us-east-1" }  # minimal config
+
+# With optional fields:
+ps = { type = "aws-ps", region = "us-east-1", profile = "my-aws-profile", prefix = "/myapp/prod/" }
 ```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `region` | Yes | AWS region (e.g. `us-east-1`) |
+| `profile` | No | AWS CLI profile name from `~/.aws/config`. Falls back to the default credential chain if omitted. |
+| `prefix` | No | Prepended to all parameter names |
+
+The `profile` field is useful when you have multiple AWS accounts or roles configured and want to pin a provider to a specific one without relying on `AWS_PROFILE` in the environment.
 
 ## Creating Parameters
 
@@ -273,9 +284,9 @@ ps = { type = "aws-ps", region = "us-east-1", prefix = "/myapp/staging/" }
 [profiles.staging.secrets]
 DATABASE_URL = { provider = "ps", value = "database/url" }
 
-# Production: AWS Parameter Store
+# Production: AWS Parameter Store using a dedicated AWS profile
 [profiles.production.providers]
-ps = { type = "aws-ps", region = "us-east-1", prefix = "/myapp/prod/" }
+ps = { type = "aws-ps", region = "us-east-1", profile = "prod-account", prefix = "/myapp/prod/" }
 
 [profiles.production.secrets]
 DATABASE_URL = { provider = "ps", value = "database/url" }

--- a/docs/providers/aws-ps.md
+++ b/docs/providers/aws-ps.md
@@ -130,11 +130,11 @@ ps = { type = "aws-ps", region = "us-east-1" }  # minimal config
 ps = { type = "aws-ps", region = "us-east-1", profile = "my-aws-profile", prefix = "/myapp/prod/" }
 ```
 
-| Field | Required | Description |
-|-------|----------|-------------|
-| `region` | Yes | AWS region (e.g. `us-east-1`) |
-| `profile` | No | AWS CLI profile name from `~/.aws/config`. Falls back to the default credential chain if omitted. |
-| `prefix` | No | Prepended to all parameter names |
+| Field     | Required | Description                                                                                       |
+| --------- | -------- | ------------------------------------------------------------------------------------------------- |
+| `region`  | Yes      | AWS region (e.g. `us-east-1`)                                                                     |
+| `profile` | No       | AWS CLI profile name from `~/.aws/config`. Falls back to the default credential chain if omitted. |
+| `prefix`  | No       | Prepended to all parameter names                                                                  |
 
 The `profile` field is useful when you have multiple AWS accounts or roles configured and want to pin a provider to a specific one without relying on `AWS_PROFILE` in the environment.
 

--- a/docs/providers/aws-sm.md
+++ b/docs/providers/aws-sm.md
@@ -134,11 +134,11 @@ aws = { type = "aws-sm", region = "us-east-1" }  # minimal config
 aws = { type = "aws-sm", region = "us-east-1", profile = "my-aws-profile", prefix = "myapp/" }
 ```
 
-| Field | Required | Description |
-|-------|----------|-------------|
-| `region` | Yes | AWS region (e.g. `us-east-1`) |
-| `profile` | No | AWS CLI profile name from `~/.aws/config`. Falls back to the default credential chain if omitted. |
-| `prefix` | No | Prepended to all secret names |
+| Field     | Required | Description                                                                                       |
+| --------- | -------- | ------------------------------------------------------------------------------------------------- |
+| `region`  | Yes      | AWS region (e.g. `us-east-1`)                                                                     |
+| `profile` | No       | AWS CLI profile name from `~/.aws/config`. Falls back to the default credential chain if omitted. |
+| `prefix`  | No       | Prepended to all secret names                                                                     |
 
 The `profile` field is useful when you have multiple AWS accounts or roles configured and want to pin a provider to a specific one without relying on `AWS_PROFILE` in the environment.
 

--- a/docs/providers/aws-sm.md
+++ b/docs/providers/aws-sm.md
@@ -128,8 +128,19 @@ If running on EC2, ECS, Lambda, or other AWS services:
 
 ```toml
 [providers]
-aws = { type = "aws-sm", region = "us-east-1", prefix = "myapp/" }  # prefix is optional
+aws = { type = "aws-sm", region = "us-east-1" }  # minimal config
+
+# With optional fields:
+aws = { type = "aws-sm", region = "us-east-1", profile = "my-aws-profile", prefix = "myapp/" }
 ```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `region` | Yes | AWS region (e.g. `us-east-1`) |
+| `profile` | No | AWS CLI profile name from `~/.aws/config`. Falls back to the default credential chain if omitted. |
+| `prefix` | No | Prepended to all secret names |
+
+The `profile` field is useful when you have multiple AWS accounts or roles configured and want to pin a provider to a specific one without relying on `AWS_PROFILE` in the environment.
 
 ## Creating Secrets
 
@@ -236,9 +247,9 @@ aws = { type = "aws-sm", region = "us-east-1", prefix = "myapp-staging/" }
 [profiles.staging.secrets]
 DATABASE_URL = { provider = "aws", value = "database-url" }  # → myapp-staging/database-url
 
-# Production: AWS Secrets Manager (us-west-2)
+# Production: AWS Secrets Manager (us-west-2) using a dedicated AWS profile
 [profiles.production.providers]
-aws = { type = "aws-sm", region = "us-west-2", prefix = "myapp-prod/" }
+aws = { type = "aws-sm", region = "us-west-2", profile = "prod-account", prefix = "myapp-prod/" }
 
 [profiles.production.secrets]
 DATABASE_URL = { provider = "aws", value = "database-url" }  # → myapp-prod/database-url

--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -348,6 +348,9 @@
             "prefix": {
               "$ref": "#/$defs/OptionStringOrSecretRef"
             },
+            "profile": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
             "region": {
               "$ref": "#/$defs/StringOrSecretRef"
             },
@@ -437,6 +440,9 @@
           "type": "object",
           "properties": {
             "prefix": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "profile": {
               "$ref": "#/$defs/OptionStringOrSecretRef"
             },
             "region": {

--- a/providers/aws-ps.toml
+++ b/providers/aws-ps.toml
@@ -16,6 +16,12 @@ placeholder = "us-east-1"
 label = "AWS Region:"
 wizard = true
 
+[fields.profile]
+type = "optional"
+placeholder = "my-aws-profile"
+label = "AWS profile (optional):"
+wizard = true
+
 [fields.prefix]
 type = "optional"
 placeholder = "/myapp/prod/"

--- a/providers/aws-sm.toml
+++ b/providers/aws-sm.toml
@@ -16,6 +16,12 @@ placeholder = "us-east-1"
 label = "AWS Region:"
 wizard = true
 
+[fields.profile]
+type = "optional"
+placeholder = "my-aws-profile"
+label = "AWS profile (optional):"
+wizard = true
+
 [fields.prefix]
 type = "optional"
 placeholder = "fnox/"

--- a/src/commands/provider/add.rs
+++ b/src/commands/provider/add.rs
@@ -73,6 +73,7 @@ impl AddCommand {
             },
             ProviderType::Aws => crate::config::ProviderConfig::AwsSecretsManager {
                 region: StringOrSecretRef::from("us-east-1"),
+                profile: OptionStringOrSecretRef::none(),
                 prefix: OptionStringOrSecretRef::none(),
             },
             ProviderType::Vault => crate::config::ProviderConfig::HashiCorpVault {
@@ -91,6 +92,7 @@ impl AddCommand {
             },
             ProviderType::AwsParameterStore => crate::config::ProviderConfig::AwsParameterStore {
                 region: StringOrSecretRef::from("us-east-1"),
+                profile: OptionStringOrSecretRef::none(),
                 prefix: OptionStringOrSecretRef::literal("/myapp/prod/"),
             },
             ProviderType::AzureKms => crate::config::ProviderConfig::AzureKms {

--- a/src/providers/aws_ps.rs
+++ b/src/providers/aws_ps.rs
@@ -145,7 +145,7 @@ impl AwsParameterStoreProvider {
             .region(aws_sdk_ssm::config::Region::new(self.region.clone()));
 
         if let Some(profile) = &self.profile {
-            builder = builder.profile_name(profile.clone());
+            builder = builder.profile_name(profile);
         }
 
         let config = builder.load().await;

--- a/src/providers/aws_sm.rs
+++ b/src/providers/aws_sm.rs
@@ -174,7 +174,7 @@ impl AwsSecretsManagerProvider {
         );
 
         if let Some(profile) = &self.profile {
-            builder = builder.profile_name(profile.clone());
+            builder = builder.profile_name(profile);
         }
 
         let config = builder.load().await;

--- a/src/providers/aws_sm.rs
+++ b/src/providers/aws_sm.rs
@@ -147,12 +147,17 @@ fn extract_name_from_arn(arn_or_name: &str) -> String {
 
 pub struct AwsSecretsManagerProvider {
     region: String,
+    profile: Option<String>,
     prefix: Option<String>,
 }
 
 impl AwsSecretsManagerProvider {
-    pub fn new(region: String, prefix: Option<String>) -> Self {
-        Self { region, prefix }
+    pub fn new(region: String, profile: Option<String>, prefix: Option<String>) -> Self {
+        Self {
+            region,
+            profile,
+            prefix,
+        }
     }
 
     pub fn get_secret_name(&self, key: &str) -> String {
@@ -164,14 +169,15 @@ impl AwsSecretsManagerProvider {
 
     /// Create an AWS Secrets Manager client
     async fn create_client(&self) -> Result<Client> {
-        // Load AWS config with the specified region
-        let config = aws_config::defaults(BehaviorVersion::latest())
-            .region(aws_sdk_secretsmanager::config::Region::new(
-                self.region.clone(),
-            ))
-            .load()
-            .await;
+        let mut builder = aws_config::defaults(BehaviorVersion::latest()).region(
+            aws_sdk_secretsmanager::config::Region::new(self.region.clone()),
+        );
 
+        if let Some(profile) = &self.profile {
+            builder = builder.profile_name(profile.clone());
+        }
+
+        let config = builder.load().await;
         Ok(Client::new(&config))
     }
 


### PR DESCRIPTION
## WHY
So that you can define the desired AWS Profile in your provider configuration, rather than depending on a potentially changing `AWS_PROFILE` variable. 

This can be helpful where you potentially have a lot of different accounts or profiles and need to ensure that certain repositories always fetch parameters/secrets from the correct profile. 

## WHAT
* Updates provider  AWS Parameter Store to support new attribute `profile`
* Updates provider AWS Secrets Manager to support new attribute `profile` 