### PR TITLE
feat(init): add -f as short alias for --force

### DIFF
--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -449,22 +449,22 @@
         "args": [],
         "flags": [
           {
+            "name": "force",
+            "usage": "-f --force",
+            "help": "Overwrite existing configuration file",
+            "help_first_line": "Overwrite existing configuration file",
+            "short": ["f"],
+            "long": ["force"],
+            "hide": false,
+            "global": false
+          },
+          {
             "name": "global",
             "usage": "-g --global",
             "help": "Initialize the global config file (~/.config/fnox/config.toml)",
             "help_first_line": "Initialize the global config file (~/.config/fnox/config.toml)",
             "short": ["g"],
             "long": ["global"],
-            "hide": false,
-            "global": false
-          },
-          {
-            "name": "force",
-            "usage": "--force",
-            "help": "Overwrite existing configuration file",
-            "help_first_line": "Overwrite existing configuration file",
-            "short": [],
-            "long": ["force"],
             "hide": false,
             "global": false
           },

--- a/docs/cli/init.md
+++ b/docs/cli/init.md
@@ -9,13 +9,13 @@ Initialize a new fnox configuration file
 
 ## Flags
 
+### `-f --force`
+
+Overwrite existing configuration file
+
 ### `-g --global`
 
 Initialize the global config file (~/.config/fnox/config.toml)
-
-### `--force`
-
-Overwrite existing configuration file
 
 ### `--skip-wizard`
 

--- a/fnox.usage.kdl
+++ b/fnox.usage.kdl
@@ -87,8 +87,8 @@ cmd import help="Import secrets from various sources" {
 }
 cmd init help="Initialize a new fnox configuration file" {
     alias i
+    flag "-f --force" help="Overwrite existing configuration file"
     flag "-g --global" help="Initialize the global config file (~/.config/fnox/config.toml)"
-    flag --force help="Overwrite existing configuration file"
     flag --skip-wizard help="Skip the interactive wizard and create a minimal config"
 }
 cmd lease subcommand_required=#true help="Manage ephemeral credential leases" {

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -9,13 +9,13 @@ use std::collections::HashMap;
 #[derive(Debug, Args)]
 #[command(visible_alias = "i")]
 pub struct InitCommand {
-    /// Initialize the global config file (~/.config/fnox/config.toml)
-    #[arg(short = 'g', long)]
-    global: bool,
-
     /// Overwrite existing configuration file
     #[arg(short, long)]
     force: bool,
+
+    /// Initialize the global config file (~/.config/fnox/config.toml)
+    #[arg(short = 'g', long)]
+    global: bool,
 
     /// Skip the interactive wizard and create a minimal config
     #[arg(long)]

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -14,7 +14,7 @@ pub struct InitCommand {
     global: bool,
 
     /// Overwrite existing configuration file
-    #[arg(long)]
+    #[arg(short, long)]
     force: bool,
 
     /// Skip the interactive wizard and create a minimal config


### PR DESCRIPTION
## Summary
- Add `-f` short flag for `--force` on the `init` command
- The `import` and `sync` commands already had `-f`; this makes it consistent

## Test plan
- [x] `cargo check` passes
- [ ] Verify `fnox init -f` works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CLI flag metadata change with no impact to config generation logic beyond how the option is invoked.
> 
> **Overview**
> Adds `-f` as a short option for the `init` command’s `--force` flag, aligning the CLI UX with other commands that already support `-f` for overwrite/skip confirmations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf8853ff1ac4568240f12228b2f0a0848eb84ce1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->