### PR TITLE
chore: release v1.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 # Changelog
 
-## [1.16.0](https://github.com/jdx/fnox/compare/v1.15.1..v1.16.0) - 2026-03-07
+## [1.16.1](https://github.com/jdx/fnox/compare/v1.16.0..v1.16.1) - 2026-03-08
+
+### 🐛 Bug Fixes
+
+- **(set)** error on encryption failure; use LocalStack for AWS tests by [@jdx](https://github.com/jdx) in [#324](https://github.com/jdx/fnox/pull/324)
+
+### 📦️ Dependency Updates
+
+- add Cross.toml to install libudev-dev for linux cross-compilation by [@jdx](https://github.com/jdx) in [#326](https://github.com/jdx/fnox/pull/326)
+
+## [1.16.0](https://github.com/jdx/fnox/compare/v1.15.1..v1.16.0) - 2026-03-08
+
+### 🐛 Bug Fixes
+
+- **(docs)** escape angle brackets in lease create doc by [@jdx](https://github.com/jdx) in [#323](https://github.com/jdx/fnox/pull/323)
 
 ### 🛡️ Security
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2209,7 +2209,7 @@ dependencies = [
 
 [[package]]
 name = "fnox"
-version = "1.16.0"
+version = "1.16.1"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fnox"
-version = "1.16.0"
+version = "1.16.1"
 edition = "2024"
 authors = ["@jdx"]
 description = "A flexible secret management tool supporting multiple providers and encryption methods"

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -1478,7 +1478,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.16.0",
+  "version": "1.16.1",
   "usage": "Usage: fnox [OPTIONS] <COMMAND>",
   "complete": {
     "key": {

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -4,7 +4,7 @@
 
 **Usage**: `fnox [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.16.0
+**Version**: 1.16.1
 
 - **Usage**: `fnox [FLAGS] <SUBCOMMAND>`
 

--- a/fnox.usage.kdl
+++ b/fnox.usage.kdl
@@ -1,7 +1,7 @@
 min_usage_version "1.3"
 name fnox
 bin fnox
-version "1.16.0"
+version "1.16.1"
 about "A flexible secret management tool by @jdx"
 usage "Usage: fnox [OPTIONS] <COMMAND>"
 flag "-c --config" help="Path to the configuration file (default: fnox.toml, searches parent directories)" global=#true default=fnox.toml {


### PR DESCRIPTION
### 🐛 Bug Fixes

- **(set)** error on encryption failure; use LocalStack for AWS tests by [@jdx](https://github.com/jdx) in [#324](https://github.com/jdx/fnox/pull/324)

### 📦️ Dependency Updates

- add Cross.toml to install libudev-dev for linux cross-compilation by [@jdx](https://github.com/jdx) in [#326](https://github.com/jdx/fnox/pull/326)