### PR TITLE
fix(ci): retry lint step to handle transient pkl fetch failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,7 +248,11 @@ jobs:
       - name: Run tests
         run: cargo test
       - name: Check formatting
-        run: mise run lint
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          command: mise run lint
       - name: Run clippy
         run: cargo clippy -- -D warnings
 


### PR DESCRIPTION
## Summary
- Wraps the "Check formatting" (`mise run lint`) step in `nick-fields/retry` with 3 attempts, matching the existing retry pattern used for bats tests
- Fixes transient CI failures caused by GitHub returning 502 when pkl fetches the hk config package from GitHub Releases

## Context
https://github.com/jdx/fnox/actions/runs/22832770600/job/66223824636

## Test plan
- [ ] CI passes on this PR itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that alters retry behavior for linting; no production code paths or security-sensitive logic are affected.
> 
> **Overview**
> Improves CI resilience by wrapping the `Check formatting` step (`mise run lint`) in `nick-fields/retry` with a 5-minute timeout and up to 3 attempts, matching the retry behavior already used elsewhere in the workflow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b79f3ac05ab6eaa2bee7a53910a90371e518fb3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->