### PR TITLE
feat(vault): make address field optional and fallback to VAULT_ADDR

### DIFF
--- a/docs/providers/vault.md
+++ b/docs/providers/vault.md
@@ -24,7 +24,7 @@ sudo apt update && sudo apt install vault
 
 ```toml
 [providers]
-vault = { type = "vault", path = "secret/myapp" } # address is optional
+vault = { type = "vault", path = "secret/myapp" } # address and token are optional
 ```
 
 - **address**: (Optional) The Vault server address. Falls back to `FNOX_VAULT_ADDR` or `VAULT_ADDR`.

--- a/docs/providers/vault.md
+++ b/docs/providers/vault.md
@@ -24,8 +24,12 @@ sudo apt update && sudo apt install vault
 
 ```toml
 [providers]
-vault = { type = "vault", address = "https://vault.example.com:8200", path = "secret/myapp" }  # token optional, can use VAULT_TOKEN env var
+vault = { type = "vault", path = "secret/myapp" } # address is optional
 ```
+
+- **address**: (Optional) The Vault server address. Falls back to `FNOX_VAULT_ADDR` or `VAULT_ADDR`.
+- **path**: (Required) The base path for secrets in Vault (e.g., `secret/myapp`).
+- **token**: (Optional) Vault token. Falls back to `FNOX_VAULT_TOKEN` or `VAULT_TOKEN`.
 
 ## Setup
 

--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -400,7 +400,7 @@
           "type": "object",
           "properties": {
             "address": {
-              "$ref": "#/$defs/StringOrSecretRef"
+              "$ref": "#/$defs/OptionStringOrSecretRef"
             },
             "namespace": {
               "$ref": "#/$defs/OptionStringOrSecretRef"
@@ -417,7 +417,7 @@
             }
           },
           "additionalProperties": false,
-          "required": ["type", "address"]
+          "required": ["type"]
         },
         {
           "type": "object",

--- a/docs/reference/environment.md
+++ b/docs/reference/environment.md
@@ -245,11 +245,11 @@ Used by Bitwarden provider.
 ### HashiCorp Vault
 
 ```bash
-export VAULT_ADDR="https://vault.example.com:8200"
-export VAULT_TOKEN="hvs.CAESIJ..."
+export VAULT_ADDR="https://vault.example.com:8200"   # Or FNOX_VAULT_ADDR
+export VAULT_TOKEN="hvs.CAESIJ..."                # Or FNOX_VAULT_TOKEN
 ```
 
-Used by Vault provider.
+Used by Vault provider. `FNOX_` prefixed variables take precedence over standard Vault environment variables.
 
 ## Editor
 

--- a/example.fnox.toml
+++ b/example.fnox.toml
@@ -37,8 +37,8 @@ prefix = "myapp/"
 
 [providers.vault_dev]
 type = "vault"
-address = "http://localhost:8200"
 path = "secret/myapp"
+# address = "http://localhost:8200" # Optional, falls back to FNOX_VAULT_ADDR or VAULT_ADDR
 
 # Default profile secrets (top level)
 # Used when --profile is not specified or FNOX_PROFILE is not set

--- a/providers/vault.toml
+++ b/providers/vault.toml
@@ -12,7 +12,7 @@ Set: export VAULT_ADDR=http://localhost:8200
 Set: export VAULT_TOKEN=<token>"""
 
 [fields.address]
-type = "required"
+type = "optional"
 placeholder = "http://localhost:8200"
 label = "Vault address:"
 wizard = true

--- a/src/commands/provider/add.rs
+++ b/src/commands/provider/add.rs
@@ -77,7 +77,7 @@ impl AddCommand {
                 prefix: OptionStringOrSecretRef::none(),
             },
             ProviderType::Vault => crate::config::ProviderConfig::HashiCorpVault {
-                address: StringOrSecretRef::from("http://localhost:8200"),
+                address: OptionStringOrSecretRef::literal("http://localhost:8200"),
                 path: OptionStringOrSecretRef::literal("secret"),
                 token: OptionStringOrSecretRef::none(),
                 namespace: OptionStringOrSecretRef::none(),

--- a/src/providers/vault.rs
+++ b/src/providers/vault.rs
@@ -185,7 +185,7 @@ impl crate::providers::Provider for HashiCorpVaultProvider {
         if let Some(addr) = address {
             tracing::debug!("Testing connection to Vault at {}", addr);
         } else {
-            tracing::debug!("Testing connection to Vault (using environment VAULT_ADDR)");
+            tracing::debug!("Testing connection to Vault (address not specified in config or environment)");
         }
 
         // Try to get Vault status

--- a/src/providers/vault.rs
+++ b/src/providers/vault.rs
@@ -66,14 +66,14 @@ impl HashiCorpVaultProvider {
         }
 
         // Set VAULT_TOKEN from provider config or environment
-        let token = self.get_token().ok_or_else(|| {
-            FnoxError::ProviderAuthFailed {
+        let token = self
+            .get_token()
+            .ok_or_else(|| FnoxError::ProviderAuthFailed {
                 provider: "HashiCorp Vault".to_string(),
                 details: "VAULT_TOKEN not set".to_string(),
                 hint: "Set VAULT_TOKEN in provider config or environment".to_string(),
                 url: "https://fnox.jdx.dev/providers/vault".to_string(),
-            }
-        })?;
+            })?;
 
         tracing::debug!(
             "Setting VAULT_TOKEN environment variable (token length: {})",

--- a/src/providers/vault.rs
+++ b/src/providers/vault.rs
@@ -209,7 +209,12 @@ impl crate::providers::Provider for HashiCorpVaultProvider {
 }
 
 pub fn env_dependencies() -> &'static [&'static str] {
-    &["VAULT_TOKEN", "FNOX_VAULT_TOKEN", "VAULT_ADDR", "FNOX_VAULT_ADDR"]
+    &[
+        "VAULT_TOKEN",
+        "FNOX_VAULT_TOKEN",
+        "VAULT_ADDR",
+        "FNOX_VAULT_ADDR",
+    ]
 }
 
 fn vault_token() -> Option<String> {

--- a/src/providers/vault.rs
+++ b/src/providers/vault.rs
@@ -185,7 +185,9 @@ impl crate::providers::Provider for HashiCorpVaultProvider {
         if let Some(addr) = address {
             tracing::debug!("Testing connection to Vault at {}", addr);
         } else {
-            tracing::debug!("Testing connection to Vault (address not specified in config or environment)");
+            tracing::debug!(
+                "Testing connection to Vault (address not specified in config or environment)"
+            );
         }
 
         // Try to get Vault status

--- a/src/providers/vault.rs
+++ b/src/providers/vault.rs
@@ -48,12 +48,9 @@ impl HashiCorpVaultProvider {
 
         // Set VAULT_ADDR from provider config or environment
         let address = self.get_address().ok_or_else(|| {
-            FnoxError::ProviderAuthFailed {
-                provider: "HashiCorp Vault".to_string(),
-                details: "VAULT_ADDR not set".to_string(),
-                hint: "Set VAULT_ADDR in provider config or environment (e.g., export VAULT_ADDR=http://localhost:8200)".to_string(),
-                url: "https://fnox.jdx.dev/providers/vault".to_string(),
-            }
+            FnoxError::Config(
+                "HashiCorp Vault provider address is not configured. Please set it in your provider configuration or via the VAULT_ADDR environment variable.".to_string(),
+            )
         })?;
 
         tracing::debug!("Setting VAULT_ADDR to '{}'", address);

--- a/test/vault.bats
+++ b/test/vault.bats
@@ -335,7 +335,7 @@ EOF
 
 	assert_failure
 	assert_output --partial "1.2.3.4:5678"
-	refute_output --partial "missing field \`address\`"
+	refute_output --partial 'missing field `address`'
 }
 
 @test "Vault provider with description field" {

--- a/test/vault.bats
+++ b/test/vault.bats
@@ -360,3 +360,23 @@ EOF
 	# Cleanup
 	delete_test_vault_secret "$secret_name"
 }
+
+@test "Vault provider fails with semantic error when address and VAULT_ADDR are missing" {
+	# Create config without address
+	cat >"${FNOX_CONFIG_FILE:-fnox.toml}" <<EOF
+root = true
+[providers.vault]
+type = "vault"
+
+[secrets]
+MY_SECRET = { provider = "vault", value = "foo" }
+EOF
+
+	# Ensure VAULT_ADDR and FNOX_VAULT_ADDR are not set
+	unset VAULT_ADDR
+	unset FNOX_VAULT_ADDR
+
+	run "$FNOX_BIN" get MY_SECRET
+	assert_failure
+	assert_output --partial "Configuration error: HashiCorp Vault provider address is not configured"
+}

--- a/test/vault.bats
+++ b/test/vault.bats
@@ -306,6 +306,38 @@ EOF
 	assert_success
 }
 
+@test "Vault provider uses VAULT_ADDR from environment if address is missing" {
+	# Create config without address
+	cat >"${FNOX_CONFIG_FILE:-fnox.toml}" <<EOF
+root = true
+[providers.vault]
+type = "vault"
+path = "secret/test"
+
+[secrets]
+MY_SECRET = { provider = "vault", value = "foo" }
+EOF
+
+	# Set VAULT_ADDR to a dummy value
+	VAULT_ADDR_BACKUP="$VAULT_ADDR"
+	export VAULT_ADDR="http://1.2.3.4:5678"
+
+	# Run fnox get. It should fail with a connection error to 1.2.3.4:5678,
+	# proving it used the environment variable instead of failing with a TOML error.
+	run "$FNOX_BIN" get MY_SECRET
+
+	# Restore VAULT_ADDR
+	if [ -n "$VAULT_ADDR_BACKUP" ]; then
+		export VAULT_ADDR="$VAULT_ADDR_BACKUP"
+	else
+		unset VAULT_ADDR
+	fi
+
+	assert_failure
+	assert_output --partial "1.2.3.4:5678"
+	refute_output --partial "missing field \`address\`"
+}
+
 @test "Vault provider with description field" {
 	create_vault_config
 


### PR DESCRIPTION
This PR modifies the HashiCorp Vault provider to allow for a more flexible configuration, especially in environments where Vault connectivity is already defined via
  environment variables.


  Changes:
   - Optional Address: Changed the address field from required to optional in the provider definition.
   - Environment Fallback: Implemented logic in the Vault provider to fallback to VAULT_ADDR (or FNOX_VAULT_ADDR) if the address is not explicitly provided in fnox.toml.
   - Template Update: Updated the fnox provider add vault command to generate the new optional field structure.
   - Testing: Added a dedicated test case to test/vault.bats to verify that the fallback mechanism correctly identifies and uses the environment variable.