### PR TITLE
feat(cloudflare): add Cloudflare API token lease backend

### DIFF
--- a/docs/guide/leases.md
+++ b/docs/guide/leases.md
@@ -294,6 +294,7 @@ The subprocess still runs — just without the lease credentials. This means oth
 | [GCP IAM](/leases/gcp-iam)         | `gcp-iam`     | 1 hour       | No-op (native TTL)      |
 | [Azure Token](/leases/azure-token) | `azure-token` | ~1 hour      | No-op (native TTL)      |
 | [HashiCorp Vault](/leases/vault)   | `vault`       | 24 hours     | Vault lease revocation  |
+| [Cloudflare](/leases/cloudflare)   | `cloudflare`  | 24 hours     | Token deletion          |
 | [Custom Command](/leases/command)  | `command`     | 24 hours     | Optional revoke command |
 
 ## Managing Leases

--- a/docs/leases/cloudflare.md
+++ b/docs/leases/cloudflare.md
@@ -22,7 +22,7 @@ name = "Zone Read"
 | Field        | Required | Description                                                                          |
 | ------------ | -------- | ------------------------------------------------------------------------------------ |
 | `account_id` | No       | Cloudflare account ID. Substituted into `{account_id}` placeholders in resource keys |
-| `policies`   | Yes      | Array of permission policies (see below)                                             |
+| `policies`   | No       | Array of permission policies (see below); required for lease creation                |
 | `env_var`    | No       | Environment variable name for the token (default: `"CLOUDFLARE_API_TOKEN"`)          |
 | `duration`   | No       | Token lifetime (e.g., `"1h"`, `"30m"`, default: backend max of 24h)                  |
 

--- a/docs/leases/cloudflare.md
+++ b/docs/leases/cloudflare.md
@@ -1,0 +1,153 @@
+# Cloudflare
+
+The `cloudflare` lease backend creates short-lived, scoped Cloudflare API tokens using the [Cloudflare API Tokens API](https://developers.cloudflare.com/api/resources/user/subresources/tokens/methods/create/). A parent token with the **API Tokens: Edit** permission creates child tokens that are scoped to only the permissions you specify and automatically expire.
+
+## Configuration
+
+```toml
+[leases.cf]
+type = "cloudflare"
+account_id = "abc123def456"
+duration = "1h"
+
+[[leases.cf.policies]]
+effect = "allow"
+resources = { "com.cloudflare.api.account.abc123def456" = "*" }
+
+[[leases.cf.policies.permission_groups]]
+id = "c8fed203ed3043cba015a93ad1616f1f"
+name = "Zone Read"
+```
+
+| Field        | Required | Description                                                                          |
+| ------------ | -------- | ------------------------------------------------------------------------------------ |
+| `account_id` | No       | Cloudflare account ID. Substituted into `{account_id}` placeholders in resource keys |
+| `policies`   | Yes      | Array of permission policies (see below)                                             |
+| `env_var`    | No       | Environment variable name for the token (default: `"CLOUDFLARE_API_TOKEN"`)          |
+| `duration`   | No       | Token lifetime (e.g., `"1h"`, `"30m"`, default: backend max of 24h)                  |
+
+### Policy fields
+
+| Field               | Required | Description                                                           |
+| ------------------- | -------- | --------------------------------------------------------------------- |
+| `effect`            | No       | `"allow"` (default) or `"deny"`                                       |
+| `permission_groups` | Yes      | Array of `{ id, name }` objects (name is optional, for documentation) |
+| `resources`         | Yes      | Resource scope map (e.g., `{ "com.cloudflare.api.account.*" = "*" }`) |
+
+To find permission group IDs, use the [Cloudflare API](https://developers.cloudflare.com/api/resources/user/subresources/tokens/subresources/permission_groups/methods/list/) or run:
+
+```bash
+curl -s -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+  "https://api.cloudflare.com/client/v4/user/tokens/permission_groups" | jq '.result[]'
+```
+
+## Prerequisites
+
+The backend needs a parent API token that can create other tokens. fnox looks for it in environment variables:
+
+1. `CLOUDFLARE_API_TOKEN`
+2. `CF_API_TOKEN`
+
+The parent token must have the **API Tokens: Edit** permission. If not found, fnox prints:
+
+```
+Cloudflare API token not found. Set CLOUDFLARE_API_TOKEN with a token that has 'API Tokens: Edit' permission.
+```
+
+## Credentials Produced
+
+| Environment Variable   | Description                  |
+| ---------------------- | ---------------------------- |
+| `CLOUDFLARE_API_TOKEN` | Short-lived scoped API token |
+
+The env var name is configurable via the `env_var` field.
+
+## Limits
+
+- **Max duration:** 24 hours
+- **Revocation:** Supported — fnox deletes the token via `DELETE /user/tokens/{id}`
+
+## Examples
+
+### With stored credentials
+
+```toml
+[providers.op]
+type = "1password"
+vault = "Development"
+
+[secrets]
+CLOUDFLARE_API_TOKEN = { provider = "op", value = "Cloudflare/api token" }
+
+[leases.cf]
+type = "cloudflare"
+account_id = "abc123def456"
+duration = "1h"
+
+[[leases.cf.policies]]
+effect = "allow"
+resources = { "com.cloudflare.api.account.abc123def456" = "*" }
+
+[[leases.cf.policies.permission_groups]]
+id = "c8fed203ed3043cba015a93ad1616f1f"
+name = "Zone Read"
+
+[[leases.cf.policies.permission_groups]]
+id = "82e64a83756745bbbb1c9c2701bf816b"
+name = "DNS Read"
+```
+
+```bash
+fnox exec -- wrangler deploy
+```
+
+### Using {account_id} placeholder
+
+If you set `account_id`, you can use `{account_id}` in resource keys to avoid repeating it:
+
+```toml
+[leases.cf]
+type = "cloudflare"
+account_id = "abc123def456"
+duration = "2h"
+
+[[leases.cf.policies]]
+resources = { "com.cloudflare.api.account.{account_id}" = "*" }
+
+[[leases.cf.policies.permission_groups]]
+id = "e086da7e2179491d91ee5f35b3c14571"
+name = "Workers Scripts Write"
+```
+
+### Custom env var name
+
+```toml
+[leases.cf]
+type = "cloudflare"
+env_var = "CF_TOKEN"
+duration = "30m"
+
+[[leases.cf.policies]]
+resources = { "com.cloudflare.api.account.*" = "*" }
+
+[[leases.cf.policies.permission_groups]]
+id = "c8fed203ed3043cba015a93ad1616f1f"
+name = "Zone Read"
+```
+
+### Common permission groups
+
+| Permission Group      | ID                                 |
+| --------------------- | ---------------------------------- |
+| Zone Read             | `c8fed203ed3043cba015a93ad1616f1f` |
+| Zone Settings Write   | `e17beae8b8cb423a99571f9c20b2b9fc` |
+| DNS Read              | `82e64a83756745bbbb1c9c2701bf816b` |
+| DNS Write             | `4755a26eedb94da69e1066d98aa820be` |
+| Workers Scripts Write | `e086da7e2179491d91ee5f35b3c14571` |
+| Workers Routes Write  | `28f4b596e7d643029c524985477ae49a` |
+
+Use the permission groups API to find the full list for your account.
+
+## See Also
+
+- [Credential Leases](/guide/leases) — overview and approaches

--- a/docs/leases/cloudflare.md
+++ b/docs/leases/cloudflare.md
@@ -1,6 +1,8 @@
 # Cloudflare
 
-The `cloudflare` lease backend creates short-lived, scoped Cloudflare API tokens using the [Cloudflare API Tokens API](https://developers.cloudflare.com/api/resources/user/subresources/tokens/methods/create/). A parent token with the **API Tokens: Edit** permission creates child tokens that are scoped to only the permissions you specify and automatically expire.
+The `cloudflare` lease backend creates short-lived, scoped Cloudflare API tokens using the [Cloudflare API Tokens API](https://developers.cloudflare.com/api/resources/user/subresources/tokens/methods/create/). A parent token with the **API Tokens: Edit** permission creates child tokens that automatically expire.
+
+By default, the child token inherits the same policies (permissions and resource scopes) as the parent token. You can override this by specifying explicit `policies` in the configuration.
 
 ## Configuration
 
@@ -22,7 +24,7 @@ name = "Zone Read"
 | Field        | Required | Description                                                                          |
 | ------------ | -------- | ------------------------------------------------------------------------------------ |
 | `account_id` | No       | Cloudflare account ID. Substituted into `{account_id}` placeholders in resource keys |
-| `policies`   | No       | Array of permission policies (see below); required for lease creation                |
+| `policies`   | No       | Array of permission policies (see below); omit to inherit from parent token          |
 | `env_var`    | No       | Environment variable name for the token (default: `"CLOUDFLARE_API_TOKEN"`)          |
 | `duration`   | No       | Token lifetime (e.g., `"1h"`, `"30m"`, default: backend max of 24h)                  |
 
@@ -68,6 +70,16 @@ The env var name is configurable via the `env_var` field.
 - **Revocation:** Supported — fnox deletes the token via `DELETE /user/tokens/{id}`
 
 ## Examples
+
+### Minimal (inherit parent policies)
+
+```toml
+[leases.cf]
+type = "cloudflare"
+duration = "1h"
+```
+
+The child token gets the same permissions as the parent. This is the simplest setup — just ensure the parent token has the **API Tokens: Edit** permission plus whatever permissions your workflow needs.
 
 ### With stored credentials
 

--- a/docs/leases/cloudflare.md
+++ b/docs/leases/cloudflare.md
@@ -4,6 +4,8 @@ The `cloudflare` lease backend creates short-lived, scoped Cloudflare API tokens
 
 By default, the child token inherits the same policies (permissions and resource scopes) as the parent token. You can override this by specifying explicit `policies` in the configuration.
 
+When `account_id` is set, fnox uses the [account-owned tokens API](https://developers.cloudflare.com/fundamentals/api/get-started/account-owned-tokens/) (`/accounts/{id}/tokens`) instead of the user tokens API. Account tokens are ideal for CI/CD and team workflows since they aren't tied to an individual user.
+
 ## Configuration
 
 ```toml
@@ -21,12 +23,12 @@ id = "c8fed203ed3043cba015a93ad1616f1f"
 name = "Zone Read"
 ```
 
-| Field        | Required | Description                                                                          |
-| ------------ | -------- | ------------------------------------------------------------------------------------ |
-| `account_id` | No       | Cloudflare account ID. Substituted into `{account_id}` placeholders in resource keys |
-| `policies`   | No       | Array of permission policies (see below); omit to inherit from parent token          |
-| `env_var`    | No       | Environment variable name for the token (default: `"CLOUDFLARE_API_TOKEN"`)          |
-| `duration`   | No       | Token lifetime (e.g., `"1h"`, `"30m"`, default: backend max of 24h)                  |
+| Field        | Required | Description                                                                                                                      |
+| ------------ | -------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `account_id` | No       | Cloudflare account ID. When set, uses account-owned tokens API and substitutes into `{account_id}` placeholders in resource keys |
+| `policies`   | No       | Array of permission policies (see below); omit to inherit from parent token                                                      |
+| `env_var`    | No       | Environment variable name for the token (default: `"CLOUDFLARE_API_TOKEN"`)                                                      |
+| `duration`   | No       | Token lifetime (e.g., `"1h"`, `"30m"`, default: backend max of 24h)                                                              |
 
 ### Policy fields
 

--- a/docs/leases/cloudflare.md
+++ b/docs/leases/cloudflare.md
@@ -4,7 +4,7 @@ The `cloudflare` lease backend creates short-lived, scoped Cloudflare API tokens
 
 By default, the child token inherits the same policies (permissions and resource scopes) as the parent token. You can override this by specifying explicit `policies` in the configuration.
 
-When `account_id` is set, fnox uses the [account-owned tokens API](https://developers.cloudflare.com/fundamentals/api/get-started/account-owned-tokens/) (`/accounts/{id}/tokens`) instead of the user tokens API. Account tokens are ideal for CI/CD and team workflows since they aren't tied to an individual user.
+Set `token_type = "account"` to use [account-owned tokens](https://developers.cloudflare.com/fundamentals/api/get-started/account-owned-tokens/) (`/accounts/{id}/tokens`) instead of user tokens. Account tokens are ideal for CI/CD and team workflows since they aren't tied to an individual user.
 
 ## Configuration
 
@@ -23,12 +23,15 @@ id = "c8fed203ed3043cba015a93ad1616f1f"
 name = "Zone Read"
 ```
 
-| Field        | Required | Description                                                                                                                      |
-| ------------ | -------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `account_id` | No       | Cloudflare account ID. When set, uses account-owned tokens API and substitutes into `{account_id}` placeholders in resource keys |
-| `policies`   | No       | Array of permission policies (see below); omit to inherit from parent token                                                      |
-| `env_var`    | No       | Environment variable name for the token (default: `"CLOUDFLARE_API_TOKEN"`)                                                      |
-| `duration`   | No       | Token lifetime (e.g., `"1h"`, `"30m"`, default: backend max of 24h)                                                              |
+| Field        | Required | Description                                                                               |
+| ------------ | -------- | ----------------------------------------------------------------------------------------- |
+| `token_type` | No       | `"user"` (default) or `"account"` — selects user-owned vs account-owned tokens API        |
+| `account_id` | No\*     | Cloudflare account ID. Also substituted into `{account_id}` placeholders in resource keys |
+| `policies`   | No       | Array of permission policies (see below); omit to inherit from parent token               |
+| `env_var`    | No       | Environment variable name for the token (default: `"CLOUDFLARE_API_TOKEN"`)               |
+| `duration`   | No       | Token lifetime (e.g., `"1h"`, `"30m"`, default: backend max of 24h)                       |
+
+\* Required when `token_type = "account"`.
 
 ### Policy fields
 
@@ -69,7 +72,7 @@ The env var name is configurable via the `env_var` field.
 ## Limits
 
 - **Max duration:** 24 hours
-- **Revocation:** Supported — fnox deletes the token via `DELETE /user/tokens/{id}`
+- **Revocation:** Supported — fnox deletes the token via the Cloudflare API
 
 ## Examples
 
@@ -82,6 +85,16 @@ duration = "1h"
 ```
 
 The child token gets the same permissions as the parent. This is the simplest setup — just ensure the parent token has the **API Tokens: Edit** permission plus whatever permissions your workflow needs.
+
+### Account-owned token
+
+```toml
+[leases.cf]
+type = "cloudflare"
+token_type = "account"
+account_id = "abc123def456"
+duration = "1h"
+```
 
 ### With stored credentials
 

--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -120,6 +120,20 @@
       "type": "string",
       "enum": ["allow", "deny"]
     },
+    "CloudflareTokenType": {
+      "oneOf": [
+        {
+          "description": "User-owned token (POST /user/tokens)",
+          "type": "string",
+          "const": "user"
+        },
+        {
+          "description": "Account-owned token (POST /accounts/{account_id}/tokens)",
+          "type": "string",
+          "const": "account"
+        }
+      ]
+    },
     "IfMissing": {
       "type": "string",
       "enum": ["error", "warn", "ignore"]
@@ -254,11 +268,15 @@
               "default": "CLOUDFLARE_API_TOKEN"
             },
             "policies": {
-              "type": "array",
-              "default": [],
+              "type": ["array", "null"],
               "items": {
                 "$ref": "#/$defs/CloudflarePolicy"
               }
+            },
+            "token_type": {
+              "description": "Token type: \"user\" (default) or \"account\"",
+              "$ref": "#/$defs/CloudflareTokenType",
+              "default": "user"
             },
             "type": {
               "type": "string",

--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -96,8 +96,7 @@
       "type": "object",
       "properties": {
         "effect": {
-          "description": "\"allow\" or \"deny\"",
-          "type": "string",
+          "$ref": "#/$defs/CloudflarePolicyEffect",
           "default": "allow"
         },
         "permission_groups": {
@@ -110,10 +109,16 @@
         "resources": {
           "description": "Resource scope, e.g. {\"com.cloudflare.api.account.*\": \"*\"}",
           "type": "object",
-          "additionalProperties": true
+          "additionalProperties": {
+            "type": "string"
+          }
         }
       },
       "required": ["permission_groups", "resources"]
+    },
+    "CloudflarePolicyEffect": {
+      "type": "string",
+      "enum": ["allow", "deny"]
     },
     "IfMissing": {
       "type": "string",

--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -79,6 +79,42 @@
       "type": "string",
       "enum": ["bw", "rbw"]
     },
+    "CloudflarePermissionGroup": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": ["string", "null"]
+        }
+      },
+      "required": ["id"]
+    },
+    "CloudflarePolicy": {
+      "description": "A Cloudflare API token permission policy.\nMaps to the Cloudflare API's `policies` array in POST /user/tokens.",
+      "type": "object",
+      "properties": {
+        "effect": {
+          "description": "\"allow\" or \"deny\"",
+          "type": "string",
+          "default": "allow"
+        },
+        "permission_groups": {
+          "description": "Permission group IDs (UUIDs from Cloudflare's permission groups API)",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CloudflarePermissionGroup"
+          }
+        },
+        "resources": {
+          "description": "Resource scope, e.g. {\"com.cloudflare.api.account.*\": \"*\"}",
+          "type": "object",
+          "additionalProperties": true
+        }
+      },
+      "required": ["permission_groups", "resources"]
+    },
     "IfMissing": {
       "type": "string",
       "enum": ["error", "warn", "ignore"]
@@ -197,6 +233,34 @@
             }
           },
           "required": ["type", "scope"]
+        },
+        {
+          "description": "Cloudflare API Token",
+          "type": "object",
+          "properties": {
+            "account_id": {
+              "type": ["string", "null"]
+            },
+            "duration": {
+              "type": ["string", "null"]
+            },
+            "env_var": {
+              "type": "string",
+              "default": "CLOUDFLARE_API_TOKEN"
+            },
+            "policies": {
+              "type": "array",
+              "default": [],
+              "items": {
+                "$ref": "#/$defs/CloudflarePolicy"
+              }
+            },
+            "type": {
+              "type": "string",
+              "const": "cloudflare"
+            }
+          },
+          "required": ["type"]
         },
         {
           "description": "Generic Command Backend",

--- a/src/commands/lease.rs
+++ b/src/commands/lease.rs
@@ -112,28 +112,6 @@ impl LeaseCreateCommand {
         let profile_secrets = config.get_secrets(&profile)?;
         let resolved_secrets = resolve_secrets_batch(&config, &profile, &profile_secrets).await?;
 
-        // Hard-fail if any secret consumed by this lease backend failed to resolve.
-        // resolve_secrets_batch respects if_missing (default: "warn"), which would
-        // silently swallow auth errors (e.g. FIDO2 PIN failure) and produce a
-        // misleading "token not found" error later in check_prerequisites.
-        let required: std::collections::HashSet<&str> = backend_config
-            .required_env_vars()
-            .iter()
-            .map(|(k, _)| *k)
-            .collect();
-        let failed: Vec<_> = resolved_secrets
-            .iter()
-            .filter(|(k, v)| v.is_none() && required.contains(k.as_str()))
-            .map(|(k, _)| k.as_str())
-            .collect();
-        if !failed.is_empty() {
-            return Err(FnoxError::Config(format!(
-                "Failed to resolve secrets required by lease backend '{}': {}",
-                self.backend_name,
-                failed.join(", "),
-            )));
-        }
-
         let mut _temp_env_guard = TempEnvGuard::default();
         let _temp_files =
             lease::set_secrets_as_env(&resolved_secrets, &profile_secrets, &mut _temp_env_guard)?;
@@ -153,6 +131,7 @@ impl LeaseCreateCommand {
                 &profile,
                 &project_dir,
                 &leases,
+                &resolved_secrets,
                 &mut _temp_env_guard,
             )
             .await
@@ -170,6 +149,7 @@ impl LeaseCreateCommand {
                 &config,
                 &profile,
                 &project_dir,
+                &resolved_secrets,
                 &mut _temp_env_guard,
             )
             .await
@@ -183,6 +163,7 @@ impl LeaseCreateCommand {
         profile: &str,
         project_dir: &std::path::Path,
         leases: &IndexMap<String, crate::lease_backends::LeaseBackendConfig>,
+        resolved_secrets: &indexmap::IndexMap<String, Option<String>>,
         temp_env_guard: &mut TempEnvGuard,
     ) -> Result<()> {
         let mut errors: Vec<String> = Vec::new();
@@ -195,6 +176,7 @@ impl LeaseCreateCommand {
                     config,
                     profile,
                     project_dir,
+                    resolved_secrets,
                     temp_env_guard,
                 )
                 .await
@@ -231,8 +213,31 @@ impl LeaseCreateCommand {
         config: &Config,
         profile: &str,
         project_dir: &std::path::Path,
+        resolved_secrets: &indexmap::IndexMap<String, Option<String>>,
         temp_env_guard: &mut TempEnvGuard,
     ) -> Result<()> {
+        // Hard-fail if any secret required by this lease backend failed to resolve.
+        // resolve_secrets_batch respects if_missing (default: "warn"), which would
+        // silently swallow auth errors (e.g. FIDO2 PIN failure) and produce a
+        // misleading "token not found" error later in check_prerequisites.
+        let required: std::collections::HashSet<&str> = backend_config
+            .required_env_vars()
+            .iter()
+            .map(|(k, _)| *k)
+            .collect();
+        let failed: Vec<_> = resolved_secrets
+            .iter()
+            .filter(|(k, v)| v.is_none() && required.contains(k.as_str()))
+            .map(|(k, _)| k.as_str())
+            .collect();
+        if !failed.is_empty() {
+            return Err(FnoxError::Config(format!(
+                "Failed to resolve secrets required by lease backend '{}': {}",
+                backend_name,
+                failed.join(", "),
+            )));
+        }
+
         // Check prerequisites and prompt for missing env vars if --interactive
         if let Some(missing) = backend_config.check_prerequisites() {
             let required_vars = backend_config.required_env_vars();

--- a/src/commands/lease.rs
+++ b/src/commands/lease.rs
@@ -156,6 +156,7 @@ impl LeaseCreateCommand {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn run_all(
         &self,
         _cli: &Cli,
@@ -206,6 +207,7 @@ impl LeaseCreateCommand {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn create_single(
         &self,
         backend_name: &str,

--- a/src/commands/lease.rs
+++ b/src/commands/lease.rs
@@ -111,6 +111,29 @@ impl LeaseCreateCommand {
         // Resolve secrets once upfront (shared across all backends)
         let profile_secrets = config.get_secrets(&profile)?;
         let resolved_secrets = resolve_secrets_batch(&config, &profile, &profile_secrets).await?;
+
+        // Hard-fail if any secret consumed by this lease backend failed to resolve.
+        // resolve_secrets_batch respects if_missing (default: "warn"), which would
+        // silently swallow auth errors (e.g. FIDO2 PIN failure) and produce a
+        // misleading "token not found" error later in check_prerequisites.
+        let required: std::collections::HashSet<&str> = backend_config
+            .required_env_vars()
+            .iter()
+            .map(|(k, _)| *k)
+            .collect();
+        let failed: Vec<_> = resolved_secrets
+            .iter()
+            .filter(|(k, v)| v.is_none() && required.contains(k.as_str()))
+            .map(|(k, _)| k.as_str())
+            .collect();
+        if !failed.is_empty() {
+            return Err(FnoxError::Config(format!(
+                "Failed to resolve secrets required by lease backend '{}': {}",
+                self.backend_name,
+                failed.join(", "),
+            )));
+        }
+
         let mut _temp_env_guard = TempEnvGuard::default();
         let _temp_files =
             lease::set_secrets_as_env(&resolved_secrets, &profile_secrets, &mut _temp_env_guard)?;

--- a/src/lease_backends/aws_sts.rs
+++ b/src/lease_backends/aws_sts.rs
@@ -8,6 +8,32 @@ use std::time::Duration;
 
 const URL: &str = "https://fnox.jdx.dev/leases/aws-sts";
 
+/// Check if AWS credentials are available.
+pub fn check_prerequisites(profile: &Option<String>) -> Option<String> {
+    let has_env = (std::env::var("AWS_ACCESS_KEY_ID").is_ok()
+        && std::env::var("AWS_SECRET_ACCESS_KEY").is_ok())
+        || std::env::var("AWS_PROFILE").is_ok();
+    let has_profile = profile.is_some();
+    let has_sso = std::env::var("AWS_SSO_SESSION").is_ok();
+    let has_creds_file = dirs::home_dir()
+        .map(|h| h.join(".aws/credentials").exists() || h.join(".aws/config").exists())
+        .unwrap_or(false);
+    if has_env || has_profile || has_sso || has_creds_file {
+        None
+    } else {
+        Some("AWS credentials not found. Run 'aws sso login' or set AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY.".to_string())
+    }
+}
+
+/// Env vars for interactive prompting.
+pub fn required_env_vars() -> Vec<(&'static str, &'static str)> {
+    vec![
+        ("AWS_ACCESS_KEY_ID", "AWS access key"),
+        ("AWS_SECRET_ACCESS_KEY", "AWS secret key"),
+        ("AWS_SESSION_TOKEN", "AWS session token (optional)"),
+    ]
+}
+
 pub struct AwsStsBackend {
     region: String,
     profile: Option<String>,

--- a/src/lease_backends/azure_token.rs
+++ b/src/lease_backends/azure_token.rs
@@ -8,6 +8,29 @@ use std::time::Duration;
 
 const URL: &str = "https://fnox.jdx.dev/leases/azure-token";
 
+pub fn check_prerequisites() -> Option<String> {
+    let has_sp = std::env::var("AZURE_CLIENT_ID").is_ok()
+        && std::env::var("AZURE_CLIENT_SECRET").is_ok()
+        && std::env::var("AZURE_TENANT_ID").is_ok();
+    if has_sp {
+        return None;
+    }
+    let has_az = which::which("az").is_ok();
+    if has_az {
+        None
+    } else {
+        Some("Azure credentials not found. Run 'az login' or set AZURE_CLIENT_ID/AZURE_CLIENT_SECRET/AZURE_TENANT_ID.".to_string())
+    }
+}
+
+pub fn required_env_vars() -> Vec<(&'static str, &'static str)> {
+    vec![
+        ("AZURE_CLIENT_ID", "Azure application (client) ID"),
+        ("AZURE_CLIENT_SECRET", "Azure client secret"),
+        ("AZURE_TENANT_ID", "Azure tenant (directory) ID"),
+    ]
+}
+
 pub struct AzureTokenBackend {
     scope: String,
     env_var: String,

--- a/src/lease_backends/cloudflare.rs
+++ b/src/lease_backends/cloudflare.rs
@@ -67,42 +67,61 @@ impl CloudflareBackend {
             })
     }
 
+    /// Returns the tokens API base path.
+    /// With `account_id`: `/accounts/{id}/tokens` (account-owned tokens).
+    /// Without: `/user/tokens` (user-owned tokens).
+    fn tokens_path(&self) -> String {
+        match &self.account_id {
+            Some(id) => format!("{API_BASE}/accounts/{id}/tokens"),
+            None => format!("{API_BASE}/user/tokens"),
+        }
+    }
+
     /// Build the policies array for the Cloudflare API request, substituting
     /// the account ID into resource keys that contain the `{account_id}` placeholder.
     fn build_api_policies(
         policies: &[CloudflarePolicy],
         account_id: &Option<String>,
-    ) -> Vec<serde_json::Value> {
-        policies
-            .iter()
-            .map(|p| {
-                let mut resources = serde_json::Map::new();
-                for (key, value) in &p.resources {
-                    let resolved_key = if let Some(account_id) = account_id {
-                        key.replace("{account_id}", account_id)
-                    } else {
-                        key.clone()
-                    };
-                    resources.insert(resolved_key, serde_json::Value::String(value.clone()));
+    ) -> Result<Vec<serde_json::Value>> {
+        let mut result = Vec::with_capacity(policies.len());
+        for p in policies {
+            let mut resources = serde_json::Map::new();
+            for (key, value) in &p.resources {
+                if key.contains("{account_id}") && account_id.is_none() {
+                    return Err(FnoxError::Config(
+                        "Resource key contains '{account_id}' placeholder but 'account_id' \
+                         is not set in the Cloudflare backend config."
+                            .to_string(),
+                    ));
                 }
-                serde_json::json!({
-                    "effect": p.effect,
-                    "resources": resources,
-                    "permission_groups": p.permission_groups,
-                })
-            })
-            .collect()
+                let resolved_key = if let Some(account_id) = account_id {
+                    key.replace("{account_id}", account_id)
+                } else {
+                    key.clone()
+                };
+                resources.insert(resolved_key, serde_json::Value::String(value.clone()));
+            }
+            result.push(serde_json::json!({
+                "effect": p.effect,
+                "resources": resources,
+                "permission_groups": p.permission_groups,
+            }));
+        }
+        Ok(result)
     }
 
     /// Fetch the parent token's policies from the Cloudflare API.
-    /// Uses GET /user/tokens/verify to get the token ID, then
-    /// GET /user/tokens/{id} to retrieve its full policy configuration.
-    async fn fetch_parent_policies(parent_token: &str) -> Result<Vec<serde_json::Value>> {
+    /// Uses GET .../tokens/verify to get the token ID, then
+    /// GET .../tokens/{id} to retrieve its full policy configuration.
+    async fn fetch_parent_policies(
+        tokens_path: &str,
+        parent_token: &str,
+    ) -> Result<Vec<serde_json::Value>> {
         let client = crate::http::http_client();
 
         // Step 1: verify token to get its ID
         let verify_resp: serde_json::Value = client
-            .get(format!("{API_BASE}/user/tokens/verify"))
+            .get(format!("{tokens_path}/verify"))
             .bearer_auth(parent_token)
             .send()
             .await
@@ -132,7 +151,7 @@ impl CloudflareBackend {
 
         // Step 2: fetch full token details including policies
         let details_resp: serde_json::Value = client
-            .get(format!("{API_BASE}/user/tokens/{token_id}"))
+            .get(format!("{tokens_path}/{token_id}"))
             .bearer_auth(parent_token)
             .send()
             .await
@@ -180,6 +199,7 @@ impl CloudflareBackend {
 impl LeaseBackend for CloudflareBackend {
     async fn create_lease(&self, duration: Duration, label: &str) -> Result<Lease> {
         let parent_token = Self::get_api_token()?;
+        let tokens_path = self.tokens_path();
 
         let now = chrono::Utc::now();
         let expires_on =
@@ -194,10 +214,10 @@ impl LeaseBackend for CloudflareBackend {
 
         // Use configured policies, or inherit from the parent token
         let policies = if let Some(ref configured) = self.policies {
-            Self::build_api_policies(configured, &self.account_id)
+            Self::build_api_policies(configured, &self.account_id)?
         } else {
             tracing::info!("No policies configured; inheriting from parent token");
-            Self::fetch_parent_policies(&parent_token).await?
+            Self::fetch_parent_policies(&tokens_path, &parent_token).await?
         };
 
         let body = serde_json::json!({
@@ -208,7 +228,7 @@ impl LeaseBackend for CloudflareBackend {
 
         let client = crate::http::http_client();
         let response = client
-            .post(format!("{API_BASE}/user/tokens"))
+            .post(&tokens_path)
             .bearer_auth(&parent_token)
             .json(&body)
             .send()
@@ -297,10 +317,11 @@ impl LeaseBackend for CloudflareBackend {
 
     async fn revoke_lease(&self, lease_id: &str) -> Result<()> {
         let parent_token = Self::get_api_token()?;
+        let tokens_path = self.tokens_path();
 
         let client = crate::http::http_client();
         let response = client
-            .delete(format!("{API_BASE}/user/tokens/{lease_id}"))
+            .delete(format!("{tokens_path}/{lease_id}"))
             .bearer_auth(&parent_token)
             .send()
             .await

--- a/src/lease_backends/cloudflare.rs
+++ b/src/lease_backends/cloudflare.rs
@@ -236,7 +236,7 @@ impl LeaseBackend for CloudflareBackend {
         let policies = if let Some(ref configured) = self.policies {
             Self::build_api_policies(configured, &self.account_id)?
         } else {
-            tracing::info!("No policies configured; inheriting from parent token");
+            tracing::debug!("No policies configured; inheriting from parent token");
             Self::fetch_parent_policies(&tokens_path, &parent_token).await?
         };
 

--- a/src/lease_backends/cloudflare.rs
+++ b/src/lease_backends/cloudflare.rs
@@ -208,17 +208,19 @@ impl CloudflareBackend {
     }
 
     /// Fetch the parent token's policies from the Cloudflare API.
-    /// Always uses the /user/tokens endpoint for verify and details — the
-    /// /accounts/{id}/tokens/verify endpoint does not exist.
-    async fn fetch_parent_policies(parent_token: &str) -> Result<Vec<serde_json::Value>> {
-        let user_tokens_path = format!("{API_BASE}/user/tokens");
+    /// Uses the appropriate tokens path based on token type — account-scoped
+    /// tokens must verify via `/accounts/{id}/tokens/verify`, not `/user/tokens/verify`.
+    async fn fetch_parent_policies(
+        tokens_path: &str,
+        parent_token: &str,
+    ) -> Result<Vec<serde_json::Value>> {
         let client = crate::http::http_client();
 
         // Step 1: verify token to get its ID
         let verify_resp = Self::cf_api_call(
             &client,
             parent_token,
-            &format!("{user_tokens_path}/verify"),
+            &format!("{tokens_path}/verify"),
             "verify parent token",
         )
         .await?;
@@ -236,7 +238,7 @@ impl CloudflareBackend {
         let details_resp = Self::cf_api_call(
             &client,
             parent_token,
-            &format!("{user_tokens_path}/{token_id}"),
+            &format!("{tokens_path}/{token_id}"),
             "fetch parent token details",
         )
         .await?;
@@ -325,7 +327,7 @@ impl LeaseBackend for CloudflareBackend {
             Self::build_api_policies(configured, &self.account_id)?
         } else {
             tracing::debug!("No policies configured; inheriting from parent token");
-            Self::fetch_parent_policies(&parent_token).await?
+            Self::fetch_parent_policies(&tokens_path, &parent_token).await?
         };
 
         let body = serde_json::json!({

--- a/src/lease_backends/cloudflare.rs
+++ b/src/lease_backends/cloudflare.rs
@@ -141,6 +141,72 @@ impl CloudflareBackend {
         Ok(result)
     }
 
+    /// Make a GET request to the Cloudflare API, checking the HTTP status code
+    /// and returning a proper auth error for 401/403 responses.
+    async fn cf_api_call(
+        client: &reqwest::Client,
+        token: &str,
+        url: &str,
+        action: &str,
+    ) -> Result<serde_json::Value> {
+        let response = client
+            .get(url)
+            .bearer_auth(token)
+            .send()
+            .await
+            .map_err(|e| FnoxError::ProviderApiError {
+                provider: "Cloudflare".to_string(),
+                details: e.to_string(),
+                hint: format!("Failed to {action}"),
+                url: URL.to_string(),
+            })?;
+
+        let status = response.status();
+        let body: serde_json::Value =
+            response
+                .json()
+                .await
+                .map_err(|e| FnoxError::ProviderInvalidResponse {
+                    provider: "Cloudflare".to_string(),
+                    details: e.to_string(),
+                    hint: format!("Unexpected response while trying to {action}"),
+                    url: URL.to_string(),
+                })?;
+
+        if !status.is_success() {
+            let errors = body["errors"]
+                .as_array()
+                .and_then(|arr| {
+                    let msgs: Vec<_> = arr.iter().filter_map(|e| e["message"].as_str()).collect();
+                    if msgs.is_empty() {
+                        None
+                    } else {
+                        Some(msgs.join("; "))
+                    }
+                })
+                .unwrap_or_else(|| format!("HTTP {status}"));
+
+            if status.as_u16() == 401 || status.as_u16() == 403 {
+                return Err(FnoxError::ProviderAuthFailed {
+                    provider: "Cloudflare".to_string(),
+                    details: errors,
+                    hint:
+                        "Check that your parent API token is valid and has sufficient permissions"
+                            .to_string(),
+                    url: URL.to_string(),
+                });
+            }
+            return Err(FnoxError::ProviderApiError {
+                provider: "Cloudflare".to_string(),
+                details: errors,
+                hint: format!("Failed to {action}"),
+                url: URL.to_string(),
+            });
+        }
+
+        Ok(body)
+    }
+
     /// Fetch the parent token's policies from the Cloudflare API.
     /// Always uses the /user/tokens endpoint for verify and details — the
     /// /accounts/{id}/tokens/verify endpoint does not exist.
@@ -149,25 +215,13 @@ impl CloudflareBackend {
         let client = crate::http::http_client();
 
         // Step 1: verify token to get its ID
-        let verify_resp: serde_json::Value = client
-            .get(format!("{user_tokens_path}/verify"))
-            .bearer_auth(parent_token)
-            .send()
-            .await
-            .map_err(|e| FnoxError::ProviderApiError {
-                provider: "Cloudflare".to_string(),
-                details: e.to_string(),
-                hint: "Failed to verify parent token".to_string(),
-                url: URL.to_string(),
-            })?
-            .json()
-            .await
-            .map_err(|e| FnoxError::ProviderInvalidResponse {
-                provider: "Cloudflare".to_string(),
-                details: e.to_string(),
-                hint: "Unexpected response from Cloudflare verify endpoint".to_string(),
-                url: URL.to_string(),
-            })?;
+        let verify_resp = Self::cf_api_call(
+            &client,
+            parent_token,
+            &format!("{user_tokens_path}/verify"),
+            "verify parent token",
+        )
+        .await?;
 
         let token_id = verify_resp["result"]["id"].as_str().ok_or_else(|| {
             FnoxError::ProviderInvalidResponse {
@@ -179,25 +233,13 @@ impl CloudflareBackend {
         })?;
 
         // Step 2: fetch full token details including policies
-        let details_resp: serde_json::Value = client
-            .get(format!("{user_tokens_path}/{token_id}"))
-            .bearer_auth(parent_token)
-            .send()
-            .await
-            .map_err(|e| FnoxError::ProviderApiError {
-                provider: "Cloudflare".to_string(),
-                details: e.to_string(),
-                hint: "Failed to fetch parent token details".to_string(),
-                url: URL.to_string(),
-            })?
-            .json()
-            .await
-            .map_err(|e| FnoxError::ProviderInvalidResponse {
-                provider: "Cloudflare".to_string(),
-                details: e.to_string(),
-                hint: "Unexpected response from Cloudflare token details endpoint".to_string(),
-                url: URL.to_string(),
-            })?;
+        let details_resp = Self::cf_api_call(
+            &client,
+            parent_token,
+            &format!("{user_tokens_path}/{token_id}"),
+            "fetch parent token details",
+        )
+        .await?;
 
         let policies = details_resp["result"]["policies"]
             .as_array()

--- a/src/lease_backends/cloudflare.rs
+++ b/src/lease_backends/cloudflare.rs
@@ -12,7 +12,7 @@ const TOKEN_NAME_PREFIX: &str = "fnox-lease-";
 
 pub struct CloudflareBackend {
     account_id: Option<String>,
-    policies: Vec<CloudflarePolicy>,
+    policies: Option<Vec<CloudflarePolicy>>,
     env_var: String,
 }
 
@@ -46,7 +46,7 @@ pub struct CloudflarePermissionGroup {
 impl CloudflareBackend {
     pub fn new(
         account_id: Option<String>,
-        policies: Vec<CloudflarePolicy>,
+        policies: Option<Vec<CloudflarePolicy>>,
         env_var: String,
     ) -> Self {
         Self {
@@ -69,13 +69,16 @@ impl CloudflareBackend {
 
     /// Build the policies array for the Cloudflare API request, substituting
     /// the account ID into resource keys that contain the `{account_id}` placeholder.
-    fn build_api_policies(&self) -> Vec<serde_json::Value> {
-        self.policies
+    fn build_api_policies(
+        policies: &[CloudflarePolicy],
+        account_id: &Option<String>,
+    ) -> Vec<serde_json::Value> {
+        policies
             .iter()
             .map(|p| {
                 let mut resources = serde_json::Map::new();
                 for (key, value) in &p.resources {
-                    let resolved_key = if let Some(account_id) = &self.account_id {
+                    let resolved_key = if let Some(account_id) = account_id {
                         key.replace("{account_id}", account_id)
                     } else {
                         key.clone()
@@ -90,17 +93,92 @@ impl CloudflareBackend {
             })
             .collect()
     }
+
+    /// Fetch the parent token's policies from the Cloudflare API.
+    /// Uses GET /user/tokens/verify to get the token ID, then
+    /// GET /user/tokens/{id} to retrieve its full policy configuration.
+    async fn fetch_parent_policies(parent_token: &str) -> Result<Vec<serde_json::Value>> {
+        let client = crate::http::http_client();
+
+        // Step 1: verify token to get its ID
+        let verify_resp: serde_json::Value = client
+            .get(format!("{API_BASE}/user/tokens/verify"))
+            .bearer_auth(parent_token)
+            .send()
+            .await
+            .map_err(|e| FnoxError::ProviderApiError {
+                provider: "Cloudflare".to_string(),
+                details: e.to_string(),
+                hint: "Failed to verify parent token".to_string(),
+                url: URL.to_string(),
+            })?
+            .json()
+            .await
+            .map_err(|e| FnoxError::ProviderInvalidResponse {
+                provider: "Cloudflare".to_string(),
+                details: e.to_string(),
+                hint: "Unexpected response from Cloudflare verify endpoint".to_string(),
+                url: URL.to_string(),
+            })?;
+
+        let token_id = verify_resp["result"]["id"].as_str().ok_or_else(|| {
+            FnoxError::ProviderInvalidResponse {
+                provider: "Cloudflare".to_string(),
+                details: "Verify response missing 'result.id'".to_string(),
+                hint: "Check that the parent token is valid".to_string(),
+                url: URL.to_string(),
+            }
+        })?;
+
+        // Step 2: fetch full token details including policies
+        let details_resp: serde_json::Value = client
+            .get(format!("{API_BASE}/user/tokens/{token_id}"))
+            .bearer_auth(parent_token)
+            .send()
+            .await
+            .map_err(|e| FnoxError::ProviderApiError {
+                provider: "Cloudflare".to_string(),
+                details: e.to_string(),
+                hint: "Failed to fetch parent token details".to_string(),
+                url: URL.to_string(),
+            })?
+            .json()
+            .await
+            .map_err(|e| FnoxError::ProviderInvalidResponse {
+                provider: "Cloudflare".to_string(),
+                details: e.to_string(),
+                hint: "Unexpected response from Cloudflare token details endpoint".to_string(),
+                url: URL.to_string(),
+            })?;
+
+        let policies = details_resp["result"]["policies"]
+            .as_array()
+            .ok_or_else(|| FnoxError::ProviderInvalidResponse {
+                provider: "Cloudflare".to_string(),
+                details: "Token details response missing 'result.policies'".to_string(),
+                hint: "Check that the parent token is valid and accessible".to_string(),
+                url: URL.to_string(),
+            })?;
+
+        // Strip the policy `id` field — Cloudflare assigns new IDs to the child token
+        let cleaned: Vec<serde_json::Value> = policies
+            .iter()
+            .map(|p| {
+                let mut policy = p.clone();
+                if let Some(obj) = policy.as_object_mut() {
+                    obj.remove("id");
+                }
+                policy
+            })
+            .collect();
+
+        Ok(cleaned)
+    }
 }
 
 #[async_trait]
 impl LeaseBackend for CloudflareBackend {
     async fn create_lease(&self, duration: Duration, label: &str) -> Result<Lease> {
-        if self.policies.is_empty() {
-            return Err(FnoxError::Config(
-                "Cloudflare backend requires at least one policy with permission_groups and resources.".to_string(),
-            ));
-        }
-
         let parent_token = Self::get_api_token()?;
 
         let now = chrono::Utc::now();
@@ -113,7 +191,14 @@ impl LeaseBackend for CloudflareBackend {
         } else {
             raw_name
         };
-        let policies = self.build_api_policies();
+
+        // Use configured policies, or inherit from the parent token
+        let policies = if let Some(ref configured) = self.policies {
+            Self::build_api_policies(configured, &self.account_id)
+        } else {
+            tracing::info!("No policies configured; inheriting from parent token");
+            Self::fetch_parent_policies(&parent_token).await?
+        };
 
         let body = serde_json::json!({
             "name": name,

--- a/src/lease_backends/cloudflare.rs
+++ b/src/lease_backends/cloudflare.rs
@@ -7,6 +7,8 @@ use std::time::Duration;
 
 const URL: &str = "https://fnox.jdx.dev/leases/cloudflare";
 const API_BASE: &str = "https://api.cloudflare.com/client/v4";
+const MAX_TOKEN_NAME_LEN: usize = 100;
+const TOKEN_NAME_PREFIX: &str = "fnox-lease-";
 
 pub struct CloudflareBackend {
     account_id: Option<String>,
@@ -14,17 +16,24 @@ pub struct CloudflareBackend {
     env_var: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum CloudflarePolicyEffect {
+    #[default]
+    Allow,
+    Deny,
+}
+
 /// A Cloudflare API token permission policy.
 /// Maps to the Cloudflare API's `policies` array in POST /user/tokens.
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct CloudflarePolicy {
-    /// "allow" or "deny"
-    #[serde(default = "default_effect")]
-    pub effect: String,
+    #[serde(default)]
+    pub effect: CloudflarePolicyEffect,
     /// Permission group IDs (UUIDs from Cloudflare's permission groups API)
     pub permission_groups: Vec<CloudflarePermissionGroup>,
     /// Resource scope, e.g. {"com.cloudflare.api.account.*": "*"}
-    pub resources: IndexMap<String, serde_json::Value>,
+    pub resources: IndexMap<String, String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
@@ -32,10 +41,6 @@ pub struct CloudflarePermissionGroup {
     pub id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
-}
-
-fn default_effect() -> String {
-    "allow".to_string()
 }
 
 impl CloudflareBackend {
@@ -75,19 +80,12 @@ impl CloudflareBackend {
                     } else {
                         key.clone()
                     };
-                    resources.insert(resolved_key, value.clone());
+                    resources.insert(resolved_key, serde_json::Value::String(value.clone()));
                 }
                 serde_json::json!({
                     "effect": p.effect,
                     "resources": resources,
-                    "permission_groups": p.permission_groups.iter().map(|pg| {
-                        let mut m = serde_json::Map::new();
-                        m.insert("id".to_string(), serde_json::Value::String(pg.id.clone()));
-                        if let Some(name) = &pg.name {
-                            m.insert("name".to_string(), serde_json::Value::String(name.clone()));
-                        }
-                        serde_json::Value::Object(m)
-                    }).collect::<Vec<_>>(),
+                    "permission_groups": p.permission_groups,
                 })
             })
             .collect()
@@ -97,18 +95,29 @@ impl CloudflareBackend {
 #[async_trait]
 impl LeaseBackend for CloudflareBackend {
     async fn create_lease(&self, duration: Duration, label: &str) -> Result<Lease> {
+        if self.policies.is_empty() {
+            return Err(FnoxError::Config(
+                "Cloudflare backend requires at least one policy with permission_groups and resources.".to_string(),
+            ));
+        }
+
         let parent_token = Self::get_api_token()?;
 
         let now = chrono::Utc::now();
-        let expires_on = now + chrono::Duration::seconds(duration.as_secs() as i64);
+        let expires_on =
+            now + chrono::Duration::seconds(duration.as_secs().min(i64::MAX as u64) as i64);
 
-        let name = format!("fnox-lease-{label}");
+        let raw_name = format!("{TOKEN_NAME_PREFIX}{label}");
+        let name = if raw_name.len() > MAX_TOKEN_NAME_LEN {
+            raw_name[..MAX_TOKEN_NAME_LEN].to_string()
+        } else {
+            raw_name
+        };
         let policies = self.build_api_policies();
 
         let body = serde_json::json!({
             "name": name,
             "policies": policies,
-            "not_before": now.to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
             "expires_on": expires_on.to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         });
 
@@ -141,11 +150,13 @@ impl LeaseBackend for CloudflareBackend {
         if !status.is_success() || !resp["success"].as_bool().unwrap_or(false) {
             let errors = resp["errors"]
                 .as_array()
-                .map(|arr| {
-                    arr.iter()
-                        .filter_map(|e| e["message"].as_str())
-                        .collect::<Vec<_>>()
-                        .join("; ")
+                .and_then(|arr| {
+                    let msgs: Vec<_> = arr.iter().filter_map(|e| e["message"].as_str()).collect();
+                    if msgs.is_empty() {
+                        None
+                    } else {
+                        Some(msgs.join("; "))
+                    }
                 })
                 .unwrap_or_else(|| format!("HTTP {status}"));
 

--- a/src/lease_backends/cloudflare.rs
+++ b/src/lease_backends/cloudflare.rs
@@ -1,0 +1,248 @@
+use crate::error::{FnoxError, Result};
+use crate::lease_backends::{Lease, LeaseBackend};
+use async_trait::async_trait;
+use indexmap::IndexMap;
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+const URL: &str = "https://fnox.jdx.dev/leases/cloudflare";
+const API_BASE: &str = "https://api.cloudflare.com/client/v4";
+
+pub struct CloudflareBackend {
+    account_id: Option<String>,
+    policies: Vec<CloudflarePolicy>,
+    env_var: String,
+}
+
+/// A Cloudflare API token permission policy.
+/// Maps to the Cloudflare API's `policies` array in POST /user/tokens.
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct CloudflarePolicy {
+    /// "allow" or "deny"
+    #[serde(default = "default_effect")]
+    pub effect: String,
+    /// Permission group IDs (UUIDs from Cloudflare's permission groups API)
+    pub permission_groups: Vec<CloudflarePermissionGroup>,
+    /// Resource scope, e.g. {"com.cloudflare.api.account.*": "*"}
+    pub resources: IndexMap<String, serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct CloudflarePermissionGroup {
+    pub id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+}
+
+fn default_effect() -> String {
+    "allow".to_string()
+}
+
+impl CloudflareBackend {
+    pub fn new(
+        account_id: Option<String>,
+        policies: Vec<CloudflarePolicy>,
+        env_var: String,
+    ) -> Self {
+        Self {
+            account_id,
+            policies,
+            env_var,
+        }
+    }
+
+    fn get_api_token() -> Result<String> {
+        std::env::var("CLOUDFLARE_API_TOKEN")
+            .or_else(|_| std::env::var("CF_API_TOKEN"))
+            .map_err(|_| FnoxError::ProviderAuthFailed {
+                provider: "Cloudflare".to_string(),
+                details: "No parent API token found".to_string(),
+                hint: "Set CLOUDFLARE_API_TOKEN or CF_API_TOKEN with a token that has 'API Tokens: Edit' permission".to_string(),
+                url: URL.to_string(),
+            })
+    }
+
+    /// Build the policies array for the Cloudflare API request, substituting
+    /// the account ID into resource keys that contain the `{account_id}` placeholder.
+    fn build_api_policies(&self) -> Vec<serde_json::Value> {
+        self.policies
+            .iter()
+            .map(|p| {
+                let mut resources = serde_json::Map::new();
+                for (key, value) in &p.resources {
+                    let resolved_key = if let Some(account_id) = &self.account_id {
+                        key.replace("{account_id}", account_id)
+                    } else {
+                        key.clone()
+                    };
+                    resources.insert(resolved_key, value.clone());
+                }
+                serde_json::json!({
+                    "effect": p.effect,
+                    "resources": resources,
+                    "permission_groups": p.permission_groups.iter().map(|pg| {
+                        let mut m = serde_json::Map::new();
+                        m.insert("id".to_string(), serde_json::Value::String(pg.id.clone()));
+                        if let Some(name) = &pg.name {
+                            m.insert("name".to_string(), serde_json::Value::String(name.clone()));
+                        }
+                        serde_json::Value::Object(m)
+                    }).collect::<Vec<_>>(),
+                })
+            })
+            .collect()
+    }
+}
+
+#[async_trait]
+impl LeaseBackend for CloudflareBackend {
+    async fn create_lease(&self, duration: Duration, label: &str) -> Result<Lease> {
+        let parent_token = Self::get_api_token()?;
+
+        let now = chrono::Utc::now();
+        let expires_on = now + chrono::Duration::seconds(duration.as_secs() as i64);
+
+        let name = format!("fnox-lease-{label}");
+        let policies = self.build_api_policies();
+
+        let body = serde_json::json!({
+            "name": name,
+            "policies": policies,
+            "not_before": now.to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+            "expires_on": expires_on.to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+        });
+
+        let client = crate::http::http_client();
+        let response = client
+            .post(format!("{API_BASE}/user/tokens"))
+            .bearer_auth(&parent_token)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| FnoxError::ProviderApiError {
+                provider: "Cloudflare".to_string(),
+                details: e.to_string(),
+                hint: "Failed to connect to Cloudflare API".to_string(),
+                url: URL.to_string(),
+            })?;
+
+        let status = response.status();
+        let resp: serde_json::Value =
+            response
+                .json()
+                .await
+                .map_err(|e| FnoxError::ProviderInvalidResponse {
+                    provider: "Cloudflare".to_string(),
+                    details: e.to_string(),
+                    hint: "Unexpected response from Cloudflare API".to_string(),
+                    url: URL.to_string(),
+                })?;
+
+        if !status.is_success() || !resp["success"].as_bool().unwrap_or(false) {
+            let errors = resp["errors"]
+                .as_array()
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|e| e["message"].as_str())
+                        .collect::<Vec<_>>()
+                        .join("; ")
+                })
+                .unwrap_or_else(|| format!("HTTP {status}"));
+
+            if status.as_u16() == 401 || status.as_u16() == 403 {
+                return Err(FnoxError::ProviderAuthFailed {
+                    provider: "Cloudflare".to_string(),
+                    details: errors,
+                    hint: "Check that your parent API token has 'API Tokens: Edit' permission"
+                        .to_string(),
+                    url: URL.to_string(),
+                });
+            }
+            return Err(FnoxError::ProviderApiError {
+                provider: "Cloudflare".to_string(),
+                details: errors,
+                hint: "Check policies and account_id configuration".to_string(),
+                url: URL.to_string(),
+            });
+        }
+
+        let result = &resp["result"];
+        let token_value =
+            result["value"]
+                .as_str()
+                .ok_or_else(|| FnoxError::ProviderInvalidResponse {
+                    provider: "Cloudflare".to_string(),
+                    details: "Response missing 'result.value' field".to_string(),
+                    hint: "Unexpected response from Cloudflare API".to_string(),
+                    url: URL.to_string(),
+                })?;
+
+        let token_id = result["id"]
+            .as_str()
+            .ok_or_else(|| FnoxError::ProviderInvalidResponse {
+                provider: "Cloudflare".to_string(),
+                details: "Response missing 'result.id' field".to_string(),
+                hint: "Unexpected response from Cloudflare API".to_string(),
+                url: URL.to_string(),
+            })?;
+
+        let mut credentials = IndexMap::new();
+        credentials.insert(self.env_var.clone(), token_value.to_string());
+
+        // Use the Cloudflare token ID as the lease ID for revocation
+        let lease_id = token_id.to_string();
+
+        Ok(Lease {
+            credentials,
+            expires_at: Some(expires_on),
+            lease_id,
+        })
+    }
+
+    async fn revoke_lease(&self, lease_id: &str) -> Result<()> {
+        let parent_token = Self::get_api_token()?;
+
+        let client = crate::http::http_client();
+        let response = client
+            .delete(format!("{API_BASE}/user/tokens/{lease_id}"))
+            .bearer_auth(&parent_token)
+            .send()
+            .await
+            .map_err(|e| FnoxError::ProviderApiError {
+                provider: "Cloudflare".to_string(),
+                details: e.to_string(),
+                hint: "Failed to revoke Cloudflare API token".to_string(),
+                url: URL.to_string(),
+            })?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body_text = response.text().await.unwrap_or_default();
+            if status.as_u16() == 401 || status.as_u16() == 403 {
+                return Err(FnoxError::ProviderAuthFailed {
+                    provider: "Cloudflare".to_string(),
+                    details: body_text,
+                    hint: "Check that your parent API token has 'API Tokens: Edit' permission"
+                        .to_string(),
+                    url: URL.to_string(),
+                });
+            }
+            // 404 = token already deleted — treat as success
+            if status.as_u16() != 404 {
+                return Err(FnoxError::ProviderApiError {
+                    provider: "Cloudflare".to_string(),
+                    details: format!("HTTP {}: {}", status, body_text),
+                    hint: "Failed to revoke Cloudflare API token".to_string(),
+                    url: URL.to_string(),
+                });
+            }
+        }
+
+        Ok(())
+    }
+
+    fn max_lease_duration(&self) -> Duration {
+        // Cloudflare doesn't enforce a hard max, but 24h is a reasonable default
+        Duration::from_secs(24 * 3600)
+    }
+}

--- a/src/lease_backends/cloudflare.rs
+++ b/src/lease_backends/cloudflare.rs
@@ -11,9 +11,20 @@ const MAX_TOKEN_NAME_LEN: usize = 100;
 const TOKEN_NAME_PREFIX: &str = "fnox-lease-";
 
 pub struct CloudflareBackend {
+    token_type: CloudflareTokenType,
     account_id: Option<String>,
     policies: Option<Vec<CloudflarePolicy>>,
     env_var: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum CloudflareTokenType {
+    /// User-owned token (POST /user/tokens)
+    #[default]
+    User,
+    /// Account-owned token (POST /accounts/{account_id}/tokens)
+    Account,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, Default)]
@@ -45,15 +56,23 @@ pub struct CloudflarePermissionGroup {
 
 impl CloudflareBackend {
     pub fn new(
+        token_type: CloudflareTokenType,
         account_id: Option<String>,
         policies: Option<Vec<CloudflarePolicy>>,
         env_var: String,
-    ) -> Self {
-        Self {
+    ) -> Result<Self> {
+        if matches!(token_type, CloudflareTokenType::Account) && account_id.is_none() {
+            return Err(FnoxError::Config(
+                "Cloudflare backend: 'account_id' is required when token_type is 'account'."
+                    .to_string(),
+            ));
+        }
+        Ok(Self {
+            token_type,
             account_id,
             policies,
             env_var,
-        }
+        })
     }
 
     fn get_api_token() -> Result<String> {
@@ -67,13 +86,14 @@ impl CloudflareBackend {
             })
     }
 
-    /// Returns the tokens API base path.
-    /// With `account_id`: `/accounts/{id}/tokens` (account-owned tokens).
-    /// Without: `/user/tokens` (user-owned tokens).
+    /// Returns the tokens API base path based on `token_type`.
     fn tokens_path(&self) -> String {
-        match &self.account_id {
-            Some(id) => format!("{API_BASE}/accounts/{id}/tokens"),
-            None => format!("{API_BASE}/user/tokens"),
+        match self.token_type {
+            CloudflareTokenType::Account => {
+                let id = self.account_id.as_ref().expect("validated in new()");
+                format!("{API_BASE}/accounts/{id}/tokens")
+            }
+            CloudflareTokenType::User => format!("{API_BASE}/user/tokens"),
         }
     }
 

--- a/src/lease_backends/cloudflare.rs
+++ b/src/lease_backends/cloudflare.rs
@@ -103,8 +103,19 @@ impl CloudflareBackend {
         policies: &[CloudflarePolicy],
         account_id: &Option<String>,
     ) -> Result<Vec<serde_json::Value>> {
+        if policies.is_empty() {
+            return Err(FnoxError::Config(
+                "Cloudflare backend: 'policies' must contain at least one policy.".to_string(),
+            ));
+        }
         let mut result = Vec::with_capacity(policies.len());
         for p in policies {
+            if p.permission_groups.is_empty() {
+                return Err(FnoxError::Config(
+                    "Cloudflare backend: each policy must have at least one permission group."
+                        .to_string(),
+                ));
+            }
             let mut resources = serde_json::Map::new();
             for (key, value) in &p.resources {
                 if key.contains("{account_id}") && account_id.is_none() {
@@ -131,17 +142,15 @@ impl CloudflareBackend {
     }
 
     /// Fetch the parent token's policies from the Cloudflare API.
-    /// Uses GET .../tokens/verify to get the token ID, then
-    /// GET .../tokens/{id} to retrieve its full policy configuration.
-    async fn fetch_parent_policies(
-        tokens_path: &str,
-        parent_token: &str,
-    ) -> Result<Vec<serde_json::Value>> {
+    /// Always uses the /user/tokens endpoint for verify and details — the
+    /// /accounts/{id}/tokens/verify endpoint does not exist.
+    async fn fetch_parent_policies(parent_token: &str) -> Result<Vec<serde_json::Value>> {
+        let user_tokens_path = format!("{API_BASE}/user/tokens");
         let client = crate::http::http_client();
 
         // Step 1: verify token to get its ID
         let verify_resp: serde_json::Value = client
-            .get(format!("{tokens_path}/verify"))
+            .get(format!("{user_tokens_path}/verify"))
             .bearer_auth(parent_token)
             .send()
             .await
@@ -171,7 +180,7 @@ impl CloudflareBackend {
 
         // Step 2: fetch full token details including policies
         let details_resp: serde_json::Value = client
-            .get(format!("{tokens_path}/{token_id}"))
+            .get(format!("{user_tokens_path}/{token_id}"))
             .bearer_auth(parent_token)
             .send()
             .await
@@ -200,32 +209,43 @@ impl CloudflareBackend {
             })?;
 
         // Clean up inherited policies for use as child token config:
-        // 1. Strip the policy `id` field — Cloudflare assigns new IDs
+        // 1. Only extract fields the create endpoint accepts (effect, resources,
+        //    permission_groups) — drop server-generated fields like id, status,
+        //    created_on, modified_on which would cause validation errors.
         // 2. Remove "API Tokens" permission groups — Cloudflare forbids
-        //    sub-tokens from managing other tokens
+        //    sub-tokens from managing other tokens.
+        // 3. Only keep permission group `id` (strip `name` and other metadata).
         let cleaned: Vec<serde_json::Value> = policies
             .iter()
             .filter_map(|p| {
-                let mut policy = p.clone();
-                let obj = policy.as_object_mut()?;
-                obj.remove("id");
+                let obj = p.as_object()?;
 
-                // Filter out token-management permission groups
-                if let Some(groups) = obj
-                    .get_mut("permission_groups")
-                    .and_then(|v| v.as_array_mut())
-                {
-                    groups.retain(|g| {
+                // Filter out token-management permission groups, keeping only id
+                let groups: Vec<serde_json::Value> = obj
+                    .get("permission_groups")
+                    .and_then(|v| v.as_array())
+                    .into_iter()
+                    .flatten()
+                    .filter(|g| {
                         let name = g["name"].as_str().unwrap_or("");
                         !name.contains("API Tokens")
-                    });
-                    // Drop the entire policy if no permission groups remain
-                    if groups.is_empty() {
-                        return None;
-                    }
+                    })
+                    .filter_map(|g| {
+                        let id = g["id"].as_str()?;
+                        Some(serde_json::json!({ "id": id }))
+                    })
+                    .collect();
+
+                // Drop the entire policy if no permission groups remain
+                if groups.is_empty() {
+                    return None;
                 }
 
-                Some(policy)
+                Some(serde_json::json!({
+                    "effect": obj.get("effect").cloned().unwrap_or(serde_json::json!("allow")),
+                    "resources": obj.get("resources").cloned().unwrap_or(serde_json::json!({})),
+                    "permission_groups": groups,
+                }))
             })
             .collect();
 
@@ -252,8 +272,8 @@ impl LeaseBackend for CloudflareBackend {
             now + chrono::Duration::seconds(duration.as_secs().min(i64::MAX as u64) as i64);
 
         let raw_name = format!("{TOKEN_NAME_PREFIX}{label}");
-        let name = if raw_name.len() > MAX_TOKEN_NAME_LEN {
-            raw_name[..MAX_TOKEN_NAME_LEN].to_string()
+        let name = if raw_name.chars().count() > MAX_TOKEN_NAME_LEN {
+            raw_name.chars().take(MAX_TOKEN_NAME_LEN).collect()
         } else {
             raw_name
         };
@@ -263,7 +283,7 @@ impl LeaseBackend for CloudflareBackend {
             Self::build_api_policies(configured, &self.account_id)?
         } else {
             tracing::debug!("No policies configured; inheriting from parent token");
-            Self::fetch_parent_policies(&tokens_path, &parent_token).await?
+            Self::fetch_parent_policies(&parent_token).await?
         };
 
         let body = serde_json::json!({

--- a/src/lease_backends/cloudflare.rs
+++ b/src/lease_backends/cloudflare.rs
@@ -199,17 +199,43 @@ impl CloudflareBackend {
                 url: URL.to_string(),
             })?;
 
-        // Strip the policy `id` field — Cloudflare assigns new IDs to the child token
+        // Clean up inherited policies for use as child token config:
+        // 1. Strip the policy `id` field — Cloudflare assigns new IDs
+        // 2. Remove "API Tokens" permission groups — Cloudflare forbids
+        //    sub-tokens from managing other tokens
         let cleaned: Vec<serde_json::Value> = policies
             .iter()
-            .map(|p| {
+            .filter_map(|p| {
                 let mut policy = p.clone();
-                if let Some(obj) = policy.as_object_mut() {
-                    obj.remove("id");
+                let obj = policy.as_object_mut()?;
+                obj.remove("id");
+
+                // Filter out token-management permission groups
+                if let Some(groups) = obj
+                    .get_mut("permission_groups")
+                    .and_then(|v| v.as_array_mut())
+                {
+                    groups.retain(|g| {
+                        let name = g["name"].as_str().unwrap_or("");
+                        !name.contains("API Tokens")
+                    });
+                    // Drop the entire policy if no permission groups remain
+                    if groups.is_empty() {
+                        return None;
+                    }
                 }
-                policy
+
+                Some(policy)
             })
             .collect();
+
+        if cleaned.is_empty() {
+            return Err(FnoxError::Config(
+                "Parent token only has 'API Tokens' permissions which cannot be inherited. \
+                 Configure explicit policies or use a parent token with additional permissions."
+                    .to_string(),
+            ));
+        }
 
         Ok(cleaned)
     }

--- a/src/lease_backends/cloudflare.rs
+++ b/src/lease_backends/cloudflare.rs
@@ -10,6 +10,23 @@ const API_BASE: &str = "https://api.cloudflare.com/client/v4";
 const MAX_TOKEN_NAME_LEN: usize = 100;
 const TOKEN_NAME_PREFIX: &str = "fnox-lease-";
 
+pub fn check_prerequisites() -> Option<String> {
+    let has_token =
+        std::env::var("CLOUDFLARE_API_TOKEN").is_ok() || std::env::var("CF_API_TOKEN").is_ok();
+    if has_token {
+        None
+    } else {
+        Some("Cloudflare API token not found. Set CLOUDFLARE_API_TOKEN with a token that has 'API Tokens: Edit' permission.".to_string())
+    }
+}
+
+pub fn required_env_vars() -> Vec<(&'static str, &'static str)> {
+    vec![(
+        "CLOUDFLARE_API_TOKEN",
+        "Cloudflare API token with 'API Tokens: Edit' permission (or set CF_API_TOKEN)",
+    )]
+}
+
 pub struct CloudflareBackend {
     token_type: CloudflareTokenType,
     account_id: Option<String>,

--- a/src/lease_backends/command.rs
+++ b/src/lease_backends/command.rs
@@ -7,6 +7,14 @@ use tokio::process::Command;
 
 const URL: &str = "https://fnox.jdx.dev/leases/command";
 
+pub fn check_prerequisites() -> Option<String> {
+    None
+}
+
+pub fn required_env_vars() -> Vec<(&'static str, &'static str)> {
+    vec![]
+}
+
 pub struct CommandBackend {
     create_command: String,
     revoke_command: Option<String>,

--- a/src/lease_backends/gcp_iam.rs
+++ b/src/lease_backends/gcp_iam.rs
@@ -6,6 +6,29 @@ use std::time::Duration;
 
 const URL: &str = "https://fnox.jdx.dev/leases/gcp-iam";
 
+pub fn check_prerequisites() -> Option<String> {
+    let has_env = std::env::var("GOOGLE_APPLICATION_CREDENTIALS").is_ok()
+        || std::env::var("GCP_SERVICE_ACCOUNT_KEY").is_ok();
+    let has_adc = dirs::config_dir()
+        .map(|c| {
+            c.join("gcloud/application_default_credentials.json")
+                .exists()
+        })
+        .unwrap_or(false);
+    if has_env || has_adc {
+        None
+    } else {
+        Some("GCP credentials not found. Run 'gcloud auth application-default login' or set GOOGLE_APPLICATION_CREDENTIALS.".to_string())
+    }
+}
+
+pub fn required_env_vars() -> Vec<(&'static str, &'static str)> {
+    vec![(
+        "GOOGLE_APPLICATION_CREDENTIALS",
+        "path to service account JSON key file",
+    )]
+}
+
 pub struct GcpIamBackend {
     service_account_email: String,
     scopes: Vec<String>,

--- a/src/lease_backends/mod.rs
+++ b/src/lease_backends/mod.rs
@@ -122,6 +122,9 @@ pub enum LeaseBackendConfig {
     },
     /// Cloudflare API Token
     Cloudflare {
+        /// Token type: "user" (default) or "account"
+        #[serde(default)]
+        token_type: cloudflare::CloudflareTokenType,
         #[serde(skip_serializing_if = "Option::is_none")]
         account_id: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -314,15 +317,17 @@ impl LeaseBackendConfig {
                 azure_token::AzureTokenBackend::new(scope.clone(), env_var.clone()),
             )),
             LeaseBackendConfig::Cloudflare {
+                token_type,
                 account_id,
                 policies,
                 env_var,
                 ..
             } => Ok(Box::new(cloudflare::CloudflareBackend::new(
+                token_type.clone(),
                 account_id.clone(),
                 policies.clone(),
                 env_var.clone(),
-            ))),
+            )?)),
             LeaseBackendConfig::Command {
                 create_command,
                 revoke_command,

--- a/src/lease_backends/mod.rs
+++ b/src/lease_backends/mod.rs
@@ -124,6 +124,7 @@ pub enum LeaseBackendConfig {
     Cloudflare {
         #[serde(skip_serializing_if = "Option::is_none")]
         account_id: Option<String>,
+        #[serde(default)]
         policies: Vec<cloudflare::CloudflarePolicy>,
         #[serde(default = "default_cloudflare_env_var")]
         env_var: String,

--- a/src/lease_backends/mod.rs
+++ b/src/lease_backends/mod.rs
@@ -264,10 +264,16 @@ impl LeaseBackendConfig {
                 ("AZURE_CLIENT_SECRET", "Azure client secret"),
                 ("AZURE_TENANT_ID", "Azure tenant (directory) ID"),
             ],
-            LeaseBackendConfig::Cloudflare { .. } => vec![(
-                "CLOUDFLARE_API_TOKEN",
-                "Cloudflare API token with 'API Tokens: Edit' permission (or set CF_API_TOKEN)",
-            )],
+            LeaseBackendConfig::Cloudflare { .. } => vec![
+                (
+                    "CLOUDFLARE_API_TOKEN",
+                    "Cloudflare API token with 'API Tokens: Edit' permission",
+                ),
+                (
+                    "CF_API_TOKEN",
+                    "Cloudflare API token (alternative to CLOUDFLARE_API_TOKEN)",
+                ),
+            ],
             LeaseBackendConfig::Command { .. } => vec![],
         }
     }

--- a/src/lease_backends/mod.rs
+++ b/src/lease_backends/mod.rs
@@ -264,16 +264,10 @@ impl LeaseBackendConfig {
                 ("AZURE_CLIENT_SECRET", "Azure client secret"),
                 ("AZURE_TENANT_ID", "Azure tenant (directory) ID"),
             ],
-            LeaseBackendConfig::Cloudflare { .. } => vec![
-                (
-                    "CLOUDFLARE_API_TOKEN",
-                    "Cloudflare API token with 'API Tokens: Edit' permission",
-                ),
-                (
-                    "CF_API_TOKEN",
-                    "Cloudflare API token (alternative to CLOUDFLARE_API_TOKEN)",
-                ),
-            ],
+            LeaseBackendConfig::Cloudflare { .. } => vec![(
+                "CLOUDFLARE_API_TOKEN",
+                "Cloudflare API token with 'API Tokens: Edit' permission (or set CF_API_TOKEN)",
+            )],
             LeaseBackendConfig::Command { .. } => vec![],
         }
     }

--- a/src/lease_backends/mod.rs
+++ b/src/lease_backends/mod.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 
 pub mod aws_sts;
 pub mod azure_token;
+pub mod cloudflare;
 pub mod command;
 pub mod gcp_iam;
 pub mod vault;
@@ -56,6 +57,10 @@ fn default_vault_method() -> String {
 
 fn default_azure_env_var() -> String {
     "AZURE_ACCESS_TOKEN".to_string()
+}
+
+fn default_cloudflare_env_var() -> String {
+    "CLOUDFLARE_API_TOKEN".to_string()
 }
 
 /// Generate a unique lease ID with a prefix.
@@ -111,6 +116,16 @@ pub enum LeaseBackendConfig {
     AzureToken {
         scope: String,
         #[serde(default = "default_azure_env_var")]
+        env_var: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        duration: Option<String>,
+    },
+    /// Cloudflare API Token
+    Cloudflare {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        account_id: Option<String>,
+        policies: Vec<cloudflare::CloudflarePolicy>,
+        #[serde(default = "default_cloudflare_env_var")]
         env_var: String,
         #[serde(skip_serializing_if = "Option::is_none")]
         duration: Option<String>,
@@ -197,6 +212,15 @@ impl LeaseBackendConfig {
                     Some("Azure credentials not found. Run 'az login' or set AZURE_CLIENT_ID/AZURE_CLIENT_SECRET/AZURE_TENANT_ID.".to_string())
                 }
             }
+            LeaseBackendConfig::Cloudflare { .. } => {
+                let has_token = std::env::var("CLOUDFLARE_API_TOKEN").is_ok()
+                    || std::env::var("CF_API_TOKEN").is_ok();
+                if has_token {
+                    None
+                } else {
+                    Some("Cloudflare API token not found. Set CLOUDFLARE_API_TOKEN with a token that has 'API Tokens: Edit' permission.".to_string())
+                }
+            }
             LeaseBackendConfig::Command { .. } => {
                 // Can't easily validate command availability without running it
                 None
@@ -236,6 +260,10 @@ impl LeaseBackendConfig {
                 ("AZURE_CLIENT_SECRET", "Azure client secret"),
                 ("AZURE_TENANT_ID", "Azure tenant (directory) ID"),
             ],
+            LeaseBackendConfig::Cloudflare { .. } => vec![(
+                "CLOUDFLARE_API_TOKEN",
+                "Cloudflare API token with 'API Tokens: Edit' permission",
+            )],
             LeaseBackendConfig::Command { .. } => vec![],
         }
     }
@@ -284,6 +312,16 @@ impl LeaseBackendConfig {
             LeaseBackendConfig::AzureToken { scope, env_var, .. } => Ok(Box::new(
                 azure_token::AzureTokenBackend::new(scope.clone(), env_var.clone()),
             )),
+            LeaseBackendConfig::Cloudflare {
+                account_id,
+                policies,
+                env_var,
+                ..
+            } => Ok(Box::new(cloudflare::CloudflareBackend::new(
+                account_id.clone(),
+                policies.clone(),
+                env_var.clone(),
+            ))),
             LeaseBackendConfig::Command {
                 create_command,
                 revoke_command,
@@ -327,6 +365,7 @@ impl LeaseBackendConfig {
             | LeaseBackendConfig::GcpIam { duration, .. }
             | LeaseBackendConfig::Vault { duration, .. }
             | LeaseBackendConfig::AzureToken { duration, .. }
+            | LeaseBackendConfig::Cloudflare { duration, .. }
             | LeaseBackendConfig::Command { duration, .. } => duration.as_deref(),
         }
     }

--- a/src/lease_backends/mod.rs
+++ b/src/lease_backends/mod.rs
@@ -152,83 +152,14 @@ impl LeaseBackendConfig {
     /// Returns a human-readable message describing what's missing, or None if ready.
     pub fn check_prerequisites(&self) -> Option<String> {
         match self {
-            LeaseBackendConfig::AwsSts { profile, .. } => {
-                // AWS SDK supports many auth methods; check the most common ones
-                let has_env = (std::env::var("AWS_ACCESS_KEY_ID").is_ok()
-                    && std::env::var("AWS_SECRET_ACCESS_KEY").is_ok())
-                    || std::env::var("AWS_PROFILE").is_ok();
-                let has_profile = profile.is_some();
-                let has_sso = std::env::var("AWS_SSO_SESSION").is_ok();
-                let has_creds_file = dirs::home_dir()
-                    .map(|h| h.join(".aws/credentials").exists() || h.join(".aws/config").exists())
-                    .unwrap_or(false);
-                if has_env || has_profile || has_sso || has_creds_file {
-                    None
-                } else {
-                    Some("AWS credentials not found. Run 'aws sso login' or set AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY.".to_string())
-                }
-            }
-            LeaseBackendConfig::GcpIam { .. } => {
-                let has_env = std::env::var("GOOGLE_APPLICATION_CREDENTIALS").is_ok()
-                    || std::env::var("GCP_SERVICE_ACCOUNT_KEY").is_ok();
-                let has_adc = dirs::config_dir()
-                    .map(|c| {
-                        c.join("gcloud/application_default_credentials.json")
-                            .exists()
-                    })
-                    .unwrap_or(false);
-                if has_env || has_adc {
-                    None
-                } else {
-                    Some("GCP credentials not found. Run 'gcloud auth application-default login' or set GOOGLE_APPLICATION_CREDENTIALS.".to_string())
-                }
-            }
+            LeaseBackendConfig::AwsSts { profile, .. } => aws_sts::check_prerequisites(profile),
+            LeaseBackendConfig::GcpIam { .. } => gcp_iam::check_prerequisites(),
             LeaseBackendConfig::Vault { address, token, .. } => {
-                let has_addr = address.is_some()
-                    || std::env::var("VAULT_ADDR").is_ok()
-                    || std::env::var("FNOX_VAULT_ADDR").is_ok();
-                let has_token = token.is_some()
-                    || std::env::var("VAULT_TOKEN").is_ok()
-                    || std::env::var("FNOX_VAULT_TOKEN").is_ok();
-                match (has_addr, has_token) {
-                    (false, false) => Some(
-                        "Vault address and token not found. Set VAULT_ADDR and VAULT_TOKEN."
-                            .to_string(),
-                    ),
-                    (false, true) => Some("Vault address not found. Set VAULT_ADDR.".to_string()),
-                    (true, false) => Some("Vault token not found. Set VAULT_TOKEN.".to_string()),
-                    (true, true) => None,
-                }
+                vault::check_prerequisites(address, token)
             }
-            LeaseBackendConfig::AzureToken { .. } => {
-                let has_sp = std::env::var("AZURE_CLIENT_ID").is_ok()
-                    && std::env::var("AZURE_CLIENT_SECRET").is_ok()
-                    && std::env::var("AZURE_TENANT_ID").is_ok();
-                if has_sp {
-                    return None;
-                }
-                let has_az = which::which("az").is_ok();
-                if has_az {
-                    // az CLI is installed but we can't verify login state without
-                    // running a subprocess; hint the user to check if auth fails later
-                    None
-                } else {
-                    Some("Azure credentials not found. Run 'az login' or set AZURE_CLIENT_ID/AZURE_CLIENT_SECRET/AZURE_TENANT_ID.".to_string())
-                }
-            }
-            LeaseBackendConfig::Cloudflare { .. } => {
-                let has_token = std::env::var("CLOUDFLARE_API_TOKEN").is_ok()
-                    || std::env::var("CF_API_TOKEN").is_ok();
-                if has_token {
-                    None
-                } else {
-                    Some("Cloudflare API token not found. Set CLOUDFLARE_API_TOKEN with a token that has 'API Tokens: Edit' permission.".to_string())
-                }
-            }
-            LeaseBackendConfig::Command { .. } => {
-                // Can't easily validate command availability without running it
-                None
-            }
+            LeaseBackendConfig::AzureToken { .. } => azure_token::check_prerequisites(),
+            LeaseBackendConfig::Cloudflare { .. } => cloudflare::check_prerequisites(),
+            LeaseBackendConfig::Command { .. } => command::check_prerequisites(),
         }
     }
 
@@ -237,38 +168,14 @@ impl LeaseBackendConfig {
     /// interactively for missing credentials.
     pub fn required_env_vars(&self) -> Vec<(&'static str, &'static str)> {
         match self {
-            LeaseBackendConfig::AwsSts { .. } => vec![
-                ("AWS_ACCESS_KEY_ID", "AWS access key"),
-                ("AWS_SECRET_ACCESS_KEY", "AWS secret key"),
-                ("AWS_SESSION_TOKEN", "AWS session token (optional)"),
-            ],
-            LeaseBackendConfig::GcpIam { .. } => vec![(
-                "GOOGLE_APPLICATION_CREDENTIALS",
-                "path to service account JSON key file",
-            )],
+            LeaseBackendConfig::AwsSts { .. } => aws_sts::required_env_vars(),
+            LeaseBackendConfig::GcpIam { .. } => gcp_iam::required_env_vars(),
             LeaseBackendConfig::Vault { address, token, .. } => {
-                let mut vars = vec![];
-                if address.is_none() {
-                    vars.push((
-                        "VAULT_ADDR",
-                        "Vault server address (e.g., http://localhost:8200)",
-                    ));
-                }
-                if token.is_none() {
-                    vars.push(("VAULT_TOKEN", "Vault authentication token"));
-                }
-                vars
+                vault::required_env_vars(address, token)
             }
-            LeaseBackendConfig::AzureToken { .. } => vec![
-                ("AZURE_CLIENT_ID", "Azure application (client) ID"),
-                ("AZURE_CLIENT_SECRET", "Azure client secret"),
-                ("AZURE_TENANT_ID", "Azure tenant (directory) ID"),
-            ],
-            LeaseBackendConfig::Cloudflare { .. } => vec![(
-                "CLOUDFLARE_API_TOKEN",
-                "Cloudflare API token with 'API Tokens: Edit' permission (or set CF_API_TOKEN)",
-            )],
-            LeaseBackendConfig::Command { .. } => vec![],
+            LeaseBackendConfig::AzureToken { .. } => azure_token::required_env_vars(),
+            LeaseBackendConfig::Cloudflare { .. } => cloudflare::required_env_vars(),
+            LeaseBackendConfig::Command { .. } => command::required_env_vars(),
         }
     }
 

--- a/src/lease_backends/mod.rs
+++ b/src/lease_backends/mod.rs
@@ -263,7 +263,7 @@ impl LeaseBackendConfig {
             ],
             LeaseBackendConfig::Cloudflare { .. } => vec![(
                 "CLOUDFLARE_API_TOKEN",
-                "Cloudflare API token with 'API Tokens: Edit' permission",
+                "Cloudflare API token with 'API Tokens: Edit' permission (or set CF_API_TOKEN)",
             )],
             LeaseBackendConfig::Command { .. } => vec![],
         }

--- a/src/lease_backends/mod.rs
+++ b/src/lease_backends/mod.rs
@@ -124,8 +124,8 @@ pub enum LeaseBackendConfig {
     Cloudflare {
         #[serde(skip_serializing_if = "Option::is_none")]
         account_id: Option<String>,
-        #[serde(default)]
-        policies: Vec<cloudflare::CloudflarePolicy>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        policies: Option<Vec<cloudflare::CloudflarePolicy>>,
         #[serde(default = "default_cloudflare_env_var")]
         env_var: String,
         #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/lease_backends/vault.rs
+++ b/src/lease_backends/vault.rs
@@ -7,6 +7,40 @@ use std::time::Duration;
 
 const URL: &str = "https://fnox.jdx.dev/leases/vault";
 
+pub fn check_prerequisites(address: &Option<String>, token: &Option<String>) -> Option<String> {
+    let has_addr = address.is_some()
+        || std::env::var("VAULT_ADDR").is_ok()
+        || std::env::var("FNOX_VAULT_ADDR").is_ok();
+    let has_token = token.is_some()
+        || std::env::var("VAULT_TOKEN").is_ok()
+        || std::env::var("FNOX_VAULT_TOKEN").is_ok();
+    match (has_addr, has_token) {
+        (false, false) => {
+            Some("Vault address and token not found. Set VAULT_ADDR and VAULT_TOKEN.".to_string())
+        }
+        (false, true) => Some("Vault address not found. Set VAULT_ADDR.".to_string()),
+        (true, false) => Some("Vault token not found. Set VAULT_TOKEN.".to_string()),
+        (true, true) => None,
+    }
+}
+
+pub fn required_env_vars(
+    address: &Option<String>,
+    token: &Option<String>,
+) -> Vec<(&'static str, &'static str)> {
+    let mut vars = vec![];
+    if address.is_none() {
+        vars.push((
+            "VAULT_ADDR",
+            "Vault server address (e.g., http://localhost:8200)",
+        ));
+    }
+    if token.is_none() {
+        vars.push(("VAULT_TOKEN", "Vault authentication token"));
+    }
+    vars
+}
+
 pub struct VaultBackend {
     address: String,
     token: String,

--- a/src/source_registry.rs
+++ b/src/source_registry.rs
@@ -48,14 +48,6 @@ pub fn get_content(path: &Path) -> Option<Arc<String>> {
     sources.get(&canonical).cloned()
 }
 
-/// Clear all registered sources. Primarily useful for testing.
-#[cfg(test)]
-pub fn clear() {
-    if let Ok(mut sources) = SOURCES.write() {
-        sources.clear();
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -64,8 +56,6 @@ mod tests {
 
     #[test]
     fn test_register_and_get() {
-        clear();
-
         let mut temp = NamedTempFile::new().unwrap();
         writeln!(temp, "test content").unwrap();
         let path = temp.path();
@@ -81,8 +71,6 @@ mod tests {
 
     #[test]
     fn test_missing_path() {
-        clear();
-
         let path = Path::new("/nonexistent/path/to/file.toml");
         assert!(get_named_source(path).is_none());
         assert!(get_content(path).is_none());


### PR DESCRIPTION
## Summary

- Adds a new `cloudflare` lease backend that creates short-lived, scoped Cloudflare API tokens via the Cloudflare API Tokens API
- A parent token with **API Tokens: Edit** permission creates child tokens scoped to specified permission policies with automatic expiry
- Supports explicit revocation (token deletion), `{account_id}` placeholder substitution in resource keys, and configurable env var name
- Adds backend documentation (`docs/leases/cloudflare.md`) and updates the lease guide with a Cloudflare example

## Test plan

- [ ] Verify `cargo check` passes (confirmed locally)
- [ ] Manual test with a real Cloudflare account: create a parent token with "API Tokens: Edit", configure a `cloudflare` lease, run `fnox lease create`, verify scoped token works and expires
- [ ] Verify `fnox lease revoke` deletes the token via the Cloudflare API
- [ ] Verify prerequisite check reports missing `CLOUDFLARE_API_TOKEN`
- [ ] Verify JSON schema generation includes the new `Cloudflare` variant

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new external-API-backed credential issuer (Cloudflare token create/delete) and changes lease creation error handling, which could affect lease provisioning flows and failure modes.
> 
> **Overview**
> Adds a new `cloudflare` lease backend that vends short-lived, scoped Cloudflare API tokens (user- or account-owned), supports optional explicit `policies` (or inheritance from the parent token), `{account_id}` substitution, configurable env var output, and revocation via token deletion.
> 
> Updates configuration/schema and docs to expose the new backend, and refactors prerequisite/interactive env-var guidance into per-backend helpers.
> 
> Strengthens `fnox lease create` by hard-failing when secrets required by a backend fail to resolve (instead of continuing and later reporting a generic “token not found”), reducing confusing auth error paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2dbc9e3109e5e637f222d90187b0e58c6fc3c0b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->