### PR TITLE
fix(set): error on encryption failure; use LocalStack for AWS tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,10 +110,10 @@ jobs:
             hashicorp/vault:latest
           # Start Infisical (self-hosted with PostgreSQL and Redis)
           docker compose -f test/docker-compose.infisical-ci.yml up -d
-          # Start LocalStack for AWS STS lease tests
+          # Start LocalStack for AWS tests (STS leases, KMS, Secrets Manager, Parameter Store)
           docker run -d --name localstack \
             -p 4566:4566 \
-            -e SERVICES=sts,iam \
+            -e SERVICES=sts,iam,kms,secretsmanager,ssm \
             localstack/localstack:latest
           # Wait for services to be ready
           # Poll LocalStack health endpoint (can take 10-30s on cold runners)
@@ -126,10 +126,29 @@ jobs:
             curl -sf http://localhost:8200/v1/sys/health && break
             sleep 1
           done
+          # Setup LocalStack resources for AWS provider tests
+          export AWS_ACCESS_KEY_ID=test
+          export AWS_SECRET_ACCESS_KEY=test
+          export AWS_DEFAULT_REGION=us-east-1
+          # Create KMS key for tests
+          LOCALSTACK_KMS_KEY_ID=$(aws --endpoint-url http://localhost:4566 kms create-key \
+            --region us-east-1 --query 'KeyMetadata.KeyId' --output text)
+          aws --endpoint-url http://localhost:4566 kms create-alias \
+            --alias-name alias/fnox-testing \
+            --target-key-id "$LOCALSTACK_KMS_KEY_ID" \
+            --region us-east-1
+          # Create shared test secret in Secrets Manager
+          aws --endpoint-url http://localhost:4566 secretsmanager create-secret \
+            --name "fnox/test-secret" \
+            --secret-string "This is a test secret in AWS Secrets Manager!" \
+            --region us-east-1
           {
             echo "VAULT_ADDR=http://localhost:8200"
             echo "VAULT_TOKEN=fnox-test-token"
             echo "LOCALSTACK_ENDPOINT=http://localhost:4566"
+            echo "AWS_ACCESS_KEY_ID=test"
+            echo "AWS_SECRET_ACCESS_KEY=test"
+            echo "AWS_DEFAULT_REGION=us-east-1"
           } >> "$GITHUB_ENV"
       - name: Setup Bitwarden for tests
         if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,9 +146,6 @@ jobs:
             echo "VAULT_ADDR=http://localhost:8200"
             echo "VAULT_TOKEN=fnox-test-token"
             echo "LOCALSTACK_ENDPOINT=http://localhost:4566"
-            echo "AWS_ACCESS_KEY_ID=test"
-            echo "AWS_SECRET_ACCESS_KEY=test"
-            echo "AWS_DEFAULT_REGION=us-east-1"
           } >> "$GITHUB_ENV"
       - name: Setup Bitwarden for tests
         if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -283,36 +283,22 @@
             "auth_command": {
               "type": ["string", "null"]
             },
-            "type": {
-              "type": "string",
-              "const": "plain"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["type"]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "auth_command": {
-              "type": ["string", "null"]
+            "database": {
+              "$ref": "#/$defs/StringOrSecretRef"
             },
-            "key_file": {
+            "keyfile": {
               "$ref": "#/$defs/OptionStringOrSecretRef"
             },
-            "recipients": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
+            "password": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
             },
             "type": {
               "type": "string",
-              "const": "age"
+              "const": "keepass"
             }
           },
           "additionalProperties": false,
-          "required": ["type", "recipients"]
+          "required": ["type", "database"]
         },
         {
           "type": "object",
@@ -363,6 +349,43 @@
             "auth_command": {
               "type": ["string", "null"]
             },
+            "type": {
+              "type": "string",
+              "const": "plain"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "auth_command": {
+              "type": ["string", "null"]
+            },
+            "key_file": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "recipients": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "type": {
+              "type": "string",
+              "const": "age"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type", "recipients"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "auth_command": {
+              "type": ["string", "null"]
+            },
             "credential_id": {
               "$ref": "#/$defs/StringOrSecretRef"
             },
@@ -382,29 +405,6 @@
           },
           "additionalProperties": false,
           "required": ["type", "credential_id", "salt", "rp_id"]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "auth_command": {
-              "type": ["string", "null"]
-            },
-            "database": {
-              "$ref": "#/$defs/StringOrSecretRef"
-            },
-            "keyfile": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "password": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "type": {
-              "type": "string",
-              "const": "keepass"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["type", "database"]
         },
         {
           "type": "object",
@@ -432,6 +432,32 @@
         {
           "type": "object",
           "properties": {
+            "api_key": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "auth_command": {
+              "type": ["string", "null"]
+            },
+            "base_url": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            },
+            "password_list_id": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "passwordstate"
+            },
+            "verify_ssl": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type", "base_url", "password_list_id"]
+        },
+        {
+          "type": "object",
+          "properties": {
             "auth_command": {
               "type": ["string", "null"]
             },
@@ -441,29 +467,6 @@
             },
             "vault": {
               "$ref": "#/$defs/OptionStringOrSecretRef"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["type"]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "auth_command": {
-              "type": ["string", "null"]
-            },
-            "environment": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "path": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "project_id": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "type": {
-              "type": "string",
-              "const": "infisical"
             }
           },
           "additionalProperties": false,
@@ -505,28 +508,68 @@
         {
           "type": "object",
           "properties": {
-            "api_key": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
             "auth_command": {
               "type": ["string", "null"]
             },
-            "base_url": {
+            "environment": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "path": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "project_id": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "infisical"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "auth_command": {
+              "type": ["string", "null"]
+            },
+            "endpoint": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "key_id": {
               "$ref": "#/$defs/StringOrSecretRef"
             },
-            "password_list_id": {
+            "region": {
               "$ref": "#/$defs/StringOrSecretRef"
             },
             "type": {
               "type": "string",
-              "const": "passwordstate"
-            },
-            "verify_ssl": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
+              "const": "aws-kms"
             }
           },
           "additionalProperties": false,
-          "required": ["type", "base_url", "password_list_id"]
+          "required": ["type", "key_id", "region"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "auth_command": {
+              "type": ["string", "null"]
+            },
+            "key_name": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "azure-kms"
+            },
+            "vault_url": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type", "vault_url", "key_name"]
         },
         {
           "type": "object",
@@ -560,42 +603,25 @@
             "auth_command": {
               "type": ["string", "null"]
             },
-            "key_name": {
-              "$ref": "#/$defs/StringOrSecretRef"
-            },
-            "type": {
-              "type": "string",
-              "const": "azure-kms"
-            },
-            "vault_url": {
-              "$ref": "#/$defs/StringOrSecretRef"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["type", "vault_url", "key_name"]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "auth_command": {
-              "type": ["string", "null"]
-            },
             "endpoint": {
               "$ref": "#/$defs/OptionStringOrSecretRef"
             },
-            "key_id": {
-              "$ref": "#/$defs/StringOrSecretRef"
+            "prefix": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "profile": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
             },
             "region": {
               "$ref": "#/$defs/StringOrSecretRef"
             },
             "type": {
               "type": "string",
-              "const": "aws-kms"
+              "const": "aws-ps"
             }
           },
           "additionalProperties": false,
-          "required": ["type", "key_id", "region"]
+          "required": ["type", "region"]
         },
         {
           "type": "object",
@@ -617,7 +643,7 @@
             },
             "type": {
               "type": "string",
-              "const": "aws-ps"
+              "const": "aws-sm"
             }
           },
           "additionalProperties": false,
@@ -688,32 +714,6 @@
           },
           "additionalProperties": false,
           "required": ["type", "vault_url"]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "auth_command": {
-              "type": ["string", "null"]
-            },
-            "endpoint": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "prefix": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "profile": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "region": {
-              "$ref": "#/$defs/StringOrSecretRef"
-            },
-            "type": {
-              "type": "string",
-              "const": "aws-sm"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["type", "region"]
         },
         {
           "type": "object",

--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -283,22 +283,36 @@
             "auth_command": {
               "type": ["string", "null"]
             },
-            "database": {
-              "$ref": "#/$defs/StringOrSecretRef"
-            },
-            "keyfile": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "password": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
             "type": {
               "type": "string",
-              "const": "keepass"
+              "const": "plain"
             }
           },
           "additionalProperties": false,
-          "required": ["type", "database"]
+          "required": ["type"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "auth_command": {
+              "type": ["string", "null"]
+            },
+            "key_file": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "recipients": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "type": {
+              "type": "string",
+              "const": "age"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type", "recipients"]
         },
         {
           "type": "object",
@@ -349,43 +363,6 @@
             "auth_command": {
               "type": ["string", "null"]
             },
-            "type": {
-              "type": "string",
-              "const": "plain"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["type"]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "auth_command": {
-              "type": ["string", "null"]
-            },
-            "key_file": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "recipients": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "type": {
-              "type": "string",
-              "const": "age"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["type", "recipients"]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "auth_command": {
-              "type": ["string", "null"]
-            },
             "credential_id": {
               "$ref": "#/$defs/StringOrSecretRef"
             },
@@ -405,6 +382,29 @@
           },
           "additionalProperties": false,
           "required": ["type", "credential_id", "salt", "rp_id"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "auth_command": {
+              "type": ["string", "null"]
+            },
+            "database": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            },
+            "keyfile": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "password": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "keepass"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type", "database"]
         },
         {
           "type": "object",
@@ -432,32 +432,6 @@
         {
           "type": "object",
           "properties": {
-            "api_key": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "auth_command": {
-              "type": ["string", "null"]
-            },
-            "base_url": {
-              "$ref": "#/$defs/StringOrSecretRef"
-            },
-            "password_list_id": {
-              "$ref": "#/$defs/StringOrSecretRef"
-            },
-            "type": {
-              "type": "string",
-              "const": "passwordstate"
-            },
-            "verify_ssl": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["type", "base_url", "password_list_id"]
-        },
-        {
-          "type": "object",
-          "properties": {
             "auth_command": {
               "type": ["string", "null"]
             },
@@ -467,6 +441,29 @@
             },
             "vault": {
               "$ref": "#/$defs/OptionStringOrSecretRef"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "auth_command": {
+              "type": ["string", "null"]
+            },
+            "environment": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "path": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "project_id": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "infisical"
             }
           },
           "additionalProperties": false,
@@ -508,65 +505,28 @@
         {
           "type": "object",
           "properties": {
+            "api_key": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
             "auth_command": {
               "type": ["string", "null"]
             },
-            "environment": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "path": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "project_id": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "type": {
-              "type": "string",
-              "const": "infisical"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["type"]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "auth_command": {
-              "type": ["string", "null"]
-            },
-            "key_id": {
+            "base_url": {
               "$ref": "#/$defs/StringOrSecretRef"
             },
-            "region": {
+            "password_list_id": {
               "$ref": "#/$defs/StringOrSecretRef"
             },
             "type": {
               "type": "string",
-              "const": "aws-kms"
+              "const": "passwordstate"
+            },
+            "verify_ssl": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
             }
           },
           "additionalProperties": false,
-          "required": ["type", "key_id", "region"]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "auth_command": {
-              "type": ["string", "null"]
-            },
-            "key_name": {
-              "$ref": "#/$defs/StringOrSecretRef"
-            },
-            "type": {
-              "type": "string",
-              "const": "azure-kms"
-            },
-            "vault_url": {
-              "$ref": "#/$defs/StringOrSecretRef"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["type", "vault_url", "key_name"]
+          "required": ["type", "base_url", "password_list_id"]
         },
         {
           "type": "object",
@@ -600,6 +560,52 @@
             "auth_command": {
               "type": ["string", "null"]
             },
+            "key_name": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "azure-kms"
+            },
+            "vault_url": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type", "vault_url", "key_name"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "auth_command": {
+              "type": ["string", "null"]
+            },
+            "endpoint": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "key_id": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            },
+            "region": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "aws-kms"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type", "key_id", "region"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "auth_command": {
+              "type": ["string", "null"]
+            },
+            "endpoint": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
             "prefix": {
               "$ref": "#/$defs/OptionStringOrSecretRef"
             },
@@ -612,29 +618,6 @@
             "type": {
               "type": "string",
               "const": "aws-ps"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["type", "region"]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "auth_command": {
-              "type": ["string", "null"]
-            },
-            "prefix": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "profile": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "region": {
-              "$ref": "#/$defs/StringOrSecretRef"
-            },
-            "type": {
-              "type": "string",
-              "const": "aws-sm"
             }
           },
           "additionalProperties": false,
@@ -705,6 +688,32 @@
           },
           "additionalProperties": false,
           "required": ["type", "vault_url"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "auth_command": {
+              "type": ["string", "null"]
+            },
+            "endpoint": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "prefix": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "profile": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "region": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "aws-sm"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type", "region"]
         },
         {
           "type": "object",

--- a/providers/aws-kms.toml
+++ b/providers/aws-kms.toml
@@ -22,3 +22,8 @@ type = "required"
 placeholder = "us-east-1"
 label = "AWS Region:"
 wizard = true
+
+[fields.endpoint]
+type = "optional"
+placeholder = "http://localhost:4566"
+label = "Custom endpoint URL (optional):"

--- a/providers/aws-ps.toml
+++ b/providers/aws-ps.toml
@@ -27,3 +27,8 @@ type = "optional"
 placeholder = "/myapp/prod/"
 label = "Parameter path prefix (optional):"
 wizard = true
+
+[fields.endpoint]
+type = "optional"
+placeholder = "http://localhost:4566"
+label = "Custom endpoint URL (optional):"

--- a/providers/aws-sm.toml
+++ b/providers/aws-sm.toml
@@ -27,3 +27,8 @@ type = "optional"
 placeholder = "fnox/"
 label = "Secret name prefix (optional):"
 wizard = true
+
+[fields.endpoint]
+type = "optional"
+placeholder = "http://localhost:4566"
+label = "Custom endpoint URL (optional):"

--- a/src/commands/provider/add.rs
+++ b/src/commands/provider/add.rs
@@ -86,6 +86,7 @@ impl AddCommand {
                 region: StringOrSecretRef::from("us-east-1"),
                 profile: OptionStringOrSecretRef::none(),
                 prefix: OptionStringOrSecretRef::none(),
+                endpoint: OptionStringOrSecretRef::none(),
                 auth_command: None,
             },
             ProviderType::Vault => crate::config::ProviderConfig::HashiCorpVault {
@@ -103,12 +104,14 @@ impl AddCommand {
             ProviderType::AwsKms => crate::config::ProviderConfig::AwsKms {
                 region: StringOrSecretRef::from("us-east-1"),
                 key_id: StringOrSecretRef::from("alias/my-key"),
+                endpoint: OptionStringOrSecretRef::none(),
                 auth_command: None,
             },
             ProviderType::AwsParameterStore => crate::config::ProviderConfig::AwsParameterStore {
                 region: StringOrSecretRef::from("us-east-1"),
                 profile: OptionStringOrSecretRef::none(),
                 prefix: OptionStringOrSecretRef::literal("/myapp/prod/"),
+                endpoint: OptionStringOrSecretRef::none(),
                 auth_command: None,
             },
             ProviderType::AzureKms => crate::config::ProviderConfig::AzureKms {

--- a/src/commands/set.rs
+++ b/src/commands/set.rs
@@ -147,19 +147,10 @@ impl SetCommand {
                             // In dry-run mode, skip actual encryption
                             (Some("<encrypted>".to_string()), None)
                         } else {
-                            // Encrypt with the provider
-                            match provider.encrypt(value).await {
-                                Ok(encrypted) => (Some(encrypted), None),
-                                Err(e) => {
-                                    // Provider doesn't support encryption, store plaintext
-                                    tracing::warn!(
-                                        "Encryption not supported for provider '{}': {}. Storing plaintext.",
-                                        provider_name,
-                                        e
-                                    );
-                                    (Some(value.clone()), None)
-                                }
-                            }
+                            // Encrypt with the provider — fail on error rather than
+                            // silently storing plaintext
+                            let encrypted = provider.encrypt(value).await?;
+                            (Some(encrypted), None)
                         }
                     } else if is_remote_storage_provider {
                         tracing::debug!(

--- a/src/providers/aws_kms.rs
+++ b/src/providers/aws_kms.rs
@@ -121,11 +121,16 @@ where
 pub struct AwsKmsProvider {
     key_id: String,
     region: String,
+    endpoint: Option<String>,
 }
 
 impl AwsKmsProvider {
-    pub fn new(key_id: String, region: String) -> Result<Self> {
-        Ok(Self { key_id, region })
+    pub fn new(key_id: String, region: String, endpoint: Option<String>) -> Result<Self> {
+        Ok(Self {
+            key_id,
+            region,
+            endpoint,
+        })
     }
 
     /// Create an AWS KMS client
@@ -136,7 +141,12 @@ impl AwsKmsProvider {
             .load()
             .await;
 
-        Ok(Client::new(&config))
+        let mut kms_config_builder = aws_sdk_kms::config::Builder::from(&config);
+        if let Some(endpoint) = &self.endpoint {
+            kms_config_builder = kms_config_builder.endpoint_url(endpoint);
+        }
+
+        Ok(Client::from_conf(kms_config_builder.build()))
     }
 
     /// Decrypt a ciphertext value using KMS

--- a/src/providers/aws_ps.rs
+++ b/src/providers/aws_ps.rs
@@ -121,14 +121,21 @@ pub struct AwsParameterStoreProvider {
     region: String,
     profile: Option<String>,
     prefix: Option<String>,
+    endpoint: Option<String>,
 }
 
 impl AwsParameterStoreProvider {
-    pub fn new(region: String, profile: Option<String>, prefix: Option<String>) -> Result<Self> {
+    pub fn new(
+        region: String,
+        profile: Option<String>,
+        prefix: Option<String>,
+        endpoint: Option<String>,
+    ) -> Result<Self> {
         Ok(Self {
             region,
             profile,
             prefix,
+            endpoint,
         })
     }
 
@@ -149,7 +156,13 @@ impl AwsParameterStoreProvider {
         }
 
         let config = builder.load().await;
-        Ok(Client::new(&config))
+
+        let mut ssm_config_builder = aws_sdk_ssm::config::Builder::from(&config);
+        if let Some(endpoint) = &self.endpoint {
+            ssm_config_builder = ssm_config_builder.endpoint_url(endpoint);
+        }
+
+        Ok(Client::from_conf(ssm_config_builder.build()))
     }
 
     /// Get a parameter value from AWS Systems Manager Parameter Store

--- a/src/providers/aws_sm.rs
+++ b/src/providers/aws_sm.rs
@@ -149,14 +149,21 @@ pub struct AwsSecretsManagerProvider {
     region: String,
     profile: Option<String>,
     prefix: Option<String>,
+    endpoint: Option<String>,
 }
 
 impl AwsSecretsManagerProvider {
-    pub fn new(region: String, profile: Option<String>, prefix: Option<String>) -> Result<Self> {
+    pub fn new(
+        region: String,
+        profile: Option<String>,
+        prefix: Option<String>,
+        endpoint: Option<String>,
+    ) -> Result<Self> {
         Ok(Self {
             region,
             profile,
             prefix,
+            endpoint,
         })
     }
 
@@ -178,7 +185,13 @@ impl AwsSecretsManagerProvider {
         }
 
         let config = builder.load().await;
-        Ok(Client::new(&config))
+
+        let mut sm_config_builder = aws_sdk_secretsmanager::config::Builder::from(&config);
+        if let Some(endpoint) = &self.endpoint {
+            sm_config_builder = sm_config_builder.endpoint_url(endpoint);
+        }
+
+        Ok(Client::from_conf(sm_config_builder.build()))
     }
 
     /// Get a secret value from AWS Secrets Manager

--- a/test/aws_kms.bats
+++ b/test/aws_kms.bats
@@ -2,18 +2,17 @@
 #
 # AWS KMS Provider Tests
 #
-# These tests verify the AWS KMS provider integration with fnox.
-# Note: Tests use setup_file() to pre-encrypt shared values once,
-#       significantly reducing KMS API calls.
+# These tests verify the AWS KMS provider integration with fnox
+# using LocalStack for mock AWS services.
 #
 # Prerequisites:
-#   1. AWS credentials configured (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY)
-#   2. KMS key available (created during setup)
-#   3. IAM permissions: kms:Encrypt, kms:Decrypt, kms:DescribeKey
-#   4. Run tests: mise run test:bats -- test/aws_kms.bats
+#   1. Start LocalStack: docker run -d -p 4566:4566 -e SERVICES=kms localstack/localstack
+#   2. Set LOCALSTACK_ENDPOINT=http://localhost:4566
+#   3. Create KMS key: aws --endpoint-url $LOCALSTACK_ENDPOINT kms create-key --region us-east-1
+#   4. Create alias: aws --endpoint-url $LOCALSTACK_ENDPOINT kms create-alias --alias-name alias/fnox-testing --target-key-id <key-id> --region us-east-1
+#   5. Run tests: mise run test:bats -- test/aws_kms.bats
 #
-# Note: Tests will automatically skip if AWS credentials are not available.
-#       The mise task runs `fnox exec` which automatically decrypts provider-based secrets.
+# Note: Tests will automatically skip if LOCALSTACK_ENDPOINT is not set.
 #
 
 # File-level setup - runs once before all tests (reduces KMS API calls)
@@ -24,11 +23,15 @@ setup_file() {
 	export KMS_KEY_ID="alias/fnox-testing"
 	export KMS_REGION="us-east-1"
 
-	# Check if AWS credentials are available
-	if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
-		export SKIP_AWS_KMS_TESTS="AWS credentials not available. Ensure AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are configured."
+	if [ -z "$LOCALSTACK_ENDPOINT" ]; then
+		export SKIP_AWS_KMS_TESTS="LOCALSTACK_ENDPOINT not set. Start LocalStack and set LOCALSTACK_ENDPOINT=http://localhost:4566"
 		return
 	fi
+
+	# Set dummy AWS credentials for LocalStack
+	export AWS_ACCESS_KEY_ID="test"
+	export AWS_SECRET_ACCESS_KEY="test"
+	export AWS_DEFAULT_REGION="us-east-1"
 
 	# Check if aws CLI is installed
 	if ! command -v aws >/dev/null 2>&1; then
@@ -36,22 +39,43 @@ setup_file() {
 		return
 	fi
 
-	# Verify we can access the KMS key (single API call for all tests)
-	if ! aws kms describe-key --key-id "$KMS_KEY_ID" --region "$KMS_REGION" >/dev/null 2>&1; then
-		export SKIP_AWS_KMS_TESTS="Cannot access KMS key '$KMS_KEY_ID'. Key may not exist or permissions may be insufficient."
-		return
+	# Wait for LocalStack to be ready
+	local retries=10
+	while ! curl -sf "$LOCALSTACK_ENDPOINT/_localstack/health" >/dev/null 2>&1; do
+		retries=$((retries - 1))
+		if [ "$retries" -le 0 ]; then
+			export SKIP_AWS_KMS_TESTS="LocalStack not ready"
+			return
+		fi
+		sleep 1
+	done
+
+	# Verify we can access the KMS key
+	if ! aws --endpoint-url "$LOCALSTACK_ENDPOINT" kms describe-key --key-id "$KMS_KEY_ID" --region "$KMS_REGION" >/dev/null 2>&1; then
+		# Try to create the key and alias
+		local key_id
+		key_id=$(aws --endpoint-url "$LOCALSTACK_ENDPOINT" kms create-key \
+			--region "$KMS_REGION" --query 'KeyMetadata.KeyId' --output text 2>/dev/null)
+		if [ -n "$key_id" ]; then
+			aws --endpoint-url "$LOCALSTACK_ENDPOINT" kms create-alias \
+				--alias-name "$KMS_KEY_ID" \
+				--target-key-id "$key_id" \
+				--region "$KMS_REGION" 2>/dev/null || true
+		fi
+		if ! aws --endpoint-url "$LOCALSTACK_ENDPOINT" kms describe-key --key-id "$KMS_KEY_ID" --region "$KMS_REGION" >/dev/null 2>&1; then
+			export SKIP_AWS_KMS_TESTS="Cannot access KMS key '$KMS_KEY_ID' via LocalStack."
+			return
+		fi
 	fi
 
-	# Get the full ARN for later tests (single API call)
+	# Get the full ARN for later tests
 	export KMS_KEY_ARN
-	KMS_KEY_ARN=$(aws kms describe-key --key-id "$KMS_KEY_ID" --region "$KMS_REGION" --query 'KeyMetadata.Arn' --output text)
+	KMS_KEY_ARN=$(aws --endpoint-url "$LOCALSTACK_ENDPOINT" kms describe-key --key-id "$KMS_KEY_ID" --region "$KMS_REGION" --query 'KeyMetadata.Arn' --output text)
 
 	# Pre-encrypt shared test values using AWS CLI directly (reduces fnox encrypt calls)
-	# These ciphertexts can be reused across multiple tests
-	# Note: Using fileb:///dev/stdin to pass raw plaintext bytes to aws kms encrypt
 	export SHARED_SIMPLE_VALUE="test-plaintext-value"
 	export SHARED_SIMPLE_CIPHERTEXT
-	SHARED_SIMPLE_CIPHERTEXT=$(echo -n "$SHARED_SIMPLE_VALUE" | aws kms encrypt \
+	SHARED_SIMPLE_CIPHERTEXT=$(echo -n "$SHARED_SIMPLE_VALUE" | aws --endpoint-url "$LOCALSTACK_ENDPOINT" kms encrypt \
 		--key-id "$KMS_KEY_ID" \
 		--plaintext fileb:///dev/stdin \
 		--region "$KMS_REGION" \
@@ -60,7 +84,7 @@ setup_file() {
 
 	export SHARED_SPECIAL_VALUE='{"password":"p@ssw0rd!","key":"abc=123&xyz"}'
 	export SHARED_SPECIAL_CIPHERTEXT
-	SHARED_SPECIAL_CIPHERTEXT=$(echo -n "$SHARED_SPECIAL_VALUE" | aws kms encrypt \
+	SHARED_SPECIAL_CIPHERTEXT=$(echo -n "$SHARED_SPECIAL_VALUE" | aws --endpoint-url "$LOCALSTACK_ENDPOINT" kms encrypt \
 		--key-id "$KMS_KEY_ID" \
 		--plaintext fileb:///dev/stdin \
 		--region "$KMS_REGION" \
@@ -71,7 +95,7 @@ setup_file() {
 line2
 line3"
 	export SHARED_MULTILINE_CIPHERTEXT
-	SHARED_MULTILINE_CIPHERTEXT=$(printf '%s' "$SHARED_MULTILINE_VALUE" | aws kms encrypt \
+	SHARED_MULTILINE_CIPHERTEXT=$(printf '%s' "$SHARED_MULTILINE_VALUE" | aws --endpoint-url "$LOCALSTACK_ENDPOINT" kms encrypt \
 		--key-id "$KMS_KEY_ID" \
 		--plaintext fileb:///dev/stdin \
 		--region "$KMS_REGION" \
@@ -80,7 +104,7 @@ line3"
 
 	export SHARED_ENV_VALUE="kms-env-value"
 	export SHARED_ENV_CIPHERTEXT
-	SHARED_ENV_CIPHERTEXT=$(echo -n "$SHARED_ENV_VALUE" | aws kms encrypt \
+	SHARED_ENV_CIPHERTEXT=$(echo -n "$SHARED_ENV_VALUE" | aws --endpoint-url "$LOCALSTACK_ENDPOINT" kms encrypt \
 		--key-id "$KMS_KEY_ID" \
 		--plaintext fileb:///dev/stdin \
 		--region "$KMS_REGION" \
@@ -113,6 +137,7 @@ root = true
 type = "aws-kms"
 key_id = "$key_id"
 region = "$region"
+endpoint = "$LOCALSTACK_ENDPOINT"
 
 [secrets]
 EOF
@@ -131,6 +156,7 @@ root = true
 type = "aws-kms"
 key_id = "$key_id"
 region = "$region"
+endpoint = "$LOCALSTACK_ENDPOINT"
 
 [secrets]
 $secret_name = { provider = "kms", value = "$ciphertext" }
@@ -195,17 +221,6 @@ EOF
 	run "$FNOX_BIN" get INVALID_CIPHERTEXT
 	assert_failure
 	assert_output --partial "Failed to decode base64 ciphertext"
-}
-
-@test "fnox set warns and stores plaintext with wrong KMS key" {
-	# Create config with non-existent key (fails fast, no actual KMS encryption)
-	create_kms_config "arn:aws:kms:us-east-1:123456789012:key/00000000-0000-0000-0000-000000000000"
-
-	# When encryption fails, fnox currently warns and stores plaintext
-	run "$FNOX_BIN" set KMS_WRONG_KEY "test" --provider kms
-	assert_success
-	assert_output --partial "Encryption not supported for provider 'kms'"
-	assert_output --partial "Storing plaintext"
 }
 
 @test "fnox list shows KMS secrets" {

--- a/test/aws_kms.bats
+++ b/test/aws_kms.bats
@@ -223,15 +223,12 @@ EOF
 	assert_output --partial "Failed to decode base64 ciphertext"
 }
 
-@test "fnox set warns and stores plaintext with wrong KMS key" {
-	# Create config with non-existent key (fails fast via LocalStack NotFoundException)
+@test "fnox set fails with wrong KMS key" {
+	# Create config with non-existent key (fails via LocalStack NotFoundException)
 	create_kms_config "alias/nonexistent-key-that-does-not-exist"
 
-	# When encryption fails, fnox currently warns and stores plaintext
 	run "$FNOX_BIN" set KMS_WRONG_KEY "test" --provider kms
-	assert_success
-	assert_output --partial "Encryption not supported for provider 'kms'"
-	assert_output --partial "Storing plaintext"
+	assert_failure
 }
 
 @test "fnox list shows KMS secrets" {

--- a/test/aws_kms.bats
+++ b/test/aws_kms.bats
@@ -229,6 +229,7 @@ EOF
 
 	run "$FNOX_BIN" set KMS_WRONG_KEY "test" --provider kms
 	assert_failure
+	assert_output --partial "AWS KMS"
 }
 
 @test "fnox list shows KMS secrets" {

--- a/test/aws_kms.bats
+++ b/test/aws_kms.bats
@@ -223,6 +223,17 @@ EOF
 	assert_output --partial "Failed to decode base64 ciphertext"
 }
 
+@test "fnox set warns and stores plaintext with wrong KMS key" {
+	# Create config with non-existent key (fails fast via LocalStack NotFoundException)
+	create_kms_config "alias/nonexistent-key-that-does-not-exist"
+
+	# When encryption fails, fnox currently warns and stores plaintext
+	run "$FNOX_BIN" set KMS_WRONG_KEY "test" --provider kms
+	assert_success
+	assert_output --partial "Encryption not supported for provider 'kms'"
+	assert_output --partial "Storing plaintext"
+}
+
 @test "fnox list shows KMS secrets" {
 	create_kms_config
 

--- a/test/aws_parameter_store.bats
+++ b/test/aws_parameter_store.bats
@@ -13,12 +13,30 @@
 # Note: Tests will automatically skip if LOCALSTACK_ENDPOINT is not set.
 #
 
+setup_file() {
+	if [ -z "$LOCALSTACK_ENDPOINT" ]; then
+		export SKIP_AWS_PS_TESTS="LOCALSTACK_ENDPOINT not set. Start LocalStack and set LOCALSTACK_ENDPOINT=http://localhost:4566"
+		return
+	fi
+
+	# Wait for LocalStack to be ready
+	local retries=10
+	while ! curl -sf "$LOCALSTACK_ENDPOINT/_localstack/health" >/dev/null 2>&1; do
+		retries=$((retries - 1))
+		if [ "$retries" -le 0 ]; then
+			export SKIP_AWS_PS_TESTS="LocalStack not ready"
+			return
+		fi
+		sleep 1
+	done
+}
+
 setup() {
 	load 'test_helper/common_setup'
 	_common_setup
 
-	if [ -z "$LOCALSTACK_ENDPOINT" ]; then
-		skip "LOCALSTACK_ENDPOINT not set. Start LocalStack and set LOCALSTACK_ENDPOINT=http://localhost:4566"
+	if [ -n "$SKIP_AWS_PS_TESTS" ]; then
+		skip "$SKIP_AWS_PS_TESTS"
 	fi
 
 	# Set dummy AWS credentials for LocalStack

--- a/test/aws_parameter_store.bats
+++ b/test/aws_parameter_store.bats
@@ -2,25 +2,29 @@
 #
 # AWS Parameter Store Provider Tests
 #
-# These tests verify the AWS Systems Manager Parameter Store provider integration with fnox.
-# Note: Tests should run serially (within this file) due to AWS eventual consistency.
-#       Use `--no-parallelize-within-files` bats flag.
+# These tests verify the AWS Systems Manager Parameter Store provider integration with fnox
+# using LocalStack for mock AWS services.
 #
 # Prerequisites:
-#   1. AWS credentials from fnox.toml (decrypted via fnox exec)
-#   2. IAM permissions: ssm:GetParameter, ssm:GetParameters, ssm:PutParameter, ssm:DeleteParameter, ssm:DescribeParameters
+#   1. Start LocalStack: docker run -d -p 4566:4566 -e SERVICES=ssm localstack/localstack
+#   2. Set LOCALSTACK_ENDPOINT=http://localhost:4566
 #   3. Run tests: mise run test:bats -- test/aws_parameter_store.bats
+#
+# Note: Tests will automatically skip if LOCALSTACK_ENDPOINT is not set.
 #
 
 setup() {
 	load 'test_helper/common_setup'
 	_common_setup
 
-	# Check if AWS credentials are available
-	# (mise run test:bats automatically loads secrets via fnox exec)
-	if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
-		skip "AWS credentials not available. Ensure AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are configured."
+	if [ -z "$LOCALSTACK_ENDPOINT" ]; then
+		skip "LOCALSTACK_ENDPOINT not set. Start LocalStack and set LOCALSTACK_ENDPOINT=http://localhost:4566"
 	fi
+
+	# Set dummy AWS credentials for LocalStack
+	export AWS_ACCESS_KEY_ID="test"
+	export AWS_SECRET_ACCESS_KEY="test"
+	export AWS_DEFAULT_REGION="us-east-1"
 
 	# Check if aws CLI is installed
 	if ! command -v aws >/dev/null 2>&1; then
@@ -33,8 +37,8 @@ setup() {
 
 teardown() {
 	# Clean up any test parameters created during tests
-	if [ -n "$TEST_PARAM_NAME" ]; then
-		aws ssm delete-parameter \
+	if [ -n "$TEST_PARAM_NAME" ] && [ -n "$LOCALSTACK_ENDPOINT" ]; then
+		aws --endpoint-url "$LOCALSTACK_ENDPOINT" ssm delete-parameter \
 			--name "$TEST_PARAM_NAME" \
 			--region "$PS_REGION" >/dev/null 2>&1 || true
 	fi
@@ -58,6 +62,7 @@ root = true
 [providers.ps]
 type = "aws-ps"
 region = "$region"
+endpoint = "$LOCALSTACK_ENDPOINT"
 
 [secrets]
 EOF
@@ -69,26 +74,24 @@ root = true
 type = "aws-ps"
 region = "$region"
 prefix = "$prefix"
+endpoint = "$LOCALSTACK_ENDPOINT"
 
 [secrets]
 EOF
 	fi
 }
 
-# Helper function to create a test parameter in AWS Parameter Store
+# Helper function to create a test parameter in LocalStack
 create_test_parameter() {
 	local param_name="$1"
 	local param_value="$2"
 
-	aws ssm put-parameter \
+	aws --endpoint-url "$LOCALSTACK_ENDPOINT" ssm put-parameter \
 		--name "$param_name" \
 		--value "$param_value" \
 		--type "SecureString" \
 		--overwrite \
 		--region "$PS_REGION"
-
-	# Give AWS Parameter Store time to propagate the parameter
-	sleep 1
 
 	export TEST_PARAM_NAME="$param_name"
 }

--- a/test/aws_secrets_manager.bats
+++ b/test/aws_secrets_manager.bats
@@ -1,30 +1,31 @@
 #!/usr/bin/env bats
-# bats file_tags=expensive
 #
 # AWS Secrets Manager Provider Tests
 #
-# These tests verify the AWS Secrets Manager provider integration with fnox.
-# Note: Tests should run serially (within this file) due to AWS Secrets Manager
-#       eventual consistency. Use `--no-parallelize-within-files` bats flag.
+# These tests verify the AWS Secrets Manager provider integration with fnox
+# using LocalStack for mock AWS services.
 #
 # Prerequisites:
-#   1. AWS credentials configured (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY)
-#   2. IAM permissions: secretsmanager:GetSecretValue, secretsmanager:CreateSecret, secretsmanager:PutSecretValue
+#   1. Start LocalStack: docker run -d -p 4566:4566 -e SERVICES=secretsmanager localstack/localstack
+#   2. Set LOCALSTACK_ENDPOINT=http://localhost:4566
 #   3. Run tests: mise run test:bats -- test/aws_secrets_manager.bats
 #
-# Note: Tests will automatically skip if AWS credentials are not available.
-#       The mise task runs `fnox exec` which automatically decrypts provider-based secrets.
+# Note: Tests will automatically skip if LOCALSTACK_ENDPOINT is not set.
 #
 
 # File-level setup - runs once before all tests (reduces API calls)
 setup_file() {
 	export SM_REGION="us-east-1"
 
-	# Check if AWS credentials are available
-	if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
-		export SKIP_AWS_SM_TESTS="AWS credentials not available. Ensure AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are configured."
+	if [ -z "$LOCALSTACK_ENDPOINT" ]; then
+		export SKIP_AWS_SM_TESTS="LOCALSTACK_ENDPOINT not set. Start LocalStack and set LOCALSTACK_ENDPOINT=http://localhost:4566"
 		return
 	fi
+
+	# Set dummy AWS credentials for LocalStack
+	export AWS_ACCESS_KEY_ID="test"
+	export AWS_SECRET_ACCESS_KEY="test"
+	export AWS_DEFAULT_REGION="us-east-1"
 
 	# Check if aws CLI is installed
 	if ! command -v aws >/dev/null 2>&1; then
@@ -32,30 +33,40 @@ setup_file() {
 		return
 	fi
 
-	# Verify we can access Secrets Manager (expensive call - do once)
-	if ! aws secretsmanager list-secrets --region "$SM_REGION" --max-results 1 >/dev/null 2>&1; then
-		export SKIP_AWS_SM_TESTS="Cannot access AWS Secrets Manager. Permissions may be insufficient."
-		return
-	fi
+	# Wait for LocalStack to be ready
+	local retries=10
+	while ! curl -sf "$LOCALSTACK_ENDPOINT/_localstack/health" >/dev/null 2>&1; do
+		retries=$((retries - 1))
+		if [ "$retries" -le 0 ]; then
+			export SKIP_AWS_SM_TESTS="LocalStack not ready"
+			return
+		fi
+		sleep 1
+	done
 
-	# Create a shared test secret for reuse across multiple tests
-	# This reduces API calls vs creating/deleting per test
+	# Create shared test secrets in LocalStack
 	export SHARED_SECRET_NAME="fnox-test/shared-test-$$"
 	export SHARED_SECRET_VALUE="shared-test-value-for-fnox"
-	aws secretsmanager create-secret \
+	aws --endpoint-url "$LOCALSTACK_ENDPOINT" secretsmanager create-secret \
 		--name "$SHARED_SECRET_NAME" \
 		--secret-string "$SHARED_SECRET_VALUE" \
 		--region "$SM_REGION" >/dev/null 2>&1
 
-	# Wait for propagation (eventual consistency)
-	sleep 2
+	# Create the pre-existing test secret
+	aws --endpoint-url "$LOCALSTACK_ENDPOINT" secretsmanager create-secret \
+		--name "fnox/test-secret" \
+		--secret-string "This is a test secret in AWS Secrets Manager!" \
+		--region "$SM_REGION" >/dev/null 2>&1 ||
+		aws --endpoint-url "$LOCALSTACK_ENDPOINT" secretsmanager put-secret-value \
+			--secret-id "fnox/test-secret" \
+			--secret-string "This is a test secret in AWS Secrets Manager!" \
+			--region "$SM_REGION" >/dev/null 2>&1
 }
 
 # File-level teardown - runs once after all tests
 teardown_file() {
-	# Clean up shared test secret
-	if [ -n "$SHARED_SECRET_NAME" ]; then
-		aws secretsmanager delete-secret \
+	if [ -n "$SHARED_SECRET_NAME" ] && [ -n "$LOCALSTACK_ENDPOINT" ]; then
+		aws --endpoint-url "$LOCALSTACK_ENDPOINT" secretsmanager delete-secret \
 			--secret-id "$SHARED_SECRET_NAME" \
 			--force-delete-without-recovery \
 			--region "$SM_REGION" >/dev/null 2>&1 || true
@@ -92,6 +103,7 @@ root = true
 [providers.sm]
 type = "aws-sm"
 region = "$region"
+endpoint = "$LOCALSTACK_ENDPOINT"
 
 [secrets]
 EOF
@@ -103,6 +115,7 @@ root = true
 type = "aws-sm"
 region = "$region"
 prefix = "$prefix"
+endpoint = "$LOCALSTACK_ENDPOINT"
 
 [secrets]
 EOF
@@ -113,10 +126,8 @@ EOF
 	create_sm_config
 
 	# Use the shared test secret (created in setup_file)
-	# Extract the suffix after "fnox-test/" prefix
 	local secret_suffix="${SHARED_SECRET_NAME#fnox-test/}"
 
-	# Add secret reference to config (using just the name without prefix)
 	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.SM_TEST]
@@ -124,7 +135,6 @@ provider = "sm"
 value = "${secret_suffix}"
 EOF
 
-	# Get the secret
 	run "$FNOX_BIN" get SM_TEST
 	assert_success
 	assert_output "$SHARED_SECRET_VALUE"
@@ -133,11 +143,8 @@ EOF
 @test "fnox get with prefix prepends prefix to secret name" {
 	create_sm_config "us-east-1" "fnox-test/"
 
-	# Use the shared test secret (created in setup_file)
-	# Extract the suffix after "fnox-test/" prefix
 	local secret_suffix="${SHARED_SECRET_NAME#fnox-test/}"
 
-	# Add secret reference using just the suffix (prefix will be prepended)
 	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.PREFIXED_SECRET]
@@ -145,7 +152,6 @@ provider = "sm"
 value = "${secret_suffix}"
 EOF
 
-	# Get the secret
 	run "$FNOX_BIN" get PREFIXED_SECRET
 	assert_success
 	assert_output "$SHARED_SECRET_VALUE"
@@ -154,7 +160,6 @@ EOF
 @test "fnox get without prefix uses full secret name" {
 	create_sm_config "us-east-1" ""
 
-	# Use existing fnox/test-secret (no prefix, so full path required)
 	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.FULL_NAME_SECRET]
@@ -162,7 +167,6 @@ provider = "sm"
 value = "fnox/test-secret"
 EOF
 
-	# Get the secret
 	run "$FNOX_BIN" get FULL_NAME_SECRET
 	assert_success
 	assert_output "This is a test secret in AWS Secrets Manager!"
@@ -210,7 +214,6 @@ EOF
 @test "fnox get respects region configuration" {
 	create_sm_config "us-east-1"
 
-	# Use the shared test secret to verify region config works
 	local secret_suffix="${SHARED_SECRET_NAME#fnox-test/}"
 
 	cat >>"${FNOX_CONFIG_FILE}" <<EOF
@@ -220,14 +223,12 @@ provider = "sm"
 value = "${secret_suffix}"
 EOF
 
-	# Get the secret
 	run "$FNOX_BIN" get REGIONAL_SECRET
 	assert_success
 	assert_output "$SHARED_SECRET_VALUE"
 }
 
 @test "AWS Secrets Manager works with existing fnox/test-secret" {
-	# Test with the pre-created secret from setup
 	create_sm_config "us-east-1" "fnox/"
 
 	cat >>"${FNOX_CONFIG_FILE}" <<EOF
@@ -237,7 +238,6 @@ provider = "sm"
 value = "test-secret"
 EOF
 
-	# Get the secret
 	run "$FNOX_BIN" get EXISTING_SECRET
 	assert_success
 	assert_output "This is a test secret in AWS Secrets Manager!"

--- a/test/azure_kms.bats
+++ b/test/azure_kms.bats
@@ -140,15 +140,13 @@ EOF
 	assert_output --partial "Failed to decode base64 ciphertext"
 }
 
-@test "fnox set warns and stores plaintext with wrong key" {
+@test "fnox set fails with wrong key" {
 	# Create config with non-existent key
 	create_azure_kms_config "https://fnox-testing-kv.vault.azure.net/" "non-existent-key"
 
-	# When encryption fails, fnox currently warns and stores plaintext
+	# Encryption failure should be a hard error
 	run "$FNOX_BIN" set AZURE_KMS_WRONG_KEY "test" --provider azure-kms
-	assert_success
-	assert_output --partial "Encryption not supported for provider 'azure-kms'"
-	assert_output --partial "Storing plaintext"
+	assert_failure
 }
 
 @test "fnox list shows Azure KMS secrets" {

--- a/test/azure_kms.bats
+++ b/test/azure_kms.bats
@@ -147,6 +147,7 @@ EOF
 	# Encryption failure should be a hard error
 	run "$FNOX_BIN" set AZURE_KMS_WRONG_KEY "test" --provider azure-kms
 	assert_failure
+	assert_output --partial "Azure Key Vault"
 }
 
 @test "fnox list shows Azure KMS secrets" {

--- a/test/local_config.bats
+++ b/test/local_config.bats
@@ -188,18 +188,16 @@ EOF
 }
 
 @test "fnox.local.toml can override default_provider" {
-	# Create main config with default provider
+	# Create main config with default provider (use plain to avoid encryption)
 	cat >fnox.toml <<EOF
 root = true
 default_provider = "main_provider"
 
 [providers.main_provider]
-type = "age"
-recipients = ["age1maintest"]
+type = "plain"
 
 [providers.alt_provider]
-type = "age"
-recipients = ["age1alttest"]
+type = "plain"
 EOF
 
 	# Create local config that changes default provider

--- a/test/profile_config.bats
+++ b/test/profile_config.bats
@@ -335,18 +335,16 @@ EOF
 }
 
 @test 'fnox.$FNOX_PROFILE.toml can override default_provider' {
-	# Create main config with default provider
+	# Create main config with default provider (use plain to avoid encryption)
 	cat >fnox.toml <<EOF
 root = true
 default_provider = "main_provider"
 
 [providers.main_provider]
-type = "age"
-recipients = ["age1maintest"]
+type = "plain"
 
 [providers.alt_provider]
-type = "age"
-recipients = ["age1alttest"]
+type = "plain"
 EOF
 
 	# Create profile config that changes default provider


### PR DESCRIPTION
## Summary

- **Fix encryption failure fallback**: `fnox set` previously swallowed encryption errors from any encryption provider (age, aws-kms, azure-kms, gcp-kms, fido2, yubikey) and silently stored secrets as plaintext. Now encryption failures are hard errors.
- Add `endpoint` optional field to AWS KMS, Secrets Manager, and Parameter Store providers for custom endpoint support (e.g., LocalStack)
- Convert all AWS test files to use LocalStack instead of real AWS credentials
- Expand LocalStack services in CI from `sts,iam` to `sts,iam,kms,secretsmanager,ssm`

## Test plan

- [ ] CI passes with LocalStack-backed AWS tests on Ubuntu
- [ ] macOS tests skip gracefully (no LocalStack available)
- [ ] KMS error-path test verifies encryption failure is a hard error
- [ ] All existing non-AWS tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes secret-writing semantics by failing instead of silently storing plaintext, which may break existing workflows that relied on the fallback. Adds new AWS endpoint configuration paths and rewires AWS tests/CI to LocalStack, which could surface environment-specific issues.
> 
> **Overview**
> **Behavior change:** `fnox set` no longer falls back to storing plaintext when an encryption provider fails; encryption errors now fail the command.
> 
> **AWS provider updates:** Adds optional `endpoint` support to `aws-kms`, `aws-sm`, and `aws-ps` provider configs (schema + wizard metadata), and wires it through the AWS SDK clients so requests can target custom endpoints (e.g., LocalStack).
> 
> **Test/CI changes:** CI now starts LocalStack with additional services and pre-creates KMS/Secrets Manager resources; AWS bats tests are rewritten to use `LOCALSTACK_ENDPOINT` with dummy creds and updated assertions (including expecting failures on wrong keys).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c4aeaeaf681b03a1ef5bca8e06139ebc97f25a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->