### PR TITLE
fix(deps): add libudev-dev to release-plz CI workflow

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libdbus-1-dev pkg-config
+          sudo apt-get install -y libdbus-1-dev libudev-dev pkg-config
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
         with:
           experimental: true


### PR DESCRIPTION
## Summary
- The `hidapi` crate (used by FIDO2 provider) requires `libudev` on Linux
- Other CI jobs (`ci.yml`, `autofix.yml`) already install `libudev-dev` but `release-plz.yml` was missing it
- This caused build failure: `Unable to find libudev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only dependency change; low risk aside from potential Ubuntu package installation flakiness/latency.
> 
> **Overview**
> Updates the `release-plz` GitHub Actions workflow to install `libudev-dev` alongside existing system dependencies, aligning it with other CI jobs and preventing Linux build failures for crates that require `libudev`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 67e5def7ab9de6bc4272168d574da9c93f03355f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->