### PR TITLE
docs: add guide for fnox sync

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -61,6 +61,7 @@ export default defineConfig({
             link: "/guide/missing-secrets",
           },
           { text: "Import/Export", link: "/guide/import-export" },
+          { text: "Syncing Secrets Locally", link: "/guide/sync" },
           { text: "Credential Leases", link: "/guide/leases" },
         ],
       },

--- a/docs/guide/sync.md
+++ b/docs/guide/sync.md
@@ -1,6 +1,6 @@
 # Syncing Secrets Locally
 
-`fnox sync` fetches secrets from remote providers (1Password, AWS Secrets Manager, etc.) and re-encrypts them with a local encryption provider (age, YubiKey via age plugin, AWS KMS, etc.). The encrypted values are stored in your config so that subsequent access is instant and offline — no remote calls needed.
+`fnox sync` fetches secrets from remote providers (1Password, AWS Secrets Manager, etc.) and re-encrypts them with a local encryption provider (age, YubiKey via age plugin, AWS KMS, etc.). The encrypted values are stored in `fnox.local.toml` (gitignored) so that subsequent access is instant and offline — no remote calls needed.
 
 ## Why Sync?
 
@@ -23,7 +23,7 @@ This works, but every time you `cd` into the project (with [shell integration](/
 With `fnox sync`, you pull those values once and cache them locally with a fast, offline encryption provider:
 
 ```bash
-fnox sync --provider age
+fnox sync --provider age --config fnox.local.toml
 ```
 
 Now entering the directory is instant — secrets are decrypted locally from age without any remote calls.
@@ -39,51 +39,39 @@ When fnox resolves secrets, it checks for a `sync` field first and uses that ins
 
 ## Basic Usage
 
-### Sync all remote secrets to age
-
 ```bash
 # Set up an age provider if you haven't already
 fnox set --provider age  # or add [providers.age] to your config
 
-# Sync everything
-fnox sync --provider age
+# Sync everything to fnox.local.toml
+fnox sync --provider age --config fnox.local.toml
 ```
 
 ### Preview what would be synced
 
 ```bash
-fnox sync --provider age --dry-run
+fnox sync --provider age --config fnox.local.toml --dry-run
 ```
 
 ### Sync specific secrets
 
 ```bash
-fnox sync --provider age DATABASE_URL STRIPE_KEY
+fnox sync --provider age --config fnox.local.toml DATABASE_URL STRIPE_KEY
 ```
 
 ### Sync only secrets from a specific source
 
 ```bash
-fnox sync --provider age --source op
+fnox sync --provider age --config fnox.local.toml --source op
 ```
 
 ### Filter by regex pattern
 
 ```bash
-fnox sync --provider age --filter "^DB_"
+fnox sync --provider age --config fnox.local.toml --filter "^DB_"
 ```
 
-## Caching in fnox.local.toml
-
-By default, `fnox sync` writes the sync cache to the project `fnox.toml`. Since the cache contains encrypted values that are specific to your machine/key, you'll typically want to keep them out of version control.
-
-The recommended pattern: keep your shared secret references in `fnox.toml` (committed) and sync the cached values into `fnox.local.toml` (gitignored):
-
-```bash
-# Sync writes to fnox.local.toml by default when it exists,
-# or you can use --config to target it explicitly
-fnox sync --provider age --config fnox.local.toml
-```
+## What It Looks Like
 
 After syncing, your files look like this:
 
@@ -126,7 +114,7 @@ recipients = ["age1yubikey1q..."]  # YubiKey recipient
 ```
 
 ```bash
-fnox sync --provider age
+fnox sync --provider age --config fnox.local.toml
 ```
 
 Secrets are encrypted to your YubiKey's age identity. Decryption requires the YubiKey to be plugged in, adding hardware-based security to your local cache.
@@ -136,20 +124,10 @@ Secrets are encrypted to your YubiKey's age identity. Decryption requires the Yu
 When secrets change in the remote provider, re-run sync to update the local cache:
 
 ```bash
-fnox sync --provider age --force
+fnox sync --provider age --config fnox.local.toml --force
 ```
 
 The `--force` flag skips the confirmation prompt. fnox re-fetches from the original provider and re-encrypts.
-
-## Syncing to Global Config
-
-If you want synced secrets available across all projects (e.g., shared API keys):
-
-```bash
-fnox sync --provider age --global
-```
-
-This writes to `~/.config/fnox/config.toml` instead of the project config.
 
 ## Full Workflow Example
 

--- a/docs/guide/sync.md
+++ b/docs/guide/sync.md
@@ -138,15 +138,15 @@ git clone https://github.com/myorg/my-api && cd my-api
 # 2. Make sure fnox.local.toml is gitignored
 echo "fnox.local.toml" >> .gitignore
 
-# 3. Set up your age key (one-time)
+# 3. Set up your age key (one-time) — note the public key printed to your terminal
 age-keygen -o ~/.config/fnox/age.txt
 export FNOX_AGE_KEY=$(grep "AGE-SECRET-KEY" ~/.config/fnox/age.txt)
 
-# 4. Add age provider to your config
-cat >> fnox.toml << 'EOF'
+# 4. Add age provider to your config, replacing the recipient with your public key from step 3
+cat >> fnox.toml << EOF
 [providers.age]
 type = "age"
-recipients = ["age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"]
+recipients = ["$(grep 'public key:' ~/.config/fnox/age.txt | awk '{print $NF}')"]
 EOF
 
 # 5. Sync all 1Password secrets to local age encryption

--- a/docs/guide/sync.md
+++ b/docs/guide/sync.md
@@ -15,7 +15,7 @@ vault = "Engineering"
 [secrets]
 DATABASE_URL = { provider = "op", value = "Database/url" }
 STRIPE_KEY = { provider = "op", value = "Stripe/secret-key" }
-SENDGRID_KEY = { provider = "op", value = "Stripe/api-key" }
+SENDGRID_KEY = { provider = "op", value = "SendGrid/api-key" }
 ```
 
 This works, but every time you `cd` into the project (with [shell integration](/guide/shell-integration)), fnox calls 1Password to fetch each secret. This is slow and requires network access.

--- a/docs/guide/sync.md
+++ b/docs/guide/sync.md
@@ -1,0 +1,187 @@
+# Syncing Secrets Locally
+
+`fnox sync` fetches secrets from remote providers (1Password, AWS Secrets Manager, etc.) and re-encrypts them with a local encryption provider (age, YubiKey via age plugin, AWS KMS, etc.). The encrypted values are stored in your config so that subsequent access is instant and offline — no remote calls needed.
+
+## Why Sync?
+
+A typical team setup stores secrets in a shared provider like 1Password:
+
+```toml
+# fnox.toml (committed)
+[providers.op]
+type = "1password"
+vault = "Engineering"
+
+[secrets]
+DATABASE_URL = { provider = "op", value = "Database/url" }
+STRIPE_KEY = { provider = "op", value = "Stripe/secret-key" }
+SENDGRID_KEY = { provider = "op", value = "Stripe/api-key" }
+```
+
+This works, but every time you `cd` into the project (with [shell integration](/guide/shell-integration)), fnox calls 1Password to fetch each secret. This is slow and requires network access.
+
+With `fnox sync`, you pull those values once and cache them locally with a fast, offline encryption provider:
+
+```bash
+fnox sync --provider age
+```
+
+Now entering the directory is instant — secrets are decrypted locally from age without any remote calls.
+
+## How It Works
+
+1. fnox reads all secrets from your merged config
+2. It resolves each secret's plaintext value from the original remote provider
+3. It encrypts each value with the target provider (e.g., age)
+4. It writes the encrypted cache into your config as a `sync` field on each secret
+
+When fnox resolves secrets, it checks for a `sync` field first and uses that instead of calling the original provider.
+
+## Basic Usage
+
+### Sync all remote secrets to age
+
+```bash
+# Set up an age provider if you haven't already
+fnox set --provider age  # or add [providers.age] to your config
+
+# Sync everything
+fnox sync --provider age
+```
+
+### Preview what would be synced
+
+```bash
+fnox sync --provider age --dry-run
+```
+
+### Sync specific secrets
+
+```bash
+fnox sync --provider age DATABASE_URL STRIPE_KEY
+```
+
+### Sync only secrets from a specific source
+
+```bash
+fnox sync --provider age --source op
+```
+
+### Filter by regex pattern
+
+```bash
+fnox sync --provider age --filter "^DB_"
+```
+
+## Caching in fnox.local.toml
+
+By default, `fnox sync` writes the sync cache to the project `fnox.toml`. Since the cache contains encrypted values that are specific to your machine/key, you'll typically want to keep them out of version control.
+
+The recommended pattern: keep your shared secret references in `fnox.toml` (committed) and sync the cached values into `fnox.local.toml` (gitignored):
+
+```bash
+# Sync writes to fnox.local.toml by default when it exists,
+# or you can use --config to target it explicitly
+fnox sync --provider age --config fnox.local.toml
+```
+
+After syncing, your files look like this:
+
+**fnox.toml** (committed — the source of truth):
+
+```toml
+[providers.op]
+type = "1password"
+vault = "Engineering"
+
+[providers.age]
+type = "age"
+recipients = ["age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"]
+
+[secrets]
+DATABASE_URL = { provider = "op", value = "Database/url" }
+STRIPE_KEY = { provider = "op", value = "Stripe/secret-key" }
+SENDGRID_KEY = { provider = "op", value = "SendGrid/api-key" }
+```
+
+**fnox.local.toml** (gitignored — your local cache):
+
+```toml
+[secrets]
+DATABASE_URL = { provider = "op", value = "Database/url", sync = { provider = "age", value = "YWdlLWVuY3J5cHRpb24..." } }
+STRIPE_KEY = { provider = "op", value = "Stripe/secret-key", sync = { provider = "age", value = "YWdlLWVuY3J5cHRpb24..." } }
+SENDGRID_KEY = { provider = "op", value = "SendGrid/api-key", sync = { provider = "age", value = "YWdlLWVuY3J5cHRpb24..." } }
+```
+
+When you `cd` into the project, fnox sees the `sync` field and decrypts with age locally — no 1Password calls.
+
+## Using a YubiKey
+
+If you use a YubiKey with the [age-plugin-yubikey](https://github.com/str4d/age-plugin-yubikey), syncing works the same way. Your age provider just uses the YubiKey identity:
+
+```toml
+[providers.age]
+type = "age"
+recipients = ["age1yubikey1q..."]  # YubiKey recipient
+```
+
+```bash
+fnox sync --provider age
+```
+
+Secrets are encrypted to your YubiKey's age identity. Decryption requires the YubiKey to be plugged in, adding hardware-based security to your local cache.
+
+## Refreshing the Cache
+
+When secrets change in the remote provider, re-run sync to update the local cache:
+
+```bash
+fnox sync --provider age --force
+```
+
+The `--force` flag skips the confirmation prompt. fnox re-fetches from the original provider and re-encrypts.
+
+## Syncing to Global Config
+
+If you want synced secrets available across all projects (e.g., shared API keys):
+
+```bash
+fnox sync --provider age --global
+```
+
+This writes to `~/.config/fnox/config.toml` instead of the project config.
+
+## Full Workflow Example
+
+```bash
+# 1. Clone a project with 1Password secrets in fnox.toml
+git clone https://github.com/myorg/my-api && cd my-api
+
+# 2. Make sure fnox.local.toml is gitignored
+echo "fnox.local.toml" >> .gitignore
+
+# 3. Set up your age key (one-time)
+age-keygen -o ~/.config/fnox/age.txt
+export FNOX_AGE_KEY=$(grep "AGE-SECRET-KEY" ~/.config/fnox/age.txt)
+
+# 4. Add age provider to your config
+cat >> fnox.toml << 'EOF'
+[providers.age]
+type = "age"
+recipients = ["age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"]
+EOF
+
+# 5. Sync all 1Password secrets to local age encryption
+fnox sync --provider age --config fnox.local.toml
+
+# 6. Done — entering the directory is now instant
+cd .. && cd my-api
+# Secrets load from local age cache, no 1Password calls
+```
+
+## Next Steps
+
+- [Import/Export](/guide/import-export) - Migrate secrets between formats
+- [Shell Integration](/guide/shell-integration) - Auto-load secrets on `cd`
+- [Hierarchical Config](/guide/hierarchical-config) - Organize configs across directories
+- [Providers](/providers/overview) - All available providers


### PR DESCRIPTION
## Summary
- Adds a new guide page explaining `fnox sync` for caching remote provider secrets locally
- Covers the key use case: syncing 1Password (or other remote) secrets into `fnox.local.toml` with age/YubiKey encryption for instant, offline access
- Includes sections on basic usage, the fnox.local.toml pattern, YubiKey support, refreshing cache, and a full end-to-end workflow example
- Adds sidebar entry under Guide section

## Test plan
- [ ] Verify the guide renders correctly in VitePress (`mise run docs:dev`)
- [ ] Confirm sidebar link works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes (new page + sidebar link) with no impact on runtime behavior or security-sensitive code.
> 
> **Overview**
> Adds a new Guide page (`docs/guide/sync.md`) documenting `fnox sync` for caching secrets fetched from remote providers into a gitignored `fnox.local.toml`, including usage patterns (dry-run, filtering, source selection), the `sync` field format, YubiKey/age examples, and cache refresh workflow.
> 
> Updates the VitePress sidebar (`docs/.vitepress/config.mjs`) to include a **new “Syncing Secrets Locally”** entry under *Features*.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c5611f906a947d4ff57a42e8a662c1a1611e5ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->