### PR TITLE
fix(set): write to lowest-priority existing config file

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -39,7 +39,7 @@ pub mod version;
 #[command(help_expected = true)]
 pub struct Cli {
     /// Path to the configuration file (default: fnox.toml, searches parent directories)
-    #[arg(short, long, default_value = "fnox.toml", global = true)]
+    #[arg(short, long, default_value = crate::config::DEFAULT_CONFIG_FILENAME, global = true)]
     pub config: PathBuf,
 
     /// Profile to use (default: default, or FNOX_PROFILE env var)

--- a/src/commands/set.rs
+++ b/src/commands/set.rs
@@ -263,7 +263,7 @@ impl SetCommand {
             })?;
             // Only use auto-detection when --config is the clap default ("fnox.toml").
             // Any other value means the user explicitly chose a config file.
-            if cli.config == std::path::Path::new("fnox.toml") {
+            if cli.config == std::path::Path::new(config::DEFAULT_CONFIG_FILENAME) {
                 config::find_local_config(&current_dir, Some(&profile))
             } else {
                 current_dir.join(&cli.config)

--- a/src/commands/set.rs
+++ b/src/commands/set.rs
@@ -1,5 +1,5 @@
 use crate::commands::Cli;
-use crate::config::{Config, IfMissing};
+use crate::config::{self, Config, IfMissing};
 use crate::error::{FnoxError, Result};
 use clap::Args;
 use std::io::{self, Read};
@@ -258,11 +258,11 @@ impl SetCommand {
             }
             global_path
         } else {
-            // Save to current directory's config
+            // Save to the lowest-priority existing config file in the current directory
             let current_dir = std::env::current_dir().map_err(|e| {
                 FnoxError::Config(format!("Failed to get current directory: {}", e))
             })?;
-            current_dir.join(&cli.config)
+            config::find_local_config(&current_dir, Some(&profile))
         };
 
         if self.dry_run {

--- a/src/commands/set.rs
+++ b/src/commands/set.rs
@@ -261,12 +261,9 @@ impl SetCommand {
             let current_dir = std::env::current_dir().map_err(|e| {
                 FnoxError::Config(format!("Failed to get current directory: {}", e))
             })?;
-            // If --config was explicitly set to a non-default path, respect it
-            let default_filenames = config::all_config_filenames(Some(&profile));
-            if default_filenames
-                .iter()
-                .any(|f| cli.config == std::path::Path::new(f))
-            {
+            // Only use auto-detection when --config is the clap default ("fnox.toml").
+            // Any other value means the user explicitly chose a config file.
+            if cli.config == std::path::Path::new("fnox.toml") {
                 config::find_local_config(&current_dir, Some(&profile))
             } else {
                 current_dir.join(&cli.config)

--- a/src/commands/set.rs
+++ b/src/commands/set.rs
@@ -258,11 +258,19 @@ impl SetCommand {
             }
             global_path
         } else {
-            // Save to the lowest-priority existing config file in the current directory
             let current_dir = std::env::current_dir().map_err(|e| {
                 FnoxError::Config(format!("Failed to get current directory: {}", e))
             })?;
-            config::find_local_config(&current_dir, Some(&profile))
+            // If --config was explicitly set to a non-default path, respect it
+            let default_filenames = config::all_config_filenames(Some(&profile));
+            if default_filenames
+                .iter()
+                .any(|f| cli.config == std::path::Path::new(f))
+            {
+                config::find_local_config(&current_dir, Some(&profile))
+            } else {
+                current_dir.join(&cli.config)
+            }
         };
 
         if self.dry_run {

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,12 +29,24 @@ pub fn all_config_filenames(profile: Option<&str>) -> Vec<String> {
     files
 }
 
-/// Find the lowest-priority existing config file in `dir`.
+/// Find the most appropriate existing config file in `dir` for writing.
 ///
-/// Searches all config filenames in load order (lowest priority first) and
-/// returns the first one that exists on disk. Falls back to `fnox.toml` if
-/// no config files exist yet.
+/// When a non-default profile is active, prefers the profile-specific file
+/// (e.g. `fnox.staging.toml`) if it exists, so secrets stay scoped to that
+/// profile. Otherwise falls back to the lowest-priority existing file.
+/// If no config files exist yet, returns `fnox.toml`.
 pub fn find_local_config(dir: &Path, profile: Option<&str>) -> PathBuf {
+    // If a non-default profile is specified, prefer its config file first
+    if let Some(p) = profile.filter(|p| *p != "default") {
+        for name in [format!("fnox.{p}.toml"), format!(".fnox.{p}.toml")] {
+            let path = dir.join(&name);
+            if path.exists() {
+                return path;
+            }
+        }
+    }
+
+    // Fall back to lowest-priority existing file
     let filenames = all_config_filenames(profile);
     for name in &filenames {
         let path = dir.join(name);
@@ -1648,7 +1660,26 @@ mod tests {
         std::fs::write(dir.path().join("fnox.toml"), "").unwrap();
         std::fs::write(dir.path().join("fnox.staging.toml"), "").unwrap();
         let result = super::find_local_config(dir.path(), Some("staging"));
-        // fnox.toml is lowest priority and exists
+        // Profile-specific file is preferred when profile is active
+        assert_eq!(result, dir.path().join("fnox.staging.toml"));
+    }
+
+    #[test]
+    fn test_find_local_config_default_profile_with_base() {
+        // Default profile should still pick fnox.toml (lowest priority)
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("fnox.toml"), "").unwrap();
+        std::fs::write(dir.path().join("fnox.local.toml"), "").unwrap();
+        let result = super::find_local_config(dir.path(), Some("default"));
+        assert_eq!(result, dir.path().join("fnox.toml"));
+    }
+
+    #[test]
+    fn test_find_local_config_profile_only_base_exists() {
+        // Profile specified but only base config exists — fall back to it
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("fnox.toml"), "").unwrap();
+        let result = super::find_local_config(dir.path(), Some("staging"));
         assert_eq!(result, dir.path().join("fnox.toml"));
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -52,12 +52,22 @@ pub fn find_local_config(dir: &Path, profile: Option<&str>) -> PathBuf {
         }
     }
 
-    // Fall back to lowest-priority existing base file (skip profile files already checked above)
-    let filenames = all_config_filenames(None);
-    for name in &filenames {
+    // Fall back to lowest-priority existing base file.
+    // When a profile is active, exclude local files (fnox.local.toml, .fnox.local.toml)
+    // to avoid silently routing profile-scoped secrets into a gitignored local-override file.
+    let is_profiled = profile.is_some_and(|p| p != "default");
+    for name in &["fnox.toml", ".fnox.toml"] {
         let path = dir.join(name);
         if path.exists() {
             return path;
+        }
+    }
+    if !is_profiled {
+        for name in &["fnox.local.toml", ".fnox.local.toml"] {
+            let path = dir.join(name);
+            if path.exists() {
+                return path;
+            }
         }
     }
     dir.join(DEFAULT_CONFIG_FILENAME)
@@ -1687,5 +1697,24 @@ mod tests {
         std::fs::write(dir.path().join("fnox.toml"), "").unwrap();
         let result = super::find_local_config(dir.path(), Some("staging"));
         assert_eq!(result, dir.path().join("fnox.toml"));
+    }
+
+    #[test]
+    fn test_find_local_config_profile_skips_local_file() {
+        // When a profile is active and only fnox.local.toml exists,
+        // should NOT write there — fall through to creating fnox.toml
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("fnox.local.toml"), "").unwrap();
+        let result = super::find_local_config(dir.path(), Some("staging"));
+        assert_eq!(result, dir.path().join("fnox.toml"));
+    }
+
+    #[test]
+    fn test_find_local_config_no_profile_uses_local_file() {
+        // Without a profile, fnox.local.toml is a valid write target
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("fnox.local.toml"), "").unwrap();
+        let result = super::find_local_config(dir.path(), None);
+        assert_eq!(result, dir.path().join("fnox.local.toml"));
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,7 +17,7 @@ use strum::VariantNames;
 /// Returns all config filenames in load order (first = lowest priority, last = highest priority).
 ///
 /// Order: main configs → profile configs → local configs
-/// Within each group, dotfiles come first (higher priority than non-dotfiles).
+/// Within each group, non-dotfiles come first (lower priority); dotfiles follow (higher priority).
 pub fn all_config_filenames(profile: Option<&str>) -> Vec<String> {
     let mut files = vec!["fnox.toml".to_string(), ".fnox.toml".to_string()];
     if let Some(p) = profile.filter(|p| *p != "default") {
@@ -1640,5 +1640,15 @@ mod tests {
         std::fs::write(dir.path().join("fnox.staging.toml"), "").unwrap();
         let result = super::find_local_config(dir.path(), Some("staging"));
         assert_eq!(result, dir.path().join("fnox.staging.toml"));
+    }
+
+    #[test]
+    fn test_find_local_config_profile_with_base() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("fnox.toml"), "").unwrap();
+        std::fs::write(dir.path().join("fnox.staging.toml"), "").unwrap();
+        let result = super::find_local_config(dir.path(), Some("staging"));
+        // fnox.toml is lowest priority and exists
+        assert_eq!(result, dir.path().join("fnox.toml"));
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,6 +29,22 @@ pub fn all_config_filenames(profile: Option<&str>) -> Vec<String> {
     files
 }
 
+/// Find the lowest-priority existing config file in `dir`.
+///
+/// Searches all config filenames in load order (lowest priority first) and
+/// returns the first one that exists on disk. Falls back to `fnox.toml` if
+/// no config files exist yet.
+pub fn find_local_config(dir: &Path, profile: Option<&str>) -> PathBuf {
+    let filenames = all_config_filenames(profile);
+    for name in &filenames {
+        let path = dir.join(name);
+        if path.exists() {
+            return path;
+        }
+    }
+    dir.join("fnox.toml")
+}
+
 // Re-export ProviderConfig from providers module
 pub use crate::providers::ProviderConfig;
 
@@ -1575,5 +1591,54 @@ mod tests {
 
         let secrets = config.get_secrets("prod").unwrap();
         assert!(secrets.is_empty());
+    }
+
+    #[test]
+    fn test_find_local_config_no_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let result = super::find_local_config(dir.path(), None);
+        assert_eq!(result, dir.path().join("fnox.toml"));
+    }
+
+    #[test]
+    fn test_find_local_config_only_fnox_toml() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("fnox.toml"), "").unwrap();
+        let result = super::find_local_config(dir.path(), None);
+        assert_eq!(result, dir.path().join("fnox.toml"));
+    }
+
+    #[test]
+    fn test_find_local_config_only_local_toml() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("fnox.local.toml"), "").unwrap();
+        let result = super::find_local_config(dir.path(), None);
+        assert_eq!(result, dir.path().join("fnox.local.toml"));
+    }
+
+    #[test]
+    fn test_find_local_config_both_exist() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("fnox.toml"), "").unwrap();
+        std::fs::write(dir.path().join("fnox.local.toml"), "").unwrap();
+        let result = super::find_local_config(dir.path(), None);
+        // Should pick fnox.toml (lowest priority)
+        assert_eq!(result, dir.path().join("fnox.toml"));
+    }
+
+    #[test]
+    fn test_find_local_config_only_dotfile() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(".fnox.toml"), "").unwrap();
+        let result = super::find_local_config(dir.path(), None);
+        assert_eq!(result, dir.path().join(".fnox.toml"));
+    }
+
+    #[test]
+    fn test_find_local_config_profile() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("fnox.staging.toml"), "").unwrap();
+        let result = super::find_local_config(dir.path(), Some("staging"));
+        assert_eq!(result, dir.path().join("fnox.staging.toml"));
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,12 +14,18 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use strum::VariantNames;
 
+/// Default config filename, used as the clap default for `--config`.
+pub const DEFAULT_CONFIG_FILENAME: &str = "fnox.toml";
+
 /// Returns all config filenames in load order (first = lowest priority, last = highest priority).
 ///
 /// Order: main configs → profile configs → local configs
 /// Within each group, non-dotfiles come first (lower priority); dotfiles follow (higher priority).
 pub fn all_config_filenames(profile: Option<&str>) -> Vec<String> {
-    let mut files = vec!["fnox.toml".to_string(), ".fnox.toml".to_string()];
+    let mut files = vec![
+        DEFAULT_CONFIG_FILENAME.to_string(),
+        ".fnox.toml".to_string(),
+    ];
     if let Some(p) = profile.filter(|p| *p != "default") {
         files.push(format!("fnox.{p}.toml"));
         files.push(format!(".fnox.{p}.toml"));
@@ -46,15 +52,15 @@ pub fn find_local_config(dir: &Path, profile: Option<&str>) -> PathBuf {
         }
     }
 
-    // Fall back to lowest-priority existing file
-    let filenames = all_config_filenames(profile);
+    // Fall back to lowest-priority existing base file (skip profile files already checked above)
+    let filenames = all_config_filenames(None);
     for name in &filenames {
         let path = dir.join(name);
         if path.exists() {
             return path;
         }
     }
-    dir.join("fnox.toml")
+    dir.join(DEFAULT_CONFIG_FILENAME)
 }
 
 // Re-export ProviderConfig from providers module

--- a/test/config_hierarchy_set.bats
+++ b/test/config_hierarchy_set.bats
@@ -195,3 +195,53 @@ EOF
 	refute_output --partial "CHILD_SECRET"
 	refute_output --partial "updated-child-value"
 }
+
+@test "fnox set writes to fnox.local.toml when it is the only config file" {
+	# Only create fnox.local.toml, no fnox.toml
+	cat >fnox.local.toml <<EOF
+[providers.plain]
+type = "plain"
+EOF
+
+	run "$FNOX_BIN" set MY_SECRET "my-value"
+	assert_success
+
+	# Secret should be written to fnox.local.toml
+	run cat fnox.local.toml
+	assert_success
+	assert_output --partial "MY_SECRET"
+
+	# fnox.toml should NOT have been created
+	assert [ ! -f fnox.toml ]
+}
+
+@test "fnox set writes to fnox.toml when both fnox.toml and fnox.local.toml exist" {
+	# Create both files
+	cat >fnox.toml <<EOF
+[providers.plain]
+type = "plain"
+
+[secrets]
+EXISTING = { default = "existing" }
+EOF
+
+	cat >fnox.local.toml <<EOF
+[secrets]
+LOCAL_OVERRIDE = { default = "local" }
+EOF
+
+	run "$FNOX_BIN" set NEW_SECRET "new-value"
+	assert_success
+
+	# Secret should be written to fnox.toml (lowest priority)
+	run cat fnox.toml
+	assert_success
+	assert_output --partial "NEW_SECRET"
+	assert_output --partial "EXISTING"
+
+	# fnox.local.toml should NOT have the new secret
+	run cat fnox.local.toml
+	assert_success
+	refute_output --partial "NEW_SECRET"
+	assert_output --partial "LOCAL_OVERRIDE"
+}

--- a/test/config_hierarchy_set.bats
+++ b/test/config_hierarchy_set.bats
@@ -245,3 +245,33 @@ EOF
 	refute_output --partial "NEW_SECRET"
 	assert_output --partial "LOCAL_OVERRIDE"
 }
+
+@test "fnox set --profile staging writes to fnox.staging.toml when it exists alongside fnox.toml" {
+	cat >fnox.toml <<EOF
+[providers.plain]
+type = "plain"
+
+[secrets]
+BASE_SECRET = { default = "base" }
+EOF
+
+	cat >fnox.staging.toml <<EOF
+[secrets]
+STAGING_EXISTING = { default = "staging" }
+EOF
+
+	run "$FNOX_BIN" set --profile staging NEW_STAGING "staging-value"
+	assert_success
+
+	# Secret should be written to fnox.staging.toml (profile-specific)
+	run cat fnox.staging.toml
+	assert_success
+	assert_output --partial "NEW_STAGING"
+	assert_output --partial "STAGING_EXISTING"
+
+	# fnox.toml should NOT have the new secret
+	run cat fnox.toml
+	assert_success
+	refute_output --partial "NEW_STAGING"
+	assert_output --partial "BASE_SECRET"
+}


### PR DESCRIPTION
## Summary
- `fnox set` now writes to the lowest-priority existing config file in the current directory instead of always targeting `fnox.toml`
- If only `fnox.local.toml` exists, secrets are written there instead of creating a new `fnox.toml`
- If both `fnox.toml` and `fnox.local.toml` exist, writes to `fnox.toml` (lowest priority)
- Falls back to `fnox.toml` if no config files exist yet
- Adds `find_local_config()` helper in `config.rs` for reuse by other commands

## Test plan
- [x] 6 unit tests for `find_local_config` covering: no files, only fnox.toml, only fnox.local.toml, both exist, dotfile, profile-specific
- [x] 2 new bats integration tests for `fnox set` write target behavior
- [x] All existing `config_hierarchy_set` bats tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes where secrets are persisted on disk, which can surprise users and affect repo state (creating/modifying different config files), but the logic is localized and covered by new unit/integration tests.
> 
> **Overview**
> Updates `fnox set` to **write into the most appropriate existing config file in the current directory**: it now prefers an existing profile-specific file (e.g. `fnox.staging.toml`) when a non-default profile is active, otherwise chooses the lowest-priority existing base file (e.g. `fnox.toml` over `fnox.local.toml`), falling back to creating `fnox.toml` when nothing exists.
> 
> Introduces `config::DEFAULT_CONFIG_FILENAME` and a reusable `config::find_local_config()` helper, and adds unit + Bats integration tests to lock in the new write-target behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc2d3ec0704e479b0a3abb68e9a0939feeea6a32. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->