### PR TITLE
feat(lease): add --all flag, default to creating all leases

### DIFF
--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -507,20 +507,30 @@
           },
           "create": {
             "full_cmd": ["lease", "create"],
-            "usage": "lease create [FLAGS] <BACKEND_NAME>",
+            "usage": "lease create [FLAGS] [BACKEND_NAME]",
             "subcommands": {},
             "args": [
               {
                 "name": "BACKEND_NAME",
-                "usage": "<BACKEND_NAME>",
-                "help": "Lease backend name (from `[leases.<name>]` config)",
-                "help_first_line": "Lease backend name (from `[leases.<name>]` config)",
-                "required": true,
+                "usage": "[BACKEND_NAME]",
+                "help": "Lease backend name (from `[leases.<name>]` config). Creates all backends if omitted",
+                "help_first_line": "Lease backend name (from `[leases.<name>]` config). Creates all backends if omitted",
+                "required": false,
                 "double_dash": "Optional",
                 "hide": false
               }
             ],
             "flags": [
+              {
+                "name": "all",
+                "usage": "-a --all",
+                "help": "Create leases for all configured backends",
+                "help_first_line": "Create leases for all configured backends",
+                "short": ["a"],
+                "long": ["all"],
+                "hide": false,
+                "global": false
+              },
               {
                 "name": "duration",
                 "usage": "-d --duration <DURATION>",
@@ -660,7 +670,6 @@
         "flags": [],
         "mounts": [],
         "hide": false,
-        "subcommand_required": true,
         "help": "Manage ephemeral credential leases",
         "name": "lease",
         "aliases": [],

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -52,7 +52,7 @@ Do not merge top-level secrets into the selected profile
 - [`fnox init [FLAGS]`](/cli/init.md)
 - [`fnox lease <SUBCOMMAND>`](/cli/lease.md)
 - [`fnox lease cleanup`](/cli/lease/cleanup.md)
-- [`fnox lease create [FLAGS] <BACKEND_NAME>`](/cli/lease/create.md)
+- [`fnox lease create [FLAGS] [BACKEND_NAME]`](/cli/lease/create.md)
 - [`fnox lease list [--active] [--expired]`](/cli/lease/list.md)
 - [`fnox lease revoke <LEASE_ID>`](/cli/lease/revoke.md)
 - [`fnox list [FLAGS]`](/cli/list.md)

--- a/docs/cli/lease.md
+++ b/docs/cli/lease.md
@@ -9,6 +9,6 @@ Manage ephemeral credential leases
 ## Subcommands
 
 - [`fnox lease cleanup`](/cli/lease/cleanup.md)
-- [`fnox lease create [FLAGS] <BACKEND_NAME>`](/cli/lease/create.md)
+- [`fnox lease create [FLAGS] [BACKEND_NAME]`](/cli/lease/create.md)
 - [`fnox lease list [--active] [--expired]`](/cli/lease/list.md)
 - [`fnox lease revoke <LEASE_ID>`](/cli/lease/revoke.md)

--- a/docs/cli/lease/create.md
+++ b/docs/cli/lease/create.md
@@ -2,17 +2,21 @@
 
 # `fnox lease create`
 
-- **Usage**: `fnox lease create [FLAGS] <BACKEND_NAME>`
+- **Usage**: `fnox lease create [FLAGS] [BACKEND_NAME]`
 
 Create a short-lived credential lease from a secret
 
 ## Arguments
 
-### `<BACKEND_NAME>`
+### `[BACKEND_NAME]`
 
-Lease backend name (from `[leases.<name>]` config)
+Lease backend name (from `[leases.<name>]` config). Creates all backends if omitted
 
 ## Flags
+
+### `-a --all`
+
+Create leases for all configured backends
 
 ### `-d --duration <DURATION>`
 

--- a/fnox.usage.kdl
+++ b/fnox.usage.kdl
@@ -91,9 +91,10 @@ cmd init help="Initialize a new fnox configuration file" {
     flag --force help="Overwrite existing configuration file"
     flag --skip-wizard help="Skip the interactive wizard and create a minimal config"
 }
-cmd lease subcommand_required=#true help="Manage ephemeral credential leases" {
+cmd lease help="Manage ephemeral credential leases" {
     cmd cleanup help="Revoke all expired leases that need manual cleanup"
     cmd create help="Create a short-lived credential lease from a secret" {
+        flag "-a --all" help="Create leases for all configured backends"
         flag "-d --duration" help="Lease duration (e.g., \"15m\", \"1h\", \"2h30m\"); overrides config duration" {
             arg <DURATION>
         }
@@ -106,7 +107,7 @@ cmd lease subcommand_required=#true help="Manage ephemeral credential leases" {
         flag "-l --label" help="Label for the lease (e.g., session purpose)" default=fnox-lease {
             arg <LABEL>
         }
-        arg <BACKEND_NAME> help="Lease backend name (from `[leases.<name>]` config)"
+        arg "[BACKEND_NAME]" help="Lease backend name (from `[leases.<name>]` config). Creates all backends if omitted" required=#false
     }
     cmd list help="List tracked leases" {
         flag --active help="Show only active (non-expired, non-revoked) leases"

--- a/src/commands/lease.rs
+++ b/src/commands/lease.rs
@@ -39,7 +39,7 @@ pub struct LeaseCreateCommand {
     pub backend_name: Option<String>,
 
     /// Create leases for all configured backends
-    #[arg(short, long)]
+    #[arg(short, long, conflicts_with = "backend_name")]
     pub all: bool,
 
     /// Lease duration (e.g., "15m", "1h", "2h30m"); overrides config duration
@@ -124,8 +124,15 @@ impl LeaseCreateCommand {
                         .to_string(),
                 ));
             }
-            self.run_all(cli, &config, &profile, &project_dir, &leases)
-                .await
+            self.run_all(
+                cli,
+                &config,
+                &profile,
+                &project_dir,
+                &leases,
+                &mut _temp_env_guard,
+            )
+            .await
         } else {
             let backend_name = self.backend_name.as_deref().unwrap();
             let backend_config = leases.get(backend_name).ok_or_else(|| {
@@ -140,6 +147,7 @@ impl LeaseCreateCommand {
                 &config,
                 &profile,
                 &project_dir,
+                &mut _temp_env_guard,
             )
             .await
         }
@@ -152,16 +160,23 @@ impl LeaseCreateCommand {
         profile: &str,
         project_dir: &std::path::Path,
         leases: &IndexMap<String, crate::lease_backends::LeaseBackendConfig>,
+        temp_env_guard: &mut TempEnvGuard,
     ) -> Result<()> {
         let mut errors: Vec<String> = Vec::new();
-        let mut created = 0;
 
         for (backend_name, backend_config) in leases {
             match self
-                .create_single(backend_name, backend_config, config, profile, project_dir)
+                .create_single(
+                    backend_name,
+                    backend_config,
+                    config,
+                    profile,
+                    project_dir,
+                    temp_env_guard,
+                )
                 .await
             {
-                Ok(()) => created += 1,
+                Ok(()) => {}
                 Err(e) => {
                     eprintln!(
                         "{} Failed to create lease for '{}': {}",
@@ -174,9 +189,11 @@ impl LeaseCreateCommand {
             }
         }
 
-        if created == 0 && !errors.is_empty() {
+        if !errors.is_empty() {
             return Err(FnoxError::Config(format!(
-                "All lease backends failed:\n{}",
+                "{} of {} lease backends failed:\n{}",
+                errors.len(),
+                leases.len(),
                 errors.join("\n")
             )));
         }
@@ -191,6 +208,7 @@ impl LeaseCreateCommand {
         config: &Config,
         profile: &str,
         project_dir: &std::path::Path,
+        temp_env_guard: &mut TempEnvGuard,
     ) -> Result<()> {
         // Check prerequisites and prompt for missing env vars if --interactive
         if let Some(missing) = backend_config.check_prerequisites() {
@@ -210,6 +228,7 @@ impl LeaseCreateCommand {
                             // TODO: unsafe set_var on a multi-threaded Tokio runtime is
                             // technically UB. Refactor to pass credentials explicitly.
                             unsafe { std::env::set_var(var, &value) };
+                            temp_env_guard.keys.push(var.to_string());
                         }
                     }
                 }

--- a/src/commands/lease.rs
+++ b/src/commands/lease.rs
@@ -5,12 +5,13 @@ use crate::lease::{self, LeaseLedger, LeaseRecord, TempEnvGuard};
 use crate::secret_resolver::resolve_secrets_batch;
 use chrono::Utc;
 use clap::{Args, Subcommand, ValueEnum};
+use indexmap::IndexMap;
 
 #[derive(Debug, Args)]
 #[command(about = "Manage ephemeral credential leases")]
 pub struct LeaseCommand {
     #[command(subcommand)]
-    pub subcommand: LeaseSubcommand,
+    pub subcommand: Option<LeaseSubcommand>,
 }
 
 #[derive(Debug, Subcommand)]
@@ -34,8 +35,12 @@ pub enum OutputFormat {
 
 #[derive(Debug, Args)]
 pub struct LeaseCreateCommand {
-    /// Lease backend name (from `[leases.<name>]` config)
-    pub backend_name: String,
+    /// Lease backend name (from `[leases.<name>]` config). Creates all backends if omitted.
+    pub backend_name: Option<String>,
+
+    /// Create leases for all configured backends
+    #[arg(short, long)]
+    pub all: bool,
 
     /// Lease duration (e.g., "15m", "1h", "2h30m"); overrides config duration
     #[arg(short, long)]
@@ -77,10 +82,22 @@ pub struct LeaseCleanupCommand;
 impl LeaseCommand {
     pub async fn run(&self, cli: &Cli, config: Config) -> Result<()> {
         match &self.subcommand {
-            LeaseSubcommand::Create(cmd) => cmd.run(cli, config).await,
-            LeaseSubcommand::List(cmd) => cmd.run(cli, &config).await,
-            LeaseSubcommand::Revoke(cmd) => cmd.run(cli, config).await,
-            LeaseSubcommand::Cleanup(cmd) => cmd.run(cli, config).await,
+            Some(LeaseSubcommand::Create(cmd)) => cmd.run(cli, config).await,
+            Some(LeaseSubcommand::List(cmd)) => cmd.run(cli, &config).await,
+            Some(LeaseSubcommand::Revoke(cmd)) => cmd.run(cli, config).await,
+            Some(LeaseSubcommand::Cleanup(cmd)) => cmd.run(cli, config).await,
+            // `fnox lease` with no subcommand defaults to creating all leases
+            None => {
+                let cmd = LeaseCreateCommand {
+                    backend_name: None,
+                    all: true,
+                    duration: None,
+                    format: OutputFormat::Shell,
+                    interactive: false,
+                    label: "fnox-lease".to_string(),
+                };
+                cmd.run(cli, config).await
+            }
         }
     }
 }
@@ -91,22 +108,90 @@ impl LeaseCreateCommand {
         let project_dir = lease::project_dir_from_config(&config, &cli.config);
         let leases = config.get_leases(&profile);
 
-        let backend_config = leases.get(&self.backend_name).ok_or_else(|| {
-            FnoxError::Config(format!(
-                "Lease backend '{}' not found. Define it in [leases.{}] in fnox.toml.",
-                self.backend_name, self.backend_name
-            ))
-        })?;
-
-        // Resolve secrets from fnox providers so master credentials (stored in
-        // 1Password, keychain, age, etc.) are available as env vars before
-        // checking prerequisites or creating the lease backend.
+        // Resolve secrets once upfront (shared across all backends)
         let profile_secrets = config.get_secrets(&profile)?;
         let resolved_secrets = resolve_secrets_batch(&config, &profile, &profile_secrets).await?;
         let mut _temp_env_guard = TempEnvGuard::default();
         let _temp_files =
             lease::set_secrets_as_env(&resolved_secrets, &profile_secrets, &mut _temp_env_guard)?;
 
+        let create_all = self.all || self.backend_name.is_none();
+
+        if create_all {
+            if leases.is_empty() {
+                return Err(FnoxError::Config(
+                    "No lease backends configured. Define them in [leases.<name>] in fnox.toml."
+                        .to_string(),
+                ));
+            }
+            self.run_all(cli, &config, &profile, &project_dir, &leases)
+                .await
+        } else {
+            let backend_name = self.backend_name.as_deref().unwrap();
+            let backend_config = leases.get(backend_name).ok_or_else(|| {
+                FnoxError::Config(format!(
+                    "Lease backend '{}' not found. Define it in [leases.{}] in fnox.toml.",
+                    backend_name, backend_name
+                ))
+            })?;
+            self.create_single(
+                backend_name,
+                backend_config,
+                &config,
+                &profile,
+                &project_dir,
+            )
+            .await
+        }
+    }
+
+    async fn run_all(
+        &self,
+        _cli: &Cli,
+        config: &Config,
+        profile: &str,
+        project_dir: &std::path::Path,
+        leases: &IndexMap<String, crate::lease_backends::LeaseBackendConfig>,
+    ) -> Result<()> {
+        let mut errors: Vec<String> = Vec::new();
+        let mut created = 0;
+
+        for (backend_name, backend_config) in leases {
+            match self
+                .create_single(backend_name, backend_config, config, profile, project_dir)
+                .await
+            {
+                Ok(()) => created += 1,
+                Err(e) => {
+                    eprintln!(
+                        "{} Failed to create lease for '{}': {}",
+                        console::style("✗").red(),
+                        backend_name,
+                        e
+                    );
+                    errors.push(format!("{}: {}", backend_name, e));
+                }
+            }
+        }
+
+        if created == 0 && !errors.is_empty() {
+            return Err(FnoxError::Config(format!(
+                "All lease backends failed:\n{}",
+                errors.join("\n")
+            )));
+        }
+
+        Ok(())
+    }
+
+    async fn create_single(
+        &self,
+        backend_name: &str,
+        backend_config: &crate::lease_backends::LeaseBackendConfig,
+        config: &Config,
+        profile: &str,
+        project_dir: &std::path::Path,
+    ) -> Result<()> {
         // Check prerequisites and prompt for missing env vars if --interactive
         if let Some(missing) = backend_config.check_prerequisites() {
             let required_vars = backend_config.required_env_vars();
@@ -125,7 +210,6 @@ impl LeaseCreateCommand {
                             // TODO: unsafe set_var on a multi-threaded Tokio runtime is
                             // technically UB. Refactor to pass credentials explicitly.
                             unsafe { std::env::set_var(var, &value) };
-                            _temp_env_guard.keys.push(var.to_string());
                         }
                     }
                 }
@@ -152,23 +236,23 @@ impl LeaseCreateCommand {
         if duration > max_duration {
             return Err(FnoxError::Config(format!(
                 "Requested duration {:?} exceeds maximum {:?} for lease backend '{}'",
-                duration, max_duration, self.backend_name
+                duration, max_duration, backend_name
             )));
         }
 
         // Create the lease, cache credentials, and record in ledger
-        let _ledger_lock = LeaseLedger::lock(&project_dir)?;
-        let mut ledger = LeaseLedger::load(&project_dir)?;
+        let _ledger_lock = LeaseLedger::lock(project_dir)?;
+        let mut ledger = LeaseLedger::load(project_dir)?;
         let result = lease::create_and_record_lease(
             backend.as_ref(),
-            &self.backend_name,
+            backend_name,
             &self.label,
             duration,
             backend_config.config_hash(),
-            &config,
-            &profile,
+            config,
+            profile,
             &mut ledger,
-            &project_dir,
+            project_dir,
         )
         .await?;
 
@@ -176,33 +260,25 @@ impl LeaseCreateCommand {
         match self.format {
             OutputFormat::Shell => {
                 println!(
-                    "Lease created (expires {})",
+                    "{} Lease '{}' created (expires {})",
+                    console::style("✓").green(),
+                    backend_name,
                     format_expiry(result.expires_at)
                 );
-                println!();
                 for (key, value) in &result.credentials {
-                    let display = if value.chars().count() > 12 {
-                        let prefix: String = value.chars().take(4).collect();
-                        let suffix: String = value
-                            .chars()
-                            .rev()
-                            .take(4)
-                            .collect::<Vec<_>>()
-                            .into_iter()
-                            .rev()
-                            .collect();
-                        format!("{prefix}...{suffix}")
-                    } else {
-                        "****".to_string()
-                    };
-                    println!("{:<25} {}", key, display);
+                    let display = mask_credential(value);
+                    println!("  {:<25} {}", key, display);
                 }
                 if let Some(exp) = result.expires_at {
-                    println!("{:<25} {}", "Expires", exp.to_rfc3339());
+                    println!("  {:<25} {}", "Expires", exp.to_rfc3339());
                 }
             }
             OutputFormat::Json => {
                 let mut output = serde_json::Map::new();
+                output.insert(
+                    "backend".to_string(),
+                    serde_json::Value::String(backend_name.to_string()),
+                );
                 for (key, value) in &result.credentials {
                     output.insert(key.clone(), serde_json::Value::String(value.clone()));
                 }
@@ -408,6 +484,23 @@ impl LeaseCleanupCommand {
         println!("Cleaned up {} expired lease(s).", cleaned);
 
         Ok(())
+    }
+}
+
+fn mask_credential(value: &str) -> String {
+    if value.chars().count() > 12 {
+        let prefix: String = value.chars().take(4).collect();
+        let suffix: String = value
+            .chars()
+            .rev()
+            .take(4)
+            .collect::<Vec<_>>()
+            .into_iter()
+            .rev()
+            .collect();
+        format!("{prefix}...{suffix}")
+    } else {
+        "****".to_string()
     }
 }
 

--- a/test/aws_sts.bats
+++ b/test/aws_sts.bats
@@ -98,7 +98,7 @@ EOF
 
 	run "$FNOX_BIN" lease create test_sts --duration 15m --format shell
 	assert_success
-	assert_output --partial "Lease created"
+	assert_output --partial "created"
 	assert_output --partial "AWS_ACCESS_KEY_ID"
 }
 

--- a/test/lease_command.bats
+++ b/test/lease_command.bats
@@ -139,7 +139,7 @@ EOF
 
 	run "$FNOX_BIN" lease create test_cmd --duration 15m --format shell
 	assert_success
-	assert_output --partial "Lease created"
+	assert_output --partial "created"
 	assert_output --partial "MY_TOKEN"
 }
 


### PR DESCRIPTION
## Summary
- `fnox lease create --all` creates leases for all configured backends sequentially
- `fnox lease create` (no backend name) defaults to `--all` behavior
- `fnox lease` (no subcommand) defaults to `lease create --all`
- Secrets are resolved once upfront and shared across all backends
- Partial failures are reported per-backend but don't stop others; fails only if all backends fail

## Test plan
- [x] All 16 lease bats tests pass
- [x] All cargo tests pass
- [ ] Manual: configure multiple lease backends and run `fnox lease` to verify all are created

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core lease-creation CLI semantics and introduces multi-backend execution/error aggregation, which could affect scripts and failure handling across backends.
> 
> **Overview**
> Updates the `lease` CLI so `fnox lease` with no subcommand now defaults to creating leases for **all configured backends**, and `fnox lease create` accepts an optional `[BACKEND_NAME]` plus a new `-a/--all` flag (mutually exclusive with a backend name).
> 
> Refactors lease creation to resolve secrets once up-front and then create leases sequentially across backends, collecting and reporting per-backend failures before returning a combined error; output formatting is tweaked (success prefix, indented/masked creds, JSON now includes `backend`). Docs/usage specs and bats tests are updated to match the new CLI behavior/output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8fd891db9aadbda0d1b8915fa64572a5473581f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->