### PR TITLE
fix(deps): add Cross.toml to install libudev-dev for linux cross-compilation

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,12 @@
+[target.x86_64-unknown-linux-gnu]
+pre-build = [
+    "apt-get update",
+    "apt-get install -y libudev-dev",
+]
+
+[target.aarch64-unknown-linux-gnu]
+pre-build = [
+    "dpkg --add-architecture $CROSS_DEB_ARCH",
+    "apt-get update",
+    "apt-get install -y libudev-dev:$CROSS_DEB_ARCH",
+]


### PR DESCRIPTION
## Summary
- Adds `Cross.toml` with pre-build commands to install `libudev-dev` in Docker containers used by `cross` for Linux targets
- Fixes build failures for `x86_64-unknown-linux-gnu` and `aarch64-unknown-linux-gnu` caused by missing `libudev` (required by `hidapi` crate)
- Uses `$CROSS_DEB_ARCH` for aarch64 to install the correct architecture's package

## Test plan
- [x] `cross build --target x86_64-unknown-linux-gnu` succeeds locally
- [x] `cross build --target aarch64-unknown-linux-gnu` building locally
- [ ] CI release workflow passes for both Linux targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-only configuration change that affects cross-compilation container setup, with minimal impact on runtime behavior.
> 
> **Overview**
> Adds a new `Cross.toml` to customize `cross` Docker images for Linux builds by running pre-build apt commands.
> 
> The pre-build steps install `libudev-dev` for `x86_64-unknown-linux-gnu`, and for `aarch64-unknown-linux-gnu` they add the appropriate Debian architecture and install the arch-specific `libudev-dev` package via `$CROSS_DEB_ARCH`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cca6388c78aab6d813e2ab10dbb5443e8228ebd5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->