### PR TITLE
fix(deps): publish to crates.io on release

### DIFF
--- a/mise-tasks/release-plz
+++ b/mise-tasks/release-plz
@@ -12,6 +12,7 @@ if [ -z "$released_versions" ] || ! echo "$released_versions" | grep -q "^v$cur_
     # Only create and push the tag - let the release workflow handle creating the release
     git tag "v$cur_version"
     git push --tags
+    cargo publish -p fnox
   fi
   exit 0
 fi


### PR DESCRIPTION
## Summary
- Adds `cargo publish -p fnox` to the release-plz script after tag creation
- The `CARGO_REGISTRY_TOKEN` secret was already configured in the workflow but never used
- Fixes crates.io being stuck at v0.1.0 (from 5 months ago)

Closes https://github.com/jdx/fnox/discussions/311

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the release automation to publish the crate to crates.io; mistakes here could publish an unintended version or break the release pipeline.
> 
> **Overview**
> Ensures releases actually get published to crates.io by extending `mise-tasks/release-plz` to run `cargo publish -p fnox` immediately after tagging and pushing the new `vX.Y.Z` tag.
> 
> This changes the release path from *tag-only* to *tag + crates.io publish* (when `DRY_RUN=0`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2dd33636a6b8b2905c22e2a5d23b27ac96febef8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->