### PR TITLE
perf(aws-sm): skip expensive tests on non-release PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,7 @@ jobs:
           TRANCHE: ${{ matrix.tranche }}
           TRANCHE_COUNT: 2
           KEEPASS_PASSWORD: fnox-test-password
+          BATS_FILTER_TAGS: ${{ (github.event_name != 'pull_request' || !startsWith(github.head_ref, 'release-plz')) && '!expensive' || '' }}
         with:
           timeout_minutes: 10
           max_attempts: 3

--- a/mise.toml
+++ b/mise.toml
@@ -32,11 +32,15 @@ run = "cargo test"
 [tasks."test:bats"]
 description = "Run bats tests only"
 run = '''
+filter_tags=""
+if [ -n "$BATS_FILTER_TAGS" ]; then
+  filter_tags="--filter-tags $BATS_FILTER_TAGS"
+fi
 if [ -n "$TRANCHE" ] && [ -n "$TRANCHE_COUNT" ]; then
   tests=$(ls -1 test/*.bats | sort | awk -v t=$TRANCHE -v n=$TRANCHE_COUNT 'NR % n == t')
-  fnox exec -- bats --jobs 16 $tests
+  fnox exec -- bats --jobs 16 $filter_tags $tests
 else
-  fnox exec -- bats --jobs 16 {{arg(name='test', var=true, default='test')}}
+  fnox exec -- bats --jobs 16 $filter_tags {{arg(name='test', var=true, default='test')}}
 fi
 '''
 

--- a/test/aws_secrets_manager.bats
+++ b/test/aws_secrets_manager.bats
@@ -1,4 +1,5 @@
 #!/usr/bin/env bats
+# bats file_tags=expensive
 #
 # AWS Secrets Manager Provider Tests
 #


### PR DESCRIPTION
## Summary
- Tag AWS Secrets Manager tests as `expensive` using bats `file_tags`
- Only run `expensive` tests on `release-plz` PRs; all other PRs and pushes to main filter them out via `--filter-tags !expensive`
- Add `BATS_FILTER_TAGS` env var support to the `test:bats` mise task

## Test plan
- [ ] Verify AWS SM tests are skipped on this PR (check bats output for skipped tests)
- [ ] Verify AWS SM tests still run on release-plz PRs
- [ ] Locally: `BATS_FILTER_TAGS='!expensive' mise run test:bats` skips AWS SM tests
- [ ] Locally: `mise run test:bats` runs all tests as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CI/test orchestration and test metadata. Main risk is unintentionally skipping the AWS Secrets Manager bats coverage if the tag/filter condition is misconfigured.
> 
> **Overview**
> CI now passes `BATS_FILTER_TAGS='!expensive'` to `mise run test:bats` for non-`release-plz` PRs and non-PR runs, so tagged tests are skipped by default.
> 
> The `test:bats` mise task now conditionally adds `--filter-tags $BATS_FILTER_TAGS` when invoking bats, and `test/aws_secrets_manager.bats` is marked with `# bats file_tags=expensive` to opt into this filtering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c071a071b1c2e3731586b8a85455873ada71434. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->