### PR TITLE
fix(exec): forward signals to child and exit silently on failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2251,6 +2251,7 @@ dependencies = [
  "keyring",
  "miette",
  "miniz_oxide",
+ "nix 0.31.2",
  "openssl-sys",
  "pluralizer",
  "proc-macro2",
@@ -2269,6 +2270,7 @@ dependencies = [
  "sha2",
  "shellexpand",
  "shlex",
+ "signal-hook 0.4.3",
  "strsim",
  "strum 0.27.2",
  "tabled",
@@ -2995,7 +2997,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68df315d2857b2d8d2898be54a85e1d001bbbe0dbb5f8ef847b48dd3a23c4527"
 dependencies = [
  "cfg-if",
- "nix",
+ "nix 0.30.1",
  "widestring",
  "windows",
 ]
@@ -3913,6 +3915,18 @@ name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,8 @@ walkdir = "2"
 xx = { version = "2", features = ["fslock"] }
 which = "7"
 yubico_manager = "0.9"
+signal-hook = "0.4.3"
+nix = { version = "0.31.2", features = ["signal", "process"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 dbus = { version = "0.9", features = ["vendored"] }

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -158,24 +158,39 @@ impl ExecCommand {
         // from the parent process environment so the child doesn't inherit them.
         drop(_temp_env_guard);
 
-        let status = cmd
-            .status()
-            .map_err(|e| FnoxError::CommandExecutionFailed {
-                command: self.command.join(" "),
-                source: e,
-            })?;
-
-        if !status.success()
-            && let Some(code) = status.code()
+        // On Unix, replace the fnox process with the child via exec(2).
+        // This avoids an extra process wrapper and ensures signals are
+        // delivered directly to the child. Temp files are intentionally
+        // leaked since our destructors won't run after exec.
+        #[cfg(unix)]
         {
-            return Err(FnoxError::CommandExitFailed {
+            use std::os::unix::process::CommandExt;
+            // Persist temp files so they survive exec (drop would delete them)
+            for tf in _temp_files {
+                tf.into_temp_path().keep().ok();
+            }
+            let err = cmd.exec();
+            return Err(FnoxError::CommandExecutionFailed {
                 command: self.command.join(" "),
-                status: code,
+                source: err,
             });
         }
 
-        // Temp files are automatically deleted when _temp_files goes out of scope
-        Ok(())
+        #[cfg(not(unix))]
+        {
+            let status = cmd
+                .status()
+                .map_err(|e| FnoxError::CommandExecutionFailed {
+                    command: self.command.join(" "),
+                    source: e,
+                })?;
+
+            if !status.success() {
+                std::process::exit(status.code().unwrap_or(1));
+            }
+
+            Ok(())
+        }
     }
 }
 

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -158,39 +158,53 @@ impl ExecCommand {
         // from the parent process environment so the child doesn't inherit them.
         drop(_temp_env_guard);
 
-        // On Unix, replace the fnox process with the child via exec(2).
-        // This avoids an extra process wrapper and ensures signals are
-        // delivered directly to the child. Temp files are intentionally
-        // leaked since our destructors won't run after exec.
+        let mut child = cmd.spawn().map_err(|e| FnoxError::CommandExecutionFailed {
+            command: self.command.join(" "),
+            source: e,
+        })?;
+
+        // Forward SIGINT/SIGTERM to the child so Ctrl-C and `kill` reach it.
         #[cfg(unix)]
         {
-            use std::os::unix::process::CommandExt;
-            // Persist temp files so they survive exec (drop would delete them)
-            for tf in _temp_files {
-                tf.into_temp_path().keep().ok();
+            let child_pid = nix::unistd::Pid::from_raw(child.id() as i32);
+            unsafe {
+                // Ignore signals in the parent — the child handles them.
+                // When the child exits we propagate its exit code below.
+                signal_hook::low_level::register(signal_hook::consts::SIGINT, move || {
+                    nix::sys::signal::kill(child_pid, nix::sys::signal::SIGINT).ok();
+                })
+                .ok();
+                signal_hook::low_level::register(signal_hook::consts::SIGTERM, move || {
+                    nix::sys::signal::kill(child_pid, nix::sys::signal::SIGTERM).ok();
+                })
+                .ok();
             }
-            let err = cmd.exec();
-            return Err(FnoxError::CommandExecutionFailed {
+        }
+
+        let status = child
+            .wait()
+            .map_err(|e| FnoxError::CommandExecutionFailed {
                 command: self.command.join(" "),
-                source: err,
-            });
-        }
+                source: e,
+            })?;
 
-        #[cfg(not(unix))]
-        {
-            let status = cmd
-                .status()
-                .map_err(|e| FnoxError::CommandExecutionFailed {
-                    command: self.command.join(" "),
-                    source: e,
-                })?;
+        // Temp files are cleaned up when _temp_files drops here
+        drop(_temp_files);
 
-            if !status.success() {
-                std::process::exit(status.code().unwrap_or(1));
+        if !status.success() {
+            // Exit silently — the child already printed its own errors.
+            #[cfg(unix)]
+            {
+                use std::os::unix::process::ExitStatusExt;
+                // If killed by signal, exit with 128+signal (standard convention)
+                if let Some(sig) = status.signal() {
+                    std::process::exit(128 + sig);
+                }
             }
-
-            Ok(())
+            std::process::exit(status.code().unwrap_or(1));
         }
+
+        Ok(())
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -432,10 +432,6 @@ pub enum FnoxError {
         source: std::io::Error,
     },
 
-    #[error("Command exited with status {status}: {command}")]
-    #[diagnostic(code(fnox::command::exit_failed))]
-    CommandExitFailed { command: String, status: i32 },
-
     // ========================================================================
     // Import Errors
     // ========================================================================


### PR DESCRIPTION
## Summary
- Replace `exec(2)` with `spawn` + `wait` so Rust destructors run and `as_file` temp files are properly cleaned up
- Forward SIGINT/SIGTERM to the child process via `signal-hook` + `nix` so Ctrl-C and `kill` reach it
- Exit silently with the child's exit code (128+signal for signal deaths) instead of printing a noisy fnox error message
- Adds `signal-hook` and `nix` (signal, process features) as dependencies

## Test plan
- [x] `test/file_secrets.bats` passes — temp files are cleaned up after exec
- [ ] CI passes on both ubuntu and macos
- [ ] Ctrl-C during `fnox exec -- sleep 60` kills the child

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes process lifecycle and Unix signal handling for `fnox exec`, which can affect termination semantics and exit codes across platforms.
> 
> **Overview**
> `fnox exec` now spawns the subprocess and, on Unix, forwards `SIGINT`/`SIGTERM` to the child so Ctrl-C/`kill` behave as expected.
> 
> On subprocess failure, `exec` no longer returns a `FnoxError`; it exits silently with the child’s exit status (including `128+signal` when terminated by a signal), and the `CommandExitFailed` error variant is removed.
> 
> Adds `signal-hook` and `nix` (signal/process features) dependencies and updates `Cargo.lock` accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit faea52c15527626faae5a371cbda0dd7a99516e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->