### PR TITLE
chore: release v1.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [1.15.0](https://github.com/jdx/fnox/compare/v1.14.0..v1.15.0) - 2026-03-02
+
+### 🚀 Features
+
+- **(provider)** allow auth_command override per-provider in config by [@jdx](https://github.com/jdx) in [#305](https://github.com/jdx/fnox/pull/305)
+- **(vault)** make address field optional and fallback to VAULT_ADDR by [@chermed](https://github.com/chermed) in [#301](https://github.com/jdx/fnox/pull/301)
+- add `fnox sync` command by [@jdx](https://github.com/jdx) in [#298](https://github.com/jdx/fnox/pull/298)
+- nushell integration by [@tiptenbrink](https://github.com/tiptenbrink) in [#304](https://github.com/jdx/fnox/pull/304)
+
+### 🐛 Bug Fixes
+
+- **(provider)** only trigger auth prompt for ProviderAuthFailed errors by [@TyceHerrman](https://github.com/TyceHerrman) in [#297](https://github.com/jdx/fnox/pull/297)
+- **(provider)** add missing provider add types and proton-pass vault by [@TyceHerrman](https://github.com/TyceHerrman) in [#302](https://github.com/jdx/fnox/pull/302)
+
+### New Contributors
+
+- @chermed made their first contribution in [#301](https://github.com/jdx/fnox/pull/301)
+- @tiptenbrink made their first contribution in [#304](https://github.com/jdx/fnox/pull/304)
+
 ## [1.14.0](https://github.com/jdx/fnox/compare/v1.13.0..v1.14.0) - 2026-02-28
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2035,7 +2035,7 @@ dependencies = [
 
 [[package]]
 name = "fnox"
-version = "1.14.0"
+version = "1.15.0"
 dependencies = [
  "age",
  "anyhow",
@@ -3508,12 +3508,13 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
  "bitflags",
  "libc",
+ "plain",
  "redox_syscall 0.7.3",
 ]
 
@@ -4246,6 +4247,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
 name = "pluralizer"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4399,12 +4406,9 @@ dependencies = [
 
 [[package]]
 name = "pxfm"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7186d3822593aa4393561d186d1393b3923e9d6163d3fbfd6e825e3e6cf3e6a8"
-dependencies = [
- "num-traits",
-]
+checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
 
 [[package]]
 name = "quick-error"
@@ -5584,6 +5588,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
+]
+
+[[package]]
 name = "strum_macros"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5601,6 +5614,18 @@ name = "strum_macros"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -6415,9 +6440,9 @@ checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "usage-lib"
-version = "2.18.1"
+version = "2.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4384d884d1f94c1426ded60ed074a4ffe4052067952bc52fb2f91c40c249e725"
+checksum = "1851c9ddbc3a428af152852227363e7f66b73ca2ce732c8db3c2d4ab37eb63d2"
 dependencies = [
  "clap",
  "heck",
@@ -6430,7 +6455,7 @@ dependencies = [
  "roff",
  "serde",
  "shell-words",
- "strum 0.27.2",
+ "strum 0.28.0",
  "tera",
  "thiserror 2.0.18",
  "versions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fnox"
-version = "1.14.0"
+version = "1.15.0"
 edition = "2024"
 authors = ["@jdx"]
 description = "A flexible secret management tool supporting multiple providers and encryption methods"

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -1296,7 +1296,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.14.0",
+  "version": "1.15.0",
   "usage": "Usage: fnox [OPTIONS] <COMMAND>",
   "complete": {
     "key": {

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -4,7 +4,7 @@
 
 **Usage**: `fnox [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.14.0
+**Version**: 1.15.0
 
 - **Usage**: `fnox [FLAGS] <SUBCOMMAND>`
 

--- a/fnox.usage.kdl
+++ b/fnox.usage.kdl
@@ -1,7 +1,7 @@
 min_usage_version "1.3"
 name fnox
 bin fnox
-version "1.14.0"
+version "1.15.0"
 about "A flexible secret management tool by @jdx"
 usage "Usage: fnox [OPTIONS] <COMMAND>"
 flag "-c --config" help="Path to the configuration file (default: fnox.toml, searches parent directories)" global=#true default=fnox.toml {


### PR DESCRIPTION
### 🚀 Features

- **(provider)** allow auth_command override per-provider in config by [@jdx](https://github.com/jdx) in [#305](https://github.com/jdx/fnox/pull/305)
- **(vault)** make address field optional and fallback to VAULT_ADDR by [@chermed](https://github.com/chermed) in [#301](https://github.com/jdx/fnox/pull/301)
- add `fnox sync` command by [@jdx](https://github.com/jdx) in [#298](https://github.com/jdx/fnox/pull/298)
- nushell integration by [@tiptenbrink](https://github.com/tiptenbrink) in [#304](https://github.com/jdx/fnox/pull/304)

### 🐛 Bug Fixes

- **(provider)** only trigger auth prompt for ProviderAuthFailed errors by [@TyceHerrman](https://github.com/TyceHerrman) in [#297](https://github.com/jdx/fnox/pull/297)
- **(provider)** add missing provider add types and proton-pass vault by [@TyceHerrman](https://github.com/TyceHerrman) in [#302](https://github.com/jdx/fnox/pull/302)

### New Contributors

- @chermed made their first contribution in [#301](https://github.com/jdx/fnox/pull/301)
- @tiptenbrink made their first contribution in [#304](https://github.com/jdx/fnox/pull/304)