### PR TITLE
feat: nushell integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ fnox get DATABASE_URL
 fnox exec -- npm start
 
 # Enable shell integration (auto-load on cd)
-eval "$(fnox activate bash)"  # or zsh, fish
+eval "$(fnox activate bash)"  # or zsh, fish — see docs for Nushell
 ```
 
 ## What is fnox?

--- a/docs/cli/activate.md
+++ b/docs/cli/activate.md
@@ -10,7 +10,7 @@ Output shell activation code to enable automatic secret loading
 
 ### `[SHELL]`
 
-Shell to generate activation code for (bash, zsh, fish)
+Shell to generate activation code for (bash, zsh, fish, nu)
 
 ## Flags
 

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -13,8 +13,8 @@
           {
             "name": "SHELL",
             "usage": "[SHELL]",
-            "help": "Shell to generate activation code for (bash, zsh, fish)",
-            "help_first_line": "Shell to generate activation code for (bash, zsh, fish)",
+            "help": "Shell to generate activation code for (bash, zsh, fish, nu)",
+            "help_first_line": "Shell to generate activation code for (bash, zsh, fish, nu)",
             "required": false,
             "double_dash": "Optional",
             "hide": false
@@ -291,8 +291,8 @@
           {
             "name": "shell",
             "usage": "-s --shell <SHELL>",
-            "help": "Shell type (bash, zsh, fish)",
-            "help_first_line": "Shell type (bash, zsh, fish)",
+            "help": "Shell type (bash, zsh, fish, nu)",
+            "help_first_line": "Shell type (bash, zsh, fish, nu)",
             "short": ["s"],
             "long": ["shell"],
             "hide": false,

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -50,6 +50,8 @@ eval "$(fnox activate bash)"  # or zsh, fish
 echo 'eval "$(fnox activate bash)"' >> ~/.bashrc
 ```
 
+For Nushell setup, see the [Shell Integration](/guide/shell-integration) guide.
+
 Now secrets auto-load:
 
 ```bash

--- a/docs/guide/shell-integration.md
+++ b/docs/guide/shell-integration.md
@@ -23,6 +23,14 @@ eval "$(fnox activate zsh)"
 fnox activate fish | source
 ```
 
+```nu [Nushell]
+# Requires Nushell 0.96+
+# Add to the end of your Nushell configuration
+# (find it by running `$nu.config-path` in Nushell):
+mkdir ($nu.data-dir | path join "vendor/autoload")
+fnox activate nu | save -f ($nu.data-dir | path join "vendor/autoload/fnox.nu")
+```
+
 :::
 
 ## How It Works

--- a/docs/index.md
+++ b/docs/index.md
@@ -53,7 +53,7 @@ fnox get DATABASE_URL
 fnox exec -- npm start
 
 # Enable shell integration (auto-load secrets on cd)
-eval "$(fnox activate bash)"  # or zsh, fish
+eval "$(fnox activate bash)"  # or zsh, fish — see docs for Nushell
 ```
 
 ## How It Works

--- a/fnox.usage.kdl
+++ b/fnox.usage.kdl
@@ -21,7 +21,7 @@ flag --no-color help="Disable colored output" global=#true
 flag --no-defaults help="Do not merge top-level secrets into the selected profile" global=#true
 cmd activate help="Output shell activation code to enable automatic secret loading" {
     flag --no-hook-env help="Don't automatically invoke hook-env (for testing)"
-    arg "[SHELL]" help="Shell to generate activation code for (bash, zsh, fish)" required=#false
+    arg "[SHELL]" help="Shell to generate activation code for (bash, zsh, fish, nu)" required=#false
 }
 cmd check help="Check if all required secrets are defined and configured" {
     alias c
@@ -60,7 +60,7 @@ cmd get help="Get a secret value" {
     arg <KEY> help="Secret key to retrieve"
 }
 cmd hook-env hide=#true help="Internal command used by shell hooks to load secrets" {
-    flag "-s --shell" help="Shell type (bash, zsh, fish)" {
+    flag "-s --shell" help="Shell type (bash, zsh, fish, nu)" {
         arg <SHELL>
     }
 }

--- a/src/commands/activate.rs
+++ b/src/commands/activate.rs
@@ -5,7 +5,7 @@ use clap::Parser;
 #[derive(Debug, Parser)]
 #[command(about = "Output shell activation code to enable automatic secret loading")]
 pub struct ActivateCommand {
-    /// Shell to generate activation code for (bash, zsh, fish)
+    /// Shell to generate activation code for (bash, zsh, fish, nu)
     #[arg(value_name = "SHELL")]
     pub shell: Option<String>,
 

--- a/src/shell/nushell.rs
+++ b/src/shell/nushell.rs
@@ -36,7 +36,7 @@ def --env _fnox_apply [json: string] {
 def --env --wrapped fnox [...rest] {{
     let command = ($rest | first | default "")
     match $command {{
-        "deactivate" | "shell" => {{
+        "deactivate" => {{
             let result = (do -i {{ ^"{exe}" $command ...($rest | skip 1) }} | complete)
             if ($result.stderr | str trim | is-not-empty) {{
                 print -e $result.stderr

--- a/src/shell/nushell.rs
+++ b/src/shell/nushell.rs
@@ -1,0 +1,145 @@
+use super::{ActivateOptions, Shell};
+use std::fmt;
+
+pub struct Nushell;
+
+impl Shell for Nushell {
+    fn activate(&self, opts: ActivateOptions) -> String {
+        let mut out = String::new();
+        let exe = opts.exe.display().to_string();
+
+        out.push_str("$env.FNOX_SHELL = \"nu\"\n");
+
+        // Helper: apply JSON from fnox hook-env / deactivate in the current shell.
+        // Handles {"set": {...}, "unset": [...]} structured output.
+        out.push_str(
+            r#"
+def --env _fnox_apply [json: string] {
+    let changes = ($json | from json)
+    if "set" in $changes and ($changes.set | is-not-empty) {
+        $changes.set | load-env
+    }
+    if "unset" in $changes and ($changes.unset | is-not-empty) {
+        for $var in $changes.unset {
+            hide-env -i $var
+        }
+    }
+}
+"#,
+        );
+
+        // Wrapper function: most subcommands just call the binary directly.
+        // `deactivate` and `shell` need to modify the current shell's environment,
+        // so the binary outputs JSON that _fnox_apply interprets.
+        out.push_str(&format!(
+            r#"
+def --env --wrapped fnox [...rest] {{
+    let command = ($rest | first | default "")
+    match $command {{
+        "deactivate" | "shell" => {{
+            let result = (do -i {{ ^"{exe}" $command ...($rest | skip 1) }} | complete)
+            if ($result.stderr | str trim | is-not-empty) {{
+                print -e $result.stderr
+            }}
+            if $result.exit_code == 0 and ($result.stdout | str trim | is-not-empty) {{
+                _fnox_apply $result.stdout
+            }}
+            if $command == "deactivate" {{
+                $env.config = ($env.config | upsert hooks.pre_prompt ($env.config.hooks.pre_prompt? | default [] | where {{ ($in | describe) != "closure" or (view source $in) !~ "_fnox_hook" }}))
+                hide-env -i FNOX_SHELL
+                hide-env -i __FNOX_SESSION
+            }}
+        }}
+        _ => {{ ^"{exe}" ...$rest }}
+    }}
+}}
+"#,
+        ));
+
+        // --no-hook-env: skip registering the prompt hook (used by tests to
+        // verify the activation output in isolation).
+        if !opts.no_hook_env {
+            out.push_str(&format!(
+                r#"
+def --env _fnox_hook [] {{
+    let result = (do -i {{ ^"{exe}" hook-env -s nu }} | complete)
+    if ($result.stderr | str trim | is-not-empty) {{
+        print -e $result.stderr
+    }}
+    if $result.exit_code == 0 and ($result.stdout | str trim | is-not-empty) {{
+        _fnox_apply $result.stdout
+    }}
+}}
+"#,
+            ));
+
+            // Only hook pre_prompt — it fires after every cd anyway (prompt is
+            // redrawn), so a separate env_change.PWD hook would just cause a
+            // redundant process spawn that early-exit optimises away.
+            out.push_str(
+                r#"
+$env.config = ($env.config | upsert hooks.pre_prompt ($env.config.hooks.pre_prompt? | default [] | append {|| _fnox_hook }))
+"#,
+            );
+
+            out.push_str("_fnox_hook\n");
+        }
+
+        out
+    }
+
+    fn deactivate(&self) -> String {
+        // Nushell has no eval — deactivation is handled by deactivate_output()
+        // producing JSON, and the wrapper function cleaning up hooks/env inline.
+        unimplemented!("Nushell uses deactivate_output() instead")
+    }
+
+    fn set_env(&self, _key: &str, _value: &str) -> String {
+        // Nushell has no eval — hook_env_output() produces JSON directly.
+        unimplemented!("Nushell uses hook_env_output() instead")
+    }
+
+    fn unset_env(&self, _key: &str) -> String {
+        // Nushell has no eval — hook_env_output() produces JSON directly.
+        unimplemented!("Nushell uses hook_env_output() instead")
+    }
+
+    fn hook_env_output(
+        &self,
+        added: &[(String, String)],
+        removed: &[String],
+        session_encoded: &str,
+    ) -> String {
+        let mut set_map = serde_json::Map::new();
+        for (key, value) in added {
+            set_map.insert(key.clone(), serde_json::Value::String(value.clone()));
+        }
+        set_map.insert(
+            "__FNOX_SESSION".to_string(),
+            serde_json::Value::String(session_encoded.to_string()),
+        );
+        let unset_list: Vec<serde_json::Value> = removed
+            .iter()
+            .map(|k| serde_json::Value::String(k.clone()))
+            .collect();
+        serde_json::json!({"set": set_map, "unset": unset_list}).to_string()
+    }
+
+    fn deactivate_output(&self, secret_keys: &[String]) -> String {
+        // Output JSON that the wrapper's _fnox_apply can parse.
+        // Hook removal and FNOX_SHELL/SESSION cleanup are handled
+        // inline by the wrapper function after applying this output.
+        let mut unset_keys: Vec<serde_json::Value> = secret_keys
+            .iter()
+            .map(|k| serde_json::Value::String(k.clone()))
+            .collect();
+        unset_keys.push(serde_json::Value::String("__FNOX_SESSION".to_string()));
+        serde_json::json!({"set": {}, "unset": unset_keys}).to_string()
+    }
+}
+
+impl fmt::Display for Nushell {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "nu")
+    }
+}


### PR DESCRIPTION
Hi! Thanks a lot for this library. A few years back I tried to write something similar (I tried to wrap the Bitwarden CLI) but failed to create truly pleasant DX. So happy to see a much better dev has basically solved it.

However, I'd love to have NuShell integration, which is what this PR contributes. I didn't see anything like a CONTRIBUTING.md so if you'd rather have me make a Discussion first or similar, please let me know.

Note, that since NuShell doesn't support eval, it requires a slightly different implementation. Main idea is that instead of outputting the set/unset env commands fnox provides JSON which the wrapper then interprets. To not have NuShell special cases in the deactivate.rs and hook_env.rs I added 2 new functions to the shell trait which Nushell overrides directly, while the originally supported shells just keep working the same due to a default implementation of those functions.

Note: Claude was used in the development of this PR, mainly providing heavy lifting for the Nushell script code. 
