### PR TITLE
fix(provider): add missing provider add types and proton-pass vault

### DIFF
--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -573,7 +573,7 @@
         "subcommands": {
           "add": {
             "full_cmd": ["provider", "add"],
-            "usage": "provider add [-g --global] <PROVIDER> <PROVIDER_TYPE>",
+            "usage": "provider add [-g --global] [--vault <VAULT>] <PROVIDER> <PROVIDER_TYPE>",
             "subcommands": {},
             "args": [
               {
@@ -604,8 +604,15 @@
                     "azure-sm",
                     "gcp",
                     "gcp-kms",
+                    "bitwarden",
+                    "bitwarden-sm",
                     "infisical",
+                    "keepass",
+                    "keychain",
+                    "password-store",
                     "passwordstate",
+                    "plain",
+                    "proton-pass",
                     "vault"
                   ]
                 }
@@ -621,6 +628,23 @@
                 "long": ["global"],
                 "hide": false,
                 "global": false
+              },
+              {
+                "name": "vault",
+                "usage": "--vault <VAULT>",
+                "help": "Default Proton Pass vault name (only valid with provider type proton-pass)",
+                "help_first_line": "Default Proton Pass vault name (only valid with provider type proton-pass)",
+                "short": [],
+                "long": ["vault"],
+                "hide": false,
+                "global": false,
+                "arg": {
+                  "name": "VAULT",
+                  "usage": "<VAULT>",
+                  "required": true,
+                  "double_dash": "Optional",
+                  "hide": false
+                }
               }
             ],
             "mounts": [],

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -53,7 +53,7 @@ Do not merge top-level secrets into the selected profile
 - [`fnox list [FLAGS]`](/cli/list.md)
 - [`fnox profiles`](/cli/profiles.md)
 - [`fnox provider <SUBCOMMAND>`](/cli/provider.md)
-- [`fnox provider add [-g --global] <PROVIDER> <PROVIDER_TYPE>`](/cli/provider/add.md)
+- [`fnox provider add [-g --global] [--vault <VAULT>] <PROVIDER> <PROVIDER_TYPE>`](/cli/provider/add.md)
 - [`fnox provider list`](/cli/provider/list.md)
 - [`fnox provider remove [-g --global] <PROVIDER>`](/cli/provider/remove.md)
 - [`fnox provider test [-a --all] [PROVIDER]`](/cli/provider/test.md)

--- a/docs/cli/provider.md
+++ b/docs/cli/provider.md
@@ -8,7 +8,7 @@ Manage providers (defaults to list)
 
 ## Subcommands
 
-- [`fnox provider add [-g --global] <PROVIDER> <PROVIDER_TYPE>`](/cli/provider/add.md)
+- [`fnox provider add [-g --global] [--vault <VAULT>] <PROVIDER> <PROVIDER_TYPE>`](/cli/provider/add.md)
 - [`fnox provider list`](/cli/provider/list.md)
 - [`fnox provider remove [-g --global] <PROVIDER>`](/cli/provider/remove.md)
 - [`fnox provider test [-a --all] [PROVIDER]`](/cli/provider/test.md)

--- a/docs/cli/provider/add.md
+++ b/docs/cli/provider/add.md
@@ -2,7 +2,7 @@
 
 # `fnox provider add`
 
-- **Usage**: `fnox provider add [-g --global] <PROVIDER> <PROVIDER_TYPE>`
+- **Usage**: `fnox provider add [-g --global] [--vault <VAULT>] <PROVIDER> <PROVIDER_TYPE>`
 - **Aliases**: `a`, `set`
 
 Add a new provider
@@ -28,8 +28,15 @@ Provider type
 - `azure-sm`
 - `gcp`
 - `gcp-kms`
+- `bitwarden`
+- `bitwarden-sm`
 - `infisical`
+- `keepass`
+- `keychain`
+- `password-store`
 - `passwordstate`
+- `plain`
+- `proton-pass`
 - `vault`
 
 ## Flags
@@ -37,3 +44,7 @@ Provider type
 ### `-g --global`
 
 Add to the global config file (~/.config/fnox/config.toml)
+
+### `--vault <VAULT>`
+
+Default Proton Pass vault name (only valid with provider type proton-pass)

--- a/fnox.usage.kdl
+++ b/fnox.usage.kdl
@@ -106,9 +106,12 @@ cmd provider help="Manage providers (defaults to list)" {
     cmd add help="Add a new provider" {
         alias a set
         flag "-g --global" help="Add to the global config file (~/.config/fnox/config.toml)"
+        flag --vault help="Default Proton Pass vault name (only valid with provider type proton-pass)" {
+            arg <VAULT>
+        }
         arg <PROVIDER> help="Provider name"
         arg <PROVIDER_TYPE> help="Provider type" {
-            choices "1password" age aws aws-kms aws-ps azure-kms azure-sm gcp gcp-kms infisical passwordstate vault
+            choices "1password" age aws aws-kms aws-ps azure-kms azure-sm gcp gcp-kms bitwarden bitwarden-sm infisical keepass keychain password-store passwordstate plain proton-pass vault
         }
     }
     cmd list help="List available providers" {

--- a/test/proton-pass.bats
+++ b/test/proton-pass.bats
@@ -231,37 +231,6 @@ EOF
 	assert_output --partial "First Proton Pass secret"
 }
 
-@test "fnox provider add creates Proton Pass provider config" {
-	# Initialize fnox first
-	run "$FNOX_BIN" init
-	assert_success
-
-	# Add a Proton Pass provider
-	run "$FNOX_BIN" provider add mypass proton-pass
-	assert_success
-
-	# Check the config file
-	run cat "$FNOX_CONFIG_FILE"
-	assert_output --partial "[providers.mypass]"
-	assert_output --partial 'type = "proton-pass"'
-}
-
-@test "fnox provider add with vault creates proper config" {
-	# Initialize fnox first
-	run "$FNOX_BIN" init
-	assert_success
-
-	# Add a Proton Pass provider with vault
-	run "$FNOX_BIN" provider add mypass proton-pass --vault "MyVault"
-	assert_success
-
-	# Check the config file
-	run cat "$FNOX_CONFIG_FILE"
-	assert_output --partial "[providers.mypass]"
-	assert_output --partial 'type = "proton-pass"'
-	assert_output --partial 'vault = "MyVault"'
-}
-
 @test "Proton Pass provider fails gracefully with missing authentication" {
 	# This test verifies that fnox returns an auth_failed error when not authenticated
 	# The setup() function skips auth check for tests with "fails gracefully" in the name

--- a/test/provider_add.bats
+++ b/test/provider_add.bats
@@ -1,0 +1,86 @@
+#!/usr/bin/env bats
+
+setup() {
+	load 'test_helper/common_setup'
+	_common_setup
+}
+
+teardown() {
+	_common_teardown
+}
+
+@test "fnox provider add supports all provider types" {
+	# name|cli-type|serialized-type — single source of truth for all provider types
+	local providers
+	providers="onepass|1password|1password
+agep|age|age
+awssm|aws|aws-sm
+awskms|aws-kms|aws-kms
+awsps|aws-ps|aws-ps
+azurekms|azure-kms|azure-kms
+azuresm|azure-sm|azure-sm
+gcpsm|gcp|gcp-sm
+gcpkms|gcp-kms|gcp-kms
+bitwarden|bitwarden|bitwarden
+bws|bitwarden-sm|bitwarden-sm
+infisical|infisical|infisical
+keepass|keepass|keepass
+keychain|keychain|keychain
+passstore|password-store|password-store
+passwordstate|passwordstate|passwordstate
+plain|plain|plain
+proton|proton-pass|proton-pass
+vault|vault|vault"
+
+	run "$FNOX_BIN" init --skip-wizard
+	assert_success
+
+	while IFS='|' read -r provider_name provider_type expected_type; do
+		run "$FNOX_BIN" provider add "$provider_name" "$provider_type"
+		assert_success
+		assert_output --partial "Added provider '$provider_name'"
+	done <<< "$providers"
+
+	run cat "$FNOX_CONFIG_FILE"
+	assert_success
+	while IFS='|' read -r provider_name _ expected_type; do
+		assert_output --partial "[providers.$provider_name]"
+		assert_output --partial "type = \"$expected_type\""
+	done <<< "$providers"
+}
+
+@test "fnox provider add creates Proton Pass provider config" {
+	run "$FNOX_BIN" init --skip-wizard
+	assert_success
+
+	run "$FNOX_BIN" provider add mypass proton-pass
+	assert_success
+
+	run cat "$FNOX_CONFIG_FILE"
+	assert_success
+	assert_output --partial "[providers.mypass]"
+	assert_output --partial 'type = "proton-pass"'
+}
+
+@test "fnox provider add with vault creates proper config" {
+	run "$FNOX_BIN" init --skip-wizard
+	assert_success
+
+	run "$FNOX_BIN" provider add mypass proton-pass --vault "MyVault"
+	assert_success
+
+	run cat "$FNOX_CONFIG_FILE"
+	assert_success
+	assert_output --partial "[providers.mypass]"
+	assert_output --partial 'type = "proton-pass"'
+	assert_output --partial 'vault = "MyVault"'
+}
+
+@test "fnox provider add --vault fails for non-proton provider types" {
+	run "$FNOX_BIN" init --skip-wizard
+	assert_success
+
+	run "$FNOX_BIN" provider add myage age --vault "bad-vault"
+	assert_failure
+	assert_output --partial "--vault is only supported for provider type"
+}

--- a/test/provider_add.bats
+++ b/test/provider_add.bats
@@ -39,14 +39,14 @@ vault|vault|vault"
 		run "$FNOX_BIN" provider add "$provider_name" "$provider_type"
 		assert_success
 		assert_output --partial "Added provider '$provider_name'"
-	done <<< "$providers"
+	done <<<"$providers"
 
 	run cat "$FNOX_CONFIG_FILE"
 	assert_success
 	while IFS='|' read -r provider_name _ expected_type; do
 		assert_output --partial "[providers.$provider_name]"
 		assert_output --partial "type = \"$expected_type\""
-	done <<< "$providers"
+	done <<<"$providers"
 }
 
 @test "fnox provider add creates Proton Pass provider config" {


### PR DESCRIPTION
## Context

PR #292 added proton-pass provider support, but provider add did not include proton-pass type acceptance. This PR fixes that gap and adds tests to prevent future mismatches.

## Summary

- `fnox provider add` now accepts `proton-pass`.
- `provider add` also now accepts other currently defined provider types missing from the CLI enum.
- Added `proton-pass --vault` support with validation.
- Added deterministic regression tests and a guard test to catch future mismatches.

## Changes

### 1) Update `ProviderType` acceptance in `provider add`

Updated `src/commands/provider/mod.rs`:

- Added missing provider types:
  - `bitwarden`
  - `bitwarden-sm`
  - `keepass`
  - `keychain`
  - `password-store`
  - `plain`
  - `proton-pass`
- Preserved existing CLI alias behavior:
  - `aws` maps to AWS Secrets Manager
  - `gcp` maps to GCP Secret Manager
- Added explicit `#[strum(serialize = "keepass")]` for `KeePass`.

### 2) Add `--vault` for Proton Pass

Updated `src/commands/provider/add.rs`:

- Added `--vault <VAULT>` to `provider add`.
- Added validation so `--vault` is accepted only for `proton-pass`.
- Non-`proton-pass` usage returns a clear `FnoxError::Config` message.

### 3) Add missing provider template mappings in `provider add`

Updated `src/commands/provider/add.rs`:

- `bitwarden` -> `ProviderConfig::Bitwarden { ..., backend: None }`
- `bitwarden-sm` -> `ProviderConfig::BitwardenSecretsManager { ... }`
- `keepass` -> `ProviderConfig::KeePass { database: "~/secrets.kdbx", ... }`
- `keychain` -> `ProviderConfig::Keychain { service: "fnox", ... }`
- `password-store` -> `ProviderConfig::PasswordStore { prefix: "fnox/", ... }`
- `plain` -> `ProviderConfig::Plain`
- `proton-pass` -> `ProviderConfig::ProtonPass { vault: <from --vault or none> }`

### 4) Make regression tests deterministic

- Added `test/provider_add.bats` with:
  - matrix coverage for supported `provider add` types
  - `proton-pass` add test
  - `proton-pass --vault` positive test
  - negative test for `--vault` on non-`proton-pass`
- Moved Proton `provider add` tests out of auth-gated `test/proton-pass.bats`.
- Deduplicated repeated provider-list heredoc in `test/provider_add.bats` into a shared variable.

### 5) Add mismatch guard test

Added test in `src/commands/provider/mod.rs`:

- Compares CLI-accepted `ProviderType::value_variants()` against `providers/*.toml`.
- Normalizes intentional aliases (`aws-sm -> aws`, `gcp-sm -> gcp`).
- Fails if provider definitions and `provider add` acceptance diverge.

### 6) Regenerate CLI usage/docs artifacts

Regenerated:

- `fnox.usage.kdl`
- `docs/cli/provider/add.md`
- `docs/cli/provider.md`
- `docs/cli/index.md`
- `docs/cli/commands.json`

## User-facing behavior changes

- `fnox provider add <NAME> proton-pass` now works.
- `fnox provider add <NAME> proton-pass --vault <VAULT>` now works.
- `--vault` with non-`proton-pass` providers now fails with a clear config error.
- Additional provider types listed above are now accepted by `provider add`.

## Validation

Ran locally:

1. `cargo test commands::provider::tests::provider_add_types_match_provider_definitions -- --exact`
2. `mise run test:bats -- test/provider_add.bats`

## Scope / Non-goals

- Hotfix scope only: fix the #292 proton-pass add gap and harden against recurrence.
- No metadata-driven refactor of `provider add` in this PR.
- No provider guide expansion beyond regenerated CLI usage artifacts.

## Follow-ups

1. Metadata-driven `provider add` generation
- Why: remove manual enum/template maintenance and prevent this mismatch class.
- Possible implementation: derive accepted types and template generation from shared provider metadata (`providers/*.toml` + codegen path).

2. Provider-specific flag strategy (avoid future flag sprawl)
- Why: `--vault` is reasonable as a single targeted flag today; complexity grows if additional provider-specific flags are introduced.
- Possible implementation: if more provider-specific flags are added, introduce a validated generic `--set key=value` mechanism or route provider-specific inputs through metadata-driven wizard/config generation.

3. Config-dir setup deduplication
- Why: config-dir ensure/create logic is duplicated across command paths.
- Possible implementation: centralize config-dir setup in one helper reused by `init` and provider command flows.

---

_This PR description was drafted with Codex and reviewed/edited by me before posting._
