### PR TITLE
feat(proton-pass): add Proton Pass provider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Format: `<type>(<scope>): <description>` (lowercase, imperative mood)
 
 **Types:** `feat`, `fix`, `refactor`, `docs`, `style`, `perf`, `test`, `chore`, `security`
 
-**Scopes:** command names (`get`, `set`, `exec`, `list`, `provider`), provider names (`age`, `1password`, `bitwarden`, `bitwarden-sm`, `aws-kms`, `aws-sm`, `aws-ps`, `keychain`, `keepass`, `infisical`, `passwordstate`, `pass`), subsystems (`config`, `encryption`, `env`, `deps`)
+**Scopes:** command names (`get`, `set`, `exec`, `list`, `provider`), provider names (`age`, `1password`, `bitwarden`, `bitwarden-sm`, `aws-kms`, `aws-sm`, `aws-ps`, `keychain`, `keepass`, `infisical`, `passwordstate`, `pass`, `proton-pass`), subsystems (`config`, `encryption`, `env`, `deps`)
 
 Examples: `fix(aws-sm): handle pagination for large secret lists`, `feat(exec): add --no-inherit flag`
 
@@ -94,6 +94,7 @@ All providers follow the same pattern: config in `fnox.toml` stores references/n
 | Infisical           | `infisical`      | Infisical                 | `infisical` CLI          |
 | Passwordstate       | `passwordstate`  | Passwordstate server      | `reqwest` HTTP           |
 | password-store      | `password-store` | GPG files                 | `pass` CLI               |
+| Proton Pass         | `proton-pass`    | Proton Pass vault         | `pass-cli` CLI           |
 
 **Common provider config fields:** `type` (required), `prefix` (optional namespace), `region` (AWS providers). Most providers support `value` as item name, `item/field` for specific fields.
 

--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -124,6 +124,26 @@
         {
           "type": "object",
           "properties": {
+            "database": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            },
+            "keyfile": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "password": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "keepass"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type", "database"]
+        },
+        {
+          "type": "object",
+          "properties": {
             "gpg_opts": {
               "$ref": "#/$defs/OptionStringOrSecretRef"
             },
@@ -155,26 +175,6 @@
         {
           "type": "object",
           "properties": {
-            "database": {
-              "$ref": "#/$defs/StringOrSecretRef"
-            },
-            "keyfile": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "password": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "type": {
-              "type": "string",
-              "const": "keepass"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["type", "database"]
-        },
-        {
-          "type": "object",
-          "properties": {
             "key_file": {
               "$ref": "#/$defs/OptionStringOrSecretRef"
             },
@@ -191,6 +191,26 @@
           },
           "additionalProperties": false,
           "required": ["type", "recipients"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "account": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "token": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "1password"
+            },
+            "vault": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type"]
         },
         {
           "type": "object",
@@ -214,6 +234,20 @@
           },
           "additionalProperties": false,
           "required": ["type", "base_url", "password_list_id"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "proton-pass"
+            },
+            "vault": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type"]
         },
         {
           "type": "object",
@@ -268,22 +302,19 @@
         {
           "type": "object",
           "properties": {
-            "account": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
+            "key_id": {
+              "$ref": "#/$defs/StringOrSecretRef"
             },
-            "token": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
+            "region": {
+              "$ref": "#/$defs/StringOrSecretRef"
             },
             "type": {
               "type": "string",
-              "const": "1password"
-            },
-            "vault": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
+              "const": "aws-kms"
             }
           },
           "additionalProperties": false,
-          "required": ["type"]
+          "required": ["type", "key_id", "region"]
         },
         {
           "type": "object",
@@ -301,23 +332,6 @@
           },
           "additionalProperties": false,
           "required": ["type", "vault_url", "key_name"]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "key_id": {
-              "$ref": "#/$defs/StringOrSecretRef"
-            },
-            "region": {
-              "$ref": "#/$defs/StringOrSecretRef"
-            },
-            "type": {
-              "type": "string",
-              "const": "aws-kms"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["type", "key_id", "region"]
         },
         {
           "type": "object",
@@ -356,7 +370,7 @@
             },
             "type": {
               "type": "string",
-              "const": "aws-sm"
+              "const": "aws-ps"
             }
           },
           "additionalProperties": false,
@@ -368,16 +382,19 @@
             "prefix": {
               "$ref": "#/$defs/OptionStringOrSecretRef"
             },
+            "profile": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "region": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            },
             "type": {
               "type": "string",
-              "const": "azure-sm"
-            },
-            "vault_url": {
-              "$ref": "#/$defs/StringOrSecretRef"
+              "const": "aws-sm"
             }
           },
           "additionalProperties": false,
-          "required": ["type", "vault_url"]
+          "required": ["type", "region"]
         },
         {
           "type": "object",
@@ -405,23 +422,6 @@
         {
           "type": "object",
           "properties": {
-            "prefix": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "project": {
-              "$ref": "#/$defs/StringOrSecretRef"
-            },
-            "type": {
-              "type": "string",
-              "const": "gcp-sm"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["type", "project"]
-        },
-        {
-          "type": "object",
-          "properties": {
             "profile": {
               "$ref": "#/$defs/OptionStringOrSecretRef"
             },
@@ -442,19 +442,33 @@
             "prefix": {
               "$ref": "#/$defs/OptionStringOrSecretRef"
             },
-            "profile": {
+            "type": {
+              "type": "string",
+              "const": "azure-sm"
+            },
+            "vault_url": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type", "vault_url"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "prefix": {
               "$ref": "#/$defs/OptionStringOrSecretRef"
             },
-            "region": {
+            "project": {
               "$ref": "#/$defs/StringOrSecretRef"
             },
             "type": {
               "type": "string",
-              "const": "aws-ps"
+              "const": "gcp-sm"
             }
           },
           "additionalProperties": false,
-          "required": ["type", "region"]
+          "required": ["type", "project"]
         },
         {
           "type": "object",

--- a/providers/proton-pass.toml
+++ b/providers/proton-pass.toml
@@ -1,0 +1,19 @@
+# Proton Pass provider - retrieves secrets from Proton Pass
+display_name = "Proton Pass"
+serde_rename = "proton-pass"
+rust_variant = "ProtonPass"
+category = "PasswordManager"
+description = "Requires Proton Pass CLI and authenticated session"
+default_name = "protonpass"
+auth_command = "pass-cli login --interactive"
+setup_instructions = """
+Requires: Proton Pass CLI (pass-cli) and authenticated session.
+Login: pass-cli login --interactive (username/password login)
+Or: pass-cli login (opens browser for authentication)
+Set: export PROTON_PASS_PASSWORD=<password> for non-interactive login"""
+
+[fields.vault]
+type = "optional"
+placeholder = ""
+label = "Default vault name (optional):"
+wizard = true

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -20,6 +20,7 @@ pub mod onepassword;
 pub mod password_store;
 pub mod passwordstate;
 pub mod plain;
+pub mod proton_pass;
 pub mod resolved;
 pub mod resolver;
 pub mod secret_ref;
@@ -134,7 +135,7 @@ mod generated {
         use super::super::{
             age, aws_kms, aws_ps, aws_sm, azure_kms, azure_sm, bitwarden, bitwarden_sm, gcp_kms,
             gcp_sm, infisical, keepass, keychain, onepassword, password_store, passwordstate,
-            plain, vault,
+            plain, proton_pass, vault,
         };
         include!(concat!(
             env!("OUT_DIR"),

--- a/src/providers/proton_pass.rs
+++ b/src/providers/proton_pass.rs
@@ -164,6 +164,16 @@ impl ProtonPassProvider {
                 });
             }
 
+            // Check for field not found (e.g., requesting "password" on an alias item)
+            if stderr_lower.contains("field does not exist") {
+                return Err(FnoxError::ProviderSecretNotFound {
+                    provider: "Proton Pass".to_string(),
+                    secret: secret_ref.unwrap_or("<unknown>").to_string(),
+                    hint: "This item may not have the requested field. Try specifying a different field with 'item/field' syntax".to_string(),
+                    url: "https://fnox.jdx.dev/providers/proton-pass".to_string(),
+                });
+            }
+
             // Check for not found errors
             if stderr_lower.contains("not found") || stderr_lower.contains("does not exist") {
                 return Err(FnoxError::ProviderSecretNotFound {

--- a/src/providers/proton_pass.rs
+++ b/src/providers/proton_pass.rs
@@ -222,15 +222,16 @@ impl crate::providers::Provider for ProtonPassProvider {
 
         // Handle id: references using flag-based CLI args (pass:// URIs don't support item IDs)
         if let Some(id_ref) = value.strip_prefix("id:") {
-            let vault = self.vault.as_ref().ok_or_else(|| {
-                FnoxError::ProviderInvalidResponse {
+            let vault = self
+                .vault
+                .as_ref()
+                .ok_or_else(|| FnoxError::ProviderInvalidResponse {
                     provider: "Proton Pass".to_string(),
                     details: format!("Unknown vault for id-based reference: '{}'", value),
                     hint: "Specify a vault in the provider config when using id: references"
                         .to_string(),
                     url: "https://fnox.jdx.dev/providers/proton-pass".to_string(),
-                }
-            })?;
+                })?;
             let (item_id, field) = match id_ref.split_once('/') {
                 Some((id, f)) => (id, f),
                 None => (id_ref, "password"),

--- a/src/providers/proton_pass.rs
+++ b/src/providers/proton_pass.rs
@@ -1,0 +1,338 @@
+use crate::env;
+use crate::error::{FnoxError, Result};
+use async_trait::async_trait;
+use std::process::Command;
+use std::sync::LazyLock;
+
+pub struct ProtonPassProvider {
+    vault: Option<String>,
+}
+
+impl ProtonPassProvider {
+    pub fn new(vault: Option<String>) -> Self {
+        Self { vault }
+    }
+
+    /// Convert a value to a pass:// reference
+    ///
+    /// Reference formats:
+    /// - `item` -> `pass://vault/item/password` (requires vault config)
+    /// - `item/field` -> `pass://vault/item/field` (requires vault config)
+    /// - `vault/item/field` -> `pass://vault/item/field`
+    /// - `pass://vault/item/field` -> passthrough
+    ///
+    /// Note: Names containing `/` must use full `pass://` format
+    ///
+    /// The Proton Pass CLI uses SHARE_ID internally, but vault names can be
+    /// used directly and are resolved by the CLI.
+    fn value_to_reference(&self, value: &str) -> Result<String> {
+        // Validate empty values
+        let value = value.trim();
+        if value.is_empty() {
+            return Err(FnoxError::ProviderInvalidResponse {
+                provider: "Proton Pass".to_string(),
+                details: "Secret reference cannot be empty".to_string(),
+                hint: "Provide an item name, item/field, vault/item/field, or pass:// reference"
+                    .to_string(),
+                url: "https://fnox.jdx.dev/providers/proton-pass".to_string(),
+            });
+        }
+
+        // Check if value is already a full pass:// reference
+        if let Some(path) = value.strip_prefix("pass://") {
+            let parts: Vec<&str> = path.split('/').collect();
+            if parts.len() < 3 || parts.iter().any(|p| p.is_empty()) {
+                return Err(FnoxError::ProviderInvalidResponse {
+                    provider: "Proton Pass".to_string(),
+                    details: format!("Invalid pass:// reference format: '{}'", value),
+                    hint: "Expected format: pass://vault/item/field".to_string(),
+                    url: "https://fnox.jdx.dev/providers/proton-pass".to_string(),
+                });
+            }
+            return Ok(value.to_string());
+        }
+
+        let parts: Vec<&str> = value.split('/').collect();
+        match parts.len() {
+            // Single part: item name only, requires vault config
+            1 => {
+                let vault = self.vault.as_ref().ok_or_else(|| {
+                    FnoxError::ProviderInvalidResponse {
+                        provider: "Proton Pass".to_string(),
+                        details: format!("Unknown vault for secret: '{}'", value),
+                        hint: "Specify a vault in the provider config or use a full 'pass://' reference".to_string(),
+                        url: "https://fnox.jdx.dev/providers/proton-pass".to_string(),
+                    }
+                })?;
+                Ok(format!("pass://{}/{}/password", vault, parts[0]))
+            }
+            // Two parts: item/field, requires vault config
+            2 => {
+                let vault = self.vault.as_ref().ok_or_else(|| {
+                    FnoxError::ProviderInvalidResponse {
+                        provider: "Proton Pass".to_string(),
+                        details: format!("Unknown vault for secret: '{}'", value),
+                        hint: "Specify a vault in the provider config or use a full 'pass://' reference".to_string(),
+                        url: "https://fnox.jdx.dev/providers/proton-pass".to_string(),
+                    }
+                })?;
+                Ok(format!("pass://{}/{}/{}", vault, parts[0], parts[1]))
+            }
+            // Three parts: vault/item/field
+            3 => Ok(format!("pass://{}/{}/{}", parts[0], parts[1], parts[2])),
+            // More than three parts: invalid
+            _ => Err(FnoxError::ProviderInvalidResponse {
+                provider: "Proton Pass".to_string(),
+                details: format!("Invalid secret reference format: '{}'", value),
+                hint: "Expected 'item', 'item/field', 'vault/item/field', or 'pass://vault/item/field'".to_string(),
+                url: "https://fnox.jdx.dev/providers/proton-pass".to_string(),
+            }),
+        }
+    }
+
+    /// Execute pass-cli command with proper authentication environment
+    ///
+    /// The `secret_ref` parameter is used to provide better error messages for
+    /// "not found" errors. Pass `None` for commands that don't reference a secret.
+    fn execute_pass_cli_command(&self, args: &[&str], secret_ref: Option<&str>) -> Result<String> {
+        tracing::debug!("Executing pass-cli command with args: {:?}", args);
+
+        let mut cmd = Command::new("pass-cli");
+        cmd.args(args);
+
+        // Pass through Proton Pass environment variables for non-interactive auth
+        if let Some(password) = &*PROTON_PASS_PASSWORD {
+            cmd.env("PROTON_PASS_PASSWORD", password);
+        }
+        if let Some(password_file) = &*PROTON_PASS_PASSWORD_FILE {
+            cmd.env("PROTON_PASS_PASSWORD_FILE", password_file);
+        }
+        if let Some(totp) = &*PROTON_PASS_TOTP {
+            cmd.env("PROTON_PASS_TOTP", totp);
+        }
+        if let Some(totp_file) = &*PROTON_PASS_TOTP_FILE {
+            cmd.env("PROTON_PASS_TOTP_FILE", totp_file);
+        }
+        if let Some(extra_password) = &*PROTON_PASS_EXTRA_PASSWORD {
+            cmd.env("PROTON_PASS_EXTRA_PASSWORD", extra_password);
+        }
+        if let Some(extra_password_file) = &*PROTON_PASS_EXTRA_PASSWORD_FILE {
+            cmd.env("PROTON_PASS_EXTRA_PASSWORD_FILE", extra_password_file);
+        }
+
+        let output = cmd.output().map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                FnoxError::ProviderCliNotFound {
+                    provider: "Proton Pass".to_string(),
+                    cli: "pass-cli".to_string(),
+                    install_hint:
+                        "Download from https://proton.me/pass/download or use your package manager"
+                            .to_string(),
+                    url: "https://fnox.jdx.dev/providers/proton-pass".to_string(),
+                }
+            } else {
+                FnoxError::ProviderCliFailed {
+                    provider: "Proton Pass".to_string(),
+                    details: e.to_string(),
+                    hint: "Check that the Proton Pass CLI (pass-cli) is installed and accessible"
+                        .to_string(),
+                    url: "https://fnox.jdx.dev/providers/proton-pass".to_string(),
+                }
+            }
+        })?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let stderr_lower = stderr.to_lowercase();
+
+            // Check for authentication-related errors (using CLI-specific patterns)
+            if stderr_lower.contains("not logged in")
+                || stderr_lower.contains("session expired")
+                || stderr_lower.contains("login required")
+            {
+                return Err(FnoxError::ProviderAuthFailed {
+                    provider: "Proton Pass".to_string(),
+                    details: stderr.trim().to_string(),
+                    hint: "Run 'pass-cli login --interactive' to authenticate".to_string(),
+                    url: "https://fnox.jdx.dev/providers/proton-pass".to_string(),
+                });
+            }
+
+            // Check for not found errors
+            if stderr_lower.contains("not found") || stderr_lower.contains("does not exist") {
+                return Err(FnoxError::ProviderSecretNotFound {
+                    provider: "Proton Pass".to_string(),
+                    secret: secret_ref.unwrap_or("<unknown>").to_string(),
+                    hint: "Check that the vault and item exist in Proton Pass".to_string(),
+                    url: "https://fnox.jdx.dev/providers/proton-pass".to_string(),
+                });
+            }
+
+            return Err(FnoxError::ProviderCliFailed {
+                provider: "Proton Pass".to_string(),
+                details: stderr.trim().to_string(),
+                hint: "Check your Proton Pass configuration and authentication".to_string(),
+                url: "https://fnox.jdx.dev/providers/proton-pass".to_string(),
+            });
+        }
+
+        let stdout =
+            String::from_utf8(output.stdout).map_err(|e| FnoxError::ProviderInvalidResponse {
+                provider: "Proton Pass".to_string(),
+                details: format!("Invalid UTF-8 in command output: {}", e),
+                hint: "The secret value contains invalid UTF-8 characters".to_string(),
+                url: "https://fnox.jdx.dev/providers/proton-pass".to_string(),
+            })?;
+
+        Ok(stdout.trim().to_string())
+    }
+}
+
+#[async_trait]
+impl crate::providers::Provider for ProtonPassProvider {
+    async fn get_secret(&self, value: &str) -> Result<String> {
+        tracing::debug!("Getting secret '{}' from Proton Pass", value);
+
+        let reference = self.value_to_reference(value)?;
+        tracing::debug!("Reading Proton Pass secret: {}", reference);
+
+        // Use 'pass-cli item view' to fetch the secret
+        self.execute_pass_cli_command(&["item", "view", &reference], Some(&reference))
+    }
+
+    async fn test_connection(&self) -> Result<()> {
+        tracing::debug!("Testing connection to Proton Pass");
+
+        // Use 'pass-cli test' for connection testing
+        let output = self.execute_pass_cli_command(&["test"], None)?;
+
+        tracing::debug!("Proton Pass test output: {}", output);
+
+        Ok(())
+    }
+}
+
+// Environment variables for Proton Pass authentication
+// Pattern: FNOX_* prefix takes priority, fallback to native
+
+static PROTON_PASS_PASSWORD: LazyLock<Option<String>> = LazyLock::new(|| {
+    env::var("FNOX_PROTON_PASS_PASSWORD")
+        .or_else(|_| env::var("PROTON_PASS_PASSWORD"))
+        .ok()
+});
+
+static PROTON_PASS_PASSWORD_FILE: LazyLock<Option<String>> = LazyLock::new(|| {
+    env::var("FNOX_PROTON_PASS_PASSWORD_FILE")
+        .or_else(|_| env::var("PROTON_PASS_PASSWORD_FILE"))
+        .ok()
+});
+
+static PROTON_PASS_TOTP: LazyLock<Option<String>> = LazyLock::new(|| {
+    env::var("FNOX_PROTON_PASS_TOTP")
+        .or_else(|_| env::var("PROTON_PASS_TOTP"))
+        .ok()
+});
+
+static PROTON_PASS_TOTP_FILE: LazyLock<Option<String>> = LazyLock::new(|| {
+    env::var("FNOX_PROTON_PASS_TOTP_FILE")
+        .or_else(|_| env::var("PROTON_PASS_TOTP_FILE"))
+        .ok()
+});
+
+static PROTON_PASS_EXTRA_PASSWORD: LazyLock<Option<String>> = LazyLock::new(|| {
+    env::var("FNOX_PROTON_PASS_EXTRA_PASSWORD")
+        .or_else(|_| env::var("PROTON_PASS_EXTRA_PASSWORD"))
+        .ok()
+});
+
+static PROTON_PASS_EXTRA_PASSWORD_FILE: LazyLock<Option<String>> = LazyLock::new(|| {
+    env::var("FNOX_PROTON_PASS_EXTRA_PASSWORD_FILE")
+        .or_else(|_| env::var("PROTON_PASS_EXTRA_PASSWORD_FILE"))
+        .ok()
+});
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_value_to_reference_passthrough() {
+        let provider = ProtonPassProvider::new(Some("vault".to_string()));
+        let result = provider
+            .value_to_reference("pass://MyVault/item/password")
+            .unwrap();
+        assert_eq!(result, "pass://MyVault/item/password");
+    }
+
+    #[test]
+    fn test_value_to_reference_single_part_with_vault() {
+        let provider = ProtonPassProvider::new(Some("TestVault".to_string()));
+        let result = provider.value_to_reference("my-item").unwrap();
+        assert_eq!(result, "pass://TestVault/my-item/password");
+    }
+
+    #[test]
+    fn test_value_to_reference_single_part_without_vault() {
+        let provider = ProtonPassProvider::new(None);
+        let result = provider.value_to_reference("my-item");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_value_to_reference_two_parts_with_vault() {
+        let provider = ProtonPassProvider::new(Some("TestVault".to_string()));
+        let result = provider.value_to_reference("my-item/username").unwrap();
+        assert_eq!(result, "pass://TestVault/my-item/username");
+    }
+
+    #[test]
+    fn test_value_to_reference_three_parts() {
+        let provider = ProtonPassProvider::new(None);
+        let result = provider
+            .value_to_reference("OtherVault/item/field")
+            .unwrap();
+        assert_eq!(result, "pass://OtherVault/item/field");
+    }
+
+    #[test]
+    fn test_value_to_reference_too_many_parts() {
+        let provider = ProtonPassProvider::new(Some("vault".to_string()));
+        let result = provider.value_to_reference("a/b/c/d");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_value_to_reference_empty() {
+        let provider = ProtonPassProvider::new(Some("vault".to_string()));
+        let result = provider.value_to_reference("");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_value_to_reference_whitespace_only() {
+        let provider = ProtonPassProvider::new(Some("vault".to_string()));
+        let result = provider.value_to_reference("   ");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_value_to_reference_invalid_pass_uri_too_few_parts() {
+        let provider = ProtonPassProvider::new(None);
+        let result = provider.value_to_reference("pass://vault");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_value_to_reference_invalid_pass_uri_empty_parts() {
+        let provider = ProtonPassProvider::new(None);
+        let result = provider.value_to_reference("pass://vault//field");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_value_to_reference_invalid_pass_uri_vault_item_only() {
+        let provider = ProtonPassProvider::new(None);
+        let result = provider.value_to_reference("pass://vault/item");
+        assert!(result.is_err());
+    }
+}

--- a/src/providers/proton_pass.rs
+++ b/src/providers/proton_pass.rs
@@ -4,6 +4,10 @@ use async_trait::async_trait;
 use std::process::Command;
 use std::sync::LazyLock;
 
+pub fn env_dependencies() -> &'static [&'static str] {
+    &[]
+}
+
 pub struct ProtonPassProvider {
     vault: Option<String>,
 }
@@ -149,6 +153,8 @@ impl ProtonPassProvider {
             if stderr_lower.contains("not logged in")
                 || stderr_lower.contains("session expired")
                 || stderr_lower.contains("login required")
+                || stderr_lower.contains("could not get local key from keyring")
+                || stderr_lower.contains("failed to get encryption key")
             {
                 return Err(FnoxError::ProviderAuthFailed {
                     provider: "Proton Pass".to_string(),

--- a/src/source_registry.rs
+++ b/src/source_registry.rs
@@ -48,14 +48,6 @@ pub fn get_content(path: &Path) -> Option<Arc<String>> {
     sources.get(&canonical).cloned()
 }
 
-/// Clear all registered sources. Primarily useful for testing.
-#[cfg(test)]
-pub fn clear() {
-    if let Ok(mut sources) = SOURCES.write() {
-        sources.clear();
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -64,8 +56,6 @@ mod tests {
 
     #[test]
     fn test_register_and_get() {
-        clear();
-
         let mut temp = NamedTempFile::new().unwrap();
         writeln!(temp, "test content").unwrap();
         let path = temp.path();
@@ -81,8 +71,7 @@ mod tests {
 
     #[test]
     fn test_missing_path() {
-        clear();
-
+        // Avoid clearing global state here because tests run in parallel.
         let path = Path::new("/nonexistent/path/to/file.toml");
         assert!(get_named_source(path).is_none());
         assert!(get_content(path).is_none());

--- a/src/source_registry.rs
+++ b/src/source_registry.rs
@@ -48,6 +48,14 @@ pub fn get_content(path: &Path) -> Option<Arc<String>> {
     sources.get(&canonical).cloned()
 }
 
+/// Clear all registered sources. Primarily useful for testing.
+#[cfg(test)]
+pub fn clear() {
+    if let Ok(mut sources) = SOURCES.write() {
+        sources.clear();
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -56,6 +64,8 @@ mod tests {
 
     #[test]
     fn test_register_and_get() {
+        clear();
+
         let mut temp = NamedTempFile::new().unwrap();
         writeln!(temp, "test content").unwrap();
         let path = temp.path();
@@ -71,7 +81,8 @@ mod tests {
 
     #[test]
     fn test_missing_path() {
-        // Avoid clearing global state here because tests run in parallel.
+        clear();
+
         let path = Path::new("/nonexistent/path/to/file.toml");
         assert!(get_named_source(path).is_none());
         assert!(get_content(path).is_none());

--- a/src/source_registry.rs
+++ b/src/source_registry.rs
@@ -8,8 +8,28 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, LazyLock, RwLock};
 
+#[cfg(not(test))]
+type RegistryKey = PathBuf;
+#[cfg(test)]
+type RegistryKey = (std::thread::ThreadId, PathBuf);
+
+fn canonical_path(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
+#[cfg(not(test))]
+fn registry_key(path: &Path) -> RegistryKey {
+    canonical_path(path)
+}
+
+#[cfg(test)]
+fn registry_key(path: &Path) -> RegistryKey {
+    // In tests, namespace by thread to avoid parallel-test interference.
+    (std::thread::current().id(), canonical_path(path))
+}
+
 /// Global registry mapping canonical paths to their source content.
-static SOURCES: LazyLock<RwLock<HashMap<PathBuf, Arc<String>>>> =
+static SOURCES: LazyLock<RwLock<HashMap<RegistryKey, Arc<String>>>> =
     LazyLock::new(|| RwLock::new(HashMap::new()));
 
 /// Register a config file's source content for later error reporting.
@@ -17,9 +37,9 @@ static SOURCES: LazyLock<RwLock<HashMap<PathBuf, Arc<String>>>> =
 /// The path is canonicalized to ensure consistent lookups regardless of
 /// how the path was originally specified.
 pub fn register(path: &Path, content: String) {
-    let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    let key = registry_key(path);
     if let Ok(mut sources) = SOURCES.write() {
-        sources.insert(canonical, Arc::new(content));
+        sources.insert(key, Arc::new(content));
     }
 }
 
@@ -28,9 +48,9 @@ pub fn register(path: &Path, content: String) {
 /// Returns None if the path was never registered or if the lock cannot be acquired.
 /// Returns Arc<NamedSource<...>> to keep the error type size small (Arc is pointer-sized).
 pub fn get_named_source(path: &Path) -> Option<Arc<NamedSource<Arc<String>>>> {
-    let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    let key = registry_key(path);
     let sources = SOURCES.read().ok()?;
-    sources.get(&canonical).map(|content| {
+    sources.get(&key).map(|content| {
         Arc::new(NamedSource::new(
             path.display().to_string(),
             Arc::clone(content),
@@ -43,9 +63,18 @@ pub fn get_named_source(path: &Path) -> Option<Arc<NamedSource<Arc<String>>>> {
 /// Useful when you need the content without wrapping it in NamedSource.
 #[cfg(test)]
 pub fn get_content(path: &Path) -> Option<Arc<String>> {
-    let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    let key = registry_key(path);
     let sources = SOURCES.read().ok()?;
-    sources.get(&canonical).cloned()
+    sources.get(&key).cloned()
+}
+
+/// Clear all registered sources in the current test thread.
+#[cfg(test)]
+pub fn clear() {
+    if let Ok(mut sources) = SOURCES.write() {
+        let current = std::thread::current().id();
+        sources.retain(|(thread_id, _), _| *thread_id != current);
+    }
 }
 
 #[cfg(test)]
@@ -56,6 +85,8 @@ mod tests {
 
     #[test]
     fn test_register_and_get() {
+        clear();
+
         let mut temp = NamedTempFile::new().unwrap();
         writeln!(temp, "test content").unwrap();
         let path = temp.path();
@@ -71,7 +102,8 @@ mod tests {
 
     #[test]
     fn test_missing_path() {
-        // Avoid clearing global state here because tests run in parallel.
+        clear();
+
         let path = Path::new("/nonexistent/path/to/file.toml");
         assert!(get_named_source(path).is_none());
         assert!(get_content(path).is_none());

--- a/test/proton-pass.bats
+++ b/test/proton-pass.bats
@@ -1,0 +1,287 @@
+#!/usr/bin/env bats
+#
+# Proton Pass Provider Tests
+#
+# These tests verify the Proton Pass provider integration with fnox.
+#
+# Prerequisites:
+#   1. Install Proton Pass CLI: Download from https://proton.me/pass/download
+#   2. Login to Proton Pass: pass-cli login --interactive
+#   3. Create test items in a vault
+#   4. Run tests: mise run test:bats -- test/proton-pass.bats
+#
+# Note: Tests will automatically skip if:
+#       - pass-cli is not installed
+#       - Not authenticated with Proton Pass
+#       - Test vault/items don't exist
+#
+# Environment Variables:
+#   FNOX_PROTON_PASS_PASSWORD or PROTON_PASS_PASSWORD - Account password for non-interactive auth
+#   FNOX_PROTON_PASS_TOTP or PROTON_PASS_TOTP - 2FA TOTP code if enabled
+#   PROTON_PASS_TEST_VAULT - Vault name to use for tests (default: "Personal")
+#   PROTON_PASS_TEST_ITEM - An existing item in your vault that tests will read from
+#
+
+setup() {
+	load 'test_helper/common_setup'
+	_common_setup
+
+	# Check if pass-cli is installed
+	if ! command -v pass-cli >/dev/null 2>&1; then
+		skip "Proton Pass CLI (pass-cli) not installed. Download from https://proton.me/pass/download"
+	fi
+
+	# Some tests don't need authentication (like 'fnox list')
+	# Some tests intentionally run without auth (like 'fails gracefully')
+	# Only check auth if this test actually needs it
+	if [[ $BATS_TEST_DESCRIPTION != *"list"* ]] && [[ $BATS_TEST_DESCRIPTION != *"fails gracefully"* ]]; then
+		# Check if we can authenticate by running pass-cli test
+		if ! pass-cli test >/dev/null 2>&1; then
+			skip "Cannot authenticate with Proton Pass. Run 'pass-cli login --interactive' first."
+		fi
+	fi
+
+	# Set test vault (use environment variable or default to "Personal")
+	TEST_VAULT="${PROTON_PASS_TEST_VAULT:-Personal}"
+}
+
+teardown() {
+	_common_teardown
+}
+
+# Helper function to create a Proton Pass test config
+create_proton_pass_config() {
+	local vault="${1:-$TEST_VAULT}"
+	cat >"${FNOX_CONFIG_FILE:-fnox.toml}" <<EOF
+[providers.protonpass]
+type = "proton-pass"
+vault = "$vault"
+
+[secrets]
+EOF
+}
+
+# Helper function to create a Proton Pass config without vault
+create_proton_pass_config_no_vault() {
+	cat >"${FNOX_CONFIG_FILE:-fnox.toml}" <<EOF
+[providers.protonpass]
+type = "proton-pass"
+
+[secrets]
+EOF
+}
+
+@test "fnox get retrieves secret from Proton Pass with full pass:// reference" {
+	# This test requires a pre-existing item in Proton Pass
+	# Skip if test item is not configured
+	if [ -z "$PROTON_PASS_TEST_ITEM" ]; then
+		skip "PROTON_PASS_TEST_ITEM not set. Set this to an existing item name in your vault."
+	fi
+
+	create_proton_pass_config_no_vault
+
+	# Add secret reference to config using full pass:// format
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
+
+[secrets.TEST_SECRET]
+provider = "protonpass"
+value = "pass://$TEST_VAULT/$PROTON_PASS_TEST_ITEM/password"
+EOF
+
+	# Get the secret
+	run "$FNOX_BIN" get TEST_SECRET
+	assert_success
+	# Output should not be empty
+	[ -n "$output" ]
+}
+
+@test "fnox get retrieves secret with vault/item/field format" {
+	# This test requires a pre-existing item in Proton Pass
+	if [ -z "$PROTON_PASS_TEST_ITEM" ]; then
+		skip "PROTON_PASS_TEST_ITEM not set. Set this to an existing item name in your vault."
+	fi
+
+	create_proton_pass_config_no_vault
+
+	# Add secret reference to config using vault/item/field format
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
+
+[secrets.TEST_SECRET]
+provider = "protonpass"
+value = "$TEST_VAULT/$PROTON_PASS_TEST_ITEM/password"
+EOF
+
+	# Get the secret
+	run "$FNOX_BIN" get TEST_SECRET
+	assert_success
+	[ -n "$output" ]
+}
+
+@test "fnox get retrieves secret with item/field format when vault is configured" {
+	# This test requires a pre-existing item in Proton Pass
+	if [ -z "$PROTON_PASS_TEST_ITEM" ]; then
+		skip "PROTON_PASS_TEST_ITEM not set. Set this to an existing item name in your vault."
+	fi
+
+	create_proton_pass_config "$TEST_VAULT"
+
+	# Add secret reference to config using item/field format
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
+
+[secrets.TEST_SECRET]
+provider = "protonpass"
+value = "$PROTON_PASS_TEST_ITEM/password"
+EOF
+
+	# Get the secret
+	run "$FNOX_BIN" get TEST_SECRET
+	assert_success
+	[ -n "$output" ]
+}
+
+@test "fnox get retrieves secret with item name only when vault is configured" {
+	# This test requires a pre-existing item in Proton Pass
+	if [ -z "$PROTON_PASS_TEST_ITEM" ]; then
+		skip "PROTON_PASS_TEST_ITEM not set. Set this to an existing item name in your vault."
+	fi
+
+	create_proton_pass_config "$TEST_VAULT"
+
+	# Add secret reference to config using item name only (defaults to password field)
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
+
+[secrets.TEST_SECRET]
+provider = "protonpass"
+value = "$PROTON_PASS_TEST_ITEM"
+EOF
+
+	# Get the secret
+	run "$FNOX_BIN" get TEST_SECRET
+	assert_success
+	[ -n "$output" ]
+}
+
+@test "fnox get fails without vault when using item-only reference" {
+	create_proton_pass_config_no_vault
+
+	# Add secret reference without vault
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
+
+[secrets.TEST_SECRET]
+provider = "protonpass"
+value = "some-item"
+EOF
+
+	# Should fail because vault is not configured
+	run "$FNOX_BIN" get TEST_SECRET
+	assert_failure
+	assert_output --partial "Unknown vault"
+}
+
+@test "fnox get fails with invalid reference format (too many slashes)" {
+	create_proton_pass_config "$TEST_VAULT"
+
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
+
+[secrets.INVALID_FORMAT]
+provider = "protonpass"
+value = "a/b/c/d/e"
+EOF
+
+	run "$FNOX_BIN" get INVALID_FORMAT
+	assert_failure
+	assert_output --partial "Invalid secret reference format"
+}
+
+@test "fnox get fails with nonexistent item" {
+	create_proton_pass_config "$TEST_VAULT"
+
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
+
+[secrets.NONEXISTENT]
+provider = "protonpass"
+value = "nonexistent-item-$(date +%s)"
+EOF
+
+	# Should fail because item doesn't exist
+	run "$FNOX_BIN" get NONEXISTENT
+	assert_failure
+}
+
+@test "fnox list shows Proton Pass secrets" {
+	create_proton_pass_config "$TEST_VAULT"
+
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
+
+[secrets.PP_SECRET_1]
+description = "First Proton Pass secret"
+provider = "protonpass"
+value = "item1"
+
+[secrets.PP_SECRET_2]
+description = "Second Proton Pass secret"
+provider = "protonpass"
+value = "item2/username"
+EOF
+
+	run "$FNOX_BIN" list
+	assert_success
+	assert_output --partial "PP_SECRET_1"
+	assert_output --partial "PP_SECRET_2"
+	assert_output --partial "First Proton Pass secret"
+}
+
+@test "fnox provider add creates Proton Pass provider config" {
+	# Initialize fnox first
+	run "$FNOX_BIN" init
+	assert_success
+
+	# Add a Proton Pass provider
+	run "$FNOX_BIN" provider add mypass proton-pass
+	assert_success
+
+	# Check the config file
+	run cat "$FNOX_CONFIG_FILE"
+	assert_output --partial "[providers.mypass]"
+	assert_output --partial 'type = "proton-pass"'
+}
+
+@test "fnox provider add with vault creates proper config" {
+	# Initialize fnox first
+	run "$FNOX_BIN" init
+	assert_success
+
+	# Add a Proton Pass provider with vault
+	run "$FNOX_BIN" provider add mypass proton-pass --vault "MyVault"
+	assert_success
+
+	# Check the config file
+	run cat "$FNOX_CONFIG_FILE"
+	assert_output --partial "[providers.mypass]"
+	assert_output --partial 'type = "proton-pass"'
+	assert_output --partial 'vault = "MyVault"'
+}
+
+@test "Proton Pass provider fails gracefully with missing authentication" {
+	# This test verifies that fnox returns an auth_failed error when not authenticated
+	# The setup() function skips auth check for tests with "fails gracefully" in the name
+
+	create_proton_pass_config "$TEST_VAULT"
+
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
+
+[secrets.TEST_SECRET]
+provider = "protonpass"
+value = "some-item"
+EOF
+
+	# If authenticated, skip this test (we need to be unauthenticated to test auth failure)
+	if pass-cli test >/dev/null 2>&1; then
+		skip "Already authenticated with Proton Pass. Run 'pass-cli logout' to test auth failure handling."
+	fi
+
+	# Run the get command - should fail with auth_failed error
+	run "$FNOX_BIN" get TEST_SECRET
+	assert_failure
+	assert_output --partial "auth_failed"
+}


### PR DESCRIPTION
## Summary

Adds support for [Proton Pass](https://proton.me/pass) as a new provider, using the [Proton Pass CLI](https://protonpass.github.io/pass-cli/) (`pass-cli`).

- Read-only provider following the same pattern as 1Password/Bitwarden (references individual items via `pass://` URIs)
- Supports `item`, `item/field`, `vault/item/field`, full `pass://vault/item/field`, and `id:ITEM_ID` reference formats
- `id:` prefix allows disambiguating items with duplicate names using item IDs
- Detects auth failures (including keyring access errors) and missing field errors with helpful hints
- Passes through `PROTON_PASS_PASSWORD`, `PROTON_PASS_TOTP`, and related env vars for non-interactive auth
- Comprehensive bats test suite

**Known limitation:** Alias items are not supported as of pass-cli v1.5.2 — the CLI does not expose alias email addresses as accessible fields.

Closes https://github.com/jdx/fnox/discussions/140

## Configuration

```toml
[providers]
protonpass = { type = "proton-pass", vault = "Personal" }

[secrets]
MY_SECRET = { provider = "protonpass", value = "item-name" }
MY_USER = { provider = "protonpass", value = "item-name/username" }
MY_FULL = { provider = "protonpass", value = "pass://Personal/item-name/password" }
# Use id: prefix for items with duplicate names
MY_DUP = { provider = "protonpass", value = "id:ITEM_ID/password" }
```

## Test plan

- [x] `mise run build` — compiles cleanly
- [x] `mise run test:cargo` — all unit tests pass (14 proton-pass specific)
- [x] `mise run test:bats -- test/proton-pass.bats` — 11/11 pass
- [x] Manual testing with authenticated pass-cli:
  - `fnox get` retrieves secrets by name, item/field, and pass:// URI
  - `fnox get` retrieves secrets by item ID using id: prefix
  - `fnox provider test` verifies connection
  - Missing field returns helpful error with item/field hint
  - Auth failure (keyring error) correctly classified

_AI (Claude Code) was used to assist with implementation and testing._
