### PR TITLE
feat(lease): add GitHub App installation token lease backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,6 +407,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
 dependencies = [
  "aws-lc-sys",
+ "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -2247,6 +2248,7 @@ dependencies = [
  "hex",
  "hkdf",
  "indexmap 2.13.0",
+ "jsonwebtoken 10.3.0",
  "keepass",
  "keyring",
  "miette",
@@ -2588,7 +2590,7 @@ dependencies = [
  "google-cloud-metadata",
  "google-cloud-token",
  "home",
- "jsonwebtoken",
+ "jsonwebtoken 9.3.1",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -3629,6 +3631,23 @@ dependencies = [
  "ring",
  "serde",
  "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "10.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
+dependencies = [
+ "aws-lc-rs",
+ "base64 0.22.1",
+ "getrandom 0.2.17",
+ "js-sys",
+ "pem",
+ "serde",
+ "serde_json",
+ "signature",
  "simple_asn1",
 ]
 
@@ -5061,7 +5080,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -5321,7 +5340,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -5333,7 +5352,7 @@ dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -5437,7 +5456,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
  "ring",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -6766,6 +6785,12 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ name = "fnox"
 path = "src/main.rs"
 
 [dependencies]
+aes-gcm = "0.10"
 age = { version = "0.11", features = ["ssh"] }
 anyhow = "1"
 arboard = "3"
@@ -36,6 +37,7 @@ ci_info = "0.14"
 clap = { version = "4", features = ["derive", "env"] }
 console = "0.16"
 crossterm = { version = "0.29", features = ["event-stream"] }
+ctap-hid-fido2 = "3"
 data-encoding = "2"
 demand = "2"
 dirs = "6"
@@ -47,11 +49,14 @@ google-cloud-secretmanager-v1 = { version = "1.1" }
 hex = "0.4"
 hkdf = "0.12"
 indexmap = { version = "2", features = ["serde"] }
+jsonwebtoken = { version = "10", features = ["aws_lc_rs"] }
 keepass = { version = "0.8", features = ["save_kdbx4"] }
 keyring = { version = "3", features = ["apple-native", "windows-native", "sync-secret-service"] }
 miette = { version = "7", features = ["fancy"] }
 miniz_oxide = "0.8"
-pluralizer = "0.5.0"
+nix = { version = "0.31", features = ["signal", "process"] }
+pluralizer = "0.5"
+rand = "0.8"
 ratatui = "0.29"
 regex = "1"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
@@ -64,7 +69,8 @@ serde_spanned = "1"
 serde_yaml = "0.9"
 sha2 = "0.10"
 shellexpand = "3"
-shlex = "1.3.0"
+shlex = "1"
+signal-hook = "0.4"
 strsim = "0.11"
 strum = { version = "0.27", features = ["derive"] }
 tabled = { version = "0.20", features = ["ansi"] }
@@ -73,20 +79,14 @@ terminal_size = "0.4"
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }
 toml_edit = { version = "0.22", features = ["serde"] }
-aes-gcm = "0.10"
-ctap-hid-fido2 = "3.5.8"
-rand = "0.8"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-urlencoding = "2.1"
+urlencoding = "2"
 usage-lib = { version = "2", features = ["clap"] }
 walkdir = "2"
-xx = { version = "2", features = ["fslock"] }
 which = "7"
+xx = { version = "2", features = ["fslock"] }
 yubico_manager = "0.9"
-signal-hook = "0.4.3"
-nix = { version = "0.31.2", features = ["signal", "process"] }
-jsonwebtoken = { version = "10.3.0", features = ["aws_lc_rs"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 dbus = { version = "0.9", features = ["vendored"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ which = "7"
 yubico_manager = "0.9"
 signal-hook = "0.4.3"
 nix = { version = "0.31.2", features = ["signal", "process"] }
+jsonwebtoken = { version = "10.3.0", features = ["aws_lc_rs"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 dbus = { version = "0.9", features = ["vendored"] }

--- a/docs/guide/leases.md
+++ b/docs/guide/leases.md
@@ -295,6 +295,7 @@ The subprocess still runs — just without the lease credentials. This means oth
 | [Azure Token](/leases/azure-token) | `azure-token` | ~1 hour      | No-op (native TTL)      |
 | [HashiCorp Vault](/leases/vault)   | `vault`       | 24 hours     | Vault lease revocation  |
 | [Cloudflare](/leases/cloudflare)   | `cloudflare`  | 24 hours     | Token deletion          |
+| [GitHub App](/leases/github-app)   | `github-app`  | 1 hour       | No-op (native TTL)      |
 | [Custom Command](/leases/command)  | `command`     | 24 hours     | Optional revoke command |
 
 ## Managing Leases

--- a/docs/leases/github-app.md
+++ b/docs/leases/github-app.md
@@ -1,0 +1,196 @@
+# GitHub App
+
+The `github-app` lease backend creates short-lived [GitHub App installation access tokens](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-an-installation-access-token-for-a-github-app) using a GitHub App's private key. Installation tokens expire after 1 hour (GitHub's hard limit) and can be scoped to specific permissions and repositories.
+
+This is ideal for CI/CD pipelines and automation workflows where you need scoped, short-lived GitHub access instead of long-lived personal access tokens.
+
+## Configuration
+
+```toml
+[leases.github]
+type = "github-app"
+app_id = "12345"
+installation_id = "67890"
+private_key_file = "~/.config/fnox/github-app.pem"
+duration = "1h"
+
+[leases.github.permissions]
+contents = "read"
+pull_requests = "write"
+```
+
+| Field              | Required | Description                                                                          |
+| ------------------ | -------- | ------------------------------------------------------------------------------------ |
+| `app_id`           | Yes      | GitHub App ID (found in the app's settings page)                                     |
+| `installation_id`  | Yes      | Installation ID (from the app's installation URL or API)                             |
+| `private_key_file` | No\*     | Path to the GitHub App's PEM private key file (supports `~` expansion)               |
+| `env_var`          | No       | Environment variable name for the token (default: `"GITHUB_TOKEN"`)                  |
+| `permissions`      | No       | Map of permission names to access levels (omit to use all installation permissions)  |
+| `repositories`     | No       | Array of repository names to scope the token to (omit for all installed repos)       |
+| `api_base`         | No       | GitHub API base URL (default: `"https://api.github.com"`; set for GitHub Enterprise) |
+| `duration`         | No       | Ignored — GitHub controls token lifetime (always 1 hour)                             |
+
+\* Required unless `FNOX_GITHUB_APP_PRIVATE_KEY` is set.
+
+### Permission values
+
+Permissions use GitHub's [installation token permission names](https://docs.github.com/en/rest/apps/apps#create-an-installation-access-token-for-an-app). Each permission maps to an access level:
+
+| Access Level | Description         |
+| ------------ | ------------------- |
+| `"read"`     | Read-only access    |
+| `"write"`    | Read and write      |
+| `"admin"`    | Full administrative |
+
+## Prerequisites
+
+The backend needs a GitHub App private key. fnox looks for it in order:
+
+1. `FNOX_GITHUB_APP_PRIVATE_KEY` environment variable (PEM contents)
+2. `private_key_file` config option (path to PEM file)
+
+If neither is found, fnox prints:
+
+```
+GitHub App private key not found. Set FNOX_GITHUB_APP_PRIVATE_KEY or configure private_key_file pointing to a PEM file.
+```
+
+### Getting the app ID and installation ID
+
+1. **App ID**: Go to your GitHub App's settings page (`Settings > Developer settings > GitHub Apps > Your App`). The App ID is shown near the top.
+
+2. **Installation ID**: After installing the app on an organization or account, the installation ID is in the URL: `https://github.com/settings/installations/{installation_id}`. You can also find it via the API:
+
+```bash
+# List installations for your app (requires JWT auth)
+curl -H "Authorization: Bearer $JWT" \
+  https://api.github.com/app/installations
+```
+
+### Generating a private key
+
+In your GitHub App settings, scroll to "Private keys" and click "Generate a private key". Save the downloaded PEM file to a secure location.
+
+## Credentials Produced
+
+| Environment Variable | Description                           |
+| -------------------- | ------------------------------------- |
+| `GITHUB_TOKEN`       | Short-lived installation access token |
+
+The env var name is configurable via the `env_var` field.
+
+## Limits
+
+- **Max duration:** 1 hour (enforced by GitHub)
+- **Revocation:** Not supported — tokens auto-expire. GitHub's revocation API requires the token itself (not a lease ID), so fnox relies on the short TTL.
+
+## Examples
+
+### Minimal
+
+```toml
+[leases.github]
+type = "github-app"
+app_id = "12345"
+installation_id = "67890"
+private_key_file = "~/.config/fnox/github-app.pem"
+```
+
+The token gets all permissions and repository access granted to the installation.
+
+```bash
+fnox exec -- gh pr list
+```
+
+### Scoped to specific permissions
+
+```toml
+[leases.github]
+type = "github-app"
+app_id = "12345"
+installation_id = "67890"
+private_key_file = "~/.config/fnox/github-app.pem"
+
+[leases.github.permissions]
+contents = "read"
+pull_requests = "write"
+issues = "write"
+```
+
+### Scoped to specific repositories
+
+```toml
+[leases.github]
+type = "github-app"
+app_id = "12345"
+installation_id = "67890"
+private_key_file = "~/.config/fnox/github-app.pem"
+repositories = ["my-org/api", "my-org/frontend"]
+
+[leases.github.permissions]
+contents = "read"
+```
+
+### With stored private key
+
+Instead of a file, store the private key in a provider:
+
+```toml
+[providers.op]
+type = "1password"
+vault = "Infrastructure"
+
+[secrets]
+FNOX_GITHUB_APP_PRIVATE_KEY = { provider = "op", value = "GitHub App/private key" }
+
+[leases.github]
+type = "github-app"
+app_id = "12345"
+installation_id = "67890"
+```
+
+fnox resolves the secret first, then the lease backend picks it up from the environment.
+
+### Custom env var
+
+```toml
+[leases.github]
+type = "github-app"
+app_id = "12345"
+installation_id = "67890"
+private_key_file = "~/.config/fnox/github-app.pem"
+env_var = "GH_TOKEN"
+```
+
+### GitHub Enterprise
+
+```toml
+[leases.github]
+type = "github-app"
+app_id = "12345"
+installation_id = "67890"
+private_key_file = "~/.config/fnox/github-app.pem"
+api_base = "https://github.example.com/api/v3"
+```
+
+### Common permissions
+
+| Permission          | Description                            |
+| ------------------- | -------------------------------------- |
+| `contents`          | Repository contents, commits, branches |
+| `pull_requests`     | Pull requests                          |
+| `issues`            | Issues and comments                    |
+| `actions`           | GitHub Actions workflows               |
+| `packages`          | GitHub Packages                        |
+| `deployments`       | Deployment statuses                    |
+| `environments`      | Deployment environments                |
+| `metadata`          | Repository metadata (always read-only) |
+| `administration`    | Repository settings                    |
+| `members`           | Organization members                   |
+| `organization_plan` | Organization billing info              |
+
+See the [GitHub API docs](https://docs.github.com/en/rest/apps/apps#create-an-installation-access-token-for-an-app) for the full list.
+
+## See Also
+
+- [Credential Leases](/guide/leases) — overview and approaches

--- a/docs/leases/github-app.md
+++ b/docs/leases/github-app.md
@@ -26,7 +26,7 @@ pull_requests = "write"
 | `private_key_file` | No\*     | Path to the GitHub App's PEM private key file (supports `~` expansion)               |
 | `env_var`          | No       | Environment variable name for the token (default: `"GITHUB_TOKEN"`)                  |
 | `permissions`      | No       | Map of permission names to access levels (omit to use all installation permissions)  |
-| `repositories`     | No       | Array of repository names to scope the token to (omit for all installed repos)       |
+| `repositories`     | No       | Array of bare repository names to scope the token to (omit for all installed repos)  |
 | `api_base`         | No       | GitHub API base URL (default: `"https://api.github.com"`; set for GitHub Enterprise) |
 | `duration`         | No       | Ignored — GitHub controls token lifetime (always 1 hour)                             |
 
@@ -82,7 +82,7 @@ The env var name is configurable via the `env_var` field.
 ## Limits
 
 - **Max duration:** 1 hour (enforced by GitHub)
-- **Revocation:** Not supported — tokens auto-expire. GitHub's revocation API requires the token itself (not a lease ID), so fnox relies on the short TTL.
+- **Revocation:** Supported — fnox calls `DELETE /installation/token` to immediately invalidate the token
 
 ## Examples
 
@@ -125,7 +125,7 @@ type = "github-app"
 app_id = "12345"
 installation_id = "67890"
 private_key_file = "~/.config/fnox/github-app.pem"
-repositories = ["my-org/api", "my-org/frontend"]
+repositories = ["api", "frontend"]
 
 [leases.github.permissions]
 contents = "read"

--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -286,6 +286,49 @@
           "required": ["type"]
         },
         {
+          "description": "GitHub App Installation Token",
+          "type": "object",
+          "properties": {
+            "api_base": {
+              "description": "GitHub API base URL (default: https://api.github.com)",
+              "type": ["string", "null"]
+            },
+            "app_id": {
+              "type": "string"
+            },
+            "duration": {
+              "type": ["string", "null"]
+            },
+            "env_var": {
+              "type": "string",
+              "default": "GITHUB_TOKEN"
+            },
+            "installation_id": {
+              "type": "string"
+            },
+            "permissions": {
+              "type": ["object", "null"],
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "private_key_file": {
+              "type": ["string", "null"]
+            },
+            "repositories": {
+              "type": ["array", "null"],
+              "items": {
+                "type": "string"
+              }
+            },
+            "type": {
+              "type": "string",
+              "const": "github-app"
+            }
+          },
+          "required": ["type", "app_id", "installation_id"]
+        },
+        {
           "description": "Generic Command Backend",
           "type": "object",
           "properties": {

--- a/src/commands/lease.rs
+++ b/src/commands/lease.rs
@@ -432,13 +432,48 @@ impl LeaseRevokeCommand {
         }
 
         let backend_name = record.backend_name.clone();
+        let cached_credentials = record.cached_credentials.clone();
+        let encryption_provider_name = record.encryption_provider.clone();
         let profile = Config::get_profile(cli.profile.as_deref());
         let leases = config.get_leases(&profile);
+
+        // Decrypt cached credentials (if encrypted) so backends can use
+        // credential values for revocation (e.g. GitHub App needs the token).
+        let decrypted_credentials = match (&cached_credentials, &encryption_provider_name) {
+            (Some(creds), Some(enc_name)) => {
+                match lease::find_encryption_provider(&config, &profile).await {
+                    lease::EncryptionProviderResult::Available(found_name, provider)
+                        if found_name == *enc_name =>
+                    {
+                        match lease::decrypt_credentials(provider.as_ref(), creds).await {
+                            Ok(decrypted) => Some(decrypted),
+                            Err(e) => {
+                                tracing::warn!(
+                                    "Failed to decrypt cached credentials for revocation: {e}"
+                                );
+                                None
+                            }
+                        }
+                    }
+                    _ => {
+                        tracing::warn!(
+                            "Encryption provider '{enc_name}' not available for credential decryption"
+                        );
+                        None
+                    }
+                }
+            }
+            (Some(creds), None) => Some(creds.clone()),
+            _ => None,
+        };
 
         if let Some(backend_config) = leases.get(&backend_name) {
             match backend_config.create_backend() {
                 Ok(backend) => {
-                    if let Err(e) = backend.revoke_lease(&self.lease_id).await {
+                    if let Err(e) = backend
+                        .revoke_lease(&self.lease_id, decrypted_credentials.as_ref())
+                        .await
+                    {
                         tracing::warn!("Backend revocation failed for '{}': {}", self.lease_id, e);
                         eprintln!(
                             "Warning: backend revocation failed; only the local ledger entry will be revoked."
@@ -501,7 +536,9 @@ impl LeaseCleanupCommand {
             if let Some(backend_config) = leases.get(&record.backend_name) {
                 match backend_config.create_backend() {
                     Ok(backend) => {
-                        if let Err(e) = backend.revoke_lease(&record.lease_id).await {
+                        // Expired leases: pass None for credentials since the
+                        // token has expired and can't be revoked server-side anyway.
+                        if let Err(e) = backend.revoke_lease(&record.lease_id, None).await {
                             tracing::warn!("Failed to revoke lease '{}': {}", record.lease_id, e);
                             // Still mark revoked locally — the credential has expired anyway
                         }

--- a/src/http.rs
+++ b/src/http.rs
@@ -5,8 +5,10 @@ pub fn http_client() -> reqwest::Client {
     let settings = crate::settings::Settings::get();
     let timeout =
         crate::lease::parse_duration(&settings.http_timeout).unwrap_or(Duration::from_secs(30));
+    let user_agent = format!("fnox/{}", env!("CARGO_PKG_VERSION"));
     reqwest::Client::builder()
         .timeout(timeout)
+        .user_agent(user_agent)
         .build()
         .unwrap_or_else(|e| {
             tracing::warn!(

--- a/src/lease_backends/aws_sts.rs
+++ b/src/lease_backends/aws_sts.rs
@@ -153,7 +153,11 @@ impl LeaseBackend for AwsStsBackend {
         })
     }
 
-    async fn revoke_lease(&self, _lease_id: &str) -> Result<()> {
+    async fn revoke_lease(
+        &self,
+        _lease_id: &str,
+        _credentials: Option<&IndexMap<String, String>>,
+    ) -> Result<()> {
         // AWS STS credentials have native TTL, no manual revocation needed
         Ok(())
     }

--- a/src/lease_backends/cloudflare.rs
+++ b/src/lease_backends/cloudflare.rs
@@ -442,7 +442,11 @@ impl LeaseBackend for CloudflareBackend {
         })
     }
 
-    async fn revoke_lease(&self, lease_id: &str) -> Result<()> {
+    async fn revoke_lease(
+        &self,
+        lease_id: &str,
+        _credentials: Option<&IndexMap<String, String>>,
+    ) -> Result<()> {
         let parent_token = Self::get_api_token()?;
         let tokens_path = self.tokens_path();
 

--- a/src/lease_backends/command.rs
+++ b/src/lease_backends/command.rs
@@ -159,7 +159,11 @@ impl LeaseBackend for CommandBackend {
         })
     }
 
-    async fn revoke_lease(&self, lease_id: &str) -> Result<()> {
+    async fn revoke_lease(
+        &self,
+        lease_id: &str,
+        _credentials: Option<&IndexMap<String, String>>,
+    ) -> Result<()> {
         let Some(revoke_cmd) = &self.revoke_command else {
             return Ok(());
         };

--- a/src/lease_backends/github_app.rs
+++ b/src/lease_backends/github_app.rs
@@ -248,9 +248,10 @@ impl LeaseBackend for GitHubAppBackend {
         let mut credentials = IndexMap::new();
         credentials.insert(self.env_var.clone(), token.to_string());
 
-        // Use the token itself as the lease_id so revoke_lease can call
-        // DELETE /installation/token (which authenticates with the token).
-        let lease_id = token.to_string();
+        // Use a hash of the token as the lease_id. This is deterministic
+        // (useful for debugging) without leaking the secret in the ledger.
+        let hash = blake3::hash(token.as_bytes());
+        let lease_id = format!("github-app-{}", &hash.to_hex()[..16]);
 
         Ok(Lease {
             credentials,
@@ -259,9 +260,23 @@ impl LeaseBackend for GitHubAppBackend {
         })
     }
 
-    async fn revoke_lease(&self, lease_id: &str) -> Result<()> {
-        // The lease_id is the installation token itself, so we can authenticate
-        // the DELETE /installation/token request with it.
+    async fn revoke_lease(
+        &self,
+        _lease_id: &str,
+        credentials: Option<&IndexMap<String, String>>,
+    ) -> Result<()> {
+        // GitHub's DELETE /installation/token requires authenticating with the
+        // token being revoked. We retrieve it from the cached credentials
+        // (which are encrypted at rest in the ledger).
+        let token = credentials
+            .and_then(|creds| creds.get(&self.env_var))
+            .ok_or_else(|| FnoxError::ProviderApiError {
+                provider: "GitHub App".to_string(),
+                details: "Cached credentials unavailable for revocation".to_string(),
+                hint: "The token may have already been cleaned up from the ledger".to_string(),
+                url: URL.to_string(),
+            })?;
+
         let api_base = self.api_base();
         let url = format!("{api_base}/installation/token");
 
@@ -270,7 +285,7 @@ impl LeaseBackend for GitHubAppBackend {
             .delete(&url)
             .header("Accept", "application/vnd.github+json")
             .header("X-GitHub-Api-Version", "2022-11-28")
-            .bearer_auth(lease_id)
+            .bearer_auth(token)
             .send()
             .await
             .map_err(|e| FnoxError::ProviderApiError {

--- a/src/lease_backends/github_app.rs
+++ b/src/lease_backends/github_app.rs
@@ -103,20 +103,11 @@ impl GitHubAppBackend {
         let iat = now.timestamp() - 60; // issued 60s in the past to allow clock drift
         let exp = iat + JWT_EXPIRY_SECS; // exp - iat must be ≤ 600s (GitHub's limit)
 
-        let app_id_num: u64 = self
-            .app_id
-            .parse()
-            .map_err(|_| FnoxError::ProviderAuthFailed {
-                provider: "GitHub App".to_string(),
-                details: format!("app_id '{}' is not a valid integer", self.app_id),
-                hint: "app_id must be a numeric GitHub App ID".to_string(),
-                url: URL.to_string(),
-            })?;
-
+        // JWT RFC 7519 defines `iss` as a StringOrURI — it must be a string.
         let claims = serde_json::json!({
             "iat": iat,
             "exp": exp,
-            "iss": app_id_num,
+            "iss": &self.app_id,
         });
 
         let key = jsonwebtoken::EncodingKey::from_rsa_pem(pem_key.as_bytes()).map_err(|e| {
@@ -240,10 +231,15 @@ impl LeaseBackend for GitHubAppBackend {
                 url: URL.to_string(),
             })?;
 
+        // Fall back to now + 1 hour if expires_at is missing or unparseable,
+        // since GitHub hard-expires installation tokens after 1 hour. Without
+        // this, a None expiry would cause the ledger to treat the token as
+        // never-expiring, serving a stale token indefinitely.
         let expires_at = resp["expires_at"]
             .as_str()
             .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
-            .map(|dt| dt.with_timezone(&chrono::Utc));
+            .map(|dt| dt.with_timezone(&chrono::Utc))
+            .or_else(|| Some(chrono::Utc::now() + chrono::Duration::hours(1)));
 
         let mut credentials = IndexMap::new();
         credentials.insert(self.env_var.clone(), token.to_string());

--- a/src/lease_backends/github_app.rs
+++ b/src/lease_backends/github_app.rs
@@ -31,10 +31,10 @@ pub fn check_prerequisites(private_key_file: &Option<String>) -> Option<String> 
 }
 
 pub fn required_env_vars() -> Vec<(&'static str, &'static str)> {
-    vec![(
-        "FNOX_GITHUB_APP_PRIVATE_KEY",
-        "GitHub App private key in PEM format (or set private_key_file in config)",
-    )]
+    // The env var is optional when private_key_file is configured, so we
+    // don't unconditionally list it as required. check_prerequisites()
+    // handles the two-path validation correctly.
+    vec![]
 }
 
 pub struct GitHubAppBackend {
@@ -101,12 +101,22 @@ impl GitHubAppBackend {
     fn generate_jwt(&self, pem_key: &str) -> Result<String> {
         let now = chrono::Utc::now();
         let iat = now.timestamp() - 60; // issued 60s in the past to allow clock drift
-        let exp = now.timestamp() + JWT_EXPIRY_SECS;
+        let exp = iat + JWT_EXPIRY_SECS; // exp - iat must be ≤ 600s (GitHub's limit)
+
+        let app_id_num: u64 = self
+            .app_id
+            .parse()
+            .map_err(|_| FnoxError::ProviderAuthFailed {
+                provider: "GitHub App".to_string(),
+                details: format!("app_id '{}' is not a valid integer", self.app_id),
+                hint: "app_id must be a numeric GitHub App ID".to_string(),
+                url: URL.to_string(),
+            })?;
 
         let claims = serde_json::json!({
             "iat": iat,
             "exp": exp,
-            "iss": self.app_id,
+            "iss": app_id_num,
         });
 
         let key = jsonwebtoken::EncodingKey::from_rsa_pem(pem_key.as_bytes()).map_err(|e| {
@@ -238,7 +248,9 @@ impl LeaseBackend for GitHubAppBackend {
         let mut credentials = IndexMap::new();
         credentials.insert(self.env_var.clone(), token.to_string());
 
-        let lease_id = super::generate_lease_id("github-app");
+        // Use the token itself as the lease_id so revoke_lease can call
+        // DELETE /installation/token (which authenticates with the token).
+        let lease_id = token.to_string();
 
         Ok(Lease {
             credentials,
@@ -248,14 +260,40 @@ impl LeaseBackend for GitHubAppBackend {
     }
 
     async fn revoke_lease(&self, lease_id: &str) -> Result<()> {
-        // Extract the token from cached credentials to revoke it.
-        // GitHub's revoke endpoint requires the token itself, not a lease ID.
-        // Since we use a generated lease_id (not the token), we can't revoke
-        // without the token value. The token auto-expires in ≤1 hour anyway.
-        tracing::debug!(
-            lease_id,
-            "GitHub App tokens auto-expire; skipping explicit revocation"
-        );
+        // The lease_id is the installation token itself, so we can authenticate
+        // the DELETE /installation/token request with it.
+        let api_base = self.api_base();
+        let url = format!("{api_base}/installation/token");
+
+        let client = crate::http::http_client();
+        let response = client
+            .delete(&url)
+            .header("Accept", "application/vnd.github+json")
+            .header("X-GitHub-Api-Version", "2022-11-28")
+            .bearer_auth(lease_id)
+            .send()
+            .await
+            .map_err(|e| FnoxError::ProviderApiError {
+                provider: "GitHub App".to_string(),
+                details: e.to_string(),
+                hint: "Failed to connect to GitHub API for token revocation".to_string(),
+                url: URL.to_string(),
+            })?;
+
+        let status = response.status();
+        if !status.is_success() {
+            // 404 = token already expired or revoked — treat as success
+            if status.as_u16() != 404 {
+                let body_text = response.text().await.unwrap_or_default();
+                return Err(FnoxError::ProviderApiError {
+                    provider: "GitHub App".to_string(),
+                    details: format!("HTTP {status}: {body_text}"),
+                    hint: "Failed to revoke GitHub installation token".to_string(),
+                    url: URL.to_string(),
+                });
+            }
+        }
+
         Ok(())
     }
 

--- a/src/lease_backends/github_app.rs
+++ b/src/lease_backends/github_app.rs
@@ -1,0 +1,265 @@
+use crate::error::{FnoxError, Result};
+use crate::lease_backends::{Lease, LeaseBackend};
+use async_trait::async_trait;
+use indexmap::IndexMap;
+
+use std::time::Duration;
+
+const URL: &str = "https://fnox.jdx.dev/leases/github-app";
+const API_BASE: &str = "https://api.github.com";
+
+/// Maximum GitHub installation token lifetime (1 hour)
+const MAX_DURATION_SECS: u64 = 3600;
+
+/// JWT expiration — GitHub accepts up to 10 minutes
+const JWT_EXPIRY_SECS: i64 = 600;
+
+pub fn check_prerequisites(private_key_file: &Option<String>) -> Option<String> {
+    let has_key = std::env::var("FNOX_GITHUB_APP_PRIVATE_KEY").is_ok()
+        || private_key_file
+            .as_ref()
+            .is_some_and(|f| std::path::Path::new(&shellexpand::tilde(f).into_owned()).exists());
+    if has_key {
+        None
+    } else {
+        Some(
+            "GitHub App private key not found. Set FNOX_GITHUB_APP_PRIVATE_KEY \
+             or configure private_key_file pointing to a PEM file."
+                .to_string(),
+        )
+    }
+}
+
+pub fn required_env_vars() -> Vec<(&'static str, &'static str)> {
+    vec![(
+        "FNOX_GITHUB_APP_PRIVATE_KEY",
+        "GitHub App private key in PEM format (or set private_key_file in config)",
+    )]
+}
+
+pub struct GitHubAppBackend {
+    app_id: String,
+    installation_id: String,
+    private_key_file: Option<String>,
+    env_var: String,
+    permissions: Option<IndexMap<String, String>>,
+    repositories: Option<Vec<String>>,
+    api_base: Option<String>,
+}
+
+impl GitHubAppBackend {
+    pub fn new(
+        app_id: String,
+        installation_id: String,
+        private_key_file: Option<String>,
+        env_var: String,
+        permissions: Option<IndexMap<String, String>>,
+        repositories: Option<Vec<String>>,
+        api_base: Option<String>,
+    ) -> Self {
+        Self {
+            app_id,
+            installation_id,
+            private_key_file,
+            env_var,
+            permissions,
+            repositories,
+            api_base,
+        }
+    }
+
+    fn api_base(&self) -> &str {
+        self.api_base.as_deref().unwrap_or(API_BASE)
+    }
+
+    fn load_private_key(&self) -> Result<String> {
+        // Prefer env var
+        if let Ok(key) = std::env::var("FNOX_GITHUB_APP_PRIVATE_KEY") {
+            return Ok(key);
+        }
+
+        // Fall back to file
+        if let Some(ref path) = self.private_key_file {
+            let expanded = shellexpand::tilde(path).into_owned();
+            std::fs::read_to_string(&expanded).map_err(|e| FnoxError::ProviderAuthFailed {
+                provider: "GitHub App".to_string(),
+                details: format!("Failed to read private key from {expanded}: {e}"),
+                hint: "Check that private_key_file points to a valid PEM file".to_string(),
+                url: URL.to_string(),
+            })
+        } else {
+            Err(FnoxError::ProviderAuthFailed {
+                provider: "GitHub App".to_string(),
+                details: "No private key available".to_string(),
+                hint: "Set FNOX_GITHUB_APP_PRIVATE_KEY or configure private_key_file".to_string(),
+                url: URL.to_string(),
+            })
+        }
+    }
+
+    /// Generate a JWT for authenticating as the GitHub App.
+    fn generate_jwt(&self, pem_key: &str) -> Result<String> {
+        let now = chrono::Utc::now();
+        let iat = now.timestamp() - 60; // issued 60s in the past to allow clock drift
+        let exp = now.timestamp() + JWT_EXPIRY_SECS;
+
+        let claims = serde_json::json!({
+            "iat": iat,
+            "exp": exp,
+            "iss": self.app_id,
+        });
+
+        let key = jsonwebtoken::EncodingKey::from_rsa_pem(pem_key.as_bytes()).map_err(|e| {
+            FnoxError::ProviderAuthFailed {
+                provider: "GitHub App".to_string(),
+                details: format!("Invalid RSA private key: {e}"),
+                hint: "Check that the private key is a valid RSA PEM file".to_string(),
+                url: URL.to_string(),
+            }
+        })?;
+
+        let header = jsonwebtoken::Header::new(jsonwebtoken::Algorithm::RS256);
+        jsonwebtoken::encode(&header, &claims, &key).map_err(|e| FnoxError::ProviderAuthFailed {
+            provider: "GitHub App".to_string(),
+            details: format!("Failed to sign JWT: {e}"),
+            hint: "Check the private key format".to_string(),
+            url: URL.to_string(),
+        })
+    }
+}
+
+#[async_trait]
+impl LeaseBackend for GitHubAppBackend {
+    async fn create_lease(&self, _duration: Duration, _label: &str) -> Result<Lease> {
+        let pem_key = self.load_private_key()?;
+        let jwt = self.generate_jwt(&pem_key)?;
+        let api_base = self.api_base();
+
+        let mut body = serde_json::Map::new();
+        if let Some(ref permissions) = self.permissions {
+            body.insert(
+                "permissions".to_string(),
+                serde_json::to_value(permissions).unwrap(),
+            );
+        }
+        if let Some(ref repositories) = self.repositories {
+            body.insert(
+                "repositories".to_string(),
+                serde_json::to_value(repositories).unwrap(),
+            );
+        }
+
+        let client = crate::http::http_client();
+        let url = format!(
+            "{api_base}/app/installations/{}/access_tokens",
+            self.installation_id
+        );
+
+        let response = client
+            .post(&url)
+            .header("Accept", "application/vnd.github+json")
+            .header("X-GitHub-Api-Version", "2022-11-28")
+            .bearer_auth(&jwt)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| FnoxError::ProviderApiError {
+                provider: "GitHub App".to_string(),
+                details: e.to_string(),
+                hint: "Failed to connect to GitHub API".to_string(),
+                url: URL.to_string(),
+            })?;
+
+        let status = response.status();
+        let resp: serde_json::Value =
+            response
+                .json()
+                .await
+                .map_err(|e| FnoxError::ProviderInvalidResponse {
+                    provider: "GitHub App".to_string(),
+                    details: e.to_string(),
+                    hint: "Unexpected response from GitHub API".to_string(),
+                    url: URL.to_string(),
+                })?;
+
+        if !status.is_success() {
+            let message = resp["message"]
+                .as_str()
+                .unwrap_or(&format!("HTTP {status}"))
+                .to_string();
+
+            if status.as_u16() == 401 || status.as_u16() == 403 {
+                return Err(FnoxError::ProviderAuthFailed {
+                    provider: "GitHub App".to_string(),
+                    details: message,
+                    hint: "Check app_id, installation_id, and private key".to_string(),
+                    url: URL.to_string(),
+                });
+            }
+            if status.as_u16() == 404 {
+                return Err(FnoxError::ProviderApiError {
+                    provider: "GitHub App".to_string(),
+                    details: message,
+                    hint: "Check that the installation_id is correct and the app is installed"
+                        .to_string(),
+                    url: URL.to_string(),
+                });
+            }
+            if status.as_u16() == 422 {
+                return Err(FnoxError::ProviderApiError {
+                    provider: "GitHub App".to_string(),
+                    details: message,
+                    hint: "Check permissions and repositories configuration".to_string(),
+                    url: URL.to_string(),
+                });
+            }
+            return Err(FnoxError::ProviderApiError {
+                provider: "GitHub App".to_string(),
+                details: message,
+                hint: "Failed to create installation access token".to_string(),
+                url: URL.to_string(),
+            });
+        }
+
+        let token = resp["token"]
+            .as_str()
+            .ok_or_else(|| FnoxError::ProviderInvalidResponse {
+                provider: "GitHub App".to_string(),
+                details: "Response missing 'token' field".to_string(),
+                hint: "Unexpected response from GitHub API".to_string(),
+                url: URL.to_string(),
+            })?;
+
+        let expires_at = resp["expires_at"]
+            .as_str()
+            .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+            .map(|dt| dt.with_timezone(&chrono::Utc));
+
+        let mut credentials = IndexMap::new();
+        credentials.insert(self.env_var.clone(), token.to_string());
+
+        let lease_id = super::generate_lease_id("github-app");
+
+        Ok(Lease {
+            credentials,
+            expires_at,
+            lease_id,
+        })
+    }
+
+    async fn revoke_lease(&self, lease_id: &str) -> Result<()> {
+        // Extract the token from cached credentials to revoke it.
+        // GitHub's revoke endpoint requires the token itself, not a lease ID.
+        // Since we use a generated lease_id (not the token), we can't revoke
+        // without the token value. The token auto-expires in ≤1 hour anyway.
+        tracing::debug!(
+            lease_id,
+            "GitHub App tokens auto-expire; skipping explicit revocation"
+        );
+        Ok(())
+    }
+
+    fn max_lease_duration(&self) -> Duration {
+        Duration::from_secs(MAX_DURATION_SECS)
+    }
+}

--- a/src/lease_backends/github_app.rs
+++ b/src/lease_backends/github_app.rs
@@ -268,14 +268,12 @@ impl LeaseBackend for GitHubAppBackend {
         // GitHub's DELETE /installation/token requires authenticating with the
         // token being revoked. We retrieve it from the cached credentials
         // (which are encrypted at rest in the ledger).
-        let token = credentials
-            .and_then(|creds| creds.get(&self.env_var))
-            .ok_or_else(|| FnoxError::ProviderApiError {
-                provider: "GitHub App".to_string(),
-                details: "Cached credentials unavailable for revocation".to_string(),
-                hint: "The token may have already been cleaned up from the ledger".to_string(),
-                url: URL.to_string(),
-            })?;
+        let Some(token) = credentials.and_then(|creds| creds.get(&self.env_var)) else {
+            // No token available — either already expired/cleaned up or the
+            // encryption provider is unavailable. Skip server-side revocation
+            // silently; the local ledger entry is cleaned up by the caller.
+            return Ok(());
+        };
 
         let api_base = self.api_base();
         let url = format!("{api_base}/installation/token");

--- a/src/lease_backends/mod.rs
+++ b/src/lease_backends/mod.rs
@@ -10,6 +10,7 @@ pub mod azure_token;
 pub mod cloudflare;
 pub mod command;
 pub mod gcp_iam;
+pub mod github_app;
 pub mod vault;
 
 /// A credential lease with metadata for tracking and revocation
@@ -61,6 +62,10 @@ fn default_azure_env_var() -> String {
 
 fn default_cloudflare_env_var() -> String {
     "CLOUDFLARE_API_TOKEN".to_string()
+}
+
+fn default_github_env_var() -> String {
+    "GITHUB_TOKEN".to_string()
 }
 
 /// Generate a unique lease ID with a prefix.
@@ -134,6 +139,24 @@ pub enum LeaseBackendConfig {
         #[serde(skip_serializing_if = "Option::is_none")]
         duration: Option<String>,
     },
+    /// GitHub App Installation Token
+    GithubApp {
+        app_id: String,
+        installation_id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        private_key_file: Option<String>,
+        #[serde(default = "default_github_env_var")]
+        env_var: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        permissions: Option<IndexMap<String, String>>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        repositories: Option<Vec<String>>,
+        /// GitHub API base URL (default: https://api.github.com)
+        #[serde(skip_serializing_if = "Option::is_none")]
+        api_base: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        duration: Option<String>,
+    },
     /// Generic Command Backend
     Command {
         create_command: String,
@@ -159,6 +182,9 @@ impl LeaseBackendConfig {
             }
             LeaseBackendConfig::AzureToken { .. } => azure_token::check_prerequisites(),
             LeaseBackendConfig::Cloudflare { .. } => cloudflare::check_prerequisites(),
+            LeaseBackendConfig::GithubApp {
+                private_key_file, ..
+            } => github_app::check_prerequisites(private_key_file),
             LeaseBackendConfig::Command { .. } => command::check_prerequisites(),
         }
     }
@@ -175,6 +201,7 @@ impl LeaseBackendConfig {
             }
             LeaseBackendConfig::AzureToken { .. } => azure_token::required_env_vars(),
             LeaseBackendConfig::Cloudflare { .. } => cloudflare::required_env_vars(),
+            LeaseBackendConfig::GithubApp { .. } => github_app::required_env_vars(),
             LeaseBackendConfig::Command { .. } => command::required_env_vars(),
         }
     }
@@ -235,6 +262,24 @@ impl LeaseBackendConfig {
                 policies.clone(),
                 env_var.clone(),
             )?)),
+            LeaseBackendConfig::GithubApp {
+                app_id,
+                installation_id,
+                private_key_file,
+                env_var,
+                permissions,
+                repositories,
+                api_base,
+                ..
+            } => Ok(Box::new(github_app::GitHubAppBackend::new(
+                app_id.clone(),
+                installation_id.clone(),
+                private_key_file.clone(),
+                env_var.clone(),
+                permissions.clone(),
+                repositories.clone(),
+                api_base.clone(),
+            ))),
             LeaseBackendConfig::Command {
                 create_command,
                 revoke_command,
@@ -279,6 +324,7 @@ impl LeaseBackendConfig {
             | LeaseBackendConfig::Vault { duration, .. }
             | LeaseBackendConfig::AzureToken { duration, .. }
             | LeaseBackendConfig::Cloudflare { duration, .. }
+            | LeaseBackendConfig::GithubApp { duration, .. }
             | LeaseBackendConfig::Command { duration, .. } => duration.as_deref(),
         }
     }

--- a/src/lease_backends/mod.rs
+++ b/src/lease_backends/mod.rs
@@ -30,8 +30,16 @@ pub trait LeaseBackend: Send + Sync {
     /// Create a short-lived credential
     async fn create_lease(&self, duration: Duration, label: &str) -> Result<Lease>;
 
-    /// Revoke a previously issued lease (for cleanup)
-    async fn revoke_lease(&self, _lease_id: &str) -> Result<()> {
+    /// Revoke a previously issued lease (for cleanup).
+    /// `credentials` contains the cached credential values (decrypted) when
+    /// available — backends that need a credential value for revocation (e.g.
+    /// GitHub App, which must authenticate DELETE with the token itself) can
+    /// look it up here instead of storing secrets in `lease_id`.
+    async fn revoke_lease(
+        &self,
+        _lease_id: &str,
+        _credentials: Option<&IndexMap<String, String>>,
+    ) -> Result<()> {
         // Default: no-op (for backends with native TTL)
         Ok(())
     }

--- a/src/lease_backends/vault.rs
+++ b/src/lease_backends/vault.rs
@@ -247,7 +247,11 @@ impl LeaseBackend for VaultBackend {
         })
     }
 
-    async fn revoke_lease(&self, lease_id: &str) -> Result<()> {
+    async fn revoke_lease(
+        &self,
+        lease_id: &str,
+        _credentials: Option<&IndexMap<String, String>>,
+    ) -> Result<()> {
         let url = format!(
             "{}/v1/sys/leases/revoke",
             self.address.trim_end_matches('/')

--- a/test/lease_github_app.bats
+++ b/test/lease_github_app.bats
@@ -45,6 +45,10 @@ class Handler(http.server.BaseHTTPRequestHandler):
         self.send_header("Content-Length", str(len(body)))
         self.end_headers()
         self.wfile.write(body.encode())
+    def do_DELETE(self):
+        # DELETE /installation/token — revocation endpoint
+        self.send_response(204)
+        self.end_headers()
     def log_message(self, format, *args):
         pass
 
@@ -238,4 +242,31 @@ EOF
 	run fnox lease list
 	assert_success
 	assert_output --partial "github"
+}
+
+@test "github-app: lease revoke calls DELETE /installation/token" {
+	generate_test_key
+	start_mock_github_api
+
+	cat >"$FNOX_CONFIG_FILE" <<EOF
+[leases.github]
+type = "github-app"
+app_id = "12345"
+installation_id = "67890"
+private_key_file = "$TEST_TEMP_DIR/test-app.pem"
+api_base = "http://127.0.0.1:$MOCK_PORT"
+EOF
+
+	# Create the lease
+	run fnox lease create github
+	assert_success
+
+	# Read the ledger file directly to get the full (non-truncated) lease ID
+	local lease_id
+	lease_id=$(grep 'lease_id' "$HOME"/.local/state/fnox/leases/*.toml | head -1 | sed 's/.*= *"//;s/".*//')
+
+	# Revoke it (mock server returns 204 for DELETE)
+	run fnox lease revoke "$lease_id"
+	assert_success
+	assert_output --partial "revoked"
 }

--- a/test/lease_github_app.bats
+++ b/test/lease_github_app.bats
@@ -30,22 +30,6 @@ start_mock_github_api() {
 	local token="${2:-ghs_mock_installation_token_abc123}"
 	local expires_at="${3:-2099-01-01T00:00:00Z}"
 
-	# Simple HTTP server using bash + nc
-	cat >"$TEST_TEMP_DIR/mock-server.sh" <<SCRIPT
-#!/usr/bin/env bash
-while true; do
-	# Read request
-	read -r method path version < <(nc -l "$port" 2>/dev/null | head -1 | tr -d '\r')
-
-	# Respond with token
-	BODY='{"token":"$token","expires_at":"$expires_at","permissions":{"contents":"read"}}'
-	RESPONSE="HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: \${#BODY}\r\n\r\n\$BODY"
-	echo -ne "\$RESPONSE"
-done
-SCRIPT
-	chmod +x "$TEST_TEMP_DIR/mock-server.sh"
-
-	# Use python for a more reliable mock server
 	cat >"$TEST_TEMP_DIR/mock_github.py" <<PYEOF
 import http.server, json, sys
 
@@ -220,7 +204,7 @@ app_id = "12345"
 installation_id = "67890"
 private_key_file = "$TEST_TEMP_DIR/test-app.pem"
 api_base = "http://127.0.0.1:9882"
-repositories = ["my-org/my-repo"]
+repositories = ["my-repo"]
 EOF
 
 	run fnox lease create github

--- a/test/lease_github_app.bats
+++ b/test/lease_github_app.bats
@@ -12,7 +12,7 @@ setup() {
 
 teardown() {
 	# Kill mock server if running
-	if [[ -n "${MOCK_PID:-}" ]]; then
+	if [[ -n ${MOCK_PID:-} ]]; then
 		kill "$MOCK_PID" 2>/dev/null || true
 		wait "$MOCK_PID" 2>/dev/null || true
 	fi
@@ -24,14 +24,14 @@ generate_test_key() {
 	openssl genrsa 2048 2>/dev/null >"$TEST_TEMP_DIR/test-app.pem"
 }
 
-# Helper: start a mock GitHub API server that returns a valid token response
+# Helper: start a mock GitHub API server that returns a valid token response.
+# Binds to an OS-assigned free port and exports MOCK_PORT.
 start_mock_github_api() {
-	local port="${1:-9876}"
-	local token="${2:-ghs_mock_installation_token_abc123}"
-	local expires_at="${3:-2099-01-01T00:00:00Z}"
+	local token="${1:-ghs_mock_installation_token_abc123}"
+	local expires_at="${2:-2099-01-01T00:00:00Z}"
 
 	cat >"$TEST_TEMP_DIR/mock_github.py" <<PYEOF
-import http.server, json, sys
+import http.server, json, sys, socket
 
 class Handler(http.server.BaseHTTPRequestHandler):
     def do_POST(self):
@@ -48,23 +48,31 @@ class Handler(http.server.BaseHTTPRequestHandler):
     def log_message(self, format, *args):
         pass
 
-http.server.HTTPServer(("127.0.0.1", $port), Handler).serve_forever()
+# Bind to port 0 to let the OS pick a free port
+server = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+port = server.server_address[1]
+# Write the assigned port so the test can read it
+with open("$TEST_TEMP_DIR/mock_port", "w") as f:
+    f.write(str(port))
+server.serve_forever()
 PYEOF
 
 	python3 "$TEST_TEMP_DIR/mock_github.py" &
 	MOCK_PID=$!
-	# Wait for server to start
-	for _ in $(seq 1 20); do
-		if curl -s "http://127.0.0.1:$port" >/dev/null 2>&1; then
+	# Wait for the port file to appear
+	for _ in $(seq 1 30); do
+		if [[ -f "$TEST_TEMP_DIR/mock_port" ]]; then
 			break
 		fi
 		sleep 0.1
 	done
+	MOCK_PORT=$(cat "$TEST_TEMP_DIR/mock_port")
+	export MOCK_PORT
 }
 
 @test "github-app: creates installation token with private key file" {
 	generate_test_key
-	start_mock_github_api 9876
+	start_mock_github_api
 
 	cat >"$FNOX_CONFIG_FILE" <<EOF
 [leases.github]
@@ -72,7 +80,7 @@ type = "github-app"
 app_id = "12345"
 installation_id = "67890"
 private_key_file = "$TEST_TEMP_DIR/test-app.pem"
-api_base = "http://127.0.0.1:9876"
+api_base = "http://127.0.0.1:$MOCK_PORT"
 EOF
 
 	run fnox lease create github
@@ -82,7 +90,7 @@ EOF
 
 @test "github-app: creates installation token via env var" {
 	generate_test_key
-	start_mock_github_api 9877
+	start_mock_github_api
 
 	export FNOX_GITHUB_APP_PRIVATE_KEY
 	FNOX_GITHUB_APP_PRIVATE_KEY="$(cat "$TEST_TEMP_DIR/test-app.pem")"
@@ -92,7 +100,7 @@ EOF
 type = "github-app"
 app_id = "12345"
 installation_id = "67890"
-api_base = "http://127.0.0.1:9877"
+api_base = "http://127.0.0.1:$MOCK_PORT"
 EOF
 
 	run fnox lease create github
@@ -101,7 +109,7 @@ EOF
 
 @test "github-app: token is available via fnox exec" {
 	generate_test_key
-	start_mock_github_api 9878
+	start_mock_github_api
 
 	cat >"$FNOX_CONFIG_FILE" <<EOF
 [leases.github]
@@ -109,7 +117,7 @@ type = "github-app"
 app_id = "12345"
 installation_id = "67890"
 private_key_file = "$TEST_TEMP_DIR/test-app.pem"
-api_base = "http://127.0.0.1:9878"
+api_base = "http://127.0.0.1:$MOCK_PORT"
 EOF
 
 	run fnox exec -- printenv GITHUB_TOKEN
@@ -119,7 +127,7 @@ EOF
 
 @test "github-app: custom env_var" {
 	generate_test_key
-	start_mock_github_api 9879
+	start_mock_github_api
 
 	cat >"$FNOX_CONFIG_FILE" <<EOF
 [leases.github]
@@ -128,7 +136,7 @@ app_id = "12345"
 installation_id = "67890"
 private_key_file = "$TEST_TEMP_DIR/test-app.pem"
 env_var = "GH_TOKEN"
-api_base = "http://127.0.0.1:9879"
+api_base = "http://127.0.0.1:$MOCK_PORT"
 EOF
 
 	run fnox exec -- printenv GH_TOKEN
@@ -138,7 +146,7 @@ EOF
 
 @test "github-app: lease is recorded in ledger after create" {
 	generate_test_key
-	start_mock_github_api 9880
+	start_mock_github_api
 
 	cat >"$FNOX_CONFIG_FILE" <<EOF
 [leases.github]
@@ -146,7 +154,7 @@ type = "github-app"
 app_id = "12345"
 installation_id = "67890"
 private_key_file = "$TEST_TEMP_DIR/test-app.pem"
-api_base = "http://127.0.0.1:9880"
+api_base = "http://127.0.0.1:$MOCK_PORT"
 EOF
 
 	run fnox lease create github
@@ -174,7 +182,7 @@ EOF
 
 @test "github-app: supports permissions config" {
 	generate_test_key
-	start_mock_github_api 9881
+	start_mock_github_api
 
 	cat >"$FNOX_CONFIG_FILE" <<EOF
 [leases.github]
@@ -182,7 +190,7 @@ type = "github-app"
 app_id = "12345"
 installation_id = "67890"
 private_key_file = "$TEST_TEMP_DIR/test-app.pem"
-api_base = "http://127.0.0.1:9881"
+api_base = "http://127.0.0.1:$MOCK_PORT"
 
 [leases.github.permissions]
 contents = "read"
@@ -195,7 +203,7 @@ EOF
 
 @test "github-app: supports repositories config" {
 	generate_test_key
-	start_mock_github_api 9882
+	start_mock_github_api
 
 	cat >"$FNOX_CONFIG_FILE" <<EOF
 [leases.github]
@@ -203,7 +211,7 @@ type = "github-app"
 app_id = "12345"
 installation_id = "67890"
 private_key_file = "$TEST_TEMP_DIR/test-app.pem"
-api_base = "http://127.0.0.1:9882"
+api_base = "http://127.0.0.1:$MOCK_PORT"
 repositories = ["my-repo"]
 EOF
 
@@ -213,7 +221,7 @@ EOF
 
 @test "github-app: lease list shows created lease" {
 	generate_test_key
-	start_mock_github_api 9883
+	start_mock_github_api
 
 	cat >"$FNOX_CONFIG_FILE" <<EOF
 [leases.github]
@@ -221,7 +229,7 @@ type = "github-app"
 app_id = "12345"
 installation_id = "67890"
 private_key_file = "$TEST_TEMP_DIR/test-app.pem"
-api_base = "http://127.0.0.1:9883"
+api_base = "http://127.0.0.1:$MOCK_PORT"
 EOF
 
 	run fnox lease create github

--- a/test/lease_github_app.bats
+++ b/test/lease_github_app.bats
@@ -1,0 +1,249 @@
+#!/usr/bin/env bats
+#
+# GitHub App Lease Backend Tests
+#
+# These tests verify the GitHub App installation token lease backend.
+# They use a mock HTTP server to avoid requiring real GitHub credentials.
+
+setup() {
+	load 'test_helper/common_setup'
+	_common_setup
+}
+
+teardown() {
+	# Kill mock server if running
+	if [[ -n "${MOCK_PID:-}" ]]; then
+		kill "$MOCK_PID" 2>/dev/null || true
+		wait "$MOCK_PID" 2>/dev/null || true
+	fi
+	_common_teardown
+}
+
+# Helper: generate a test RSA private key
+generate_test_key() {
+	openssl genrsa 2048 2>/dev/null >"$TEST_TEMP_DIR/test-app.pem"
+}
+
+# Helper: start a mock GitHub API server that returns a valid token response
+start_mock_github_api() {
+	local port="${1:-9876}"
+	local token="${2:-ghs_mock_installation_token_abc123}"
+	local expires_at="${3:-2099-01-01T00:00:00Z}"
+
+	# Simple HTTP server using bash + nc
+	cat >"$TEST_TEMP_DIR/mock-server.sh" <<SCRIPT
+#!/usr/bin/env bash
+while true; do
+	# Read request
+	read -r method path version < <(nc -l "$port" 2>/dev/null | head -1 | tr -d '\r')
+
+	# Respond with token
+	BODY='{"token":"$token","expires_at":"$expires_at","permissions":{"contents":"read"}}'
+	RESPONSE="HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: \${#BODY}\r\n\r\n\$BODY"
+	echo -ne "\$RESPONSE"
+done
+SCRIPT
+	chmod +x "$TEST_TEMP_DIR/mock-server.sh"
+
+	# Use python for a more reliable mock server
+	cat >"$TEST_TEMP_DIR/mock_github.py" <<PYEOF
+import http.server, json, sys
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_POST(self):
+        body = json.dumps({
+            "token": "$token",
+            "expires_at": "$expires_at",
+            "permissions": {"contents": "read"}
+        })
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body.encode())
+    def log_message(self, format, *args):
+        pass
+
+http.server.HTTPServer(("127.0.0.1", $port), Handler).serve_forever()
+PYEOF
+
+	python3 "$TEST_TEMP_DIR/mock_github.py" &
+	MOCK_PID=$!
+	# Wait for server to start
+	for _ in $(seq 1 20); do
+		if curl -s "http://127.0.0.1:$port" >/dev/null 2>&1; then
+			break
+		fi
+		sleep 0.1
+	done
+}
+
+@test "github-app: creates installation token with private key file" {
+	generate_test_key
+	start_mock_github_api 9876
+
+	cat >"$FNOX_CONFIG_FILE" <<EOF
+[leases.github]
+type = "github-app"
+app_id = "12345"
+installation_id = "67890"
+private_key_file = "$TEST_TEMP_DIR/test-app.pem"
+api_base = "http://127.0.0.1:9876"
+EOF
+
+	run fnox lease create github
+	assert_success
+	assert_output --partial "github"
+}
+
+@test "github-app: creates installation token via env var" {
+	generate_test_key
+	start_mock_github_api 9877
+
+	export FNOX_GITHUB_APP_PRIVATE_KEY
+	FNOX_GITHUB_APP_PRIVATE_KEY="$(cat "$TEST_TEMP_DIR/test-app.pem")"
+
+	cat >"$FNOX_CONFIG_FILE" <<EOF
+[leases.github]
+type = "github-app"
+app_id = "12345"
+installation_id = "67890"
+api_base = "http://127.0.0.1:9877"
+EOF
+
+	run fnox lease create github
+	assert_success
+}
+
+@test "github-app: token is available via fnox exec" {
+	generate_test_key
+	start_mock_github_api 9878
+
+	cat >"$FNOX_CONFIG_FILE" <<EOF
+[leases.github]
+type = "github-app"
+app_id = "12345"
+installation_id = "67890"
+private_key_file = "$TEST_TEMP_DIR/test-app.pem"
+api_base = "http://127.0.0.1:9878"
+EOF
+
+	run fnox exec -- printenv GITHUB_TOKEN
+	assert_success
+	assert_line "ghs_mock_installation_token_abc123"
+}
+
+@test "github-app: custom env_var" {
+	generate_test_key
+	start_mock_github_api 9879
+
+	cat >"$FNOX_CONFIG_FILE" <<EOF
+[leases.github]
+type = "github-app"
+app_id = "12345"
+installation_id = "67890"
+private_key_file = "$TEST_TEMP_DIR/test-app.pem"
+env_var = "GH_TOKEN"
+api_base = "http://127.0.0.1:9879"
+EOF
+
+	run fnox exec -- printenv GH_TOKEN
+	assert_success
+	assert_line "ghs_mock_installation_token_abc123"
+}
+
+@test "github-app: lease is recorded in ledger after create" {
+	generate_test_key
+	start_mock_github_api 9880
+
+	cat >"$FNOX_CONFIG_FILE" <<EOF
+[leases.github]
+type = "github-app"
+app_id = "12345"
+installation_id = "67890"
+private_key_file = "$TEST_TEMP_DIR/test-app.pem"
+api_base = "http://127.0.0.1:9880"
+EOF
+
+	run fnox lease create github
+	assert_success
+
+	# Verify the lease shows up as active
+	run fnox lease list --active
+	assert_success
+	assert_output --partial "github"
+}
+
+@test "github-app: fails with missing private key" {
+	cat >"$FNOX_CONFIG_FILE" <<EOF
+[leases.github]
+type = "github-app"
+app_id = "12345"
+installation_id = "67890"
+private_key_file = "$TEST_TEMP_DIR/nonexistent.pem"
+EOF
+
+	run fnox lease create github
+	assert_failure
+	assert_output --partial "private key"
+}
+
+@test "github-app: supports permissions config" {
+	generate_test_key
+	start_mock_github_api 9881
+
+	cat >"$FNOX_CONFIG_FILE" <<EOF
+[leases.github]
+type = "github-app"
+app_id = "12345"
+installation_id = "67890"
+private_key_file = "$TEST_TEMP_DIR/test-app.pem"
+api_base = "http://127.0.0.1:9881"
+
+[leases.github.permissions]
+contents = "read"
+pull_requests = "write"
+EOF
+
+	run fnox lease create github
+	assert_success
+}
+
+@test "github-app: supports repositories config" {
+	generate_test_key
+	start_mock_github_api 9882
+
+	cat >"$FNOX_CONFIG_FILE" <<EOF
+[leases.github]
+type = "github-app"
+app_id = "12345"
+installation_id = "67890"
+private_key_file = "$TEST_TEMP_DIR/test-app.pem"
+api_base = "http://127.0.0.1:9882"
+repositories = ["my-org/my-repo"]
+EOF
+
+	run fnox lease create github
+	assert_success
+}
+
+@test "github-app: lease list shows created lease" {
+	generate_test_key
+	start_mock_github_api 9883
+
+	cat >"$FNOX_CONFIG_FILE" <<EOF
+[leases.github]
+type = "github-app"
+app_id = "12345"
+installation_id = "67890"
+private_key_file = "$TEST_TEMP_DIR/test-app.pem"
+api_base = "http://127.0.0.1:9883"
+EOF
+
+	run fnox lease create github
+	assert_success
+
+	run fnox lease list
+	assert_success
+	assert_output --partial "github"
+}


### PR DESCRIPTION
## Summary

- Adds a new `github-app` lease backend that creates short-lived GitHub installation access tokens from a GitHub App's private key
- Supports scoping tokens to specific permissions and repositories
- Configurable `env_var` (default: `GITHUB_TOKEN`), `api_base` for GitHub Enterprise
- Tokens auto-expire in ≤1 hour (GitHub's hard limit), cached via existing lease ledger

### Example config

```toml
[leases.github]
type = "github-app"
app_id = "12345"
installation_id = "67890"
private_key_file = "~/.config/fnox/github-app.pem"

[leases.github.permissions]
contents = "read"
pull_requests = "write"

repositories = ["my-org/my-repo"]
```

## Test plan

- [x] 9 bats tests covering: token creation (file + env var), `fnox exec` integration, custom env_var, permissions/repositories config, missing key error, lease list
- [x] All tests use a mock HTTP server (no real GitHub credentials needed)
- [x] Existing cargo + bats tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new networked auth/crypto code for generating and revoking GitHub tokens and changes the `LeaseBackend::revoke_lease` API across all backends, so regressions could affect lease cleanup/revocation behavior.
> 
> **Overview**
> Adds a new **`github-app` lease backend** that creates GitHub App installation access tokens by signing a short-lived JWT with an RSA private key (from `FNOX_GITHUB_APP_PRIVATE_KEY` or `private_key_file`), supports optional permission/repository scoping and custom `api_base`, and generates non-secret `lease_id`s derived from a token hash.
> 
> Updates lease revocation to pass **decrypted cached credentials** into `LeaseBackend::revoke_lease` (trait signature change applied across existing backends) so backends can revoke using the actual credential value; `lease cleanup` now explicitly skips passing creds for expired leases. Also sets a default `User-Agent` on the shared `reqwest` client.
> 
> Extends config schema and docs to document the new backend, adds bats tests with a mock GitHub API server, and updates dependencies (`jsonwebtoken` v10 with `aws_lc_rs`, plus lockfile changes around `untrusted`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eed87bd1a4a742f7b58a3f575b566604c96a85d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->