### PR TITLE
chore: release v1.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## [1.17.0](https://github.com/jdx/fnox/compare/v1.16.1..v1.17.0) - 2026-03-09
+
+### 🚀 Features
+
+- **(cloudflare)** add Cloudflare API token lease backend by [@jdx](https://github.com/jdx) in [#335](https://github.com/jdx/fnox/pull/335)
+- **(fido2)** bump demand to v2, mask PIN during typing by [@jdx](https://github.com/jdx) in [#334](https://github.com/jdx/fnox/pull/334)
+- **(get)** resolve leased credentials from `fnox get` by [@jdx](https://github.com/jdx) in [#338](https://github.com/jdx/fnox/pull/338)
+- **(init)** add -f as short alias for --force by [@jdx](https://github.com/jdx) in [#329](https://github.com/jdx/fnox/pull/329)
+- **(lease)** add --all flag, default to creating all leases by [@jdx](https://github.com/jdx) in [#337](https://github.com/jdx/fnox/pull/337)
+- **(lease)** add GitHub App installation token lease backend by [@jdx](https://github.com/jdx) in [#342](https://github.com/jdx/fnox/pull/342)
+
+### 🐛 Bug Fixes
+
+- **(config)** fix directory locations to follow XDG spec by [@jdx](https://github.com/jdx) in [#336](https://github.com/jdx/fnox/pull/336)
+- **(exec)** use unix exec and exit silently on subprocess failure by [@jdx](https://github.com/jdx) in [#339](https://github.com/jdx/fnox/pull/339)
+- **(fido2)** remove duplicate touch prompt by [@jdx](https://github.com/jdx) in [#332](https://github.com/jdx/fnox/pull/332)
+- **(set)** write to lowest-priority existing config file by [@jdx](https://github.com/jdx) in [#331](https://github.com/jdx/fnox/pull/331)
+- **(tui)** skip providers requiring interactive auth by [@jdx](https://github.com/jdx) in [#333](https://github.com/jdx/fnox/pull/333)
+
+### 🛡️ Security
+
+- **(ci)** retry lint step to handle transient pkl fetch failures by [@jdx](https://github.com/jdx) in [#341](https://github.com/jdx/fnox/pull/341)
+- **(mcp)** add MCP server for secret-gated AI agent access by [@jdx](https://github.com/jdx) in [#343](https://github.com/jdx/fnox/pull/343)
+- add guide for fnox sync by [@jdx](https://github.com/jdx) in [#328](https://github.com/jdx/fnox/pull/328)
+
+### 🔍 Other Changes
+
+- share Rust cache across CI jobs by [@jdx](https://github.com/jdx) in [#340](https://github.com/jdx/fnox/pull/340)
+
 ## [1.16.1](https://github.com/jdx/fnox/compare/v1.16.0..v1.16.1) - 2026-03-08
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2210,7 +2210,7 @@ dependencies = [
 
 [[package]]
 name = "fnox"
-version = "1.16.1"
+version = "1.17.0"
 dependencies = [
  "aes-gcm",
  "age",
@@ -3726,9 +3726,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libdbus-sys"
@@ -7826,18 +7826,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.40"
+version = "0.8.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
+checksum = "96e13bc581734df6250836c59a5f44f3c57db9f9acb9dc8e3eaabdaf6170254d"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.40"
+version = "0.8.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
+checksum = "3545ea9e86d12ab9bba9fcd99b54c1556fd3199007def5a03c375623d05fac1c"
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fnox"
-version = "1.16.1"
+version = "1.17.0"
 edition = "2024"
 authors = ["@jdx"]
 description = "A flexible secret management tool supporting multiple providers and encryption methods"

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -1501,7 +1501,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.16.1",
+  "version": "1.17.0",
   "usage": "Usage: fnox [OPTIONS] <COMMAND>",
   "complete": {
     "key": {

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -4,7 +4,7 @@
 
 **Usage**: `fnox [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.16.1
+**Version**: 1.17.0
 
 - **Usage**: `fnox [FLAGS] <SUBCOMMAND>`
 

--- a/fnox.usage.kdl
+++ b/fnox.usage.kdl
@@ -1,7 +1,7 @@
 min_usage_version "1.3"
 name fnox
 bin fnox
-version "1.16.1"
+version "1.17.0"
 about "A flexible secret management tool by @jdx"
 usage "Usage: fnox [OPTIONS] <COMMAND>"
 flag "-c --config" help="Path to the configuration file (default: fnox.toml, searches parent directories)" global=#true default=fnox.toml {


### PR DESCRIPTION
### 🚀 Features

- **(cloudflare)** add Cloudflare API token lease backend by [@jdx](https://github.com/jdx) in [#335](https://github.com/jdx/fnox/pull/335)
- **(fido2)** bump demand to v2, mask PIN during typing by [@jdx](https://github.com/jdx) in [#334](https://github.com/jdx/fnox/pull/334)
- **(get)** resolve leased credentials from `fnox get` by [@jdx](https://github.com/jdx) in [#338](https://github.com/jdx/fnox/pull/338)
- **(init)** add -f as short alias for --force by [@jdx](https://github.com/jdx) in [#329](https://github.com/jdx/fnox/pull/329)
- **(lease)** add --all flag, default to creating all leases by [@jdx](https://github.com/jdx) in [#337](https://github.com/jdx/fnox/pull/337)
- **(lease)** add GitHub App installation token lease backend by [@jdx](https://github.com/jdx) in [#342](https://github.com/jdx/fnox/pull/342)

### 🐛 Bug Fixes

- **(config)** fix directory locations to follow XDG spec by [@jdx](https://github.com/jdx) in [#336](https://github.com/jdx/fnox/pull/336)
- **(exec)** use unix exec and exit silently on subprocess failure by [@jdx](https://github.com/jdx) in [#339](https://github.com/jdx/fnox/pull/339)
- **(fido2)** remove duplicate touch prompt by [@jdx](https://github.com/jdx) in [#332](https://github.com/jdx/fnox/pull/332)
- **(set)** write to lowest-priority existing config file by [@jdx](https://github.com/jdx) in [#331](https://github.com/jdx/fnox/pull/331)
- **(tui)** skip providers requiring interactive auth by [@jdx](https://github.com/jdx) in [#333](https://github.com/jdx/fnox/pull/333)

### 🛡️ Security

- **(ci)** retry lint step to handle transient pkl fetch failures by [@jdx](https://github.com/jdx) in [#341](https://github.com/jdx/fnox/pull/341)
- **(mcp)** add MCP server for secret-gated AI agent access by [@jdx](https://github.com/jdx) in [#343](https://github.com/jdx/fnox/pull/343)
- add guide for fnox sync by [@jdx](https://github.com/jdx) in [#328](https://github.com/jdx/fnox/pull/328)

### 🔍 Other Changes

- share Rust cache across CI jobs by [@jdx](https://github.com/jdx) in [#340](https://github.com/jdx/fnox/pull/340)