### PR TITLE
fix(sync): use sync cache field instead of overwriting provider/value

### DIFF
--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -588,6 +588,17 @@
             }
           ]
         },
+        "sync": {
+          "description": "Cached sync data (provider + encrypted value from `fnox sync`)",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SyncConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "value": {
           "description": "Value for the provider (secret name, encrypted blob, etc.)",
           "anyOf": [
@@ -619,6 +630,19 @@
           "required": ["secret"]
         }
       ]
+    },
+    "SyncConfig": {
+      "description": "Cached sync data for a secret (provider + encrypted value)",
+      "type": "object",
+      "properties": {
+        "provider": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "required": ["provider", "value"]
     },
     "string": {
       "type": "string"


### PR DESCRIPTION
## Summary

- Refactors `fnox sync` to write encrypted values to a `sync = { provider, value }` sub-object instead of overwriting the original `provider` and `value` fields
- Preserves the original source provider reference so re-running `fnox sync` re-fetches fresh values from the source
- Secret resolution checks the `sync` cache first, falling back to the main provider/value if no cache exists

**Before sync:**
```toml
DATABASE_URL = { provider = "1password", value = "op://vault/db/url" }
```

**After sync:**
```toml
DATABASE_URL = { provider = "1password", value = "op://vault/db/url", sync = { provider = "age", value = "AGE-ENCRYPTED..." } }
```

## Test plan

- [x] All 15 sync bats tests pass (including 3 new tests)
- [x] New test: config preserves original provider after sync
- [x] New test: sync field has correct TOML structure
- [x] New test: re-running sync refreshes values from source
- [x] All 546 bats tests pass (0 failures)
- [x] 99/100 cargo tests pass (1 pre-existing keychain test failure unrelated to changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how secrets are resolved and persisted by introducing a new `SecretConfig.sync` field and preferring it during resolution, which could affect decryption/lookup behavior for any synced secrets. Risk is moderate due to config schema change and altered provider selection paths, but scope is limited and covered by new sync-focused tests.
> 
> **Overview**
> `fnox sync` now writes the target encrypted output into a new per-secret `sync = { provider, value }` cache instead of overwriting the secret’s original `provider`/`value`, ensuring the source provider reference remains intact.
> 
> Secret resolution (`resolve_secret` and batch resolution) is updated to **prefer the `sync` cache** when present, while `fnox sync` explicitly clears `sync` before resolving so re-syncing re-fetches fresh values from the original provider.
> 
> Config serialization is extended to persist `sync` in TOML, and new Bats tests validate provider preservation, `sync` structure, and that re-running sync refreshes values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 16bd8e8fd389eda7f05de1527c3df94e90be7c03. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->