### PR TITLE
fix(docs): escape angle brackets in lease create doc

### DIFF
--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -513,8 +513,8 @@
               {
                 "name": "BACKEND_NAME",
                 "usage": "<BACKEND_NAME>",
-                "help": "Lease backend name (from [leases.<name>] config)",
-                "help_first_line": "Lease backend name (from [leases.<name>] config)",
+                "help": "Lease backend name (from `[leases.<name>]` config)",
+                "help_first_line": "Lease backend name (from `[leases.<name>]` config)",
                 "required": true,
                 "double_dash": "Optional",
                 "hide": false

--- a/docs/cli/lease/create.md
+++ b/docs/cli/lease/create.md
@@ -10,7 +10,7 @@ Create a short-lived credential lease from a secret
 
 ### `<BACKEND_NAME>`
 
-Lease backend name (from [leases.&lt;name&gt;] config)
+Lease backend name (from `[leases.<name>]` config)
 
 ## Flags
 

--- a/docs/cli/lease/create.md
+++ b/docs/cli/lease/create.md
@@ -10,7 +10,7 @@ Create a short-lived credential lease from a secret
 
 ### `<BACKEND_NAME>`
 
-Lease backend name (from [leases.<name>] config)
+Lease backend name (from [leases.&lt;name&gt;] config)
 
 ## Flags
 

--- a/fnox.usage.kdl
+++ b/fnox.usage.kdl
@@ -106,7 +106,7 @@ cmd lease subcommand_required=#true help="Manage ephemeral credential leases" {
         flag "-l --label" help="Label for the lease (e.g., session purpose)" default=fnox-lease {
             arg <LABEL>
         }
-        arg <BACKEND_NAME> help="Lease backend name (from [leases.<name>] config)"
+        arg <BACKEND_NAME> help="Lease backend name (from `[leases.<name>]` config)"
     }
     cmd list help="List tracked leases" {
         flag --active help="Show only active (non-expired, non-revoked) leases"

--- a/src/commands/lease.rs
+++ b/src/commands/lease.rs
@@ -34,7 +34,7 @@ pub enum OutputFormat {
 
 #[derive(Debug, Args)]
 pub struct LeaseCreateCommand {
-    /// Lease backend name (from [leases.<name>] config)
+    /// Lease backend name (from `[leases.<name>]` config)
     pub backend_name: String,
 
     /// Lease duration (e.g., "15m", "1h", "2h30m"); overrides config duration


### PR DESCRIPTION
## Summary
- Escape `<name>` in lease create doc comment to fix VitePress build error
- VitePress/Vue was parsing `<name>` as an HTML tag, causing "Element is missing end tag"

🤖 Generated with [Claude Code](https://claude.com/claude-code)