### PR TITLE
chore: share Rust cache across CI jobs

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -26,7 +26,8 @@ jobs:
           submodules: recursive
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
         with:
-          shared-key: autofix
+          shared-key: debug-ubuntu-latest
+          save-if: false
       - name: Install system dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
           submodules: recursive
       - uses: jdx/mise-action@e79ddf65a11cec7b0e882bedced08d6e976efb2d # v3
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+        with:
+          shared-key: debug-${{ matrix.os }}
+          save-if: false
       - name: Install system dependencies (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt-get update && sudo apt-get install -y libudev-dev
@@ -207,6 +210,9 @@ jobs:
           submodules: recursive
       - uses: jdx/mise-action@e79ddf65a11cec7b0e882bedced08d6e976efb2d # v3
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+        with:
+          shared-key: debug-${{ matrix.os }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Install system dependencies (Ubuntu)
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
@@ -254,6 +260,9 @@ jobs:
         with:
           submodules: recursive
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+        with:
+          shared-key: msrv
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: jdx/mise-action@e79ddf65a11cec7b0e882bedced08d6e976efb2d # v3
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libudev-dev

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -26,6 +26,9 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.FNOX_GH_TOKEN }}
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+        with:
+          shared-key: debug-ubuntu-latest
+          save-if: false
       - name: Install system dependencies
         run: |
           sudo apt-get update


### PR DESCRIPTION
## Summary
- Use `shared-key` per OS so `build`, `ci-other`, `autofix`, and `release-plz` all share one Rust cache instead of each maintaining its own
- Only `ci-other` saves the cache (on main merges) since it has the most complete artifacts (test + clippy)
- `msrv` keeps a separate key since it uses a different Rust toolchain
- Reduces from ~6 unique cache keys (~10.8 GB) down to 3

## Test plan
- [ ] Verify `autofix` job gets a cache hit instead of compiling 547 crates from scratch
- [ ] Verify `build` and `ci-other` jobs still get cache hits
- [ ] Verify cache is saved on main merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only changes affecting CI caching behavior; low risk beyond potential cache misses or slightly longer CI runs if misconfigured.
> 
> **Overview**
> **Consolidates Rust caching across GitHub Actions workflows.** `autofix`, `build`, `ci-other`, and `release-plz` now use a per-OS `shared-key` (e.g., `debug-ubuntu-latest`, `debug-macos-latest`) so they can reuse the same cache instead of creating separate ones.
> 
> Cache writes are tightened: most jobs set `save-if: false`, while `ci-other` (and `msrv` under its own `shared-key`) only saves the cache on `refs/heads/main` to reduce cache churn and size.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf43c585ec993d1a601de5161f0971d86374899b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->