### PR TITLE
feat(get): resolve leased credentials from `fnox get`

### DIFF
--- a/hk.pkl
+++ b/hk.pkl
@@ -9,7 +9,7 @@ local linters = new Mapping<String, Step> {
     ["cargo-fmt"] = Builtins.cargo_fmt
     ["cargo-check"] = Builtins.cargo_check
     ["cargo-clippy"] = (Builtins.cargo_clippy) {
-        profiles = List("slow")
+        check = "cargo clippy -q -- -D warnings"
     }
     ["shfmt"] = (Builtins.shfmt) {
         glob = List("**/*.bats", "**/*.sh", "**/*.bash")

--- a/hk.pkl
+++ b/hk.pkl
@@ -7,7 +7,6 @@ local linters = new Mapping<String, Step> {
         exclude = List("CLAUDE.md", "CHANGELOG.md") // TODO: fix symbolic links with prettier built-in: ([error] Explicitly specified pattern "CLAUDE.md" is a symbolic link.)
     }
     ["cargo-fmt"] = Builtins.cargo_fmt
-    ["cargo-check"] = Builtins.cargo_check
     ["cargo-clippy"] = (Builtins.cargo_clippy) {
         check = "cargo clippy -q -- -D warnings"
     }

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -56,6 +56,8 @@ impl ExecCommand {
                 &mut _temp_env_guard,
             )?);
             let project_dir = lease::project_dir_from_config(&config, &cli.config);
+            // Each resolve_lease call manages its own short-lived ledger locks.
+            // Leases are processed sequentially; no shared lock is needed.
             for (name, lease_config) in &leases {
                 // Check prerequisites before attempting to create/use a lease
                 let prereq_missing = lease_config.check_prerequisites();
@@ -91,6 +93,7 @@ impl ExecCommand {
                     &project_dir,
                     prereq_missing.as_deref(),
                     "exec",
+                    false,
                 )
                 .await?;
                 for (cred_key, cred_value) in creds {

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -56,19 +56,20 @@ impl ExecCommand {
                 &mut _temp_env_guard,
             )?);
             let project_dir = lease::project_dir_from_config(&config, &cli.config);
-            let ledger_lock = LeaseLedger::lock(&project_dir)?;
-            let mut ledger = LeaseLedger::load(&project_dir)?;
             for (name, lease_config) in &leases {
                 // Check prerequisites before attempting to create/use a lease
                 let prereq_missing = lease_config.check_prerequisites();
                 if let Some(ref missing) = prereq_missing {
-                    // Check if there's a cached lease we can still use
-                    let config_hash = lease_config.config_hash();
-                    if let Some(cached) = ledger.find_reusable(name, &config_hash)
-                        && cached.cached_credentials.is_some()
-                    {
-                        // Fall through to resolve_lease which will use the cache
-                    } else {
+                    // Check if there's a cached lease we can still use (short lock).
+                    let has_cache = {
+                        let _lock = LeaseLedger::lock(&project_dir)?;
+                        let ledger = LeaseLedger::load(&project_dir)?;
+                        let config_hash = lease_config.config_hash();
+                        ledger
+                            .find_reusable(name, &config_hash)
+                            .is_some_and(|r| r.cached_credentials.is_some())
+                    };
+                    if !has_cache {
                         tracing::warn!(
                             "Skipping lease '{}': {}\nRun 'fnox lease create -i {}' to set up credentials interactively.",
                             name,
@@ -81,13 +82,13 @@ impl ExecCommand {
                 // Intentionally hard-fail: if prerequisites pass but lease
                 // creation fails (network, permissions, etc.), abort rather
                 // than silently running the subprocess without expected creds.
+                // resolve_lease manages its own ledger locks with minimal scope.
                 let creds = lease::resolve_lease(
                     name,
                     lease_config,
                     &config,
                     &profile,
                     &project_dir,
-                    &mut ledger,
                     prereq_missing.as_deref(),
                     "exec",
                 )
@@ -97,11 +98,6 @@ impl ExecCommand {
                     cmd.env(cred_key, cred_value);
                 }
             }
-            // Release the ledger lock before spawning the subprocess.
-            // The lock is only needed for the load → mutate → save cycle above;
-            // holding it for the subprocess lifetime would serialize all concurrent
-            // fnox exec invocations in the same project directory.
-            drop(ledger_lock);
         }
 
         // Add resolved secrets as environment variables

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -1,11 +1,9 @@
 use crate::error::{FnoxError, Result};
 use crate::lease::{self, LeaseLedger};
-use crate::lease_backends::LeaseBackendConfig;
 use crate::secret_resolver::resolve_secrets_batch;
 use crate::temp_file_secrets::create_ephemeral_secret_file;
 use crate::{commands::Cli, config::Config};
 use clap::{Args, ValueHint};
-use indexmap::IndexMap;
 use std::collections::HashSet;
 use std::process::Command;
 use tempfile::NamedTempFile;
@@ -83,7 +81,7 @@ impl ExecCommand {
                 // Intentionally hard-fail: if prerequisites pass but lease
                 // creation fails (network, permissions, etc.), abort rather
                 // than silently running the subprocess without expected creds.
-                let creds = resolve_lease(
+                let creds = lease::resolve_lease(
                     name,
                     lease_config,
                     &config,
@@ -206,116 +204,4 @@ impl ExecCommand {
 
         Ok(())
     }
-}
-
-/// Resolve a lease backend into credentials, reusing cached credentials when available.
-/// Takes a mutable reference to the ledger to avoid double-load TOCTTOU races.
-async fn resolve_lease(
-    name: &str,
-    lease_config: &LeaseBackendConfig,
-    config: &Config,
-    profile: &str,
-    project_dir: &std::path::Path,
-    ledger: &mut LeaseLedger,
-    prereq_missing: Option<&str>,
-) -> Result<IndexMap<String, String>> {
-    // Check for a reusable cached lease (config_hash ensures stale creds
-    // are not returned after backend config changes like role ARN rotation)
-    let config_hash = lease_config.config_hash();
-    if let Some(cached_lease) = ledger.find_reusable(name, &config_hash)
-        && let Some(ref cached_creds) = cached_lease.cached_credentials
-    {
-        // If encrypted, decrypt
-        if let Some(ref enc_provider_name) = cached_lease.encryption_provider {
-            match lease::find_encryption_provider(config, profile).await {
-                lease::EncryptionProviderResult::Available(found_name, provider)
-                    if found_name == *enc_provider_name =>
-                {
-                    match lease::decrypt_credentials(provider.as_ref(), cached_creds).await {
-                        Ok(decrypted) => {
-                            tracing::debug!(
-                                "Reusing cached encrypted lease '{}' for backend '{}'",
-                                cached_lease.lease_id,
-                                name
-                            );
-                            return Ok(decrypted);
-                        }
-                        Err(e) => {
-                            tracing::warn!(
-                                "Failed to decrypt cached lease '{}': {}, creating fresh lease",
-                                cached_lease.lease_id,
-                                e
-                            );
-                        }
-                    }
-                }
-                _ => {
-                    tracing::warn!(
-                        "Encryption provider '{}' not available for cached lease '{}', creating fresh lease",
-                        enc_provider_name,
-                        cached_lease.lease_id
-                    );
-                }
-            }
-        } else {
-            // Plaintext cached credentials
-            tracing::debug!(
-                "Reusing cached plaintext lease '{}' for backend '{}'",
-                cached_lease.lease_id,
-                name
-            );
-            return Ok(cached_creds.clone());
-        }
-    }
-
-    // No reusable cache — create fresh lease.
-    // If prerequisites are missing, we cannot create a fresh lease. The caller
-    // only reaches here with prereq_missing=Some when it found a cached lease
-    // that couldn't be decrypted (e.g., encryption provider unavailable).
-    // Hard-fail so the subprocess doesn't run without expected credentials.
-    if let Some(missing) = prereq_missing {
-        return Err(FnoxError::Config(format!(
-            "Lease '{}': cached credentials could not be decrypted and \
-             prerequisites are missing: {}\n\
-             Run 'fnox lease create -i {}' to set up credentials interactively.",
-            name, missing, name
-        )));
-    }
-    let backend = lease_config.create_backend()?;
-
-    let duration_str = lease_config
-        .duration()
-        .unwrap_or(lease::DEFAULT_LEASE_DURATION);
-    let duration = lease::parse_duration(duration_str)?;
-
-    let max_duration = backend.max_lease_duration();
-    if duration > max_duration {
-        return Err(FnoxError::Config(format!(
-            "Lease duration '{}' for '{}' exceeds maximum {:?}",
-            duration_str, name, max_duration
-        )));
-    }
-
-    let label = format!("fnox-exec-{}", name);
-    let result = lease::create_and_record_lease(
-        backend.as_ref(),
-        name,
-        &label,
-        duration,
-        config_hash,
-        config,
-        profile,
-        ledger,
-        project_dir,
-    )
-    .await?;
-
-    tracing::debug!(
-        "Created lease '{}' for backend '{}' (expires {:?})",
-        result.lease_id,
-        name,
-        result.expires_at
-    );
-
-    Ok(result.credentials)
 }

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -89,6 +89,7 @@ impl ExecCommand {
                     &project_dir,
                     &mut ledger,
                     prereq_missing.as_deref(),
+                    "exec",
                 )
                 .await?;
                 for (cred_key, cred_value) in creds {

--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -28,8 +28,8 @@ impl GetCommand {
         if let Some(value) = self.resolve_from_lease(cli, &config, &profile).await? {
             let value = self.maybe_base64_decode(value)?;
             // Respect as_file from the profile secret config when present
-            if let Ok(profile_secrets) = config.get_secrets(&profile)
-                && let Some(sc) = profile_secrets.get(&self.key)
+            let profile_secrets = config.get_secrets(&profile).unwrap_or_default();
+            if let Some(sc) = profile_secrets.get(&self.key)
                 && sc.as_file
             {
                 let file_path = create_persistent_secret_file("fnox-", &self.key, &value)?;
@@ -143,19 +143,6 @@ impl GetCommand {
             lease::set_secrets_as_env(&resolved_secrets, &needed_secrets, &mut temp_env_guard)?;
 
         let prereq_missing = lease_config.check_prerequisites();
-        if let Some(ref missing) = prereq_missing {
-            let config_hash = lease_config.config_hash();
-            if ledger
-                .find_reusable(name, &config_hash)
-                .and_then(|c| c.cached_credentials.as_ref())
-                .is_none()
-            {
-                return Err(FnoxError::Config(format!(
-                    "Lease '{}': {}\nRun 'fnox lease create -i {}' to set up credentials interactively.",
-                    name, missing, name
-                )));
-            }
-        }
 
         let creds = lease::resolve_lease(
             name,

--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -152,8 +152,22 @@ impl GetCommand {
         // Resolve consumed secrets and inject them as env vars so that:
         // 1. The encryption provider can initialize (e.g. VAULT_TOKEN)
         // 2. The backend SDK can authenticate for fresh lease creation
-        let consumed: std::collections::HashSet<&str> =
+        let mut consumed: std::collections::HashSet<&str> =
             lease_config.consumed_env_vars().iter().copied().collect();
+
+        // If the cached entry is encrypted, the encryption provider may need
+        // its own credentials (e.g. Vault transit needs VAULT_TOKEN). Include
+        // the provider's env_dependencies so they get resolved and injected.
+        if let Some(ref entry) = cached_entry
+            && let Some(ref enc_provider_name) = entry.encryption_provider
+        {
+            let providers_map = config.get_providers(profile);
+            if let Some(provider_config) = providers_map.get(enc_provider_name) {
+                for dep in provider_config.env_dependencies() {
+                    consumed.insert(dep);
+                }
+            }
+        }
         // When consumed is empty the backend needs no profile secrets (e.g. it
         // authenticates via instance metadata). Avoid aborting on a transient
         // secrets-config read error that would be irrelevant in that case.
@@ -227,14 +241,10 @@ impl GetCommand {
     ) -> Result<Option<(String, IndexMap<String, SecretConfig>)>> {
         match creds.get(&self.key) {
             Some(value) => Ok(Some((value.clone(), all_secrets))),
-            // This is a backend contract violation (produces_env_var returned true
-            // but the credential map lacks the key), not a static config error.
-            // Using FnoxError::Config for now as there is no dedicated variant.
-            None => Err(FnoxError::Config(format!(
-                "Lease '{}' produced credentials at runtime but the expected key '{}' was absent. \
-                 This is a backend contract violation, not a config error.",
-                name, self.key,
-            ))),
+            None => Err(FnoxError::LeaseContractViolation {
+                lease: name.to_string(),
+                key: self.key.clone(),
+            }),
         }
     }
 }

--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -98,18 +98,8 @@ impl GetCommand {
     ) -> Result<Option<String>> {
         let leases = config.get_leases(profile);
 
-        // Set master secrets as env vars first so lease backend prerequisite
-        // checks (e.g. Vault reading VAULT_ADDR from env) can find them.
-        let profile_secrets = config.get_secrets(profile)?;
-        let resolved_secrets =
-            crate::secret_resolver::resolve_secrets_batch(config, profile, &profile_secrets)
-                .await?;
-        let mut temp_env_guard = lease::TempEnvGuard::default();
-        let _temp_files =
-            lease::set_secrets_as_env(&resolved_secrets, &profile_secrets, &mut temp_env_guard)?;
-
-        // Find which lease backend (if any) produces this key — uses config
-        // directly, no need to instantiate the backend.
+        // Fast path: check if any lease backend produces this key (pure config
+        // lookup — no network calls or backend instantiation needed).
         let matching_lease = leases
             .iter()
             .find(|(_, lease_config)| lease_config.produced_env_vars().contains(&self.key));
@@ -117,6 +107,17 @@ impl GetCommand {
         let Some((name, lease_config)) = matching_lease else {
             return Ok(None);
         };
+
+        // Only resolve master secrets when we know a lease backend needs them
+        // (e.g. VAULT_ADDR from a provider). Deferring avoids spurious failures
+        // from unrelated secrets and unnecessary work for non-lease keys.
+        let profile_secrets = config.get_secrets(profile)?;
+        let resolved_secrets =
+            crate::secret_resolver::resolve_secrets_batch(config, profile, &profile_secrets)
+                .await?;
+        let mut temp_env_guard = lease::TempEnvGuard::default();
+        let _temp_files =
+            lease::set_secrets_as_env(&resolved_secrets, &profile_secrets, &mut temp_env_guard)?;
 
         let project_dir = lease::project_dir_from_config(config, &cli.config);
         let _ledger_lock = LeaseLedger::lock(&project_dir)?;

--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -110,25 +110,15 @@ impl GetCommand {
             return Ok(None);
         };
 
-        // Only resolve the secrets the lease backend actually needs (e.g.
-        // CLOUDFLARE_API_TOKEN, VAULT_ADDR) rather than all profile secrets.
-        // This avoids spurious failures from unrelated unreachable secrets.
-        let required: std::collections::HashSet<&str> = lease_config
-            .required_env_vars()
-            .iter()
-            .map(|(k, _)| *k)
-            .collect();
+        // Resolve all profile secrets and inject them as env vars so lease
+        // backend SDKs can find credentials under any supported alias (e.g.
+        // FNOX_VAULT_TOKEN vs VAULT_TOKEN, CF_API_TOKEN vs CLOUDFLARE_API_TOKEN).
         let all_secrets = config.get_secrets(profile)?;
-        let needed_secrets: indexmap::IndexMap<_, _> = all_secrets
-            .iter()
-            .filter(|(k, _)| required.contains(k.as_str()))
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect();
         let resolved_secrets =
-            crate::secret_resolver::resolve_secrets_batch(config, profile, &needed_secrets).await?;
+            crate::secret_resolver::resolve_secrets_batch(config, profile, &all_secrets).await?;
         let mut temp_env_guard = lease::TempEnvGuard::default();
         let _temp_files =
-            lease::set_secrets_as_env(&resolved_secrets, &needed_secrets, &mut temp_env_guard)?;
+            lease::set_secrets_as_env(&resolved_secrets, &all_secrets, &mut temp_env_guard)?;
 
         let project_dir = lease::project_dir_from_config(config, &cli.config);
         let _ledger_lock = LeaseLedger::lock(&project_dir)?;

--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -28,15 +28,13 @@ impl GetCommand {
         if let Some(value) = self.resolve_from_lease(cli, &config, &profile).await? {
             let value = self.maybe_base64_decode(value)?;
             // Respect as_file from the profile secret config when present
-            if let Ok(profile_secrets) = config.get_secrets(&profile) {
-                if let Some(sc) = profile_secrets.get(&self.key) {
-                    if sc.as_file {
+            if let Ok(profile_secrets) = config.get_secrets(&profile)
+                && let Some(sc) = profile_secrets.get(&self.key)
+                    && sc.as_file {
                         let file_path = create_persistent_secret_file("fnox-", &self.key, &value)?;
                         println!("{}", file_path);
                         return Ok(());
                     }
-                }
-            }
             println!("{}", value);
             return Ok(());
         }

--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -102,23 +102,33 @@ impl GetCommand {
         // lookup — no network calls or backend instantiation needed).
         // Use rfind to match exec's last-wins semantics when multiple leases
         // produce the same key.
-        let matching_lease = leases
-            .iter()
-            .rfind(|(_, lease_config)| lease_config.produced_env_vars().contains(&self.key));
+        let matching_lease = leases.iter().rfind(|(_, lease_config)| {
+            lease_config
+                .produced_env_vars()
+                .contains(&self.key.as_str())
+        });
 
         let Some((name, lease_config)) = matching_lease else {
             return Ok(None);
         };
 
-        // Resolve all profile secrets and inject them as env vars so lease
-        // backend SDKs can find credentials under any supported alias (e.g.
-        // FNOX_VAULT_TOKEN vs VAULT_TOKEN, CF_API_TOKEN vs CLOUDFLARE_API_TOKEN).
+        // Only resolve secrets this lease backend may consume at runtime,
+        // including all known aliases (e.g. FNOX_VAULT_TOKEN, CF_API_TOKEN).
+        // This avoids unnecessary network calls to unrelated providers while
+        // still covering every env var name the backend checks.
+        let consumed: std::collections::HashSet<&str> =
+            lease_config.consumed_env_vars().into_iter().collect();
         let all_secrets = config.get_secrets(profile)?;
+        let needed_secrets: indexmap::IndexMap<_, _> = all_secrets
+            .iter()
+            .filter(|(k, _)| consumed.contains(k.as_str()))
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
         let resolved_secrets =
-            crate::secret_resolver::resolve_secrets_batch(config, profile, &all_secrets).await?;
+            crate::secret_resolver::resolve_secrets_batch(config, profile, &needed_secrets).await?;
         let mut temp_env_guard = lease::TempEnvGuard::default();
         let _temp_files =
-            lease::set_secrets_as_env(&resolved_secrets, &all_secrets, &mut temp_env_guard)?;
+            lease::set_secrets_as_env(&resolved_secrets, &needed_secrets, &mut temp_env_guard)?;
 
         let project_dir = lease::project_dir_from_config(config, &cli.config);
         let _ledger_lock = LeaseLedger::lock(&project_dir)?;

--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -209,29 +209,83 @@ impl GetCommand {
         // This matches exec.rs behaviour.
         let prereq_missing = lease_config.check_prerequisites();
 
-        // Acquire ledger lock only for the load → cache-check → mutate → save
-        // cycle. resolve_lease releases the lock (via the caller dropping it)
-        // before returning, but the outbound lease creation API call happens
-        // inside create_and_record_lease which needs the mutable ledger ref.
-        // This is acceptable because the lock protects ledger consistency,
-        // not the network call duration — and the lock scope is minimised
-        // compared to holding it across secret resolution above.
-        let _ledger_lock = LeaseLedger::lock(&project_dir)?;
-        let mut ledger = LeaseLedger::load(&project_dir)?;
+        // TOCTOU cache re-check: a concurrent process may have written a valid
+        // cache entry between our first check and now. Sync ledger read under
+        // a short lock, then release before async decryption.
+        let toctou_entry = {
+            let _lock = LeaseLedger::lock(&project_dir)?;
+            let ledger = LeaseLedger::load(&project_dir)?;
+            lease::find_cached_entry(&ledger, name, &config_hash)
+        };
+        if let Some(entry) = toctou_entry
+            && let Some(creds) = lease::resolve_cached_entry(entry, config, profile, name).await
+        {
+            return self.extract_key_from_creds(name, creds, all_secrets);
+        }
 
-        let creds = lease::resolve_lease(
+        if let Some(missing) = prereq_missing {
+            return Err(FnoxError::Config(format!(
+                "Lease '{}': no usable cached credentials and \
+                 prerequisites are missing: {}\n\
+                 Run 'fnox lease create -i {}' to set up credentials interactively.",
+                name, missing, name
+            )));
+        }
+
+        // Create the lease (async network call) outside any lock.
+        let backend = lease_config.create_backend()?;
+        let duration_str = lease_config
+            .duration()
+            .unwrap_or(lease::DEFAULT_LEASE_DURATION);
+        let duration = lease::parse_duration(duration_str)?;
+        let max_duration = backend.max_lease_duration();
+        if duration > max_duration {
+            return Err(FnoxError::Config(format!(
+                "Lease duration '{}' for '{}' exceeds maximum {:?}",
+                duration_str, name, max_duration
+            )));
+        }
+        let label = format!("fnox-get-{}", name);
+        let result = backend.create_lease(duration, &label).await?;
+
+        tracing::debug!(
+            "Created lease '{}' for backend '{}' (expires {:?})",
+            result.lease_id,
             name,
-            lease_config,
-            config,
-            profile,
-            &project_dir,
-            &mut ledger,
-            prereq_missing.as_deref(),
-            "get",
-        )
-        .await?;
+            result.expires_at
+        );
 
-        self.extract_key_from_creds(name, creds, all_secrets)
+        // Encrypt credentials for caching (async, may call encryption provider).
+        let (cached_credentials, encryption_provider) =
+            lease::cache_credentials(config, profile, &result.credentials, &result.lease_id).await;
+
+        // Acquire lock only for the synchronous ledger write.
+        {
+            let _lock = LeaseLedger::lock(&project_dir)?;
+            let mut ledger = LeaseLedger::load(&project_dir)?;
+            ledger.add(lease::LeaseRecord {
+                lease_id: result.lease_id.clone(),
+                backend_name: name.to_string(),
+                label,
+                created_at: chrono::Utc::now(),
+                expires_at: result.expires_at,
+                revoked: false,
+                cached_credentials,
+                encryption_provider,
+                config_hash: Some(config_hash),
+            });
+            if let Err(save_err) = ledger.save(&project_dir) {
+                tracing::warn!(
+                    "Lease '{}' created for backend '{}' but ledger save failed: {}. \
+                     This lease is untracked and must be revoked manually.",
+                    result.lease_id,
+                    name,
+                    save_err
+                );
+            }
+        }
+
+        self.extract_key_from_creds(name, result.credentials, all_secrets)
     }
 
     fn extract_key_from_creds(

--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -108,16 +108,25 @@ impl GetCommand {
             return Ok(None);
         };
 
-        // Only resolve master secrets when we know a lease backend needs them
-        // (e.g. VAULT_ADDR from a provider). Deferring avoids spurious failures
-        // from unrelated secrets and unnecessary work for non-lease keys.
-        let profile_secrets = config.get_secrets(profile)?;
+        // Only resolve the secrets the lease backend actually needs (e.g.
+        // CLOUDFLARE_API_TOKEN, VAULT_ADDR) rather than all profile secrets.
+        // This avoids spurious failures from unrelated unreachable secrets.
+        let required: std::collections::HashSet<&str> = lease_config
+            .required_env_vars()
+            .iter()
+            .map(|(k, _)| *k)
+            .collect();
+        let all_secrets = config.get_secrets(profile)?;
+        let needed_secrets: indexmap::IndexMap<_, _> = all_secrets
+            .iter()
+            .filter(|(k, _)| required.contains(k.as_str()))
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
         let resolved_secrets =
-            crate::secret_resolver::resolve_secrets_batch(config, profile, &profile_secrets)
-                .await?;
+            crate::secret_resolver::resolve_secrets_batch(config, profile, &needed_secrets).await?;
         let mut temp_env_guard = lease::TempEnvGuard::default();
         let _temp_files =
-            lease::set_secrets_as_env(&resolved_secrets, &profile_secrets, &mut temp_env_guard)?;
+            lease::set_secrets_as_env(&resolved_secrets, &needed_secrets, &mut temp_env_guard)?;
 
         let project_dir = lease::project_dir_from_config(config, &cli.config);
         let _ledger_lock = LeaseLedger::lock(&project_dir)?;

--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -1,3 +1,4 @@
+use crate::config::SecretConfig;
 use crate::error::{FnoxError, Result};
 use crate::lease::{self, LeaseLedger};
 use crate::secret_resolver::resolve_secret;
@@ -5,6 +6,7 @@ use crate::suggest::{find_similar, format_suggestions};
 use crate::temp_file_secrets::create_persistent_secret_file;
 use crate::{commands::Cli, config::Config};
 use clap::Args;
+use indexmap::IndexMap;
 
 #[derive(Debug, Args)]
 pub struct GetCommand {
@@ -25,10 +27,11 @@ impl GetCommand {
         config.validate()?;
 
         // Check if the requested key is produced by a lease backend
-        if let Some(value) = self.resolve_from_lease(cli, &config, &profile).await? {
+        if let Some((value, profile_secrets)) =
+            self.resolve_from_lease(cli, &config, &profile).await?
+        {
             let value = self.maybe_base64_decode(value)?;
             // Respect as_file from the profile secret config when present
-            let profile_secrets = config.get_secrets(&profile).unwrap_or_default();
             if let Some(sc) = profile_secrets.get(&self.key)
                 && sc.as_file
             {
@@ -98,13 +101,14 @@ impl GetCommand {
     }
 
     /// Check if the requested key is produced by a lease backend.
-    /// If so, resolve the lease and return the credential value.
+    /// If so, resolve the lease and return the credential value alongside
+    /// the profile secrets map (to avoid a redundant `get_secrets` call).
     async fn resolve_from_lease(
         &self,
         cli: &Cli,
         config: &Config,
         profile: &str,
-    ) -> Result<Option<String>> {
+    ) -> Result<Option<(String, IndexMap<String, SecretConfig>)>> {
         let leases = config.get_leases(profile);
 
         // Fast path: check if any lease backend produces this key (pure config
@@ -157,7 +161,7 @@ impl GetCommand {
         .await?;
 
         match creds.get(&self.key) {
-            Some(value) => Ok(Some(value.clone())),
+            Some(value) => Ok(Some((value.clone(), all_secrets))),
             None => Err(FnoxError::Config(format!(
                 "Lease '{}' claims to produce '{}' but returned credentials did not contain it",
                 name, self.key,

--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -111,11 +111,9 @@ impl GetCommand {
         // lookup — no network calls or backend instantiation needed).
         // Use rfind to match exec's last-wins semantics when multiple leases
         // produce the same key.
-        let matching_lease = leases.iter().rfind(|(_, lease_config)| {
-            lease_config
-                .produced_env_vars()
-                .contains(&self.key.as_str())
-        });
+        let matching_lease = leases
+            .iter()
+            .rfind(|(_, lease_config)| lease_config.produces_env_var(&self.key));
 
         let Some((name, lease_config)) = matching_lease else {
             return Ok(None);
@@ -135,13 +133,14 @@ impl GetCommand {
             .collect();
         let resolved_secrets =
             crate::secret_resolver::resolve_secrets_batch(config, profile, &needed_secrets).await?;
-        let mut temp_env_guard = lease::TempEnvGuard::default();
-        let _temp_files =
-            lease::set_secrets_as_env(&resolved_secrets, &needed_secrets, &mut temp_env_guard)?;
 
         let project_dir = lease::project_dir_from_config(config, &cli.config);
         let _ledger_lock = LeaseLedger::lock(&project_dir)?;
         let mut ledger = LeaseLedger::load(&project_dir)?;
+
+        let mut temp_env_guard = lease::TempEnvGuard::default();
+        let _temp_files =
+            lease::set_secrets_as_env(&resolved_secrets, &needed_secrets, &mut temp_env_guard)?;
 
         let prereq_missing = lease_config.check_prerequisites();
         if let Some(ref missing) = prereq_missing {

--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -26,6 +26,7 @@ impl GetCommand {
 
         // Check if the requested key is produced by a lease backend
         if let Some(value) = self.resolve_from_lease(cli, &config, &profile).await? {
+            let value = self.maybe_base64_decode(value)?;
             println!("{}", value);
             return Ok(());
         }
@@ -51,22 +52,7 @@ impl GetCommand {
         // Resolve the secret using centralized resolver
         match resolve_secret(&config, &profile, &self.key, secret_config).await {
             Ok(Some(value)) => {
-                // Check if this secret should be base64 decoded
-                let value = if self.base64_decode {
-                    let decoded_bytes =
-                        data_encoding::BASE64
-                            .decode(value.as_bytes())
-                            .map_err(|e| FnoxError::SecretDecodeFailed {
-                                details: format!("Failed to base64 decode secret: {}", e),
-                            })?;
-                    str::from_utf8(&decoded_bytes)
-                        .map_err(|e| FnoxError::SecretDecodeFailed {
-                            details: format!("decoded secret is not valid UTF-8: {}", e),
-                        })?
-                        .to_string()
-                } else {
-                    value
-                };
+                let value = self.maybe_base64_decode(value)?;
 
                 // Check if this secret should be written to a file
                 if secret_config.as_file {
@@ -85,6 +71,23 @@ impl GetCommand {
         }
     }
 
+    fn maybe_base64_decode(&self, value: String) -> Result<String> {
+        if self.base64_decode {
+            let decoded_bytes = data_encoding::BASE64
+                .decode(value.as_bytes())
+                .map_err(|e| FnoxError::SecretDecodeFailed {
+                    details: format!("Failed to base64 decode secret: {}", e),
+                })?;
+            Ok(str::from_utf8(&decoded_bytes)
+                .map_err(|e| FnoxError::SecretDecodeFailed {
+                    details: format!("decoded secret is not valid UTF-8: {}", e),
+                })?
+                .to_string())
+        } else {
+            Ok(value)
+        }
+    }
+
     /// Check if the requested key is produced by a lease backend.
     /// If so, resolve the lease and return the credential value.
     async fn resolve_from_lease(
@@ -95,20 +98,8 @@ impl GetCommand {
     ) -> Result<Option<String>> {
         let leases = config.get_leases(profile);
 
-        // Find which lease backend (if any) produces this key
-        let matching_lease = leases.iter().find(|(_, lease_config)| {
-            let backend = match lease_config.create_backend() {
-                Ok(b) => b,
-                Err(_) => return false,
-            };
-            backend.produced_env_vars().contains(&self.key)
-        });
-
-        let Some((name, lease_config)) = matching_lease else {
-            return Ok(None);
-        };
-
-        // Set master secrets as env vars so the lease backend SDK can find them
+        // Set master secrets as env vars first so lease backend prerequisite
+        // checks (e.g. Vault reading VAULT_ADDR from env) can find them.
         let profile_secrets = config.get_secrets(profile)?;
         let resolved_secrets =
             crate::secret_resolver::resolve_secrets_batch(config, profile, &profile_secrets)
@@ -116,6 +107,16 @@ impl GetCommand {
         let mut temp_env_guard = lease::TempEnvGuard::default();
         let _temp_files =
             lease::set_secrets_as_env(&resolved_secrets, &profile_secrets, &mut temp_env_guard)?;
+
+        // Find which lease backend (if any) produces this key — uses config
+        // directly, no need to instantiate the backend.
+        let matching_lease = leases
+            .iter()
+            .find(|(_, lease_config)| lease_config.produced_env_vars().contains(&self.key));
+
+        let Some((name, lease_config)) = matching_lease else {
+            return Ok(None);
+        };
 
         let project_dir = lease::project_dir_from_config(config, &cli.config);
         let _ledger_lock = LeaseLedger::lock(&project_dir)?;
@@ -144,6 +145,7 @@ impl GetCommand {
             &project_dir,
             &mut ledger,
             prereq_missing.as_deref(),
+            "get",
         )
         .await?;
 

--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -168,19 +168,23 @@ impl GetCommand {
                 }
             }
         }
-        // When consumed is empty the backend needs no profile secrets (e.g. it
-        // authenticates via instance metadata). Avoid aborting on a transient
-        // secrets-config read error that would be irrelevant in that case.
-        let all_secrets = if consumed.is_empty() {
-            config.get_secrets(profile).unwrap_or_default()
-        } else {
-            config.get_secrets(profile)?
-        };
+        // Fetch secrets with unwrap_or_default first — if no consumed var is
+        // actually present as a profile secret, the backend authenticates via
+        // non-secret means (private_key_file, instance metadata, az CLI, etc.)
+        // and a transient secrets-config read error should not abort the command.
+        let all_secrets = config.get_secrets(profile).unwrap_or_default();
         let needed_secrets: indexmap::IndexMap<_, _> = all_secrets
             .iter()
             .filter(|(k, _)| consumed.contains(k.as_str()))
             .map(|(k, v)| (k.clone(), v.clone()))
             .collect();
+        // Re-fetch with hard error if we actually need profile secrets — the
+        // unwrap_or_default result may have silently swallowed a real failure.
+        let all_secrets = if needed_secrets.is_empty() {
+            all_secrets
+        } else {
+            config.get_secrets(profile)?
+        };
         let resolved_secrets =
             crate::secret_resolver::resolve_secrets_batch(config, profile, &needed_secrets).await?;
 

--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -129,15 +129,49 @@ impl GetCommand {
         // Cache-first: check the ledger for a reusable lease before resolving
         // any secrets. This avoids network calls to secret providers when the
         // cache already has valid credentials.
-        let cached_creds = {
+        //
+        // Only the synchronous ledger read is held under the file lock;
+        // decryption (which may involve async network I/O to an encryption
+        // provider) runs after the lock is released.
+        let cached_entry = {
             let _lock = LeaseLedger::lock(&project_dir)?;
             let ledger = LeaseLedger::load(&project_dir)?;
-            lease::try_cached_credentials(&ledger, name, &config_hash, config, profile).await
+            ledger.find_reusable(name, &config_hash).and_then(|lease| {
+                lease.cached_credentials.as_ref().map(|creds| {
+                    (
+                        creds.clone(),
+                        lease.encryption_provider.clone(),
+                        lease.lease_id.clone(),
+                    )
+                })
+            })
         };
 
-        if let Some(creds) = cached_creds {
-            let all_secrets = config.get_secrets(profile)?;
-            return self.extract_key_from_creds(name, creds, all_secrets);
+        if let Some((cached_creds, enc_provider, lease_id)) = cached_entry {
+            let decrypted = if let Some(ref enc_provider_name) = enc_provider {
+                lease::try_decrypt_cached(
+                    config,
+                    profile,
+                    enc_provider_name,
+                    &cached_creds,
+                    &lease_id,
+                    name,
+                )
+                .await
+            } else {
+                tracing::debug!(
+                    "Reusing cached plaintext lease '{}' for backend '{}'",
+                    lease_id,
+                    name
+                );
+                Some(cached_creds)
+            };
+            if let Some(creds) = decrypted {
+                // as_file is a presentation hint; a get_secrets failure should
+                // not discard a successfully retrieved cached credential.
+                let all_secrets = config.get_secrets(profile).unwrap_or_default();
+                return self.extract_key_from_creds(name, creds, all_secrets);
+            }
         }
 
         // Cache miss: resolve only the consumed secrets and create a fresh lease.

--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -136,7 +136,7 @@ impl GetCommand {
         };
 
         if let Some(creds) = cached_creds {
-            let all_secrets = config.get_secrets(profile).unwrap_or_default();
+            let all_secrets = config.get_secrets(profile)?;
             return self.extract_key_from_creds(name, creds, all_secrets);
         }
 

--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -209,83 +209,18 @@ impl GetCommand {
         // This matches exec.rs behaviour.
         let prereq_missing = lease_config.check_prerequisites();
 
-        // TOCTOU cache re-check: a concurrent process may have written a valid
-        // cache entry between our first check and now. Sync ledger read under
-        // a short lock, then release before async decryption.
-        let toctou_entry = {
-            let _lock = LeaseLedger::lock(&project_dir)?;
-            let ledger = LeaseLedger::load(&project_dir)?;
-            lease::find_cached_entry(&ledger, name, &config_hash)
-        };
-        if let Some(entry) = toctou_entry
-            && let Some(creds) = lease::resolve_cached_entry(entry, config, profile, name).await
-        {
-            return self.extract_key_from_creds(name, creds, all_secrets);
-        }
-
-        if let Some(missing) = prereq_missing {
-            return Err(FnoxError::Config(format!(
-                "Lease '{}': no usable cached credentials and \
-                 prerequisites are missing: {}\n\
-                 Run 'fnox lease create -i {}' to set up credentials interactively.",
-                name, missing, name
-            )));
-        }
-
-        // Create the lease (async network call) outside any lock.
-        let backend = lease_config.create_backend()?;
-        let duration_str = lease_config
-            .duration()
-            .unwrap_or(lease::DEFAULT_LEASE_DURATION);
-        let duration = lease::parse_duration(duration_str)?;
-        let max_duration = backend.max_lease_duration();
-        if duration > max_duration {
-            return Err(FnoxError::Config(format!(
-                "Lease duration '{}' for '{}' exceeds maximum {:?}",
-                duration_str, name, max_duration
-            )));
-        }
-        let label = format!("fnox-get-{}", name);
-        let result = backend.create_lease(duration, &label).await?;
-
-        tracing::debug!(
-            "Created lease '{}' for backend '{}' (expires {:?})",
-            result.lease_id,
+        let creds = lease::resolve_lease(
             name,
-            result.expires_at
-        );
+            lease_config,
+            config,
+            profile,
+            &project_dir,
+            prereq_missing.as_deref(),
+            "get",
+        )
+        .await?;
 
-        // Encrypt credentials for caching (async, may call encryption provider).
-        let (cached_credentials, encryption_provider) =
-            lease::cache_credentials(config, profile, &result.credentials, &result.lease_id).await;
-
-        // Acquire lock only for the synchronous ledger write.
-        {
-            let _lock = LeaseLedger::lock(&project_dir)?;
-            let mut ledger = LeaseLedger::load(&project_dir)?;
-            ledger.add(lease::LeaseRecord {
-                lease_id: result.lease_id.clone(),
-                backend_name: name.to_string(),
-                label,
-                created_at: chrono::Utc::now(),
-                expires_at: result.expires_at,
-                revoked: false,
-                cached_credentials,
-                encryption_provider,
-                config_hash: Some(config_hash),
-            });
-            if let Err(save_err) = ledger.save(&project_dir) {
-                tracing::warn!(
-                    "Lease '{}' created for backend '{}' but ledger save failed: {}. \
-                     This lease is untracked and must be revoked manually.",
-                    result.lease_id,
-                    name,
-                    save_err
-                );
-            }
-        }
-
-        self.extract_key_from_creds(name, result.credentials, all_secrets)
+        self.extract_key_from_creds(name, creds, all_secrets)
     }
 
     fn extract_key_from_creds(

--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -100,9 +100,11 @@ impl GetCommand {
 
         // Fast path: check if any lease backend produces this key (pure config
         // lookup — no network calls or backend instantiation needed).
+        // Use rfind to match exec's last-wins semantics when multiple leases
+        // produce the same key.
         let matching_lease = leases
             .iter()
-            .find(|(_, lease_config)| lease_config.produced_env_vars().contains(&self.key));
+            .rfind(|(_, lease_config)| lease_config.produced_env_vars().contains(&self.key));
 
         let Some((name, lease_config)) = matching_lease else {
             return Ok(None);
@@ -159,6 +161,12 @@ impl GetCommand {
         )
         .await?;
 
-        Ok(creds.get(&self.key).cloned())
+        match creds.get(&self.key) {
+            Some(value) => Ok(Some(value.clone())),
+            None => Err(FnoxError::Config(format!(
+                "Lease '{}' claims to produce '{}' but returned credentials did not contain it",
+                name, self.key,
+            ))),
+        }
     }
 }

--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -177,22 +177,21 @@ impl GetCommand {
         // Now that credentials are in the environment, attempt encrypted cache
         // decryption. This must happen after set_secrets_as_env so the
         // encryption provider (e.g. Vault) can find its credentials.
+        // On failure, fall through to create a fresh lease — matching exec's
+        // behaviour. create_and_record_lease handles encryption failure
+        // gracefully by storing (None, None) for cached credentials.
         if let Some(entry) = cached_entry {
             // entry.encryption_provider is guaranteed Some here (plaintext
             // was handled above), so resolve_cached_entry will attempt decrypt.
             if let Some(creds) = lease::resolve_cached_entry(entry, config, profile, name).await {
                 return self.extract_key_from_creds(name, creds, all_secrets.clone());
             }
-            // Decryption failed even with credentials injected — don't silently
-            // create a new (also un-decryptable) lease that repeats the cycle.
-            return Err(FnoxError::Config(format!(
-                "Lease '{}': cached credentials could not be decrypted. \
-                 Ensure the encryption provider is reachable or run \
-                 'fnox lease create -i {}' to refresh credentials.",
-                name, name
-            )));
         }
 
+        // check_prerequisites is intentionally called after set_secrets_as_env:
+        // profile secrets (e.g. AWS_ACCESS_KEY_ID) are already injected into the
+        // process env, so prerequisites that are met via profile secrets will pass.
+        // This matches exec.rs behaviour.
         let prereq_missing = lease_config.check_prerequisites();
 
         // Acquire ledger lock only for the load → cache-check → mutate → save

--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -27,6 +27,16 @@ impl GetCommand {
         // Check if the requested key is produced by a lease backend
         if let Some(value) = self.resolve_from_lease(cli, &config, &profile).await? {
             let value = self.maybe_base64_decode(value)?;
+            // Respect as_file from the profile secret config when present
+            if let Ok(profile_secrets) = config.get_secrets(&profile) {
+                if let Some(sc) = profile_secrets.get(&self.key) {
+                    if sc.as_file {
+                        let file_path = create_persistent_secret_file("fnox-", &self.key, &value)?;
+                        println!("{}", file_path);
+                        return Ok(());
+                    }
+                }
+            }
             println!("{}", value);
             return Ok(());
         }
@@ -117,7 +127,7 @@ impl GetCommand {
         // This avoids unnecessary network calls to unrelated providers while
         // still covering every env var name the backend checks.
         let consumed: std::collections::HashSet<&str> =
-            lease_config.consumed_env_vars().into_iter().collect();
+            lease_config.consumed_env_vars().iter().copied().collect();
         let all_secrets = config.get_secrets(profile)?;
         let needed_secrets: indexmap::IndexMap<_, _> = all_secrets
             .iter()

--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -30,11 +30,12 @@ impl GetCommand {
             // Respect as_file from the profile secret config when present
             if let Ok(profile_secrets) = config.get_secrets(&profile)
                 && let Some(sc) = profile_secrets.get(&self.key)
-                    && sc.as_file {
-                        let file_path = create_persistent_secret_file("fnox-", &self.key, &value)?;
-                        println!("{}", file_path);
-                        return Ok(());
-                    }
+                && sc.as_file
+            {
+                let file_path = create_persistent_secret_file("fnox-", &self.key, &value)?;
+                println!("{}", file_path);
+                return Ok(());
+            }
             println!("{}", value);
             return Ok(());
         }

--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -139,6 +139,7 @@ impl GetCommand {
             lease::find_cached_entry(&ledger, name, &config_hash)
         };
 
+        let had_cached_entry = cached_entry.is_some();
         if let Some(entry) = cached_entry
             && let Some(creds) = lease::resolve_cached_entry(entry, config, profile, name).await
         {
@@ -146,6 +147,17 @@ impl GetCommand {
             // not discard a successfully retrieved cached credential.
             let all_secrets = config.get_secrets(profile).unwrap_or_default();
             return self.extract_key_from_creds(name, creds, all_secrets);
+        }
+
+        // A cached entry existed but decryption failed — don't silently create
+        // a new (also un-decryptable) lease that repeats the same failure cycle.
+        if had_cached_entry {
+            return Err(FnoxError::Config(format!(
+                "Lease '{}': cached credentials could not be decrypted. \
+                 Ensure the encryption provider is reachable or run \
+                 'fnox lease create -i {}' to refresh credentials.",
+                name, name
+            )));
         }
 
         // Cache miss: resolve only the consumed secrets and create a fresh lease.

--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -136,42 +136,16 @@ impl GetCommand {
         let cached_entry = {
             let _lock = LeaseLedger::lock(&project_dir)?;
             let ledger = LeaseLedger::load(&project_dir)?;
-            ledger.find_reusable(name, &config_hash).and_then(|lease| {
-                lease.cached_credentials.as_ref().map(|creds| {
-                    (
-                        creds.clone(),
-                        lease.encryption_provider.clone(),
-                        lease.lease_id.clone(),
-                    )
-                })
-            })
+            lease::find_cached_entry(&ledger, name, &config_hash)
         };
 
-        if let Some((cached_creds, enc_provider, lease_id)) = cached_entry {
-            let decrypted = if let Some(ref enc_provider_name) = enc_provider {
-                lease::try_decrypt_cached(
-                    config,
-                    profile,
-                    enc_provider_name,
-                    &cached_creds,
-                    &lease_id,
-                    name,
-                )
-                .await
-            } else {
-                tracing::debug!(
-                    "Reusing cached plaintext lease '{}' for backend '{}'",
-                    lease_id,
-                    name
-                );
-                Some(cached_creds)
-            };
-            if let Some(creds) = decrypted {
-                // as_file is a presentation hint; a get_secrets failure should
-                // not discard a successfully retrieved cached credential.
-                let all_secrets = config.get_secrets(profile).unwrap_or_default();
-                return self.extract_key_from_creds(name, creds, all_secrets);
-            }
+        if let Some(entry) = cached_entry
+            && let Some(creds) = lease::resolve_cached_entry(entry, config, profile, name).await
+        {
+            // as_file is a presentation hint; a get_secrets failure should
+            // not discard a successfully retrieved cached credential.
+            let all_secrets = config.get_secrets(profile).unwrap_or_default();
+            return self.extract_key_from_creds(name, creds, all_secrets);
         }
 
         // Cache miss: resolve only the consumed secrets and create a fresh lease.
@@ -186,14 +160,21 @@ impl GetCommand {
         let resolved_secrets =
             crate::secret_resolver::resolve_secrets_batch(config, profile, &needed_secrets).await?;
 
-        let _ledger_lock = LeaseLedger::lock(&project_dir)?;
-        let mut ledger = LeaseLedger::load(&project_dir)?;
-
         let mut temp_env_guard = lease::TempEnvGuard::default();
         let _temp_files =
             lease::set_secrets_as_env(&resolved_secrets, &needed_secrets, &mut temp_env_guard)?;
 
         let prereq_missing = lease_config.check_prerequisites();
+
+        // Acquire ledger lock only for the load → cache-check → mutate → save
+        // cycle. resolve_lease releases the lock (via the caller dropping it)
+        // before returning, but the outbound lease creation API call happens
+        // inside create_and_record_lease which needs the mutable ledger ref.
+        // This is acceptable because the lock protects ledger consistency,
+        // not the network call duration — and the lock scope is minimised
+        // compared to holding it across secret resolution above.
+        let _ledger_lock = LeaseLedger::lock(&project_dir)?;
+        let mut ledger = LeaseLedger::load(&project_dir)?;
 
         let creds = lease::resolve_lease(
             name,

--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -1,4 +1,5 @@
 use crate::error::{FnoxError, Result};
+use crate::lease::{self, LeaseLedger};
 use crate::secret_resolver::resolve_secret;
 use crate::suggest::{find_similar, format_suggestions};
 use crate::temp_file_secrets::create_persistent_secret_file;
@@ -22,6 +23,12 @@ impl GetCommand {
 
         // Validate the configuration first
         config.validate()?;
+
+        // Check if the requested key is produced by a lease backend
+        if let Some(value) = self.resolve_from_lease(cli, &config, &profile).await? {
+            println!("{}", value);
+            return Ok(());
+        }
 
         // Get the profile secrets
         let profile_secrets = config.get_secrets(&profile)?;
@@ -76,5 +83,70 @@ impl GetCommand {
             }
             Err(e) => Err(e),
         }
+    }
+
+    /// Check if the requested key is produced by a lease backend.
+    /// If so, resolve the lease and return the credential value.
+    async fn resolve_from_lease(
+        &self,
+        cli: &Cli,
+        config: &Config,
+        profile: &str,
+    ) -> Result<Option<String>> {
+        let leases = config.get_leases(profile);
+
+        // Find which lease backend (if any) produces this key
+        let matching_lease = leases.iter().find(|(_, lease_config)| {
+            let backend = match lease_config.create_backend() {
+                Ok(b) => b,
+                Err(_) => return false,
+            };
+            backend.produced_env_vars().contains(&self.key)
+        });
+
+        let Some((name, lease_config)) = matching_lease else {
+            return Ok(None);
+        };
+
+        // Set master secrets as env vars so the lease backend SDK can find them
+        let profile_secrets = config.get_secrets(profile)?;
+        let resolved_secrets =
+            crate::secret_resolver::resolve_secrets_batch(config, profile, &profile_secrets)
+                .await?;
+        let mut temp_env_guard = lease::TempEnvGuard::default();
+        let _temp_files =
+            lease::set_secrets_as_env(&resolved_secrets, &profile_secrets, &mut temp_env_guard)?;
+
+        let project_dir = lease::project_dir_from_config(config, &cli.config);
+        let _ledger_lock = LeaseLedger::lock(&project_dir)?;
+        let mut ledger = LeaseLedger::load(&project_dir)?;
+
+        let prereq_missing = lease_config.check_prerequisites();
+        if let Some(ref missing) = prereq_missing {
+            let config_hash = lease_config.config_hash();
+            if ledger
+                .find_reusable(name, &config_hash)
+                .and_then(|c| c.cached_credentials.as_ref())
+                .is_none()
+            {
+                return Err(FnoxError::Config(format!(
+                    "Lease '{}': {}\nRun 'fnox lease create -i {}' to set up credentials interactively.",
+                    name, missing, name
+                )));
+            }
+        }
+
+        let creds = lease::resolve_lease(
+            name,
+            lease_config,
+            config,
+            profile,
+            &project_dir,
+            &mut ledger,
+            prereq_missing.as_deref(),
+        )
+        .await?;
+
+        Ok(creds.get(&self.key).cloned())
     }
 }

--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -155,36 +155,33 @@ impl GetCommand {
         let mut consumed: std::collections::HashSet<&str> =
             lease_config.consumed_env_vars().iter().copied().collect();
 
-        // If the cached entry is encrypted, the encryption provider may need
-        // its own credentials (e.g. Vault transit needs VAULT_TOKEN). Include
-        // the provider's env_dependencies so they get resolved and injected.
-        if let Some(ref entry) = cached_entry
-            && let Some(ref enc_provider_name) = entry.encryption_provider
-        {
+        // Always include the default encryption provider's env deps so that
+        // create_and_record_lease can encrypt cached credentials even on a cold
+        // start (no cached_entry). Without this, the provider's credentials
+        // (e.g. VAULT_TOKEN) would never be injected and encryption would fail
+        // permanently, forcing a fresh API call on every invocation.
+        if let Ok(Some(ref default_provider_name)) = config.get_default_provider(profile) {
             let providers_map = config.get_providers(profile);
-            if let Some(provider_config) = providers_map.get(enc_provider_name) {
+            if let Some(provider_config) = providers_map.get(default_provider_name) {
                 for dep in provider_config.env_dependencies() {
                     consumed.insert(dep);
                 }
             }
         }
-        // Fetch secrets with unwrap_or_default first — if no consumed var is
-        // actually present as a profile secret, the backend authenticates via
-        // non-secret means (private_key_file, instance metadata, az CLI, etc.)
-        // and a transient secrets-config read error should not abort the command.
-        let all_secrets = config.get_secrets(profile).unwrap_or_default();
+
+        // When consumed is empty the backend needs no profile secrets (e.g. it
+        // authenticates via instance metadata). Avoid aborting on a transient
+        // secrets-config read error that would be irrelevant in that case.
+        let all_secrets = if consumed.is_empty() {
+            config.get_secrets(profile).unwrap_or_default()
+        } else {
+            config.get_secrets(profile)?
+        };
         let needed_secrets: indexmap::IndexMap<_, _> = all_secrets
             .iter()
             .filter(|(k, _)| consumed.contains(k.as_str()))
             .map(|(k, v)| (k.clone(), v.clone()))
             .collect();
-        // Re-fetch with hard error if we actually need profile secrets — the
-        // unwrap_or_default result may have silently swallowed a real failure.
-        let all_secrets = if needed_secrets.is_empty() {
-            all_secrets
-        } else {
-            config.get_secrets(profile)?
-        };
         let resolved_secrets =
             crate::secret_resolver::resolve_secrets_batch(config, profile, &needed_secrets).await?;
 

--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -123,10 +123,25 @@ impl GetCommand {
             return Ok(None);
         };
 
-        // Only resolve secrets this lease backend may consume at runtime,
-        // including all known aliases (e.g. FNOX_VAULT_TOKEN, CF_API_TOKEN).
-        // This avoids unnecessary network calls to unrelated providers while
-        // still covering every env var name the backend checks.
+        let project_dir = lease::project_dir_from_config(config, &cli.config);
+        let config_hash = lease_config.config_hash();
+
+        // Cache-first: check the ledger for a reusable lease before resolving
+        // any secrets. This avoids network calls to secret providers when the
+        // cache already has valid credentials.
+        let cached_creds = {
+            let _lock = LeaseLedger::lock(&project_dir)?;
+            let ledger = LeaseLedger::load(&project_dir)?;
+            self.try_cached_lease(&ledger, name, &config_hash, config, profile)
+                .await
+        };
+
+        if let Some(creds) = cached_creds {
+            let all_secrets = config.get_secrets(profile).unwrap_or_default();
+            return self.extract_key_from_creds(name, creds, all_secrets);
+        }
+
+        // Cache miss: resolve only the consumed secrets and create a fresh lease.
         let consumed: std::collections::HashSet<&str> =
             lease_config.consumed_env_vars().iter().copied().collect();
         let all_secrets = config.get_secrets(profile)?;
@@ -138,7 +153,6 @@ impl GetCommand {
         let resolved_secrets =
             crate::secret_resolver::resolve_secrets_batch(config, profile, &needed_secrets).await?;
 
-        let project_dir = lease::project_dir_from_config(config, &cli.config);
         let _ledger_lock = LeaseLedger::lock(&project_dir)?;
         let mut ledger = LeaseLedger::load(&project_dir)?;
 
@@ -160,6 +174,72 @@ impl GetCommand {
         )
         .await?;
 
+        self.extract_key_from_creds(name, creds, all_secrets)
+    }
+
+    /// Try to return cached credentials from the ledger without any network calls.
+    /// Returns `None` on cache miss or if decryption fails (caller should create
+    /// a fresh lease).
+    async fn try_cached_lease(
+        &self,
+        ledger: &LeaseLedger,
+        name: &str,
+        config_hash: &str,
+        config: &Config,
+        profile: &str,
+    ) -> Option<IndexMap<String, String>> {
+        let cached_lease = ledger.find_reusable(name, config_hash)?;
+        let cached_creds = cached_lease.cached_credentials.as_ref()?;
+
+        if let Some(ref enc_provider_name) = cached_lease.encryption_provider {
+            match lease::find_encryption_provider(config, profile).await {
+                lease::EncryptionProviderResult::Available(found_name, provider)
+                    if found_name == *enc_provider_name =>
+                {
+                    match lease::decrypt_credentials(provider.as_ref(), cached_creds).await {
+                        Ok(decrypted) => {
+                            tracing::debug!(
+                                "Reusing cached encrypted lease '{}' for backend '{}'",
+                                cached_lease.lease_id,
+                                name
+                            );
+                            Some(decrypted)
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                "Failed to decrypt cached lease '{}': {}, creating fresh lease",
+                                cached_lease.lease_id,
+                                e
+                            );
+                            None
+                        }
+                    }
+                }
+                _ => {
+                    tracing::warn!(
+                        "Encryption provider '{}' not available for cached lease '{}', creating fresh lease",
+                        enc_provider_name,
+                        cached_lease.lease_id
+                    );
+                    None
+                }
+            }
+        } else {
+            tracing::debug!(
+                "Reusing cached plaintext lease '{}' for backend '{}'",
+                cached_lease.lease_id,
+                name
+            );
+            Some(cached_creds.clone())
+        }
+    }
+
+    fn extract_key_from_creds(
+        &self,
+        name: &str,
+        creds: IndexMap<String, String>,
+        all_secrets: IndexMap<String, SecretConfig>,
+    ) -> Result<Option<(String, IndexMap<String, SecretConfig>)>> {
         match creds.get(&self.key) {
             Some(value) => Ok(Some((value.clone(), all_secrets))),
             None => Err(FnoxError::Config(format!(

--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -154,7 +154,14 @@ impl GetCommand {
         // 2. The backend SDK can authenticate for fresh lease creation
         let consumed: std::collections::HashSet<&str> =
             lease_config.consumed_env_vars().iter().copied().collect();
-        let all_secrets = config.get_secrets(profile)?;
+        // When consumed is empty the backend needs no profile secrets (e.g. it
+        // authenticates via instance metadata). Avoid aborting on a transient
+        // secrets-config read error that would be irrelevant in that case.
+        let all_secrets = if consumed.is_empty() {
+            config.get_secrets(profile).unwrap_or_default()
+        } else {
+            config.get_secrets(profile)?
+        };
         let needed_secrets: indexmap::IndexMap<_, _> = all_secrets
             .iter()
             .filter(|(k, _)| consumed.contains(k.as_str()))

--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -132,8 +132,7 @@ impl GetCommand {
         let cached_creds = {
             let _lock = LeaseLedger::lock(&project_dir)?;
             let ledger = LeaseLedger::load(&project_dir)?;
-            self.try_cached_lease(&ledger, name, &config_hash, config, profile)
-                .await
+            lease::try_cached_credentials(&ledger, name, &config_hash, config, profile).await
         };
 
         if let Some(creds) = cached_creds {
@@ -175,63 +174,6 @@ impl GetCommand {
         .await?;
 
         self.extract_key_from_creds(name, creds, all_secrets)
-    }
-
-    /// Try to return cached credentials from the ledger without any network calls.
-    /// Returns `None` on cache miss or if decryption fails (caller should create
-    /// a fresh lease).
-    async fn try_cached_lease(
-        &self,
-        ledger: &LeaseLedger,
-        name: &str,
-        config_hash: &str,
-        config: &Config,
-        profile: &str,
-    ) -> Option<IndexMap<String, String>> {
-        let cached_lease = ledger.find_reusable(name, config_hash)?;
-        let cached_creds = cached_lease.cached_credentials.as_ref()?;
-
-        if let Some(ref enc_provider_name) = cached_lease.encryption_provider {
-            match lease::find_encryption_provider(config, profile).await {
-                lease::EncryptionProviderResult::Available(found_name, provider)
-                    if found_name == *enc_provider_name =>
-                {
-                    match lease::decrypt_credentials(provider.as_ref(), cached_creds).await {
-                        Ok(decrypted) => {
-                            tracing::debug!(
-                                "Reusing cached encrypted lease '{}' for backend '{}'",
-                                cached_lease.lease_id,
-                                name
-                            );
-                            Some(decrypted)
-                        }
-                        Err(e) => {
-                            tracing::warn!(
-                                "Failed to decrypt cached lease '{}': {}, creating fresh lease",
-                                cached_lease.lease_id,
-                                e
-                            );
-                            None
-                        }
-                    }
-                }
-                _ => {
-                    tracing::warn!(
-                        "Encryption provider '{}' not available for cached lease '{}', creating fresh lease",
-                        enc_provider_name,
-                        cached_lease.lease_id
-                    );
-                    None
-                }
-            }
-        } else {
-            tracing::debug!(
-                "Reusing cached plaintext lease '{}' for backend '{}'",
-                cached_lease.lease_id,
-                name
-            );
-            Some(cached_creds.clone())
-        }
     }
 
     fn extract_key_from_creds(

--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -209,6 +209,10 @@ impl GetCommand {
         // This matches exec.rs behaviour.
         let prereq_missing = lease_config.check_prerequisites();
 
+        // skip_cache: true — we already performed the full cache lookup and
+        // decryption attempt above (with encryption-provider credentials
+        // injected). Skipping avoids a redundant network round-trip to the
+        // encryption provider on cache-miss.
         let creds = lease::resolve_lease(
             name,
             lease_config,
@@ -217,6 +221,7 @@ impl GetCommand {
             &project_dir,
             prereq_missing.as_deref(),
             "get",
+            true,
         )
         .await?;
 

--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -227,8 +227,12 @@ impl GetCommand {
     ) -> Result<Option<(String, IndexMap<String, SecretConfig>)>> {
         match creds.get(&self.key) {
             Some(value) => Ok(Some((value.clone(), all_secrets))),
+            // This is a backend contract violation (produces_env_var returned true
+            // but the credential map lacks the key), not a static config error.
+            // Using FnoxError::Config for now as there is no dedicated variant.
             None => Err(FnoxError::Config(format!(
-                "Lease '{}' claims to produce '{}' but returned credentials did not contain it",
+                "Lease '{}' produced credentials at runtime but the expected key '{}' was absent. \
+                 This is a backend contract violation, not a config error.",
                 name, self.key,
             ))),
         }

--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -126,41 +126,32 @@ impl GetCommand {
         let project_dir = lease::project_dir_from_config(config, &cli.config);
         let config_hash = lease_config.config_hash();
 
-        // Cache-first: check the ledger for a reusable lease before resolving
-        // any secrets. This avoids network calls to secret providers when the
-        // cache already has valid credentials.
-        //
-        // Only the synchronous ledger read is held under the file lock;
-        // decryption (which may involve async network I/O to an encryption
-        // provider) runs after the lock is released.
+        // Cache-first fast path for plaintext cached entries: no secret
+        // resolution or env injection needed, so we can return immediately.
+        // Encrypted entries are deferred until after secret injection below,
+        // since the encryption provider may need credentials from profile
+        // secrets (e.g. VAULT_TOKEN stored as a secret).
         let cached_entry = {
             let _lock = LeaseLedger::lock(&project_dir)?;
             let ledger = LeaseLedger::load(&project_dir)?;
             lease::find_cached_entry(&ledger, name, &config_hash)
         };
 
-        let had_cached_entry = cached_entry.is_some();
-        if let Some(entry) = cached_entry
-            && let Some(creds) = lease::resolve_cached_entry(entry, config, profile, name).await
+        if let Some(ref entry) = cached_entry
+            && entry.encryption_provider.is_none()
         {
-            // as_file is a presentation hint; a get_secrets failure should
-            // not discard a successfully retrieved cached credential.
+            tracing::debug!(
+                "Reusing cached plaintext lease '{}' for backend '{}'",
+                entry.lease_id,
+                name
+            );
             let all_secrets = config.get_secrets(profile).unwrap_or_default();
-            return self.extract_key_from_creds(name, creds, all_secrets);
+            return self.extract_key_from_creds(name, entry.credentials.clone(), all_secrets);
         }
 
-        // A cached entry existed but decryption failed — don't silently create
-        // a new (also un-decryptable) lease that repeats the same failure cycle.
-        if had_cached_entry {
-            return Err(FnoxError::Config(format!(
-                "Lease '{}': cached credentials could not be decrypted. \
-                 Ensure the encryption provider is reachable or run \
-                 'fnox lease create -i {}' to refresh credentials.",
-                name, name
-            )));
-        }
-
-        // Cache miss: resolve only the consumed secrets and create a fresh lease.
+        // Resolve consumed secrets and inject them as env vars so that:
+        // 1. The encryption provider can initialize (e.g. VAULT_TOKEN)
+        // 2. The backend SDK can authenticate for fresh lease creation
         let consumed: std::collections::HashSet<&str> =
             lease_config.consumed_env_vars().iter().copied().collect();
         let all_secrets = config.get_secrets(profile)?;
@@ -175,6 +166,26 @@ impl GetCommand {
         let mut temp_env_guard = lease::TempEnvGuard::default();
         let _temp_files =
             lease::set_secrets_as_env(&resolved_secrets, &needed_secrets, &mut temp_env_guard)?;
+
+        // Now that credentials are in the environment, attempt encrypted cache
+        // decryption. This must happen after set_secrets_as_env so the
+        // encryption provider (e.g. Vault) can find its credentials.
+        if let Some(entry) = cached_entry {
+            // entry.encryption_provider is guaranteed Some here (plaintext
+            // was handled above), so resolve_cached_entry will attempt decrypt.
+            if let Some(creds) = lease::resolve_cached_entry(entry, config, profile, name).await {
+                let all_secrets_for_file = config.get_secrets(profile).unwrap_or_default();
+                return self.extract_key_from_creds(name, creds, all_secrets_for_file);
+            }
+            // Decryption failed even with credentials injected — don't silently
+            // create a new (also un-decryptable) lease that repeats the cycle.
+            return Err(FnoxError::Config(format!(
+                "Lease '{}': cached credentials could not be decrypted. \
+                 Ensure the encryption provider is reachable or run \
+                 'fnox lease create -i {}' to refresh credentials.",
+                name, name
+            )));
+        }
 
         let prereq_missing = lease_config.check_prerequisites();
 

--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -174,8 +174,7 @@ impl GetCommand {
             // entry.encryption_provider is guaranteed Some here (plaintext
             // was handled above), so resolve_cached_entry will attempt decrypt.
             if let Some(creds) = lease::resolve_cached_entry(entry, config, profile, name).await {
-                let all_secrets_for_file = config.get_secrets(profile).unwrap_or_default();
-                return self.extract_key_from_creds(name, creds, all_secrets_for_file);
+                return self.extract_key_from_creds(name, creds, all_secrets.clone());
             }
             // Decryption failed even with credentials injected — don't silently
             // create a new (also un-decryptable) lease that repeats the cycle.

--- a/src/error.rs
+++ b/src/error.rs
@@ -414,6 +414,20 @@ pub enum FnoxError {
     EditorExitFailed { editor: String, status: i32 },
 
     // ========================================================================
+    // Lease Errors
+    // ========================================================================
+    #[error("Lease '{lease}' produced credentials but key '{key}' was absent")]
+    #[diagnostic(
+        code(fnox::lease::contract_violation),
+        help(
+            "The lease backend's produces_env_var() reported it provides '{key}', \
+             but the credential map returned at runtime did not contain it. \
+             This is a bug in the backend implementation."
+        )
+    )]
+    LeaseContractViolation { lease: String, key: String },
+
+    // ========================================================================
     // Command Execution Errors
     // ========================================================================
     #[error("No command specified")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -420,9 +420,11 @@ pub enum FnoxError {
     #[diagnostic(
         code(fnox::lease::contract_violation),
         help(
-            "The lease backend's produces_env_var() reported it provides '{key}', \
-             but the credential map returned at runtime did not contain it. \
-             This is a bug in the backend implementation."
+            "The lease backend '{lease}' declared it would produce env var '{key}' \
+             (via produces_env_var()), but the credential map returned at runtime \
+             did not contain it. For Vault backends, verify that the remote secret \
+             path contains the key specified in your env_map configuration. For \
+             other backends, this may indicate a bug in the backend implementation."
         )
     )]
     LeaseContractViolation { lease: String, key: String },

--- a/src/lease.rs
+++ b/src/lease.rs
@@ -508,8 +508,65 @@ pub async fn cache_credentials(
     }
 }
 
+/// Data extracted from a cached lease entry. All fields are cloned so the
+/// ledger (and its file lock) can be released before any async work.
+pub struct CachedEntry {
+    pub credentials: IndexMap<String, String>,
+    pub encryption_provider: Option<String>,
+    pub lease_id: String,
+}
+
+/// Synchronous ledger lookup: find a reusable cached entry and clone the
+/// relevant fields. This is safe to call under a file lock since it performs
+/// no I/O beyond the already-loaded ledger.
+pub fn find_cached_entry(
+    ledger: &LeaseLedger,
+    name: &str,
+    config_hash: &str,
+) -> Option<CachedEntry> {
+    let cached_lease = ledger.find_reusable(name, config_hash)?;
+    let cached_creds = cached_lease.cached_credentials.as_ref()?;
+    Some(CachedEntry {
+        credentials: cached_creds.clone(),
+        encryption_provider: cached_lease.encryption_provider.clone(),
+        lease_id: cached_lease.lease_id.clone(),
+    })
+}
+
+/// Resolve a [`CachedEntry`] into usable credentials, decrypting if needed.
+/// Returns `None` if decryption fails (caller should create a fresh lease).
+pub async fn resolve_cached_entry(
+    entry: CachedEntry,
+    config: &Config,
+    profile: &str,
+    backend_name: &str,
+) -> Option<IndexMap<String, String>> {
+    if let Some(ref enc_provider_name) = entry.encryption_provider {
+        try_decrypt_cached(
+            config,
+            profile,
+            enc_provider_name,
+            &entry.credentials,
+            &entry.lease_id,
+            backend_name,
+        )
+        .await
+    } else {
+        tracing::debug!(
+            "Reusing cached plaintext lease '{}' for backend '{}'",
+            entry.lease_id,
+            backend_name
+        );
+        Some(entry.credentials)
+    }
+}
+
 /// Try to return cached credentials from the ledger without creating a new lease.
 /// Returns `None` on cache miss, missing credentials, or if decryption fails.
+///
+/// **Note:** This performs the ledger lookup and optional decryption in a single
+/// call. When the caller holds a file lock, prefer [`find_cached_entry`] +
+/// [`resolve_cached_entry`] to release the lock before async decryption.
 pub async fn try_cached_credentials(
     ledger: &LeaseLedger,
     name: &str,
@@ -517,27 +574,8 @@ pub async fn try_cached_credentials(
     config: &Config,
     profile: &str,
 ) -> Option<IndexMap<String, String>> {
-    let cached_lease = ledger.find_reusable(name, config_hash)?;
-    let cached_creds = cached_lease.cached_credentials.as_ref()?;
-
-    if let Some(ref enc_provider_name) = cached_lease.encryption_provider {
-        try_decrypt_cached(
-            config,
-            profile,
-            enc_provider_name,
-            cached_creds,
-            &cached_lease.lease_id,
-            name,
-        )
-        .await
-    } else {
-        tracing::debug!(
-            "Reusing cached plaintext lease '{}' for backend '{}'",
-            cached_lease.lease_id,
-            name
-        );
-        Some(cached_creds.clone())
-    }
+    let entry = find_cached_entry(ledger, name, config_hash)?;
+    resolve_cached_entry(entry, config, profile, name).await
 }
 
 /// Attempt to decrypt cached credentials using the named encryption provider.

--- a/src/lease.rs
+++ b/src/lease.rs
@@ -507,6 +507,107 @@ pub async fn cache_credentials(
     }
 }
 
+/// Resolve a lease backend into credentials, reusing cached credentials when available.
+/// Shared between `fnox exec` and `fnox get`.
+pub async fn resolve_lease(
+    name: &str,
+    lease_config: &crate::lease_backends::LeaseBackendConfig,
+    config: &Config,
+    profile: &str,
+    project_dir: &Path,
+    ledger: &mut LeaseLedger,
+    prereq_missing: Option<&str>,
+) -> Result<IndexMap<String, String>> {
+    let config_hash = lease_config.config_hash();
+    if let Some(cached_lease) = ledger.find_reusable(name, &config_hash)
+        && let Some(ref cached_creds) = cached_lease.cached_credentials
+    {
+        if let Some(ref enc_provider_name) = cached_lease.encryption_provider {
+            match find_encryption_provider(config, profile).await {
+                EncryptionProviderResult::Available(found_name, provider)
+                    if found_name == *enc_provider_name =>
+                {
+                    match decrypt_credentials(provider.as_ref(), cached_creds).await {
+                        Ok(decrypted) => {
+                            tracing::debug!(
+                                "Reusing cached encrypted lease '{}' for backend '{}'",
+                                cached_lease.lease_id,
+                                name
+                            );
+                            return Ok(decrypted);
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                "Failed to decrypt cached lease '{}': {}, creating fresh lease",
+                                cached_lease.lease_id,
+                                e
+                            );
+                        }
+                    }
+                }
+                _ => {
+                    tracing::warn!(
+                        "Encryption provider '{}' not available for cached lease '{}', creating fresh lease",
+                        enc_provider_name,
+                        cached_lease.lease_id
+                    );
+                }
+            }
+        } else {
+            tracing::debug!(
+                "Reusing cached plaintext lease '{}' for backend '{}'",
+                cached_lease.lease_id,
+                name
+            );
+            return Ok(cached_creds.clone());
+        }
+    }
+
+    if let Some(missing) = prereq_missing {
+        return Err(FnoxError::Config(format!(
+            "Lease '{}': cached credentials could not be decrypted and \
+             prerequisites are missing: {}\n\
+             Run 'fnox lease create -i {}' to set up credentials interactively.",
+            name, missing, name
+        )));
+    }
+    let backend = lease_config.create_backend()?;
+
+    let duration_str = lease_config.duration().unwrap_or(DEFAULT_LEASE_DURATION);
+    let duration = parse_duration(duration_str)?;
+
+    let max_duration = backend.max_lease_duration();
+    if duration > max_duration {
+        return Err(FnoxError::Config(format!(
+            "Lease duration '{}' for '{}' exceeds maximum {:?}",
+            duration_str, name, max_duration
+        )));
+    }
+
+    let label = format!("fnox-{}", name);
+    let result = create_and_record_lease(
+        backend.as_ref(),
+        name,
+        &label,
+        duration,
+        config_hash,
+        config,
+        profile,
+        ledger,
+        project_dir,
+    )
+    .await?;
+
+    tracing::debug!(
+        "Created lease '{}' for backend '{}' (expires {:?})",
+        result.lease_id,
+        name,
+        result.expires_at
+    );
+
+    Ok(result.credentials)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/lease.rs
+++ b/src/lease.rs
@@ -535,6 +535,11 @@ pub fn find_cached_entry(
 
 /// Resolve a [`CachedEntry`] into usable credentials, decrypting if needed.
 /// Returns `None` if decryption fails (caller should create a fresh lease).
+///
+/// When called from `get.rs` the plaintext branch is unreachable because
+/// `resolve_from_lease` returns early for plaintext entries before calling
+/// this function. The plaintext path is exercised via `try_cached_credentials`
+/// → `resolve_lease` (the `fnox exec` code path).
 pub async fn resolve_cached_entry(
     entry: CachedEntry,
     config: &Config,

--- a/src/lease.rs
+++ b/src/lease.rs
@@ -538,8 +538,8 @@ pub fn find_cached_entry(
 ///
 /// When called from `get.rs` the plaintext branch is unreachable because
 /// `resolve_from_lease` returns early for plaintext entries before calling
-/// this function. The plaintext path is exercised via `try_cached_credentials`
-/// → `resolve_lease` (the `fnox exec` code path).
+/// this function. The plaintext path is exercised via `resolve_lease`'s
+/// TOCTOU cache check (shared by both `fnox exec` and `fnox get`).
 pub async fn resolve_cached_entry(
     entry: CachedEntry,
     config: &Config,
@@ -564,23 +564,6 @@ pub async fn resolve_cached_entry(
         );
         Some(entry.credentials)
     }
-}
-
-/// Try to return cached credentials from the ledger without creating a new lease.
-/// Returns `None` on cache miss, missing credentials, or if decryption fails.
-///
-/// **Note:** This performs the ledger lookup and optional decryption in a single
-/// call. When the caller holds a file lock, prefer [`find_cached_entry`] +
-/// [`resolve_cached_entry`] to release the lock before async decryption.
-pub async fn try_cached_credentials(
-    ledger: &LeaseLedger,
-    name: &str,
-    config_hash: &str,
-    config: &Config,
-    profile: &str,
-) -> Option<IndexMap<String, String>> {
-    let entry = find_cached_entry(ledger, name, config_hash)?;
-    resolve_cached_entry(entry, config, profile, name).await
 }
 
 /// Attempt to decrypt cached credentials using the named encryption provider.
@@ -629,6 +612,12 @@ pub async fn try_decrypt_cached(
 
 /// Resolve a lease backend into credentials, reusing cached credentials when available.
 /// Shared between `fnox exec` and `fnox get`.
+///
+/// Manages its own ledger locks with minimal scope: a short lock for the
+/// TOCTOU cache check (sync read, release, async decrypt), the lease creation
+/// network call and credential encryption run with no lock held, and a final
+/// short lock for the ledger write. This prevents concurrent `fnox get`/`exec`
+/// calls from serializing on a single lock for the duration of network I/O.
 #[allow(clippy::too_many_arguments)]
 pub async fn resolve_lease(
     name: &str,
@@ -636,17 +625,21 @@ pub async fn resolve_lease(
     config: &Config,
     profile: &str,
     project_dir: &Path,
-    ledger: &mut LeaseLedger,
     prereq_missing: Option<&str>,
     label_prefix: &str,
 ) -> Result<IndexMap<String, String>> {
-    // NOTE: try_cached_credentials is called again here even though `fnox get`
-    // already performed a pre-check (get.rs resolve_from_lease). This guards
-    // against a concurrent process writing a valid cache entry between that
-    // earlier check and the ledger lock acquired here. Do not remove without
-    // re-establishing that TOCTOU safety.
+    // TOCTOU cache check: sync ledger read under a short lock, then release
+    // before async decryption. Guards against a concurrent process writing a
+    // valid cache entry between an earlier check and now.
     let config_hash = lease_config.config_hash();
-    if let Some(creds) = try_cached_credentials(ledger, name, &config_hash, config, profile).await {
+    let cached_entry = {
+        let _lock = LeaseLedger::lock(project_dir)?;
+        let ledger = LeaseLedger::load(project_dir)?;
+        find_cached_entry(&ledger, name, &config_hash)
+    };
+    if let Some(entry) = cached_entry
+        && let Some(creds) = resolve_cached_entry(entry, config, profile, name).await
+    {
         return Ok(creds);
     }
 
@@ -671,19 +664,9 @@ pub async fn resolve_lease(
         )));
     }
 
+    // Create the lease (async network call) with no lock held.
     let label = format!("fnox-{}-{}", label_prefix, name);
-    let result = create_and_record_lease(
-        backend.as_ref(),
-        name,
-        &label,
-        duration,
-        config_hash,
-        config,
-        profile,
-        ledger,
-        project_dir,
-    )
-    .await?;
+    let result = backend.create_lease(duration, &label).await?;
 
     tracing::debug!(
         "Created lease '{}' for backend '{}' (expires {:?})",
@@ -691,6 +674,36 @@ pub async fn resolve_lease(
         name,
         result.expires_at
     );
+
+    // Encrypt credentials for caching (async, may call encryption provider).
+    let (cached_credentials, encryption_provider) =
+        cache_credentials(config, profile, &result.credentials, &result.lease_id).await;
+
+    // Acquire lock only for the synchronous ledger write.
+    {
+        let _lock = LeaseLedger::lock(project_dir)?;
+        let mut ledger = LeaseLedger::load(project_dir)?;
+        ledger.add(LeaseRecord {
+            lease_id: result.lease_id.clone(),
+            backend_name: name.to_string(),
+            label,
+            created_at: Utc::now(),
+            expires_at: result.expires_at,
+            revoked: false,
+            cached_credentials,
+            encryption_provider,
+            config_hash: Some(config_hash),
+        });
+        if let Err(save_err) = ledger.save(project_dir) {
+            tracing::warn!(
+                "Lease '{}' created for backend '{}' but ledger save failed: {}. \
+                 This lease is untracked and must be revoked manually.",
+                result.lease_id,
+                name,
+                save_err
+            );
+        }
+    }
 
     Ok(result.credentials)
 }

--- a/src/lease.rs
+++ b/src/lease.rs
@@ -366,25 +366,20 @@ pub async fn find_encryption_provider(config: &Config, profile: &str) -> Encrypt
     }
 }
 
-/// Create a lease, cache credentials, and record it in the ledger.
-/// Shared between `fnox exec` and `fnox lease create` to avoid duplication.
+/// Record a lease result in the ledger (add + save). No lock management —
+/// the caller must hold the ledger lock. Shared by `create_and_record_lease`
+/// and `resolve_lease` to avoid duplicating the add+save+warn pattern.
 #[allow(clippy::too_many_arguments)]
-pub async fn create_and_record_lease(
-    backend: &dyn crate::lease_backends::LeaseBackend,
+fn record_lease(
+    ledger: &mut LeaseLedger,
+    result: &crate::lease_backends::Lease,
     backend_name: &str,
     label: &str,
-    duration: std::time::Duration,
     config_hash: String,
-    config: &Config,
-    profile: &str,
-    ledger: &mut LeaseLedger,
+    cached_credentials: Option<IndexMap<String, String>>,
+    encryption_provider: Option<String>,
     project_dir: &Path,
-) -> Result<crate::lease_backends::Lease> {
-    let result = backend.create_lease(duration, label).await?;
-
-    let (cached_credentials, encryption_provider) =
-        cache_credentials(config, profile, &result.credentials, &result.lease_id).await;
-
+) {
     ledger.add(LeaseRecord {
         lease_id: result.lease_id.clone(),
         backend_name: backend_name.to_string(),
@@ -405,6 +400,37 @@ pub async fn create_and_record_lease(
             save_err
         );
     }
+}
+
+/// Create a lease, cache credentials, and record it in the ledger.
+/// Used by `fnox lease create` where the caller manages its own lock.
+#[allow(clippy::too_many_arguments)]
+pub async fn create_and_record_lease(
+    backend: &dyn crate::lease_backends::LeaseBackend,
+    backend_name: &str,
+    label: &str,
+    duration: std::time::Duration,
+    config_hash: String,
+    config: &Config,
+    profile: &str,
+    ledger: &mut LeaseLedger,
+    project_dir: &Path,
+) -> Result<crate::lease_backends::Lease> {
+    let result = backend.create_lease(duration, label).await?;
+
+    let (cached_credentials, encryption_provider) =
+        cache_credentials(config, profile, &result.credentials, &result.lease_id).await;
+
+    record_lease(
+        ledger,
+        &result,
+        backend_name,
+        label,
+        config_hash,
+        cached_credentials,
+        encryption_provider,
+        project_dir,
+    );
 
     Ok(result)
 }
@@ -614,10 +640,16 @@ pub async fn try_decrypt_cached(
 /// Shared between `fnox exec` and `fnox get`.
 ///
 /// Manages its own ledger locks with minimal scope: a short lock for the
-/// TOCTOU cache check (sync read, release, async decrypt), the lease creation
+/// cache check (sync read, release, async decrypt), the lease creation
 /// network call and credential encryption run with no lock held, and a final
 /// short lock for the ledger write. This prevents concurrent `fnox get`/`exec`
 /// calls from serializing on a single lock for the duration of network I/O.
+///
+/// When `skip_cache` is true the initial cache check is skipped entirely. Use
+/// this when the caller has already performed a cache lookup and decryption
+/// attempt (e.g. `get.rs` does its own encrypted-cache check after injecting
+/// encryption-provider credentials), avoiding a redundant network round-trip
+/// to the encryption provider on cache-miss.
 #[allow(clippy::too_many_arguments)]
 pub async fn resolve_lease(
     name: &str,
@@ -627,20 +659,24 @@ pub async fn resolve_lease(
     project_dir: &Path,
     prereq_missing: Option<&str>,
     label_prefix: &str,
+    skip_cache: bool,
 ) -> Result<IndexMap<String, String>> {
-    // TOCTOU cache check: sync ledger read under a short lock, then release
-    // before async decryption. Guards against a concurrent process writing a
-    // valid cache entry between an earlier check and now.
     let config_hash = lease_config.config_hash();
-    let cached_entry = {
-        let _lock = LeaseLedger::lock(project_dir)?;
-        let ledger = LeaseLedger::load(project_dir)?;
-        find_cached_entry(&ledger, name, &config_hash)
-    };
-    if let Some(entry) = cached_entry
-        && let Some(creds) = resolve_cached_entry(entry, config, profile, name).await
-    {
-        return Ok(creds);
+
+    if !skip_cache {
+        // Cache check: sync ledger read under a short lock, then release
+        // before async decryption. Guards against a concurrent process writing
+        // a valid cache entry between an earlier check and now.
+        let cached_entry = {
+            let _lock = LeaseLedger::lock(project_dir)?;
+            let ledger = LeaseLedger::load(project_dir)?;
+            find_cached_entry(&ledger, name, &config_hash)
+        };
+        if let Some(entry) = cached_entry
+            && let Some(creds) = resolve_cached_entry(entry, config, profile, name).await
+        {
+            return Ok(creds);
+        }
     }
 
     if let Some(missing) = prereq_missing {
@@ -683,26 +719,16 @@ pub async fn resolve_lease(
     {
         let _lock = LeaseLedger::lock(project_dir)?;
         let mut ledger = LeaseLedger::load(project_dir)?;
-        ledger.add(LeaseRecord {
-            lease_id: result.lease_id.clone(),
-            backend_name: name.to_string(),
-            label,
-            created_at: Utc::now(),
-            expires_at: result.expires_at,
-            revoked: false,
+        record_lease(
+            &mut ledger,
+            &result,
+            name,
+            &label,
+            config_hash,
             cached_credentials,
             encryption_provider,
-            config_hash: Some(config_hash),
-        });
-        if let Err(save_err) = ledger.save(project_dir) {
-            tracing::warn!(
-                "Lease '{}' created for backend '{}' but ledger save failed: {}. \
-                 This lease is untracked and must be revoked manually.",
-                result.lease_id,
-                name,
-                save_err
-            );
-        }
+            project_dir,
+        );
     }
 
     Ok(result.credentials)

--- a/src/lease.rs
+++ b/src/lease.rs
@@ -517,6 +517,7 @@ pub async fn resolve_lease(
     project_dir: &Path,
     ledger: &mut LeaseLedger,
     prereq_missing: Option<&str>,
+    label_prefix: &str,
 ) -> Result<IndexMap<String, String>> {
     let config_hash = lease_config.config_hash();
     if let Some(cached_lease) = ledger.find_reusable(name, &config_hash)
@@ -584,7 +585,7 @@ pub async fn resolve_lease(
         )));
     }
 
-    let label = format!("fnox-{}", name);
+    let label = format!("fnox-{}-{}", label_prefix, name);
     let result = create_and_record_lease(
         backend.as_ref(),
         name,

--- a/src/lease.rs
+++ b/src/lease.rs
@@ -511,6 +511,61 @@ pub async fn cache_credentials(
 /// Resolve a lease backend into credentials, reusing cached credentials when available.
 /// Shared between `fnox exec` and `fnox get`.
 #[allow(clippy::too_many_arguments)]
+/// Try to return cached credentials from the ledger without creating a new lease.
+/// Returns `None` on cache miss, missing credentials, or if decryption fails.
+pub async fn try_cached_credentials(
+    ledger: &LeaseLedger,
+    name: &str,
+    config_hash: &str,
+    config: &Config,
+    profile: &str,
+) -> Option<IndexMap<String, String>> {
+    let cached_lease = ledger.find_reusable(name, config_hash)?;
+    let cached_creds = cached_lease.cached_credentials.as_ref()?;
+
+    if let Some(ref enc_provider_name) = cached_lease.encryption_provider {
+        match find_encryption_provider(config, profile).await {
+            EncryptionProviderResult::Available(found_name, provider)
+                if found_name == *enc_provider_name =>
+            {
+                match decrypt_credentials(provider.as_ref(), cached_creds).await {
+                    Ok(decrypted) => {
+                        tracing::debug!(
+                            "Reusing cached encrypted lease '{}' for backend '{}'",
+                            cached_lease.lease_id,
+                            name
+                        );
+                        Some(decrypted)
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            "Failed to decrypt cached lease '{}': {}, creating fresh lease",
+                            cached_lease.lease_id,
+                            e
+                        );
+                        None
+                    }
+                }
+            }
+            _ => {
+                tracing::warn!(
+                    "Encryption provider '{}' not available for cached lease '{}', creating fresh lease",
+                    enc_provider_name,
+                    cached_lease.lease_id
+                );
+                None
+            }
+        }
+    } else {
+        tracing::debug!(
+            "Reusing cached plaintext lease '{}' for backend '{}'",
+            cached_lease.lease_id,
+            name
+        );
+        Some(cached_creds.clone())
+    }
+}
+
 pub async fn resolve_lease(
     name: &str,
     lease_config: &crate::lease_backends::LeaseBackendConfig,
@@ -522,48 +577,8 @@ pub async fn resolve_lease(
     label_prefix: &str,
 ) -> Result<IndexMap<String, String>> {
     let config_hash = lease_config.config_hash();
-    if let Some(cached_lease) = ledger.find_reusable(name, &config_hash)
-        && let Some(ref cached_creds) = cached_lease.cached_credentials
-    {
-        if let Some(ref enc_provider_name) = cached_lease.encryption_provider {
-            match find_encryption_provider(config, profile).await {
-                EncryptionProviderResult::Available(found_name, provider)
-                    if found_name == *enc_provider_name =>
-                {
-                    match decrypt_credentials(provider.as_ref(), cached_creds).await {
-                        Ok(decrypted) => {
-                            tracing::debug!(
-                                "Reusing cached encrypted lease '{}' for backend '{}'",
-                                cached_lease.lease_id,
-                                name
-                            );
-                            return Ok(decrypted);
-                        }
-                        Err(e) => {
-                            tracing::warn!(
-                                "Failed to decrypt cached lease '{}': {}, creating fresh lease",
-                                cached_lease.lease_id,
-                                e
-                            );
-                        }
-                    }
-                }
-                _ => {
-                    tracing::warn!(
-                        "Encryption provider '{}' not available for cached lease '{}', creating fresh lease",
-                        enc_provider_name,
-                        cached_lease.lease_id
-                    );
-                }
-            }
-        } else {
-            tracing::debug!(
-                "Reusing cached plaintext lease '{}' for backend '{}'",
-                cached_lease.lease_id,
-                name
-            );
-            return Ok(cached_creds.clone());
-        }
+    if let Some(creds) = try_cached_credentials(ledger, name, &config_hash, config, profile).await {
+        return Ok(creds);
     }
 
     if let Some(missing) = prereq_missing {

--- a/src/lease.rs
+++ b/src/lease.rs
@@ -568,7 +568,7 @@ pub async fn resolve_lease(
 
     if let Some(missing) = prereq_missing {
         return Err(FnoxError::Config(format!(
-            "Lease '{}': cached credentials could not be decrypted and \
+            "Lease '{}': no usable cached credentials and \
              prerequisites are missing: {}\n\
              Run 'fnox lease create -i {}' to set up credentials interactively.",
             name, missing, name

--- a/src/lease.rs
+++ b/src/lease.rs
@@ -508,9 +508,6 @@ pub async fn cache_credentials(
     }
 }
 
-/// Resolve a lease backend into credentials, reusing cached credentials when available.
-/// Shared between `fnox exec` and `fnox get`.
-#[allow(clippy::too_many_arguments)]
 /// Try to return cached credentials from the ledger without creating a new lease.
 /// Returns `None` on cache miss, missing credentials, or if decryption fails.
 pub async fn try_cached_credentials(
@@ -566,6 +563,9 @@ pub async fn try_cached_credentials(
     }
 }
 
+/// Resolve a lease backend into credentials, reusing cached credentials when available.
+/// Shared between `fnox exec` and `fnox get`.
+#[allow(clippy::too_many_arguments)]
 pub async fn resolve_lease(
     name: &str,
     lease_config: &crate::lease_backends::LeaseBackendConfig,

--- a/src/lease.rs
+++ b/src/lease.rs
@@ -521,38 +521,15 @@ pub async fn try_cached_credentials(
     let cached_creds = cached_lease.cached_credentials.as_ref()?;
 
     if let Some(ref enc_provider_name) = cached_lease.encryption_provider {
-        match find_encryption_provider(config, profile).await {
-            EncryptionProviderResult::Available(found_name, provider)
-                if found_name == *enc_provider_name =>
-            {
-                match decrypt_credentials(provider.as_ref(), cached_creds).await {
-                    Ok(decrypted) => {
-                        tracing::debug!(
-                            "Reusing cached encrypted lease '{}' for backend '{}'",
-                            cached_lease.lease_id,
-                            name
-                        );
-                        Some(decrypted)
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            "Failed to decrypt cached lease '{}': {}, creating fresh lease",
-                            cached_lease.lease_id,
-                            e
-                        );
-                        None
-                    }
-                }
-            }
-            _ => {
-                tracing::warn!(
-                    "Encryption provider '{}' not available for cached lease '{}', creating fresh lease",
-                    enc_provider_name,
-                    cached_lease.lease_id
-                );
-                None
-            }
-        }
+        try_decrypt_cached(
+            config,
+            profile,
+            enc_provider_name,
+            cached_creds,
+            &cached_lease.lease_id,
+            name,
+        )
+        .await
     } else {
         tracing::debug!(
             "Reusing cached plaintext lease '{}' for backend '{}'",
@@ -560,6 +537,50 @@ pub async fn try_cached_credentials(
             name
         );
         Some(cached_creds.clone())
+    }
+}
+
+/// Attempt to decrypt cached credentials using the named encryption provider.
+/// Returns `None` if the provider is unavailable or decryption fails.
+pub async fn try_decrypt_cached(
+    config: &Config,
+    profile: &str,
+    enc_provider_name: &str,
+    cached_creds: &IndexMap<String, String>,
+    lease_id: &str,
+    backend_name: &str,
+) -> Option<IndexMap<String, String>> {
+    match find_encryption_provider(config, profile).await {
+        EncryptionProviderResult::Available(found_name, provider)
+            if found_name == enc_provider_name =>
+        {
+            match decrypt_credentials(provider.as_ref(), cached_creds).await {
+                Ok(decrypted) => {
+                    tracing::debug!(
+                        "Reusing cached encrypted lease '{}' for backend '{}'",
+                        lease_id,
+                        backend_name
+                    );
+                    Some(decrypted)
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "Failed to decrypt cached lease '{}': {}, creating fresh lease",
+                        lease_id,
+                        e
+                    );
+                    None
+                }
+            }
+        }
+        _ => {
+            tracing::warn!(
+                "Encryption provider '{}' not available for cached lease '{}', creating fresh lease",
+                enc_provider_name,
+                lease_id
+            );
+            None
+        }
     }
 }
 
@@ -576,6 +597,11 @@ pub async fn resolve_lease(
     prereq_missing: Option<&str>,
     label_prefix: &str,
 ) -> Result<IndexMap<String, String>> {
+    // NOTE: try_cached_credentials is called again here even though `fnox get`
+    // already performed a pre-check (get.rs resolve_from_lease). This guards
+    // against a concurrent process writing a valid cache entry between that
+    // earlier check and the ledger lock acquired here. Do not remove without
+    // re-establishing that TOCTOU safety.
     let config_hash = lease_config.config_hash();
     if let Some(creds) = try_cached_credentials(ledger, name, &config_hash, config, profile).await {
         return Ok(creds);

--- a/src/lease.rs
+++ b/src/lease.rs
@@ -509,6 +509,7 @@ pub async fn cache_credentials(
 
 /// Resolve a lease backend into credentials, reusing cached credentials when available.
 /// Shared between `fnox exec` and `fnox get`.
+#[allow(clippy::too_many_arguments)]
 pub async fn resolve_lease(
     name: &str,
     lease_config: &crate::lease_backends::LeaseBackendConfig,

--- a/src/lease_backends/aws_sts.rs
+++ b/src/lease_backends/aws_sts.rs
@@ -136,14 +136,6 @@ impl LeaseBackend for AwsStsBackend {
         // AWS STS default max is 12 hours (can be configured per-role up to 12h)
         Duration::from_secs(12 * 3600)
     }
-
-    fn produced_env_vars(&self) -> Vec<String> {
-        vec![
-            "AWS_ACCESS_KEY_ID".to_string(),
-            "AWS_SECRET_ACCESS_KEY".to_string(),
-            "AWS_SESSION_TOKEN".to_string(),
-        ]
-    }
 }
 
 /// Sanitize a string for use as an AWS STS role session name.

--- a/src/lease_backends/aws_sts.rs
+++ b/src/lease_backends/aws_sts.rs
@@ -15,6 +15,8 @@ pub const CONSUMED_ENV_VARS: &[&str] = &[
     "AWS_SESSION_TOKEN",
     "AWS_PROFILE",
     "AWS_SSO_SESSION",
+    "AWS_CONFIG_FILE",
+    "AWS_SHARED_CREDENTIALS_FILE",
 ];
 
 pub struct AwsStsBackend {

--- a/src/lease_backends/aws_sts.rs
+++ b/src/lease_backends/aws_sts.rs
@@ -136,6 +136,14 @@ impl LeaseBackend for AwsStsBackend {
         // AWS STS default max is 12 hours (can be configured per-role up to 12h)
         Duration::from_secs(12 * 3600)
     }
+
+    fn produced_env_vars(&self) -> Vec<String> {
+        vec![
+            "AWS_ACCESS_KEY_ID".to_string(),
+            "AWS_SECRET_ACCESS_KEY".to_string(),
+            "AWS_SESSION_TOKEN".to_string(),
+        ]
+    }
 }
 
 /// Sanitize a string for use as an AWS STS role session name.

--- a/src/lease_backends/aws_sts.rs
+++ b/src/lease_backends/aws_sts.rs
@@ -8,6 +8,15 @@ use std::time::Duration;
 
 const URL: &str = "https://fnox.jdx.dev/leases/aws-sts";
 
+/// All env var names the AWS STS backend may consume at runtime.
+pub const CONSUMED_ENV_VARS: &[&str] = &[
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN",
+    "AWS_PROFILE",
+    "AWS_SSO_SESSION",
+];
+
 pub struct AwsStsBackend {
     region: String,
     profile: Option<String>,

--- a/src/lease_backends/aws_sts.rs
+++ b/src/lease_backends/aws_sts.rs
@@ -24,6 +24,8 @@ pub const CONSUMED_ENV_VARS: &[&str] = &[
     "AWS_SSO_SESSION",
     "AWS_CONFIG_FILE",
     "AWS_SHARED_CREDENTIALS_FILE",
+    "AWS_DEFAULT_REGION",
+    "AWS_REGION",
 ];
 
 /// Check if AWS credentials are available.

--- a/src/lease_backends/aws_sts.rs
+++ b/src/lease_backends/aws_sts.rs
@@ -8,6 +8,13 @@ use std::time::Duration;
 
 const URL: &str = "https://fnox.jdx.dev/leases/aws-sts";
 
+/// Env var names produced by the AWS STS backend (AssumeRole credentials).
+pub const PRODUCED_ENV_VARS: &[&str] = &[
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN",
+];
+
 /// All env var names the AWS STS backend may consume at runtime.
 pub const CONSUMED_ENV_VARS: &[&str] = &[
     "AWS_ACCESS_KEY_ID",

--- a/src/lease_backends/azure_token.rs
+++ b/src/lease_backends/azure_token.rs
@@ -102,4 +102,8 @@ impl LeaseBackend for AzureTokenBackend {
         // Azure controls token lifetime (~1 hour), not configurable by caller
         Duration::from_secs(3600)
     }
+
+    fn produced_env_vars(&self) -> Vec<String> {
+        vec![self.env_var.clone()]
+    }
 }

--- a/src/lease_backends/azure_token.rs
+++ b/src/lease_backends/azure_token.rs
@@ -102,8 +102,4 @@ impl LeaseBackend for AzureTokenBackend {
         // Azure controls token lifetime (~1 hour), not configurable by caller
         Duration::from_secs(3600)
     }
-
-    fn produced_env_vars(&self) -> Vec<String> {
-        vec![self.env_var.clone()]
-    }
 }

--- a/src/lease_backends/azure_token.rs
+++ b/src/lease_backends/azure_token.rs
@@ -8,6 +8,10 @@ use std::time::Duration;
 
 const URL: &str = "https://fnox.jdx.dev/leases/azure-token";
 
+/// All env var names the Azure Token backend may consume at runtime.
+pub const CONSUMED_ENV_VARS: &[&str] =
+    &["AZURE_CLIENT_ID", "AZURE_CLIENT_SECRET", "AZURE_TENANT_ID"];
+
 pub struct AzureTokenBackend {
     scope: String,
     env_var: String,

--- a/src/lease_backends/command.rs
+++ b/src/lease_backends/command.rs
@@ -169,9 +169,4 @@ impl LeaseBackend for CommandBackend {
     fn max_lease_duration(&self) -> Duration {
         Duration::from_secs(24 * 3600)
     }
-
-    fn produced_env_vars(&self) -> Vec<String> {
-        // Command backend output keys are dynamic, not known statically
-        vec![]
-    }
 }

--- a/src/lease_backends/command.rs
+++ b/src/lease_backends/command.rs
@@ -169,4 +169,9 @@ impl LeaseBackend for CommandBackend {
     fn max_lease_duration(&self) -> Duration {
         Duration::from_secs(24 * 3600)
     }
+
+    fn produced_env_vars(&self) -> Vec<String> {
+        // Command backend output keys are dynamic, not known statically
+        vec![]
+    }
 }

--- a/src/lease_backends/command.rs
+++ b/src/lease_backends/command.rs
@@ -7,7 +7,10 @@ use tokio::process::Command;
 
 const URL: &str = "https://fnox.jdx.dev/leases/command";
 
-/// All env var names the Command backend may consume at runtime.
+/// Command backends can consume arbitrary env vars (determined at runtime),
+/// but `fnox get` never routes through a Command backend because
+/// `produces_env_var` always returns `false` for this variant.
+/// This constant is intentionally empty and unused by the current routing logic.
 pub const CONSUMED_ENV_VARS: &[&str] = &[];
 
 pub fn check_prerequisites() -> Option<String> {

--- a/src/lease_backends/command.rs
+++ b/src/lease_backends/command.rs
@@ -7,6 +7,9 @@ use tokio::process::Command;
 
 const URL: &str = "https://fnox.jdx.dev/leases/command";
 
+/// All env var names the Command backend may consume at runtime.
+pub const CONSUMED_ENV_VARS: &[&str] = &[];
+
 pub struct CommandBackend {
     create_command: String,
     revoke_command: Option<String>,

--- a/src/lease_backends/gcp_iam.rs
+++ b/src/lease_backends/gcp_iam.rs
@@ -154,4 +154,8 @@ impl LeaseBackend for GcpIamBackend {
         // GCP default max is 1 hour (3600s); can be extended to 12h with org policy
         Duration::from_secs(3600)
     }
+
+    fn produced_env_vars(&self) -> Vec<String> {
+        vec![self.env_var.clone()]
+    }
 }

--- a/src/lease_backends/gcp_iam.rs
+++ b/src/lease_backends/gcp_iam.rs
@@ -6,6 +6,10 @@ use std::time::Duration;
 
 const URL: &str = "https://fnox.jdx.dev/leases/gcp-iam";
 
+/// All env var names the GCP IAM backend may consume at runtime.
+pub const CONSUMED_ENV_VARS: &[&str] =
+    &["GOOGLE_APPLICATION_CREDENTIALS", "GCP_SERVICE_ACCOUNT_KEY"];
+
 pub struct GcpIamBackend {
     service_account_email: String,
     scopes: Vec<String>,

--- a/src/lease_backends/gcp_iam.rs
+++ b/src/lease_backends/gcp_iam.rs
@@ -154,8 +154,4 @@ impl LeaseBackend for GcpIamBackend {
         // GCP default max is 1 hour (3600s); can be extended to 12h with org policy
         Duration::from_secs(3600)
     }
-
-    fn produced_env_vars(&self) -> Vec<String> {
-        vec![self.env_var.clone()]
-    }
 }

--- a/src/lease_backends/github_app.rs
+++ b/src/lease_backends/github_app.rs
@@ -14,6 +14,9 @@ const MAX_DURATION_SECS: u64 = 3600;
 /// JWT expiration — GitHub accepts up to 10 minutes
 const JWT_EXPIRY_SECS: i64 = 600;
 
+/// All env var names the GitHub App backend may consume at runtime.
+pub const CONSUMED_ENV_VARS: &[&str] = &["FNOX_GITHUB_APP_PRIVATE_KEY"];
+
 pub fn check_prerequisites(private_key_file: &Option<String>) -> Option<String> {
     let has_key = std::env::var("FNOX_GITHUB_APP_PRIVATE_KEY").is_ok()
         || private_key_file

--- a/src/lease_backends/mod.rs
+++ b/src/lease_backends/mod.rs
@@ -240,24 +240,14 @@ impl LeaseBackendConfig {
         }
     }
 
-    /// Environment variable keys this backend produces.
-    ///
-    /// Used by `fnox get` to match a requested key to a lease backend without
-    /// instantiating the backend.
-    ///
-    /// **Note:** The `command` backend returns an empty vector because its output
-    /// keys are dynamic (determined at runtime by the command's JSON output).
-    /// As a result, `fnox get <key>` cannot resolve credentials from command
-    /// lease backends — use `fnox exec` or `fnox lease create` instead.
-    pub fn produced_env_vars(&self) -> Vec<&str> {
+    /// Zero-allocation check whether this backend produces the given env var key.
+    pub fn produces_env_var(&self, key: &str) -> bool {
         match self {
-            LeaseBackendConfig::AwsSts { .. } => aws_sts::PRODUCED_ENV_VARS.to_vec(),
-            LeaseBackendConfig::GcpIam { env_var, .. } => vec![env_var.as_str()],
-            LeaseBackendConfig::Vault { env_map, .. } => {
-                env_map.values().map(|s| s.as_str()).collect()
-            }
-            LeaseBackendConfig::AzureToken { env_var, .. } => vec![env_var.as_str()],
-            LeaseBackendConfig::Command { .. } => vec![],
+            LeaseBackendConfig::AwsSts { .. } => aws_sts::PRODUCED_ENV_VARS.contains(&key),
+            LeaseBackendConfig::GcpIam { env_var, .. } => env_var == key,
+            LeaseBackendConfig::Vault { env_map, .. } => env_map.values().any(|v| v == key),
+            LeaseBackendConfig::AzureToken { env_var, .. } => env_var == key,
+            LeaseBackendConfig::Command { .. } => false,
         }
     }
 

--- a/src/lease_backends/mod.rs
+++ b/src/lease_backends/mod.rs
@@ -36,9 +36,6 @@ pub trait LeaseBackend: Send + Sync {
 
     /// Maximum allowed lease duration
     fn max_lease_duration(&self) -> Duration;
-
-    /// Environment variable keys this backend produces
-    fn produced_env_vars(&self) -> Vec<String>;
 }
 
 fn default_gcp_scopes() -> Vec<String> {
@@ -239,6 +236,25 @@ impl LeaseBackendConfig {
                 ("AZURE_CLIENT_SECRET", "Azure client secret"),
                 ("AZURE_TENANT_ID", "Azure tenant (directory) ID"),
             ],
+            LeaseBackendConfig::Command { .. } => vec![],
+        }
+    }
+
+    /// Environment variable keys this backend produces.
+    ///
+    /// Used by `fnox get` to match a requested key to a lease backend without
+    /// instantiating the backend. Backends with dynamic keys (like `command`)
+    /// return an empty vector — `fnox get` cannot resolve their credentials.
+    pub fn produced_env_vars(&self) -> Vec<String> {
+        match self {
+            LeaseBackendConfig::AwsSts { .. } => vec![
+                "AWS_ACCESS_KEY_ID".to_string(),
+                "AWS_SECRET_ACCESS_KEY".to_string(),
+                "AWS_SESSION_TOKEN".to_string(),
+            ],
+            LeaseBackendConfig::GcpIam { env_var, .. } => vec![env_var.clone()],
+            LeaseBackendConfig::Vault { env_map, .. } => env_map.values().cloned().collect(),
+            LeaseBackendConfig::AzureToken { env_var, .. } => vec![env_var.clone()],
             LeaseBackendConfig::Command { .. } => vec![],
         }
     }

--- a/src/lease_backends/mod.rs
+++ b/src/lease_backends/mod.rs
@@ -36,6 +36,9 @@ pub trait LeaseBackend: Send + Sync {
 
     /// Maximum allowed lease duration
     fn max_lease_duration(&self) -> Duration;
+
+    /// Environment variable keys this backend produces
+    fn produced_env_vars(&self) -> Vec<String>;
 }
 
 fn default_gcp_scopes() -> Vec<String> {

--- a/src/lease_backends/mod.rs
+++ b/src/lease_backends/mod.rs
@@ -187,7 +187,7 @@ impl LeaseBackendConfig {
             LeaseBackendConfig::Vault { env_map, .. } => env_map.values().any(|v| v == key),
             LeaseBackendConfig::AzureToken { env_var, .. } => env_var == key,
             LeaseBackendConfig::Command { .. } => false,
-            LeaseBackendConfig::Cloudflare { .. } => false,
+            LeaseBackendConfig::Cloudflare { env_var, .. } => env_var == key,
         }
     }
 

--- a/src/lease_backends/mod.rs
+++ b/src/lease_backends/mod.rs
@@ -223,6 +223,7 @@ impl LeaseBackendConfig {
             LeaseBackendConfig::AzureToken { env_var, .. } => env_var == key,
             LeaseBackendConfig::Command { .. } => false,
             LeaseBackendConfig::Cloudflare { env_var, .. } => env_var == key,
+            LeaseBackendConfig::GithubApp { env_var, .. } => env_var == key,
         }
     }
 
@@ -238,6 +239,7 @@ impl LeaseBackendConfig {
             LeaseBackendConfig::AzureToken { .. } => azure_token::CONSUMED_ENV_VARS,
             LeaseBackendConfig::Command { .. } => command::CONSUMED_ENV_VARS,
             LeaseBackendConfig::Cloudflare { .. } => cloudflare::CONSUMED_ENV_VARS,
+            LeaseBackendConfig::GithubApp { .. } => github_app::CONSUMED_ENV_VARS,
         }
     }
 

--- a/src/lease_backends/mod.rs
+++ b/src/lease_backends/mod.rs
@@ -251,11 +251,7 @@ impl LeaseBackendConfig {
     /// lease backends — use `fnox exec` or `fnox lease create` instead.
     pub fn produced_env_vars(&self) -> Vec<&str> {
         match self {
-            LeaseBackendConfig::AwsSts { .. } => vec![
-                "AWS_ACCESS_KEY_ID",
-                "AWS_SECRET_ACCESS_KEY",
-                "AWS_SESSION_TOKEN",
-            ],
+            LeaseBackendConfig::AwsSts { .. } => aws_sts::PRODUCED_ENV_VARS.to_vec(),
             LeaseBackendConfig::GcpIam { env_var, .. } => vec![env_var.as_str()],
             LeaseBackendConfig::Vault { env_map, .. } => {
                 env_map.values().map(|s| s.as_str()).collect()

--- a/src/lease_backends/mod.rs
+++ b/src/lease_backends/mod.rs
@@ -243,8 +243,12 @@ impl LeaseBackendConfig {
     /// Environment variable keys this backend produces.
     ///
     /// Used by `fnox get` to match a requested key to a lease backend without
-    /// instantiating the backend. Backends with dynamic keys (like `command`)
-    /// return an empty vector — `fnox get` cannot resolve their credentials.
+    /// instantiating the backend.
+    ///
+    /// **Note:** The `command` backend returns an empty vector because its output
+    /// keys are dynamic (determined at runtime by the command's JSON output).
+    /// As a result, `fnox get <key>` cannot resolve credentials from command
+    /// lease backends — use `fnox exec` or `fnox lease create` instead.
     pub fn produced_env_vars(&self) -> Vec<String> {
         match self {
             LeaseBackendConfig::AwsSts { .. } => vec![

--- a/src/lease_backends/mod.rs
+++ b/src/lease_backends/mod.rs
@@ -249,16 +249,47 @@ impl LeaseBackendConfig {
     /// keys are dynamic (determined at runtime by the command's JSON output).
     /// As a result, `fnox get <key>` cannot resolve credentials from command
     /// lease backends — use `fnox exec` or `fnox lease create` instead.
-    pub fn produced_env_vars(&self) -> Vec<String> {
+    pub fn produced_env_vars(&self) -> Vec<&str> {
         match self {
             LeaseBackendConfig::AwsSts { .. } => vec![
-                "AWS_ACCESS_KEY_ID".to_string(),
-                "AWS_SECRET_ACCESS_KEY".to_string(),
-                "AWS_SESSION_TOKEN".to_string(),
+                "AWS_ACCESS_KEY_ID",
+                "AWS_SECRET_ACCESS_KEY",
+                "AWS_SESSION_TOKEN",
             ],
-            LeaseBackendConfig::GcpIam { env_var, .. } => vec![env_var.clone()],
-            LeaseBackendConfig::Vault { env_map, .. } => env_map.values().cloned().collect(),
-            LeaseBackendConfig::AzureToken { env_var, .. } => vec![env_var.clone()],
+            LeaseBackendConfig::GcpIam { env_var, .. } => vec![env_var.as_str()],
+            LeaseBackendConfig::Vault { env_map, .. } => {
+                env_map.values().map(|s| s.as_str()).collect()
+            }
+            LeaseBackendConfig::AzureToken { env_var, .. } => vec![env_var.as_str()],
+            LeaseBackendConfig::Command { .. } => vec![],
+        }
+    }
+
+    /// All env var names this backend may consume at runtime, including aliases.
+    /// Used by `fnox get` to filter which profile secrets to resolve before
+    /// creating a lease. Includes both canonical names from `required_env_vars()`
+    /// and runtime aliases (e.g. `FNOX_VAULT_TOKEN`, `CF_API_TOKEN`).
+    pub fn consumed_env_vars(&self) -> Vec<&str> {
+        match self {
+            LeaseBackendConfig::AwsSts { .. } => vec![
+                "AWS_ACCESS_KEY_ID",
+                "AWS_SECRET_ACCESS_KEY",
+                "AWS_SESSION_TOKEN",
+                "AWS_PROFILE",
+                "AWS_SSO_SESSION",
+            ],
+            LeaseBackendConfig::GcpIam { .. } => {
+                vec!["GOOGLE_APPLICATION_CREDENTIALS", "GCP_SERVICE_ACCOUNT_KEY"]
+            }
+            LeaseBackendConfig::Vault { .. } => vec![
+                "VAULT_ADDR",
+                "FNOX_VAULT_ADDR",
+                "VAULT_TOKEN",
+                "FNOX_VAULT_TOKEN",
+            ],
+            LeaseBackendConfig::AzureToken { .. } => {
+                vec!["AZURE_CLIENT_ID", "AZURE_CLIENT_SECRET", "AZURE_TENANT_ID"]
+            }
             LeaseBackendConfig::Command { .. } => vec![],
         }
     }

--- a/src/lease_backends/mod.rs
+++ b/src/lease_backends/mod.rs
@@ -267,30 +267,15 @@ impl LeaseBackendConfig {
 
     /// All env var names this backend may consume at runtime, including aliases.
     /// Used by `fnox get` to filter which profile secrets to resolve before
-    /// creating a lease. Includes both canonical names from `required_env_vars()`
-    /// and runtime aliases (e.g. `FNOX_VAULT_TOKEN`, `CF_API_TOKEN`).
-    pub fn consumed_env_vars(&self) -> Vec<&str> {
+    /// creating a lease. Each backend defines its own `CONSUMED_ENV_VARS` constant
+    /// covering both canonical names and runtime aliases.
+    pub fn consumed_env_vars(&self) -> &'static [&'static str] {
         match self {
-            LeaseBackendConfig::AwsSts { .. } => vec![
-                "AWS_ACCESS_KEY_ID",
-                "AWS_SECRET_ACCESS_KEY",
-                "AWS_SESSION_TOKEN",
-                "AWS_PROFILE",
-                "AWS_SSO_SESSION",
-            ],
-            LeaseBackendConfig::GcpIam { .. } => {
-                vec!["GOOGLE_APPLICATION_CREDENTIALS", "GCP_SERVICE_ACCOUNT_KEY"]
-            }
-            LeaseBackendConfig::Vault { .. } => vec![
-                "VAULT_ADDR",
-                "FNOX_VAULT_ADDR",
-                "VAULT_TOKEN",
-                "FNOX_VAULT_TOKEN",
-            ],
-            LeaseBackendConfig::AzureToken { .. } => {
-                vec!["AZURE_CLIENT_ID", "AZURE_CLIENT_SECRET", "AZURE_TENANT_ID"]
-            }
-            LeaseBackendConfig::Command { .. } => vec![],
+            LeaseBackendConfig::AwsSts { .. } => aws_sts::CONSUMED_ENV_VARS,
+            LeaseBackendConfig::GcpIam { .. } => gcp_iam::CONSUMED_ENV_VARS,
+            LeaseBackendConfig::Vault { .. } => vault::CONSUMED_ENV_VARS,
+            LeaseBackendConfig::AzureToken { .. } => azure_token::CONSUMED_ENV_VARS,
+            LeaseBackendConfig::Command { .. } => command::CONSUMED_ENV_VARS,
         }
     }
 

--- a/src/lease_backends/vault.rs
+++ b/src/lease_backends/vault.rs
@@ -7,6 +7,14 @@ use std::time::Duration;
 
 const URL: &str = "https://fnox.jdx.dev/leases/vault";
 
+/// All env var names the Vault backend may consume at runtime.
+pub const CONSUMED_ENV_VARS: &[&str] = &[
+    "VAULT_ADDR",
+    "FNOX_VAULT_ADDR",
+    "VAULT_TOKEN",
+    "FNOX_VAULT_TOKEN",
+];
+
 pub struct VaultBackend {
     address: String,
     token: String,

--- a/src/lease_backends/vault.rs
+++ b/src/lease_backends/vault.rs
@@ -13,6 +13,7 @@ pub const CONSUMED_ENV_VARS: &[&str] = &[
     "FNOX_VAULT_ADDR",
     "VAULT_TOKEN",
     "FNOX_VAULT_TOKEN",
+    "VAULT_NAMESPACE",
 ];
 
 pub fn check_prerequisites(address: &Option<String>, token: &Option<String>) -> Option<String> {

--- a/src/lease_backends/vault.rs
+++ b/src/lease_backends/vault.rs
@@ -267,4 +267,8 @@ impl LeaseBackend for VaultBackend {
     fn max_lease_duration(&self) -> Duration {
         Duration::from_secs(24 * 3600)
     }
+
+    fn produced_env_vars(&self) -> Vec<String> {
+        self.env_map.values().cloned().collect()
+    }
 }

--- a/src/lease_backends/vault.rs
+++ b/src/lease_backends/vault.rs
@@ -267,8 +267,4 @@ impl LeaseBackend for VaultBackend {
     fn max_lease_duration(&self) -> Duration {
         Duration::from_secs(24 * 3600)
     }
-
-    fn produced_env_vars(&self) -> Vec<String> {
-        self.env_map.values().cloned().collect()
-    }
 }

--- a/src/lease_backends/vault.rs
+++ b/src/lease_backends/vault.rs
@@ -14,6 +14,12 @@ pub const CONSUMED_ENV_VARS: &[&str] = &[
     "VAULT_TOKEN",
     "FNOX_VAULT_TOKEN",
     "VAULT_NAMESPACE",
+    "VAULT_CACERT",
+    "VAULT_CAPATH",
+    "VAULT_SKIP_VERIFY",
+    "VAULT_CLIENT_CERT",
+    "VAULT_CLIENT_KEY",
+    "VAULT_TLS_SERVER_NAME",
 ];
 
 pub fn check_prerequisites(address: &Option<String>, token: &Option<String>) -> Option<String> {


### PR DESCRIPTION
## Summary
- Adds `produced_env_vars()` to the `LeaseBackend` trait so each backend declares which env var keys it produces
- `fnox get` now checks lease backends first — if the requested key matches a lease backend's output, it resolves the lease (with caching) before falling back to provider secrets
- Extracts `resolve_lease` from `exec.rs` into `lease.rs` as a shared function for both `fnox exec` and `fnox get`

## Test plan
- [ ] `fnox get AWS_ACCESS_KEY_ID` returns the leased credential (not the master secret) when an AWS STS lease is configured
- [ ] `fnox get SOME_PROVIDER_SECRET` still works for non-lease keys
- [ ] `fnox exec` still resolves leases correctly (regression check)
- [ ] Cached leases are reused by `fnox get`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch credential leasing, caching/encryption, and environment injection paths used by `fnox exec`/`get`, so regressions could affect secret retrieval or lease reuse behaviour, though the scope is localized and mostly refactoring/extension.
> 
> **Overview**
> `fnox get` now detects when the requested key is produced by a configured lease backend and resolves that lease (reusing cached credentials when possible) before falling back to normal secret/provider resolution, including honoring `as_file` output.
> 
> Lease handling is refactored: the lease resolution/caching logic previously embedded in `exec` is moved into `lease.rs` as a shared `resolve_lease` that uses short-lived ledger locks (read → unlock → async work → write) to reduce cross-process contention, and `fnox get` injects only the backend/encryption-provider *consumed* secrets into the environment when needed.
> 
> Backends now declare which env vars they may consume (and AWS STS which it produces), and a new `FnoxError::LeaseContractViolation` surfaces when a backend claims to produce a key but does not return it at runtime; housekeeping updates include `hk.pkl` linter tweaks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f6736ad6eccfe4dae49b0518f531e6e6792d4774. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->