### PR TITLE
fix(provider): only trigger auth prompt for ProviderAuthFailed errors

### DIFF
--- a/src/auth_prompt.rs
+++ b/src/auth_prompt.rs
@@ -9,26 +9,105 @@ use crate::providers::ProviderConfig;
 use demand::Confirm;
 use std::process::Command;
 
+/// Returns true if all preconditions are met for attempting an auth prompt.
+/// Pure function — no side effects, fully testable.
+fn should_attempt_auth_prompt(
+    is_auth_error: bool,
+    prompt_auth_enabled: bool,
+    has_auth_command: bool,
+) -> bool {
+    is_auth_error && prompt_auth_enabled && has_auth_command
+}
+
 /// Prompts the user to run an auth command and executes it if they agree.
 ///
 /// Returns `Ok(true)` if the auth command was run successfully,
 /// `Ok(false)` if the user declined or no auth command is available,
 /// `Err` if the auth command failed.
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Exhaustive table test for the pure decision function.
+    // Each row: (is_auth_error, prompt_enabled, has_auth_command) -> expected
+    #[test]
+    fn should_attempt_auth_prompt_truth_table() {
+        let cases = [
+            // Only true when all three conditions are met
+            (true, true, true, true),
+            // Any single false -> no prompt
+            (false, true, true, false),
+            (true, false, true, false),
+            (true, true, false, false),
+            // Two false
+            (false, false, true, false),
+            (false, true, false, false),
+            (true, false, false, false),
+            // All false
+            (false, false, false, false),
+        ];
+
+        for (is_auth, prompt_enabled, has_cmd, expected) in cases {
+            assert_eq!(
+                should_attempt_auth_prompt(is_auth, prompt_enabled, has_cmd),
+                expected,
+                "is_auth={}, prompt_enabled={}, has_cmd={} -> expected {}",
+                is_auth,
+                prompt_enabled,
+                has_cmd,
+                expected
+            );
+        }
+    }
+
+    // Integration-level: non-auth errors return Ok(false) from prompt_and_run_auth
+    #[test]
+    fn non_auth_error_skips_prompt() {
+        let config = Config::new();
+        let provider_config = ProviderConfig::Plain;
+        let error = FnoxError::ProviderSecretNotFound {
+            provider: "test".to_string(),
+            secret: "MY_SECRET".to_string(),
+            hint: "check".to_string(),
+            url: "https://example.com".to_string(),
+        };
+        let result = prompt_and_run_auth(&config, &provider_config, "test", &error);
+        assert_eq!(result.unwrap(), false);
+    }
+
+    #[test]
+    fn cli_failed_error_skips_prompt() {
+        let config = Config::new();
+        let provider_config = ProviderConfig::Plain;
+        let error = FnoxError::ProviderCliFailed {
+            provider: "test".to_string(),
+            details: "field does not exist".to_string(),
+            hint: "check".to_string(),
+            url: "https://example.com".to_string(),
+        };
+        let result = prompt_and_run_auth(&config, &provider_config, "test", &error);
+        assert_eq!(result.unwrap(), false);
+    }
+}
+
 pub fn prompt_and_run_auth(
     config: &Config,
     provider_config: &ProviderConfig,
     provider_name: &str,
     error: &FnoxError,
 ) -> Result<bool> {
-    // Check if we should prompt
-    if !config.should_prompt_auth() {
+    let auth_command = match provider_config.default_auth_command() {
+        Some(cmd) => cmd,
+        None => return Ok(false),
+    };
+
+    if !should_attempt_auth_prompt(
+        error.is_auth_error(),
+        config.should_prompt_auth(),
+        true, // has_auth_command: pre-checked above for early return; helper retains the param for full truth-table testability
+    ) {
         return Ok(false);
     }
-
-    // Get the auth command for this provider
-    let Some(auth_command) = provider_config.default_auth_command() else {
-        return Ok(false);
-    };
 
     // Show the error and prompt
     eprintln!(

--- a/src/providers/infisical.rs
+++ b/src/providers/infisical.rs
@@ -463,14 +463,12 @@ fn map_batch_error(e: &FnoxError, secret_name: &str) -> FnoxError {
             hint: hint.clone(),
             url: url.clone(),
         },
-        FnoxError::ProviderSecretNotFound { hint, url, .. } => {
-            FnoxError::ProviderSecretNotFound {
-                provider: PROVIDER_NAME.to_string(),
-                secret: secret_name.to_string(),
-                hint: hint.clone(),
-                url: url.clone(),
-            }
-        }
+        FnoxError::ProviderSecretNotFound { hint, url, .. } => FnoxError::ProviderSecretNotFound {
+            provider: PROVIDER_NAME.to_string(),
+            secret: secret_name.to_string(),
+            hint: hint.clone(),
+            url: url.clone(),
+        },
         FnoxError::ProviderCliNotFound {
             cli,
             install_hint,

--- a/src/providers/infisical.rs
+++ b/src/providers/infisical.rs
@@ -5,6 +5,9 @@ use std::collections::HashMap;
 use std::process::Command;
 use std::sync::{LazyLock, Mutex};
 
+const PROVIDER_NAME: &str = "Infisical";
+const PROVIDER_URL: &str = "https://fnox.jdx.dev/providers/infisical";
+
 pub struct InfisicalProvider {
     project_id: Option<String>,
     environment: Option<String>,
@@ -34,19 +37,19 @@ impl InfisicalProvider {
 
         // Check if we have client credentials to obtain a token
         let client_id = infisical_client_id().ok_or_else(|| FnoxError::ProviderAuthFailed {
-            provider: "Infisical".to_string(),
+            provider: PROVIDER_NAME.to_string(),
             details: "Authentication not found".to_string(),
             hint: "Set INFISICAL_TOKEN, or both INFISICAL_CLIENT_ID and INFISICAL_CLIENT_SECRET"
                 .to_string(),
-            url: "https://fnox.jdx.dev/providers/infisical".to_string(),
+            url: PROVIDER_URL.to_string(),
         })?;
 
         let client_secret =
             infisical_client_secret().ok_or_else(|| FnoxError::ProviderAuthFailed {
-                provider: "Infisical".to_string(),
+                provider: PROVIDER_NAME.to_string(),
                 details: "Client secret not found".to_string(),
                 hint: "Set INFISICAL_CLIENT_SECRET or FNOX_INFISICAL_CLIENT_SECRET".to_string(),
-                url: "https://fnox.jdx.dev/providers/infisical".to_string(),
+                url: PROVIDER_URL.to_string(),
             })?;
 
         // Acquire lock for the entire check-and-login operation to prevent race condition
@@ -93,17 +96,17 @@ impl InfisicalProvider {
         let output = cmd.output().map_err(|e| {
             if e.kind() == std::io::ErrorKind::NotFound {
                 FnoxError::ProviderCliNotFound {
-                    provider: "Infisical".to_string(),
+                    provider: PROVIDER_NAME.to_string(),
                     cli: "infisical".to_string(),
                     install_hint: "brew install infisical/get-cli/infisical".to_string(),
-                    url: "https://fnox.jdx.dev/providers/infisical".to_string(),
+                    url: PROVIDER_URL.to_string(),
                 }
             } else {
                 FnoxError::ProviderCliFailed {
-                    provider: "Infisical".to_string(),
+                    provider: PROVIDER_NAME.to_string(),
                     details: e.to_string(),
                     hint: "Check that the Infisical CLI is installed and accessible".to_string(),
-                    url: "https://fnox.jdx.dev/providers/infisical".to_string(),
+                    url: PROVIDER_URL.to_string(),
                 }
             }
         })?;
@@ -111,19 +114,19 @@ impl InfisicalProvider {
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
             return Err(FnoxError::ProviderAuthFailed {
-                provider: "Infisical".to_string(),
+                provider: PROVIDER_NAME.to_string(),
                 details: stderr.trim().to_string(),
                 hint: "Check your client ID and client secret".to_string(),
-                url: "https://fnox.jdx.dev/providers/infisical".to_string(),
+                url: PROVIDER_URL.to_string(),
             });
         }
 
         let token = String::from_utf8(output.stdout)
             .map_err(|e| FnoxError::ProviderInvalidResponse {
-                provider: "Infisical".to_string(),
+                provider: PROVIDER_NAME.to_string(),
                 details: format!("Invalid UTF-8 in command output: {}", e),
                 hint: "This is an unexpected error".to_string(),
-                url: "https://fnox.jdx.dev/providers/infisical".to_string(),
+                url: PROVIDER_URL.to_string(),
             })?
             .trim()
             .to_string();
@@ -166,17 +169,17 @@ impl InfisicalProvider {
         let output = cmd.output().map_err(|e| {
             if e.kind() == std::io::ErrorKind::NotFound {
                 FnoxError::ProviderCliNotFound {
-                    provider: "Infisical".to_string(),
+                    provider: PROVIDER_NAME.to_string(),
                     cli: "infisical".to_string(),
                     install_hint: "brew install infisical/get-cli/infisical".to_string(),
-                    url: "https://fnox.jdx.dev/providers/infisical".to_string(),
+                    url: PROVIDER_URL.to_string(),
                 }
             } else {
                 FnoxError::ProviderCliFailed {
-                    provider: "Infisical".to_string(),
+                    provider: PROVIDER_NAME.to_string(),
                     details: e.to_string(),
                     hint: "Check that the Infisical CLI is installed and accessible".to_string(),
-                    url: "https://fnox.jdx.dev/providers/infisical".to_string(),
+                    url: PROVIDER_URL.to_string(),
                 }
             }
         })?;
@@ -188,10 +191,10 @@ impl InfisicalProvider {
 
         let stdout =
             String::from_utf8(output.stdout).map_err(|e| FnoxError::ProviderInvalidResponse {
-                provider: "Infisical".to_string(),
+                provider: PROVIDER_NAME.to_string(),
                 details: format!("Invalid UTF-8 in command output: {}", e),
                 hint: "The secret value contains invalid UTF-8 characters".to_string(),
-                url: "https://fnox.jdx.dev/providers/infisical".to_string(),
+                url: PROVIDER_URL.to_string(),
             })?;
 
         Ok(stdout.trim().to_string())
@@ -243,20 +246,20 @@ impl crate::providers::Provider for InfisicalProvider {
         let json_array =
             serde_json::from_str::<Vec<serde_json::Value>>(&json_output).map_err(|e| {
                 FnoxError::ProviderInvalidResponse {
-                    provider: "Infisical".to_string(),
+                    provider: PROVIDER_NAME.to_string(),
                     details: format!("Failed to parse response for '{}': {}", value, e),
                     hint: "The Infisical CLI returned an unexpected response format".to_string(),
-                    url: "https://fnox.jdx.dev/providers/infisical".to_string(),
+                    url: PROVIDER_URL.to_string(),
                 }
             })?;
 
         // Extract the secret value from the first (and only) object
         if json_array.is_empty() {
             return Err(FnoxError::ProviderSecretNotFound {
-                provider: "Infisical".to_string(),
+                provider: PROVIDER_NAME.to_string(),
                 secret: value.to_string(),
                 hint: "Check that the secret exists in Infisical".to_string(),
-                url: "https://fnox.jdx.dev/providers/infisical".to_string(),
+                url: PROVIDER_URL.to_string(),
             });
         }
 
@@ -264,23 +267,23 @@ impl crate::providers::Provider for InfisicalProvider {
             .get("secretValue")
             .and_then(|v| v.as_str())
             .ok_or_else(|| FnoxError::ProviderInvalidResponse {
-                provider: "Infisical".to_string(),
+                provider: PROVIDER_NAME.to_string(),
                 details: format!(
                     "Invalid response format for '{}' - missing secretValue field",
                     value
                 ),
                 hint: "The Infisical CLI returned an unexpected response format".to_string(),
-                url: "https://fnox.jdx.dev/providers/infisical".to_string(),
+                url: PROVIDER_URL.to_string(),
             })?;
 
         // The Infisical CLI returns "*not found*" as a placeholder when a secret doesn't exist
         // Treat this as an error rather than returning the literal placeholder string
         if secret_value == "*not found*" {
             return Err(FnoxError::ProviderSecretNotFound {
-                provider: "Infisical".to_string(),
+                provider: PROVIDER_NAME.to_string(),
                 secret: value.to_string(),
                 hint: "Check that the secret exists in Infisical".to_string(),
-                url: "https://fnox.jdx.dev/providers/infisical".to_string(),
+                url: PROVIDER_URL.to_string(),
             });
         }
 
@@ -360,11 +363,11 @@ impl crate::providers::Provider for InfisicalProvider {
                             .map(|(key, secret_name)| {
                                 let result = value_map.get(secret_name).cloned().ok_or_else(|| {
                                     FnoxError::ProviderSecretNotFound {
-                                        provider: "Infisical".to_string(),
+                                        provider: PROVIDER_NAME.to_string(),
                                         secret: secret_name.clone(),
                                         hint: "Check that the secret exists in Infisical"
                                             .to_string(),
-                                        url: "https://fnox.jdx.dev/providers/infisical".to_string(),
+                                        url: PROVIDER_URL.to_string(),
                                     }
                                 });
                                 (key.clone(), result)
@@ -377,10 +380,10 @@ impl crate::providers::Provider for InfisicalProvider {
                             .iter()
                             .map(|(key, _)| {
                                 (key.clone(), Err(FnoxError::ProviderInvalidResponse {
-                                    provider: "Infisical".to_string(),
+                                    provider: PROVIDER_NAME.to_string(),
                                     details: format!("Failed to parse batch response: {}", e),
                                     hint: "The Infisical CLI returned an unexpected response format".to_string(),
-                                    url: "https://fnox.jdx.dev/providers/infisical".to_string(),
+                                    url: PROVIDER_URL.to_string(),
                                 }))
                             })
                             .collect()
@@ -455,24 +458,26 @@ fn map_batch_error(e: &FnoxError, secret_name: &str) -> FnoxError {
         FnoxError::ProviderAuthFailed {
             details, hint, url, ..
         } => FnoxError::ProviderAuthFailed {
-            provider: "Infisical".to_string(),
+            provider: PROVIDER_NAME.to_string(),
             details: details.clone(),
             hint: hint.clone(),
             url: url.clone(),
         },
-        FnoxError::ProviderSecretNotFound { hint, url, .. } => FnoxError::ProviderSecretNotFound {
-            provider: "Infisical".to_string(),
-            secret: secret_name.to_string(),
-            hint: hint.clone(),
-            url: url.clone(),
-        },
+        FnoxError::ProviderSecretNotFound { hint, url, .. } => {
+            FnoxError::ProviderSecretNotFound {
+                provider: PROVIDER_NAME.to_string(),
+                secret: secret_name.to_string(),
+                hint: hint.clone(),
+                url: url.clone(),
+            }
+        }
         FnoxError::ProviderCliNotFound {
             cli,
             install_hint,
             url,
             ..
         } => FnoxError::ProviderCliNotFound {
-            provider: "Infisical".to_string(),
+            provider: PROVIDER_NAME.to_string(),
             cli: cli.clone(),
             install_hint: install_hint.clone(),
             url: url.clone(),
@@ -480,7 +485,7 @@ fn map_batch_error(e: &FnoxError, secret_name: &str) -> FnoxError {
         FnoxError::ProviderInvalidResponse {
             details, hint, url, ..
         } => FnoxError::ProviderInvalidResponse {
-            provider: "Infisical".to_string(),
+            provider: PROVIDER_NAME.to_string(),
             details: details.clone(),
             hint: hint.clone(),
             url: url.clone(),
@@ -488,7 +493,7 @@ fn map_batch_error(e: &FnoxError, secret_name: &str) -> FnoxError {
         FnoxError::ProviderApiError {
             details, hint, url, ..
         } => FnoxError::ProviderApiError {
-            provider: "Infisical".to_string(),
+            provider: PROVIDER_NAME.to_string(),
             details: details.clone(),
             hint: hint.clone(),
             url: url.clone(),
@@ -496,16 +501,16 @@ fn map_batch_error(e: &FnoxError, secret_name: &str) -> FnoxError {
         FnoxError::ProviderCliFailed {
             details, hint, url, ..
         } => FnoxError::ProviderCliFailed {
-            provider: "Infisical".to_string(),
+            provider: PROVIDER_NAME.to_string(),
             details: details.clone(),
             hint: hint.clone(),
             url: url.clone(),
         },
         _ => FnoxError::ProviderCliFailed {
-            provider: "Infisical".to_string(),
+            provider: PROVIDER_NAME.to_string(),
             details: e.to_string(),
             hint: "Check your Infisical configuration".to_string(),
-            url: "https://fnox.jdx.dev/providers/infisical".to_string(),
+            url: PROVIDER_URL.to_string(),
         },
     }
 }
@@ -521,27 +526,27 @@ fn classify_cli_error(stderr: &str, secret_ref: Option<&str>) -> FnoxError {
         || stderr_lower.contains("forbidden")
     {
         return FnoxError::ProviderAuthFailed {
-            provider: "Infisical".to_string(),
+            provider: PROVIDER_NAME.to_string(),
             details: stderr.to_string(),
             hint: "Run 'infisical login' or check your INFISICAL_TOKEN".to_string(),
-            url: "https://fnox.jdx.dev/providers/infisical".to_string(),
+            url: PROVIDER_URL.to_string(),
         };
     }
 
     if stderr_lower.contains("not found") || stderr_lower.contains("does not exist") {
         return FnoxError::ProviderSecretNotFound {
-            provider: "Infisical".to_string(),
+            provider: PROVIDER_NAME.to_string(),
             secret: secret_ref.unwrap_or("<unknown>").to_string(),
             hint: "Check that the secret exists in Infisical".to_string(),
-            url: "https://fnox.jdx.dev/providers/infisical".to_string(),
+            url: PROVIDER_URL.to_string(),
         };
     }
 
     FnoxError::ProviderCliFailed {
-        provider: "Infisical".to_string(),
+        provider: PROVIDER_NAME.to_string(),
         details: stderr.to_string(),
         hint: "Check your Infisical configuration and authentication".to_string(),
-        url: "https://fnox.jdx.dev/providers/infisical".to_string(),
+        url: PROVIDER_URL.to_string(),
     }
 }
 
@@ -617,10 +622,10 @@ mod tests {
     #[test]
     fn map_batch_error_preserves_auth_failed() {
         let error = FnoxError::ProviderAuthFailed {
-            provider: "Infisical".to_string(),
+            provider: PROVIDER_NAME.to_string(),
             details: "unauthorized".to_string(),
             hint: "login".to_string(),
-            url: "https://fnox.jdx.dev/providers/infisical".to_string(),
+            url: PROVIDER_URL.to_string(),
         };
 
         let result = map_batch_error(&error, "secret1");
@@ -634,10 +639,10 @@ mod tests {
     #[test]
     fn map_batch_error_preserves_cli_not_found() {
         let error = FnoxError::ProviderCliNotFound {
-            provider: "Infisical".to_string(),
+            provider: PROVIDER_NAME.to_string(),
             cli: "infisical".to_string(),
             install_hint: "brew install".to_string(),
-            url: "https://fnox.jdx.dev/providers/infisical".to_string(),
+            url: PROVIDER_URL.to_string(),
         };
 
         let result = map_batch_error(&error, "secret1");
@@ -651,10 +656,10 @@ mod tests {
     #[test]
     fn map_batch_error_preserves_secret_not_found_with_per_secret_name() {
         let error = FnoxError::ProviderSecretNotFound {
-            provider: "Infisical".to_string(),
+            provider: PROVIDER_NAME.to_string(),
             secret: "original".to_string(),
             hint: "check".to_string(),
-            url: "https://fnox.jdx.dev/providers/infisical".to_string(),
+            url: PROVIDER_URL.to_string(),
         };
 
         let result = map_batch_error(&error, "secret_a");
@@ -669,10 +674,10 @@ mod tests {
     #[test]
     fn map_batch_error_clones_cli_failed_without_double_wrapping() {
         let error = FnoxError::ProviderCliFailed {
-            provider: "Infisical".to_string(),
+            provider: PROVIDER_NAME.to_string(),
             details: "some error".to_string(),
             hint: "original hint".to_string(),
-            url: "https://fnox.jdx.dev/providers/infisical".to_string(),
+            url: PROVIDER_URL.to_string(),
         };
 
         let result = map_batch_error(&error, "secret1");

--- a/src/providers/infisical.rs
+++ b/src/providers/infisical.rs
@@ -138,11 +138,7 @@ impl InfisicalProvider {
 
     /// Execute infisical CLI command.
     /// `secret_ref` is used for better error messages when a specific secret is being fetched.
-    fn execute_infisical_command(
-        &self,
-        args: &[&str],
-        secret_ref: Option<&str>,
-    ) -> Result<String> {
+    fn execute_infisical_command(&self, args: &[&str], secret_ref: Option<&str>) -> Result<String> {
         tracing::debug!("Executing infisical command with args: {:?}", args);
 
         let token = self.get_auth_token()?;
@@ -395,9 +391,7 @@ impl crate::providers::Provider for InfisicalProvider {
                 // Preserve the structured error variant for each secret
                 secrets
                     .iter()
-                    .map(|(key, secret_name)| {
-                        (key.clone(), Err(map_batch_error(&e, secret_name)))
-                    })
+                    .map(|(key, secret_name)| (key.clone(), Err(map_batch_error(&e, secret_name))))
                     .collect()
             }
         }
@@ -466,14 +460,12 @@ fn map_batch_error(e: &FnoxError, secret_name: &str) -> FnoxError {
             hint: hint.clone(),
             url: url.clone(),
         },
-        FnoxError::ProviderSecretNotFound { hint, url, .. } => {
-            FnoxError::ProviderSecretNotFound {
-                provider: "Infisical".to_string(),
-                secret: secret_name.to_string(),
-                hint: hint.clone(),
-                url: url.clone(),
-            }
-        }
+        FnoxError::ProviderSecretNotFound { hint, url, .. } => FnoxError::ProviderSecretNotFound {
+            provider: "Infisical".to_string(),
+            secret: secret_name.to_string(),
+            hint: hint.clone(),
+            url: url.clone(),
+        },
         FnoxError::ProviderCliNotFound {
             cli,
             install_hint,


### PR DESCRIPTION
## Summary

Fixes #291 — auth prompt was triggering for all provider errors (e.g., "secret not found", "field does not exist"), not just authentication failures.

### Changes

- **`src/error.rs`** — Add `is_auth_error()` method to `FnoxError` that returns `true` only for `ProviderAuthFailed`
- **`src/auth_prompt.rs`** — Extract `should_attempt_auth_prompt()` pure decision function; guard `prompt_and_run_auth` so non-auth errors return `Ok(false)` immediately
- **`src/providers/infisical.rs`** — Classify CLI stderr into proper error variants (`ProviderAuthFailed` for unauthorized/expired/forbidden, `ProviderSecretNotFound` for not-found); preserve structured errors in batch mode instead of rewriting to `ProviderCliFailed`

### Test plan

- [x] `is_auth_error()` returns true for `ProviderAuthFailed`, false for all other variants
- [x] `should_attempt_auth_prompt()` exhaustive truth table (8 combinations)
- [x] `classify_cli_error()` maps unauthorized/expired/forbidden to auth errors, not-found to secret errors, generic to CLI errors
- [x] `map_batch_error()` preserves all structured error variants including `ProviderCliFailed` without double-wrapping
- [x] `cargo test` — 99/99 pass, no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)