### PR TITLE
feat(provider): allow auth_command override per-provider in config

### DIFF
--- a/build/generate_providers.rs
+++ b/build/generate_providers.rs
@@ -358,10 +358,11 @@ fn generate_provider_methods(
             quote! { None }
         };
         auth_command_arms.push(quote! {
-            Self::#variant { auth_command, .. } => auth_command.as_ref().map_or(
-                #static_default,
-                |s| if s.is_empty() { None } else { Some(s.as_str()) },
-            )
+            Self::#variant { auth_command, .. } => match auth_command.as_deref() {
+                Some("") => None,
+                Some(cmd) => Some(cmd),
+                None => #static_default,
+            }
         });
         env_deps_arms.push(quote! {
             Self::#variant { .. } => #module::env_dependencies()

--- a/build/generate_providers.rs
+++ b/build/generate_providers.rs
@@ -358,7 +358,10 @@ fn generate_provider_methods(
             quote! { None }
         };
         auth_command_arms.push(quote! {
-            Self::#variant { auth_command, .. } => auth_command.as_deref().or(#static_default)
+            Self::#variant { auth_command, .. } => auth_command.as_ref().map_or(
+                #static_default,
+                |s| if s.is_empty() { None } else { Some(s.as_str()) },
+            )
         });
         env_deps_arms.push(quote! {
             Self::#variant { .. } => #module::env_dependencies()

--- a/docs/providers/bitwarden.md
+++ b/docs/providers/bitwarden.md
@@ -235,7 +235,10 @@ default_provider = "bitwarden"
 [providers.bitwarden]
 type = "bitwarden"
 backend = "rbw"
+auth_command = "rbw unlock"
 ```
+
+The `auth_command` override ensures fnox prompts with `rbw unlock` instead of the default `bw login` when authentication fails.
 
 NB: you must have set up the `rbw` CLI independently from fnox using `rbw login`.
 

--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -124,6 +124,9 @@
         {
           "type": "object",
           "properties": {
+            "auth_command": {
+              "type": ["string", "null"]
+            },
             "database": {
               "$ref": "#/$defs/StringOrSecretRef"
             },
@@ -144,6 +147,9 @@
         {
           "type": "object",
           "properties": {
+            "auth_command": {
+              "type": ["string", "null"]
+            },
             "gpg_opts": {
               "$ref": "#/$defs/OptionStringOrSecretRef"
             },
@@ -164,6 +170,9 @@
         {
           "type": "object",
           "properties": {
+            "auth_command": {
+              "type": ["string", "null"]
+            },
             "type": {
               "type": "string",
               "const": "plain"
@@ -175,6 +184,9 @@
         {
           "type": "object",
           "properties": {
+            "auth_command": {
+              "type": ["string", "null"]
+            },
             "key_file": {
               "$ref": "#/$defs/OptionStringOrSecretRef"
             },
@@ -198,6 +210,9 @@
             "account": {
               "$ref": "#/$defs/OptionStringOrSecretRef"
             },
+            "auth_command": {
+              "type": ["string", "null"]
+            },
             "token": {
               "$ref": "#/$defs/OptionStringOrSecretRef"
             },
@@ -217,6 +232,9 @@
           "properties": {
             "api_key": {
               "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "auth_command": {
+              "type": ["string", "null"]
             },
             "base_url": {
               "$ref": "#/$defs/StringOrSecretRef"
@@ -238,6 +256,9 @@
         {
           "type": "object",
           "properties": {
+            "auth_command": {
+              "type": ["string", "null"]
+            },
             "type": {
               "type": "string",
               "const": "proton-pass"
@@ -252,6 +273,9 @@
         {
           "type": "object",
           "properties": {
+            "auth_command": {
+              "type": ["string", "null"]
+            },
             "backend": {
               "anyOf": [
                 {
@@ -282,6 +306,9 @@
         {
           "type": "object",
           "properties": {
+            "auth_command": {
+              "type": ["string", "null"]
+            },
             "environment": {
               "$ref": "#/$defs/OptionStringOrSecretRef"
             },
@@ -302,6 +329,9 @@
         {
           "type": "object",
           "properties": {
+            "auth_command": {
+              "type": ["string", "null"]
+            },
             "key_id": {
               "$ref": "#/$defs/StringOrSecretRef"
             },
@@ -319,6 +349,9 @@
         {
           "type": "object",
           "properties": {
+            "auth_command": {
+              "type": ["string", "null"]
+            },
             "key_name": {
               "$ref": "#/$defs/StringOrSecretRef"
             },
@@ -336,6 +369,9 @@
         {
           "type": "object",
           "properties": {
+            "auth_command": {
+              "type": ["string", "null"]
+            },
             "key": {
               "$ref": "#/$defs/StringOrSecretRef"
             },
@@ -359,6 +395,9 @@
         {
           "type": "object",
           "properties": {
+            "auth_command": {
+              "type": ["string", "null"]
+            },
             "prefix": {
               "$ref": "#/$defs/OptionStringOrSecretRef"
             },
@@ -379,6 +418,9 @@
         {
           "type": "object",
           "properties": {
+            "auth_command": {
+              "type": ["string", "null"]
+            },
             "prefix": {
               "$ref": "#/$defs/OptionStringOrSecretRef"
             },
@@ -402,6 +444,9 @@
             "address": {
               "$ref": "#/$defs/StringOrSecretRef"
             },
+            "auth_command": {
+              "type": ["string", "null"]
+            },
             "namespace": {
               "$ref": "#/$defs/OptionStringOrSecretRef"
             },
@@ -422,6 +467,9 @@
         {
           "type": "object",
           "properties": {
+            "auth_command": {
+              "type": ["string", "null"]
+            },
             "profile": {
               "$ref": "#/$defs/OptionStringOrSecretRef"
             },
@@ -439,6 +487,9 @@
         {
           "type": "object",
           "properties": {
+            "auth_command": {
+              "type": ["string", "null"]
+            },
             "prefix": {
               "$ref": "#/$defs/OptionStringOrSecretRef"
             },
@@ -456,6 +507,9 @@
         {
           "type": "object",
           "properties": {
+            "auth_command": {
+              "type": ["string", "null"]
+            },
             "prefix": {
               "$ref": "#/$defs/OptionStringOrSecretRef"
             },
@@ -473,6 +527,9 @@
         {
           "type": "object",
           "properties": {
+            "auth_command": {
+              "type": ["string", "null"]
+            },
             "prefix": {
               "$ref": "#/$defs/OptionStringOrSecretRef"
             },

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -117,6 +117,24 @@ type = "PROVIDER_TYPE"
 # ... provider-specific fields ...
 ```
 
+### `auth_command`
+
+Override the authentication command for a specific provider instance. When provider authentication fails in a TTY, fnox prompts to run this command. By default, each provider type has a built-in auth command (e.g., `bw login` for Bitwarden, `op signin` for 1Password).
+
+```toml
+[providers]
+# Use rbw instead of the default bw CLI
+rbw = { type = "bitwarden", backend = "rbw", auth_command = "rbw unlock" }
+
+# Use a custom AWS SSO profile
+aws = { type = "aws-sm", region = "us-east-1", auth_command = "aws sso login --profile myprofile" }
+
+# Disable auth prompting for this provider
+vault = { type = "vault", address = "https://vault.example.com", auth_command = "" }
+```
+
+Setting `auth_command = ""` disables the auth prompt for that provider instance.
+
 ### Common Provider Types
 
 #### Age Encryption

--- a/src/auth_prompt.rs
+++ b/src/auth_prompt.rs
@@ -83,6 +83,7 @@ mod tests {
             vault: OptionStringOrSecretRef::literal("default"),
             account: OptionStringOrSecretRef::none(),
             token: OptionStringOrSecretRef::none(),
+            auth_command: None,
         }
     }
 

--- a/src/commands/provider/add.rs
+++ b/src/commands/provider/add.rs
@@ -135,11 +135,13 @@ impl AddCommand {
                 organization_id: OptionStringOrSecretRef::none(),
                 profile: OptionStringOrSecretRef::none(),
                 backend: None,
+                auth_command: None,
             },
             ProviderType::BitwardenSecretsManager => {
                 crate::config::ProviderConfig::BitwardenSecretsManager {
                     project_id: OptionStringOrSecretRef::none(),
                     profile: OptionStringOrSecretRef::none(),
+                    auth_command: None,
                 }
             }
             ProviderType::Age => crate::config::ProviderConfig::AgeEncryption {
@@ -157,15 +159,18 @@ impl AddCommand {
                 database: StringOrSecretRef::from("~/secrets.kdbx"),
                 keyfile: OptionStringOrSecretRef::none(),
                 password: OptionStringOrSecretRef::none(),
+                auth_command: None,
             },
             ProviderType::Keychain => crate::config::ProviderConfig::Keychain {
                 service: StringOrSecretRef::from("fnox"),
                 prefix: OptionStringOrSecretRef::none(),
+                auth_command: None,
             },
             ProviderType::PasswordStore => crate::config::ProviderConfig::PasswordStore {
                 prefix: OptionStringOrSecretRef::literal("fnox/"),
                 store_dir: OptionStringOrSecretRef::none(),
                 gpg_opts: OptionStringOrSecretRef::none(),
+                auth_command: None,
             },
             ProviderType::Passwordstate => crate::config::ProviderConfig::Passwordstate {
                 base_url: StringOrSecretRef::from("https://passwordstate.example.com"),
@@ -174,7 +179,7 @@ impl AddCommand {
                 verify_ssl: OptionStringOrSecretRef::none(),
                 auth_command: None,
             },
-            ProviderType::Plain => crate::config::ProviderConfig::Plain,
+            ProviderType::Plain => crate::config::ProviderConfig::Plain { auth_command: None },
             ProviderType::ProtonPass => crate::config::ProviderConfig::ProtonPass {
                 vault: self
                     .vault
@@ -182,6 +187,7 @@ impl AddCommand {
                     .map_or_else(OptionStringOrSecretRef::none, |vault| {
                         OptionStringOrSecretRef::literal(vault.clone())
                     }),
+                auth_command: None,
             },
         };
 

--- a/src/commands/provider/add.rs
+++ b/src/commands/provider/add.rs
@@ -80,39 +80,47 @@ impl AddCommand {
                 vault: OptionStringOrSecretRef::literal("default"),
                 account: OptionStringOrSecretRef::none(),
                 token: OptionStringOrSecretRef::none(),
+                auth_command: None,
             },
             ProviderType::Aws => crate::config::ProviderConfig::AwsSecretsManager {
                 region: StringOrSecretRef::from("us-east-1"),
                 profile: OptionStringOrSecretRef::none(),
                 prefix: OptionStringOrSecretRef::none(),
+                auth_command: None,
             },
             ProviderType::Vault => crate::config::ProviderConfig::HashiCorpVault {
                 address: StringOrSecretRef::from("http://localhost:8200"),
                 path: OptionStringOrSecretRef::literal("secret"),
                 token: OptionStringOrSecretRef::none(),
                 namespace: OptionStringOrSecretRef::none(),
+                auth_command: None,
             },
             ProviderType::Gcp => crate::config::ProviderConfig::GoogleSecretManager {
                 project: StringOrSecretRef::from("my-project"),
                 prefix: OptionStringOrSecretRef::none(),
+                auth_command: None,
             },
             ProviderType::AwsKms => crate::config::ProviderConfig::AwsKms {
                 region: StringOrSecretRef::from("us-east-1"),
                 key_id: StringOrSecretRef::from("alias/my-key"),
+                auth_command: None,
             },
             ProviderType::AwsParameterStore => crate::config::ProviderConfig::AwsParameterStore {
                 region: StringOrSecretRef::from("us-east-1"),
                 profile: OptionStringOrSecretRef::none(),
                 prefix: OptionStringOrSecretRef::literal("/myapp/prod/"),
+                auth_command: None,
             },
             ProviderType::AzureKms => crate::config::ProviderConfig::AzureKms {
                 vault_url: StringOrSecretRef::from("https://my-vault.vault.azure.net/"),
                 key_name: StringOrSecretRef::from("my-key"),
+                auth_command: None,
             },
             ProviderType::AzureSecretsManager => {
                 crate::config::ProviderConfig::AzureSecretsManager {
                     vault_url: StringOrSecretRef::from("https://my-vault.vault.azure.net/"),
                     prefix: OptionStringOrSecretRef::none(),
+                    auth_command: None,
                 }
             }
             ProviderType::GcpKms => crate::config::ProviderConfig::GcpKms {
@@ -120,6 +128,7 @@ impl AddCommand {
                 location: StringOrSecretRef::from("global"),
                 keyring: StringOrSecretRef::from("my-keyring"),
                 key: StringOrSecretRef::from("my-key"),
+                auth_command: None,
             },
             ProviderType::Bitwarden => crate::config::ProviderConfig::Bitwarden {
                 collection: OptionStringOrSecretRef::none(),
@@ -136,11 +145,13 @@ impl AddCommand {
             ProviderType::Age => crate::config::ProviderConfig::AgeEncryption {
                 recipients: vec!["age1...".to_string()],
                 key_file: OptionStringOrSecretRef::none(),
+                auth_command: None,
             },
             ProviderType::Infisical => crate::config::ProviderConfig::Infisical {
                 project_id: OptionStringOrSecretRef::literal("your-project-id"),
                 environment: OptionStringOrSecretRef::literal("dev"),
                 path: OptionStringOrSecretRef::literal("/"),
+                auth_command: None,
             },
             ProviderType::KeePass => crate::config::ProviderConfig::KeePass {
                 database: StringOrSecretRef::from("~/secrets.kdbx"),
@@ -161,6 +172,7 @@ impl AddCommand {
                 api_key: OptionStringOrSecretRef::none(),
                 password_list_id: StringOrSecretRef::from("123"),
                 verify_ssl: OptionStringOrSecretRef::none(),
+                auth_command: None,
             },
             ProviderType::Plain => crate::config::ProviderConfig::Plain,
             ProviderType::ProtonPass => crate::config::ProviderConfig::ProtonPass {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1366,9 +1366,10 @@ mod tests {
 
         // Add a provider and secret to the prod profile
         let mut prod_profile = ProfileConfig::new();
-        prod_profile
-            .providers
-            .insert("plain".to_string(), ProviderConfig::Plain);
+        prod_profile.providers.insert(
+            "plain".to_string(),
+            ProviderConfig::Plain { auth_command: None },
+        );
         let mut secret = SecretConfig::new();
         secret.set_value(Some("test-value".to_string()));
         prod_profile


### PR DESCRIPTION
## Summary

- Adds `auth_command: Option<String>` to every `ProviderConfig` variant, allowing users to override the default auth command per provider instance in their config
- The instance-level override takes priority over the static default from `providers/*.toml`
- Enables use cases like `rbw` backend for Bitwarden: `{ type = "bitwarden", backend = "rbw", auth_command = "rbw unlock" }`

Closes #291

## Example config

```toml
[providers]
rbw = { type = "bitwarden", backend = "rbw", auth_command = "rbw unlock" }
```

## Test plan

- [x] `mise run build` — code generation compiles
- [x] `mise run test:cargo` — all unit tests pass (98/98, 1 pre-existing keychain infra skip)
- [x] `mise run test:bats` — all 537 integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches generated `ProviderConfig` enum shape and matching across the codebase, which can break deserialization/pattern matches if missed. Behavior change affects auth prompting by allowing per-instance overrides (including disabling prompts with an empty string).
> 
> **Overview**
> Adds an `auth_command: Option<String>` field to **every** `ProviderConfig` variant (including previously unit-like variants), updating code generation and all match sites to treat variants as structs.
> 
> Updates `ProviderConfig::default_auth_command()` to prefer the instance-level override, fall back to the provider-type default, and treat `auth_command = ""` as *disable prompting*. Docs and the published JSON schema are updated with examples (notably Bitwarden `rbw unlock`), and CLI provider templates/tests now initialize `auth_command: None`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26538cf0287eaf69b71aa0e15dcbd039b609d94d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->