### PR TITLE
fix(fido2): remove duplicate touch prompt

### DIFF
--- a/src/providers/fido2.rs
+++ b/src/providers/fido2.rs
@@ -83,8 +83,6 @@ impl Fido2Provider {
             None
         };
 
-        eprintln!("Touch your FIDO2 key...");
-
         let device = ctap_hid_fido2::FidoKeyHidFactory::create(&ctap_hid_fido2::Cfg::init())
             .map_err(|e| FnoxError::Provider(format!("Failed to find FIDO2 device: {:?}", e)))?;
 


### PR DESCRIPTION
## Summary
- Remove redundant "Touch your FIDO2 key..." message since the `ctap_hid_fido2` library already prints "- Touch the sensor on the authenticator"

## Test plan
- [ ] Manual test: run `fnox get` or `fnox set` with a FIDO2 provider, verify only one touch prompt appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single log/UX-only change in the FIDO2 provider with no impact to credential, PIN, or cryptographic handling.
> 
> **Overview**
> Removes the extra `eprintln!("Touch your FIDO2 key...")` emitted during `get_hmac_secret()` so CLI users only see the touch prompt produced by `ctap_hid_fido2` when performing an assertion.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f86d4229ed24b955ce6acec6dd1f07f0ba8fcb5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->