### PR TITLE
feat(fido2): bump demand to v2, mask PIN during typing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1792,9 +1792,9 @@ dependencies = [
 
 [[package]]
 name = "demand"
-version = "1.8.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "907231cc77f104ad0777b4c06370cc1513e0f1181983dc617059630e6b79f36f"
+checksum = "35fbd3e6864d5351323ef4fa5db803386adf73cce6b42fcdf6a542804dc83c61"
 dependencies = [
  "console",
  "fuzzy-matcher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ clap = { version = "4", features = ["derive", "env"] }
 console = "0.16"
 crossterm = { version = "0.29", features = ["event-stream"] }
 data-encoding = "2"
-demand = "1"
+demand = "2"
 dirs = "6"
 fslock = "0.2"
 futures = "0.3"

--- a/src/providers/fido2.rs
+++ b/src/providers/fido2.rs
@@ -76,6 +76,7 @@ impl Fido2Provider {
         } else if atty::is(atty::Stream::Stderr) {
             let input = demand::Input::new("FIDO2 PIN (leave empty if not required)")
                 .placeholder("")
+                .mask_on_submit(true)
                 .run()
                 .map_err(|e| FnoxError::Provider(format!("Failed to read PIN: {e}")))?;
             if input.is_empty() { None } else { Some(input) }
@@ -175,6 +176,7 @@ pub mod setup {
         // Check if PIN is required
         let pin_input = demand::Input::new("FIDO2 PIN (leave empty if not set)")
             .placeholder("")
+            .mask_on_submit(true)
             .run()
             .map_err(|e| FnoxError::Config(format!("Failed to read PIN: {}", e)))?;
         let pin: Option<&str> = if pin_input.is_empty() {

--- a/src/providers/fido2.rs
+++ b/src/providers/fido2.rs
@@ -76,7 +76,7 @@ impl Fido2Provider {
         } else if atty::is(atty::Stream::Stderr) {
             let input = demand::Input::new("FIDO2 PIN (leave empty if not required)")
                 .placeholder("")
-                .mask_on_submit(true)
+                .password(true)
                 .run()
                 .map_err(|e| FnoxError::Provider(format!("Failed to read PIN: {e}")))?;
             if input.is_empty() { None } else { Some(input) }
@@ -176,7 +176,7 @@ pub mod setup {
         // Check if PIN is required
         let pin_input = demand::Input::new("FIDO2 PIN (leave empty if not set)")
             .placeholder("")
-            .mask_on_submit(true)
+            .password(true)
             .run()
             .map_err(|e| FnoxError::Config(format!("Failed to read PIN: {}", e)))?;
         let pin: Option<&str> = if pin_input.is_empty() {


### PR DESCRIPTION
## Summary
- Bump `demand` dependency from v1 to v2.0.0
- Use `.password(true)` for both FIDO2 PIN input prompts (runtime and setup) so the PIN is masked with asterisks during typing, preventing shoulder-surfing

## Test plan
- [x] All cargo tests pass
- [ ] Manual: run `fnox set` with a FIDO2 provider — PIN should be masked during typing

🤖 Generated with [Claude Code](https://claude.com/claude-code)