### PR TITLE
refactor(yubikey): dynamically load libusb at runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,24 +29,12 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
-dependencies = [
- "cfg-if",
- "cipher 0.3.0",
- "cpufeatures 0.2.17",
- "opaque-debug",
-]
-
-[[package]]
-name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
- "cipher 0.4.4",
+ "cipher",
  "cpufeatures 0.2.17",
 ]
 
@@ -57,8 +45,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
  "aead",
- "aes 0.8.4",
- "cipher 0.4.4",
+ "aes",
+ "cipher",
  "ctr",
  "ghash",
  "subtle",
@@ -70,7 +58,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf640be7658959746f1f0f2faab798f6098a9436a8e18e148d18bc9875e13c4b"
 dependencies = [
- "aes 0.8.4",
+ "aes",
  "aes-gcm",
  "age-core",
  "base64 0.21.7",
@@ -78,11 +66,11 @@ dependencies = [
  "bech32",
  "cbc",
  "chacha20poly1305",
- "cipher 0.4.4",
+ "cipher",
  "cookie-factory",
  "ctr",
  "curve25519-dalek",
- "hmac 0.12.1",
+ "hmac",
  "i18n-embed",
  "i18n-embed-fl",
  "lazy_static",
@@ -279,7 +267,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote",
  "syn",
  "synstructure",
 ]
@@ -291,7 +279,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote",
  "syn",
 ]
 
@@ -325,7 +313,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote",
  "syn",
 ]
 
@@ -630,7 +618,7 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "hex",
- "hmac 0.12.1",
+ "hmac",
  "http 0.2.12",
  "http 1.4.0",
  "percent-encoding",
@@ -847,7 +835,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94f7cc1bbae04cfe11de9e39e2c6dc755947901e0f4e76180ab542b6deb5e15e"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote",
  "syn",
  "tracing",
 ]
@@ -985,12 +973,6 @@ checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
@@ -1022,15 +1004,6 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
@@ -1040,25 +1013,9 @@ dependencies = [
 
 [[package]]
 name = "block-modes"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb03d1bed155d89dce0f845b7899b18a9a163e148fd004e1c28421a783e2d8e"
-dependencies = [
- "block-padding 0.2.1",
- "cipher 0.3.0",
-]
-
-[[package]]
-name = "block-modes"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e2211b0817f061502a8dd9f11a37e879e79763e3c698d2418cf824d8cb2f21e"
-
-[[package]]
-name = "block-padding"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "block-padding"
@@ -1076,7 +1033,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
 dependencies = [
  "byteorder",
- "cipher 0.4.4",
+ "cipher",
 ]
 
 [[package]]
@@ -1159,7 +1116,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
 dependencies = [
- "cipher 0.4.4",
+ "cipher",
 ]
 
 [[package]]
@@ -1199,7 +1156,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
- "cipher 0.4.4",
+ "cipher",
  "cpufeatures 0.2.17",
 ]
 
@@ -1222,7 +1179,7 @@ checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
  "chacha20 0.9.1",
- "cipher 0.4.4",
+ "cipher",
  "poly1305",
  "zeroize",
 ]
@@ -1301,15 +1258,6 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
@@ -1349,7 +1297,7 @@ checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
 dependencies = [
  "heck",
  "proc-macro2",
- "quote 1.0.45",
+ "quote",
  "syn",
 ]
 
@@ -1560,7 +1508,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "crossterm_winapi",
  "mio",
  "parking_lot",
@@ -1576,7 +1524,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "crossterm_winapi",
  "derive_more",
  "document-features",
@@ -1628,22 +1576,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-mac"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25fab6889090c8133f3deb8f73ba3c65a7f456f66436fc012a1b1e272b1e103e"
-dependencies = [
- "generic-array",
- "subtle",
-]
-
-[[package]]
 name = "ctap-hid-fido2"
 version = "3.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aab54a72e056ad648b432faab0782512a989074a0e15d7c01e24825b22b0d033"
 dependencies = [
- "aes 0.8.4",
+ "aes",
  "anyhow",
  "base64 0.22.1",
  "byteorder",
@@ -1666,7 +1604,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
- "cipher 0.4.4",
+ "cipher",
 ]
 
 [[package]]
@@ -1691,7 +1629,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote",
  "syn",
 ]
 
@@ -1724,7 +1662,7 @@ dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
- "quote 1.0.45",
+ "quote",
  "strsim",
  "syn",
 ]
@@ -1737,7 +1675,7 @@ checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
  "ident_case",
  "proc-macro2",
- "quote 1.0.45",
+ "quote",
  "strsim",
  "syn",
 ]
@@ -1749,7 +1687,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
- "quote 1.0.45",
+ "quote",
  "syn",
 ]
 
@@ -1760,7 +1698,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
- "quote 1.0.45",
+ "quote",
  "syn",
 ]
 
@@ -1856,7 +1794,7 @@ checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
  "convert_case",
  "proc-macro2",
- "quote 1.0.45",
+ "quote",
  "rustc_version",
  "syn",
 ]
@@ -1869,20 +1807,11 @@ checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
 
 [[package]]
 name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
+ "block-buffer",
  "const-oid",
  "crypto-common",
  "subtle",
@@ -1915,7 +1844,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "objc2",
 ]
 
@@ -1926,7 +1855,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote",
  "syn",
 ]
 
@@ -1970,7 +1899,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest 0.10.7",
+ "digest",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -1991,7 +1920,7 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest 0.10.7",
+ "digest",
  "ff",
  "generic-array",
  "group",
@@ -2099,7 +2028,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote",
  "syn",
 ]
 
@@ -2251,13 +2180,14 @@ dependencies = [
  "jsonwebtoken 10.3.0",
  "keepass",
  "keyring",
+ "libloading",
  "miette",
  "miniz_oxide",
  "nix 0.31.2",
  "openssl-sys",
  "pluralizer",
  "proc-macro2",
- "quote 1.0.45",
+ "quote",
  "rand 0.8.5",
  "ratatui",
  "regex",
@@ -2289,7 +2219,6 @@ dependencies = [
  "walkdir",
  "which",
  "xx",
- "yubico_manager",
 ]
 
 [[package]]
@@ -2408,7 +2337,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote",
  "syn",
 ]
 
@@ -2575,7 +2504,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "ignore",
  "walkdir",
 ]
@@ -2962,17 +2891,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac 0.12.1",
-]
-
-[[package]]
-name = "hmac"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
-dependencies = [
- "crypto-mac",
- "digest 0.9.0",
+ "hmac",
 ]
 
 [[package]]
@@ -2981,7 +2900,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -3259,7 +3178,7 @@ dependencies = [
  "i18n-embed",
  "proc-macro-error2",
  "proc-macro2",
- "quote 1.0.45",
+ "quote",
  "strsim",
  "syn",
  "unic-langid",
@@ -3274,7 +3193,7 @@ dependencies = [
  "find-crate",
  "i18n-config",
  "proc-macro2",
- "quote 1.0.45",
+ "quote",
  "syn",
 ]
 
@@ -3484,7 +3403,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
- "block-padding 0.3.3",
+ "block-padding",
  "generic-array",
 ]
 
@@ -3497,7 +3416,7 @@ dependencies = [
  "darling 0.23.0",
  "indoc",
  "proc-macro2",
- "quote 1.0.45",
+ "quote",
  "syn",
 ]
 
@@ -3669,19 +3588,19 @@ version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6ac2759c844c04f434799e3dffa99805cc383e44585a8195f89977a4b472c84"
 dependencies = [
- "aes 0.8.4",
+ "aes",
  "base64 0.22.1",
- "block-modes 0.9.1",
+ "block-modes",
  "byteorder",
  "cbc",
  "chacha20 0.9.1",
  "chrono",
- "cipher 0.4.4",
+ "cipher",
  "flate2",
  "getrandom 0.4.2",
  "hex",
  "hex-literal",
- "hmac 0.12.1",
+ "hmac",
  "js-sys",
  "rust-argon2",
  "salsa20",
@@ -3741,6 +3660,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3752,22 +3681,10 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "libc",
  "plain",
  "redox_syscall 0.7.3",
-]
-
-[[package]]
-name = "libusb1-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22e89d08bbe6816c6c5d446203b859eba35b8fa94bf1b7edb2f6d25d43f023f"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -3865,7 +3782,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote",
  "syn",
 ]
 
@@ -3936,7 +3853,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -3948,7 +3865,7 @@ version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -4093,7 +4010,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "objc2",
  "objc2-core-graphics",
  "objc2-foundation",
@@ -4105,7 +4022,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "dispatch2",
  "objc2",
 ]
@@ -4116,7 +4033,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "dispatch2",
  "objc2",
  "objc2-core-foundation",
@@ -4135,7 +4052,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -4146,7 +4063,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -4193,7 +4110,7 @@ version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -4209,7 +4126,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote",
  "syn",
 ]
 
@@ -4365,8 +4282,8 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest 0.10.7",
- "hmac 0.12.1",
+ "digest",
+ "hmac",
 ]
 
 [[package]]
@@ -4423,7 +4340,7 @@ dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
- "quote 1.0.45",
+ "quote",
  "syn",
 ]
 
@@ -4491,7 +4408,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote",
  "syn",
 ]
 
@@ -4556,7 +4473,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -4636,7 +4553,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote",
 ]
 
 [[package]]
@@ -4647,24 +4564,9 @@ checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
 dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
- "quote 1.0.45",
+ "quote",
  "syn",
 ]
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7f95648580798cc44ff8efb9bb0d7ee5205ea32e087b31b0732f3e8c2648ee2"
-dependencies = [
- "proc-macro-hack-impl",
-]
-
-[[package]]
-name = "proc-macro-hack-impl"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7be55bf0ae1635f4d7c7ddd6efc05c631e98a82104a73d35550bbc52db960027"
 
 [[package]]
 name = "proc-macro2"
@@ -4694,7 +4596,7 @@ dependencies = [
  "anyhow",
  "itertools 0.14.0",
  "proc-macro2",
- "quote 1.0.45",
+ "quote",
  "syn",
 ]
 
@@ -4774,12 +4676,6 @@ dependencies = [
  "tracing",
  "windows-sys 0.60.2",
 ]
-
-[[package]]
-name = "quote"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 
 [[package]]
 name = "quote"
@@ -4884,7 +4780,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "cassowary",
  "compact_str",
  "crossterm 0.28.1",
@@ -4905,7 +4801,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -4914,7 +4810,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -4944,7 +4840,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote",
  "syn",
 ]
 
@@ -5073,7 +4969,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac 0.12.1",
+ "hmac",
  "subtle",
 ]
 
@@ -5121,7 +5017,7 @@ checksum = "6a02ea81d9482b07e1fe156ac7cf98b6823d51fb84531936a5e1cbb4eec31ad5"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
- "quote 1.0.45",
+ "quote",
  "serde_json",
  "syn",
 ]
@@ -5158,7 +5054,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
  "const-oid",
- "digest 0.10.7",
+ "digest",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
@@ -5169,16 +5065,6 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rusb"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a5084628cc5be77b1c750b3e5ee0cc519d2f2491b3f06b78b3aac3328b00ad"
-dependencies = [
- "libc",
- "libusb1-sys",
 ]
 
 [[package]]
@@ -5211,7 +5097,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote",
  "rust-embed-utils",
  "syn",
  "walkdir",
@@ -5269,7 +5155,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -5282,7 +5168,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -5415,7 +5301,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
 dependencies = [
- "cipher 0.4.4",
+ "cipher",
 ]
 
 [[package]]
@@ -5470,7 +5356,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote",
  "serde_derive_internals",
  "syn",
 ]
@@ -5540,7 +5426,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -5553,7 +5439,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -5617,7 +5503,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote",
  "syn",
 ]
 
@@ -5628,7 +5514,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote",
  "syn",
 ]
 
@@ -5702,7 +5588,7 @@ checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",
- "quote 1.0.45",
+ "quote",
  "syn",
 ]
 
@@ -5720,19 +5606,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha-1"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.9.0",
- "opaque-debug",
-]
-
-[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5740,7 +5613,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -5751,7 +5624,7 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -5859,7 +5732,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest 0.10.7",
+ "digest",
  "rand_core 0.6.4",
 ]
 
@@ -5964,27 +5837,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
-name = "structure"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8379aeb9cf8935b018b14d9191b15096e984ad8b77424b9bce075ea15d1fa59"
-dependencies = [
- "byteorder",
- "proc-macro-hack",
- "structure-macro-impl",
-]
-
-[[package]]
-name = "structure-macro-impl"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c0529f2429c8bb5878688fffab7f700087f4bd47906e6acf03fd7361f77aca"
-dependencies = [
- "proc-macro-hack",
- "quote 0.3.15",
-]
-
-[[package]]
 name = "strum"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6019,7 +5871,7 @@ checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
  "heck",
  "proc-macro2",
- "quote 1.0.45",
+ "quote",
  "rustversion",
  "syn",
 ]
@@ -6032,7 +5884,7 @@ checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
  "heck",
  "proc-macro2",
- "quote 1.0.45",
+ "quote",
  "syn",
 ]
 
@@ -6044,7 +5896,7 @@ checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",
- "quote 1.0.45",
+ "quote",
  "syn",
 ]
 
@@ -6082,7 +5934,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote",
  "unicode-ident",
 ]
 
@@ -6102,7 +5954,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote",
  "syn",
 ]
 
@@ -6128,7 +5980,7 @@ dependencies = [
  "heck",
  "proc-macro-error2",
  "proc-macro2",
- "quote 1.0.45",
+ "quote",
  "syn",
 ]
 
@@ -6231,7 +6083,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote",
  "syn",
 ]
 
@@ -6242,7 +6094,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote",
  "syn",
 ]
 
@@ -6351,7 +6203,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote",
  "syn",
 ]
 
@@ -6560,7 +6412,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "async-compression",
- "bitflags 2.11.0",
+ "bitflags",
  "bytes",
  "futures-core",
  "futures-util",
@@ -6607,7 +6459,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote",
  "syn",
 ]
 
@@ -6672,7 +6524,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a78e83a30223c757c3947cd144a31014ff04298d8719ae10d03c31c0448c8013"
 dependencies = [
- "cipher 0.4.4",
+ "cipher",
 ]
 
 [[package]]
@@ -6736,7 +6588,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ecee5b05c459ea4cd97df7685db58699c32e070465f88dc806d7c98a5088edc"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote",
  "rustc_version",
  "syn",
 ]
@@ -7027,7 +6879,7 @@ version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
- "quote 1.0.45",
+ "quote",
  "wasm-bindgen-macro-support",
 ]
 
@@ -7039,7 +6891,7 @@ checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
  "bumpalo",
  "proc-macro2",
- "quote 1.0.45",
+ "quote",
  "syn",
  "wasm-bindgen-shared",
 ]
@@ -7094,7 +6946,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "hashbrown 0.15.5",
  "indexmap 2.13.0",
  "semver",
@@ -7268,7 +7120,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote",
  "syn",
 ]
 
@@ -7279,7 +7131,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote",
  "syn",
 ]
 
@@ -7650,7 +7502,7 @@ dependencies = [
  "anyhow",
  "prettyplease",
  "proc-macro2",
- "quote 1.0.45",
+ "quote",
  "syn",
  "wit-bindgen-core",
  "wit-bindgen-rust",
@@ -7663,7 +7515,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags",
  "indexmap 2.13.0",
  "log",
  "serde",
@@ -7803,25 +7655,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote",
  "syn",
  "synstructure",
-]
-
-[[package]]
-name = "yubico_manager"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff64094218f27836b8683bd93fa7f257475d217449eb7629746fa8eaee068eee"
-dependencies = [
- "aes 0.7.5",
- "bitflags 1.3.2",
- "block-modes 0.8.1",
- "hmac 0.11.0",
- "rand 0.8.5",
- "rusb",
- "sha-1",
- "structure",
 ]
 
 [[package]]
@@ -7840,7 +7676,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3545ea9e86d12ab9bba9fcd99b54c1556fd3199007def5a03c375623d05fac1c"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote",
  "syn",
 ]
 
@@ -7860,7 +7696,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote",
  "syn",
  "synstructure",
 ]
@@ -7881,7 +7717,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote",
  "syn",
 ]
 
@@ -7915,7 +7751,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote",
  "syn",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ usage-lib = { version = "2", features = ["clap"] }
 walkdir = "2"
 which = "7"
 xx = { version = "2", features = ["fslock"] }
-yubico_manager = "0.9"
+libloading = "0.8"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 dbus = { version = "0.9", features = ["vendored"] }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -28,6 +28,7 @@ pub mod resolver;
 pub mod secret_ref;
 pub mod vault;
 pub mod yubikey;
+pub mod yubikey_usb;
 
 pub use bitwarden::BitwardenBackend;
 pub use resolver::resolve_provider_config;

--- a/src/providers/yubikey.rs
+++ b/src/providers/yubikey.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use std::sync::OnceLock;
 
 use super::hw_encrypt;
+use super::yubikey_usb;
 
 pub fn env_dependencies() -> &'static [&'static str] {
     &[]
@@ -56,33 +57,11 @@ impl YubikeyProvider {
 
         eprintln!("Tap your YubiKey...");
 
-        let mut yk = yubico_manager::Yubico::new();
-        let device = yk
-            .find_yubikey()
-            .map_err(|e| FnoxError::Provider(format!("Failed to find YubiKey: {:?}", e)))?;
+        let device = yubikey_usb::find_yubikey()
+            .map_err(|e| FnoxError::Provider(format!("Failed to find YubiKey: {e}")))?;
 
-        let slot = match self.slot {
-            1 => yubico_manager::config::Slot::Slot1,
-            _ => yubico_manager::config::Slot::Slot2,
-        };
-        let command = match self.slot {
-            1 => yubico_manager::config::Command::ChallengeHmac1,
-            _ => yubico_manager::config::Command::ChallengeHmac2,
-        };
-        let yk_conf = yubico_manager::config::Config {
-            product_id: device.product_id,
-            vendor_id: device.vendor_id,
-            variable: false,
-            slot,
-            mode: yubico_manager::config::Mode::Sha1,
-            command,
-        };
-
-        let hmac_result = yk
-            .challenge_response_hmac(&self.challenge, yk_conf)
-            .map_err(|e| {
-                FnoxError::Provider(format!("YubiKey HMAC-SHA1 challenge failed: {:?}", e))
-            })?;
+        let hmac_result = yubikey_usb::challenge_response_hmac(&self.challenge, &device, self.slot)
+            .map_err(|e| FnoxError::Provider(format!("YubiKey HMAC-SHA1 challenge failed: {e}")))?;
 
         let secret = hmac_result.to_vec();
         guard.insert(self.provider_name.clone(), secret.clone());
@@ -120,6 +99,7 @@ impl crate::providers::Provider for YubikeyProvider {
 
 /// Setup helpers for `fnox provider add --type yubikey`
 pub mod setup {
+    use super::yubikey_usb;
     use crate::error::{FnoxError, Result};
 
     pub fn setup_yubikey(provider_name: &str) -> Result<(String, String)> {
@@ -148,36 +128,14 @@ pub mod setup {
         eprintln!("Tap your YubiKey now...");
 
         // Verify the YubiKey works with this challenge
-        let mut yk = yubico_manager::Yubico::new();
-        let device = yk
-            .find_yubikey()
-            .map_err(|e| FnoxError::Provider(format!("Failed to find YubiKey: {:?}", e)))?;
+        let device = yubikey_usb::find_yubikey()
+            .map_err(|e| FnoxError::Provider(format!("Failed to find YubiKey: {e}")))?;
 
-        let slot = match slot_num {
-            1 => yubico_manager::config::Slot::Slot1,
-            _ => yubico_manager::config::Slot::Slot2,
-        };
-        let command = match slot_num {
-            1 => yubico_manager::config::Command::ChallengeHmac1,
-            _ => yubico_manager::config::Command::ChallengeHmac2,
-        };
-        let yk_conf = yubico_manager::config::Config {
-            product_id: device.product_id,
-            vendor_id: device.vendor_id,
-            variable: false,
-            slot,
-            mode: yubico_manager::config::Mode::Sha1,
-            command,
-        };
-
-        let _ = yk
-            .challenge_response_hmac(&challenge, yk_conf)
-            .map_err(|e| {
-                FnoxError::Provider(format!(
-                    "YubiKey HMAC-SHA1 challenge failed: {:?}. Make sure HMAC-SHA1 is configured on slot {}.",
-                    e, slot_num
-                ))
-            })?;
+        yubikey_usb::challenge_response_hmac(&challenge, &device, slot_num).map_err(|e| {
+            FnoxError::Provider(format!(
+                "YubiKey HMAC-SHA1 challenge failed: {e}. Make sure HMAC-SHA1 is configured on slot {slot_num}.",
+            ))
+        })?;
 
         eprintln!(
             "YubiKey verified successfully for provider '{}'.",

--- a/src/providers/yubikey.rs
+++ b/src/providers/yubikey.rs
@@ -57,10 +57,7 @@ impl YubikeyProvider {
 
         eprintln!("Tap your YubiKey...");
 
-        let device = yubikey_usb::find_yubikey()
-            .map_err(|e| FnoxError::Provider(format!("Failed to find YubiKey: {e}")))?;
-
-        let hmac_result = yubikey_usb::challenge_response_hmac(&self.challenge, &device, self.slot)
+        let hmac_result = yubikey_usb::challenge_response_hmac(&self.challenge, self.slot)
             .map_err(|e| FnoxError::Provider(format!("YubiKey HMAC-SHA1 challenge failed: {e}")))?;
 
         let secret = hmac_result.to_vec();
@@ -128,10 +125,7 @@ pub mod setup {
         eprintln!("Tap your YubiKey now...");
 
         // Verify the YubiKey works with this challenge
-        let device = yubikey_usb::find_yubikey()
-            .map_err(|e| FnoxError::Provider(format!("Failed to find YubiKey: {e}")))?;
-
-        yubikey_usb::challenge_response_hmac(&challenge, &device, slot_num).map_err(|e| {
+        yubikey_usb::challenge_response_hmac(&challenge, slot_num).map_err(|e| {
             FnoxError::Provider(format!(
                 "YubiKey HMAC-SHA1 challenge failed: {e}. Make sure HMAC-SHA1 is configured on slot {slot_num}.",
             ))

--- a/src/providers/yubikey_usb.rs
+++ b/src/providers/yubikey_usb.rs
@@ -10,11 +10,20 @@
 
 use std::ptr;
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use crate::error::{FnoxError, Result};
 
 const VENDOR_ID: u16 = 0x1050;
+
+// Known OTP-capable YubiKey product IDs. FIDO2-only Security Keys and YubiKey Bio
+// do not support the HMAC-SHA1 HID frame protocol.
+const OTP_PRODUCT_IDS: &[u16] = &[
+    0x0010, // YubiKey 1
+    0x0110, 0x0111, 0x0112, 0x0114, 0x0116, // YubiKey NEO
+    0x0401, 0x0403, 0x0405, 0x0407, // YubiKey 4/5 OTP+U2F, OTP+U2F+CCID, OTP+CCID, OTP
+    0x0410, // YubiKey Plus
+];
 
 // HID constants
 const HID_GET_REPORT: u8 = 0x01;
@@ -41,6 +50,9 @@ const RESP_PENDING_FLAG: u8 = 0x40;
 // Commands
 const CHALLENGE_HMAC1: u8 = 0x30;
 const CHALLENGE_HMAC2: u8 = 0x38;
+
+// Timeout for wait_for polling loop
+const WAIT_TIMEOUT: Duration = Duration::from_secs(15);
 
 // Opaque libusb types
 enum LibusbContext {}
@@ -79,6 +91,9 @@ struct LibUsb {
     close: unsafe extern "C" fn(*mut LibusbDeviceHandle),
     control_transfer:
         unsafe extern "C" fn(*mut LibusbDeviceHandle, u8, u8, u16, u16, *mut u8, u16, u32) -> i32,
+    kernel_driver_active: unsafe extern "C" fn(*mut LibusbDeviceHandle, i32) -> i32,
+    detach_kernel_driver: unsafe extern "C" fn(*mut LibusbDeviceHandle, i32) -> i32,
+    claim_interface: unsafe extern "C" fn(*mut LibusbDeviceHandle, i32) -> i32,
 }
 
 impl LibUsb {
@@ -155,6 +170,21 @@ impl LibUsb {
                     u32,
                 ) -> i32>(b"libusb_control_transfer\0")
                 .map_err(|e| FnoxError::Provider(format!("libusb symbol error: {e}")))?;
+            let kernel_driver_active = *lib
+                .get::<unsafe extern "C" fn(*mut LibusbDeviceHandle, i32) -> i32>(
+                    b"libusb_kernel_driver_active\0",
+                )
+                .map_err(|e| FnoxError::Provider(format!("libusb symbol error: {e}")))?;
+            let detach_kernel_driver = *lib
+                .get::<unsafe extern "C" fn(*mut LibusbDeviceHandle, i32) -> i32>(
+                    b"libusb_detach_kernel_driver\0",
+                )
+                .map_err(|e| FnoxError::Provider(format!("libusb symbol error: {e}")))?;
+            let claim_interface = *lib
+                .get::<unsafe extern "C" fn(*mut LibusbDeviceHandle, i32) -> i32>(
+                    b"libusb_claim_interface\0",
+                )
+                .map_err(|e| FnoxError::Provider(format!("libusb symbol error: {e}")))?;
 
             Ok(LibUsb {
                 _lib: lib,
@@ -166,6 +196,9 @@ impl LibUsb {
                 open,
                 close,
                 control_transfer,
+                kernel_driver_active,
+                detach_kernel_driver,
+                claim_interface,
             })
         }
     }
@@ -200,6 +233,7 @@ impl UsbContext {
         }
 
         let result = (|| {
+            let mut found_non_otp = false;
             for i in 0..count as usize {
                 let dev = unsafe { *list.add(i) };
                 if dev.is_null() {
@@ -211,15 +245,26 @@ impl UsbContext {
                     continue;
                 }
                 if desc.id_vendor == VENDOR_ID {
-                    return Ok(Device {
-                        vendor_id: desc.id_vendor,
-                        product_id: desc.id_product,
-                    });
+                    if OTP_PRODUCT_IDS.contains(&desc.id_product) {
+                        return Ok(Device {
+                            vendor_id: desc.id_vendor,
+                            product_id: desc.id_product,
+                        });
+                    }
+                    found_non_otp = true;
                 }
             }
-            Err(FnoxError::Provider(
-                "No YubiKey found. Make sure it is plugged in.".to_string(),
-            ))
+            if found_non_otp {
+                Err(FnoxError::Provider(
+                    "Found a Yubico device, but it does not support OTP/HMAC-SHA1. \
+                     FIDO2-only Security Keys are not supported for this provider."
+                        .to_string(),
+                ))
+            } else {
+                Err(FnoxError::Provider(
+                    "No YubiKey found. Make sure it is plugged in.".to_string(),
+                ))
+            }
         })();
 
         unsafe { (self.lib.free_device_list)(list, 1) };
@@ -254,6 +299,32 @@ impl UsbContext {
                             "Failed to open YubiKey (libusb error {rc})"
                         )));
                     }
+
+                    // On Linux, detach the kernel HID driver and claim the interface.
+                    // Without this, control transfers fail with LIBUSB_ERROR_ACCESS (-3)
+                    // or LIBUSB_ERROR_BUSY (-6) because the kernel driver owns the device.
+                    // On macOS/Windows this is not needed (returns LIBUSB_ERROR_NOT_SUPPORTED).
+                    unsafe {
+                        let active = (self.lib.kernel_driver_active)(handle, 0);
+                        if active == 1 {
+                            let rc = (self.lib.detach_kernel_driver)(handle, 0);
+                            if rc < 0 && rc != -12 {
+                                // -12 = LIBUSB_ERROR_NOT_SUPPORTED (macOS/Windows)
+                                (self.lib.close)(handle);
+                                return Err(FnoxError::Provider(format!(
+                                    "Failed to detach kernel driver from YubiKey (libusb error {rc})"
+                                )));
+                            }
+                        }
+                        let rc = (self.lib.claim_interface)(handle, 0);
+                        if rc < 0 && rc != -12 {
+                            (self.lib.close)(handle);
+                            return Err(FnoxError::Provider(format!(
+                                "Failed to claim YubiKey interface (libusb error {rc})"
+                            )));
+                        }
+                    }
+
                     return Ok(DeviceHandle {
                         lib: &self.lib,
                         handle,
@@ -330,8 +401,14 @@ impl DeviceHandle<'_> {
     }
 
     fn wait_for<F: Fn(u8) -> bool>(&self, predicate: F) -> Result<[u8; 8]> {
+        let deadline = Instant::now() + WAIT_TIMEOUT;
         let mut buf = [0u8; 8];
         loop {
+            if Instant::now() > deadline {
+                return Err(FnoxError::Provider(
+                    "Timed out waiting for YubiKey response (is the key plugged in?)".to_string(),
+                ));
+            }
             self.read_report(&mut buf)?;
             let flags = buf[7];
             if predicate(flags) {
@@ -354,6 +431,9 @@ impl DeviceHandle<'_> {
             let is_last = offset + chunk_len >= FRAME_SIZE;
             let is_nonzero = packet[..7].iter().any(|&b| b != 0);
 
+            // NOTE: The YubiKey firmware treats undelivered zero-payload chunks as
+            // zero-filled. This optimization matches yubico_manager behavior and has
+            // been stable across all firmware versions since YubiKey 2.x.
             if is_first || is_last || is_nonzero {
                 packet[7] = SLOT_WRITE_FLAG | seq;
                 self.wait_for(|f| f & SLOT_WRITE_FLAG == 0)?;
@@ -373,10 +453,16 @@ impl DeviceHandle<'_> {
         let mut r0: usize = 7;
 
         loop {
+            if r0 >= 36 {
+                break;
+            }
             let mut buf = [0u8; 8];
             let n = self.read_report(&mut buf)?;
             if n < 8 {
-                break;
+                return Err(FnoxError::Provider(format!(
+                    "YubiKey returned a short HID report ({n} bytes, expected 8); \
+                     is the key still plugged in?"
+                )));
             }
             let end = (r0 + 8).min(36);
             let copy_len = end - r0;
@@ -438,7 +524,8 @@ fn build_frame(payload: &[u8; DATA_SIZE], command: u8) -> [u8; FRAME_SIZE] {
     let mut frame = [0u8; FRAME_SIZE];
     frame[..DATA_SIZE].copy_from_slice(payload);
     frame[DATA_SIZE] = command;
-    let crc = crc16(&frame[..DATA_SIZE]).to_le_bytes();
+    // CRC covers payload + command byte (65 bytes), per YubiKey protocol spec
+    let crc = crc16(&frame[..DATA_SIZE + 1]).to_le_bytes();
     frame[DATA_SIZE + 1] = crc[0];
     frame[DATA_SIZE + 2] = crc[1];
     // filler bytes remain 0
@@ -459,6 +546,12 @@ pub fn find_yubikey() -> Result<Device> {
 ///
 /// Returns the 20-byte HMAC-SHA1 response.
 pub fn challenge_response_hmac(challenge: &[u8], device: &Device, slot: u8) -> Result<[u8; 20]> {
+    if slot != 1 && slot != 2 {
+        return Err(FnoxError::Provider(format!(
+            "Invalid YubiKey slot {slot}, must be 1 or 2"
+        )));
+    }
+
     let ctx = UsbContext::new()?;
     let handle = ctx.open_device(device.vendor_id, device.product_id)?;
 

--- a/src/providers/yubikey_usb.rs
+++ b/src/providers/yubikey_usb.rs
@@ -3,6 +3,10 @@
 //! This module replaces the `yubico_manager` crate with a minimal implementation
 //! that loads libusb at runtime via `libloading`. If libusb is not installed,
 //! the binary still starts — the YubiKey provider returns a clear error when used.
+//!
+//! The YubiKey OTP frame protocol and USB HID report handling are based on
+//! yubico_manager (https://github.com/wisespace-io/yubico-rs), licensed under
+//! MIT OR Apache-2.0.
 
 use std::ptr;
 use std::thread;

--- a/src/providers/yubikey_usb.rs
+++ b/src/providers/yubikey_usb.rs
@@ -16,13 +16,20 @@ use crate::error::{FnoxError, Result};
 
 const VENDOR_ID: u16 = 0x1050;
 
-// Known OTP-capable YubiKey product IDs. FIDO2-only Security Keys and YubiKey Bio
-// do not support the HMAC-SHA1 HID frame protocol.
+// OTP-capable YubiKey product IDs, sourced from yubikey-manager (ykman).
+// Only PIDs with the OTP interface enabled support HMAC-SHA1 challenge-response.
+// PIDs without OTP (e.g. 0x0112 NEO CCID, 0x0402 FIDO, 0x0406 FIDO+CCID) are excluded.
 const OTP_PRODUCT_IDS: &[u16] = &[
-    0x0010, // YubiKey 1
-    0x0110, 0x0111, 0x0112, 0x0114, 0x0116, // YubiKey NEO
-    0x0401, 0x0403, 0x0405, 0x0407, // YubiKey 4/5 OTP+U2F, OTP+U2F+CCID, OTP+CCID, OTP
-    0x0410, // YubiKey Plus
+    0x0010, // YubiKey Standard (v1/v2) — OTP
+    0x0110, // YubiKey NEO — OTP
+    0x0111, // YubiKey NEO — OTP+CCID
+    0x0114, // YubiKey NEO — OTP+FIDO
+    0x0116, // YubiKey NEO — OTP+FIDO+CCID
+    0x0401, // YubiKey 4/5 — OTP
+    0x0403, // YubiKey 4/5 — OTP+FIDO
+    0x0405, // YubiKey 4/5 — OTP+CCID
+    0x0407, // YubiKey 4/5 — OTP+FIDO+CCID
+    0x0410, // YubiKey Plus — OTP+FIDO
 ];
 
 // HID constants
@@ -108,7 +115,12 @@ impl LibUsb {
                 "/usr/local/lib/libusb-1.0.0.dylib",
             ]
         } else if cfg!(target_os = "windows") {
-            &["libusb-1.0.dll"]
+            &[
+                "libusb-1.0.dll",
+                "C:\\Program Files\\LibUSB-Win32\\bin\\amd64\\libusb-1.0.dll",
+                "C:\\Program Files\\libusb\\bin\\libusb-1.0.dll",
+                "C:\\vcpkg\\installed\\x64-windows\\bin\\libusb-1.0.dll",
+            ]
         } else {
             // Linux / other Unix
             &["libusb-1.0.so", "libusb-1.0.so.0"]

--- a/src/providers/yubikey_usb.rs
+++ b/src/providers/yubikey_usb.rs
@@ -237,7 +237,9 @@ impl UsbContext {
         Ok(UsbContext { lib, ctx })
     }
 
-    fn find_yubikey(&self) -> Result<Device> {
+    /// Find the first OTP-capable YubiKey and open it in a single enumeration pass.
+    /// This avoids a TOCTOU gap between finding and opening the device.
+    fn find_and_open(&self) -> Result<DeviceHandle<'_>> {
         let mut list: *mut *mut LibusbDevice = ptr::null_mut();
         let count = unsafe { (self.lib.get_device_list)(self.ctx, &mut list) };
         if count < 0 {
@@ -259,53 +261,11 @@ impl UsbContext {
                     continue;
                 }
                 if desc.id_vendor == VENDOR_ID {
-                    if OTP_PRODUCT_IDS.contains(&desc.id_product) {
-                        return Ok(Device {
-                            vendor_id: desc.id_vendor,
-                            product_id: desc.id_product,
-                        });
+                    if !OTP_PRODUCT_IDS.contains(&desc.id_product) {
+                        found_non_otp = true;
+                        continue;
                     }
-                    found_non_otp = true;
-                }
-            }
-            if found_non_otp {
-                Err(FnoxError::Provider(
-                    "Found a Yubico device, but it does not support OTP/HMAC-SHA1. \
-                     FIDO2-only Security Keys are not supported for this provider."
-                        .to_string(),
-                ))
-            } else {
-                Err(FnoxError::Provider(
-                    "No YubiKey found. Make sure it is plugged in.".to_string(),
-                ))
-            }
-        })();
 
-        unsafe { (self.lib.free_device_list)(list, 1) };
-        result
-    }
-
-    fn open_device(&self, vid: u16, pid: u16) -> Result<DeviceHandle<'_>> {
-        let mut list: *mut *mut LibusbDevice = ptr::null_mut();
-        let count = unsafe { (self.lib.get_device_list)(self.ctx, &mut list) };
-        if count < 0 {
-            return Err(FnoxError::Provider(
-                "Failed to enumerate USB devices".to_string(),
-            ));
-        }
-
-        let result = (|| {
-            for i in 0..count as usize {
-                let dev = unsafe { *list.add(i) };
-                if dev.is_null() {
-                    break;
-                }
-                let mut desc = LibusbDeviceDescriptor::default();
-                let rc = unsafe { (self.lib.get_device_descriptor)(dev, &mut desc) };
-                if rc < 0 {
-                    continue;
-                }
-                if desc.id_vendor == vid && desc.id_product == pid {
                     let mut handle: *mut LibusbDeviceHandle = ptr::null_mut();
                     let rc = unsafe { (self.lib.open)(dev, &mut handle) };
                     if rc < 0 {
@@ -336,7 +296,6 @@ impl UsbContext {
                         }
                         let rc = (self.lib.claim_interface)(handle, 0);
                         if rc < 0 && rc != -12 {
-                            // Re-attach if we detached before failing
                             if driver_was_detached {
                                 (self.lib.attach_kernel_driver)(handle, 0);
                             }
@@ -354,9 +313,17 @@ impl UsbContext {
                     });
                 }
             }
-            Err(FnoxError::Provider(
-                "YubiKey not found during open".to_string(),
-            ))
+            if found_non_otp {
+                Err(FnoxError::Provider(
+                    "Found a Yubico device, but it does not support OTP/HMAC-SHA1. \
+                     FIDO2-only Security Keys are not supported for this provider."
+                        .to_string(),
+                ))
+            } else {
+                Err(FnoxError::Provider(
+                    "No YubiKey found. Make sure it is plugged in.".to_string(),
+                ))
+            }
         })();
 
         unsafe { (self.lib.free_device_list)(list, 1) };
@@ -529,12 +496,6 @@ impl Drop for DeviceHandle<'_> {
 // Ensure the handle types are Send (the raw pointers are only accessed from one thread).
 unsafe impl Send for UsbContext {}
 
-#[derive(Clone, Debug)]
-pub struct Device {
-    pub vendor_id: u16,
-    pub product_id: u16,
-}
-
 fn crc16(data: &[u8]) -> u16 {
     let mut crc = CRC_PRESET;
     for &b in data {
@@ -562,20 +523,16 @@ fn build_frame(payload: &[u8; DATA_SIZE], command: u8) -> [u8; FRAME_SIZE] {
     frame
 }
 
-/// Find a connected YubiKey. Returns device info (VID/PID).
-pub fn find_yubikey() -> Result<Device> {
-    let ctx = UsbContext::new()?;
-    ctx.find_yubikey()
-}
-
 /// Perform HMAC-SHA1 challenge-response with a YubiKey.
 ///
+/// Finds the first OTP-capable YubiKey, opens it, and performs the challenge
+/// in a single libusb context — no TOCTOU gap between discovery and use.
+///
 /// `challenge`: the raw challenge bytes (up to 64 bytes)
-/// `device`: the device returned by `find_yubikey()`
 /// `slot`: 1 or 2
 ///
 /// Returns the 20-byte HMAC-SHA1 response.
-pub fn challenge_response_hmac(challenge: &[u8], device: &Device, slot: u8) -> Result<[u8; 20]> {
+pub fn challenge_response_hmac(challenge: &[u8], slot: u8) -> Result<[u8; 20]> {
     if slot != 1 && slot != 2 {
         return Err(FnoxError::Provider(format!(
             "Invalid YubiKey slot {slot}, must be 1 or 2"
@@ -583,7 +540,7 @@ pub fn challenge_response_hmac(challenge: &[u8], device: &Device, slot: u8) -> R
     }
 
     let ctx = UsbContext::new()?;
-    let handle = ctx.open_device(device.vendor_id, device.product_id)?;
+    let handle = ctx.find_and_open()?;
 
     let mut payload = [0u8; DATA_SIZE];
     let len = challenge.len().min(DATA_SIZE);

--- a/src/providers/yubikey_usb.rs
+++ b/src/providers/yubikey_usb.rs
@@ -93,7 +93,9 @@ struct LibUsb {
         unsafe extern "C" fn(*mut LibusbDeviceHandle, u8, u8, u16, u16, *mut u8, u16, u32) -> i32,
     kernel_driver_active: unsafe extern "C" fn(*mut LibusbDeviceHandle, i32) -> i32,
     detach_kernel_driver: unsafe extern "C" fn(*mut LibusbDeviceHandle, i32) -> i32,
+    attach_kernel_driver: unsafe extern "C" fn(*mut LibusbDeviceHandle, i32) -> i32,
     claim_interface: unsafe extern "C" fn(*mut LibusbDeviceHandle, i32) -> i32,
+    release_interface: unsafe extern "C" fn(*mut LibusbDeviceHandle, i32) -> i32,
 }
 
 impl LibUsb {
@@ -180,9 +182,19 @@ impl LibUsb {
                     b"libusb_detach_kernel_driver\0",
                 )
                 .map_err(|e| FnoxError::Provider(format!("libusb symbol error: {e}")))?;
+            let attach_kernel_driver = *lib
+                .get::<unsafe extern "C" fn(*mut LibusbDeviceHandle, i32) -> i32>(
+                    b"libusb_attach_kernel_driver\0",
+                )
+                .map_err(|e| FnoxError::Provider(format!("libusb symbol error: {e}")))?;
             let claim_interface = *lib
                 .get::<unsafe extern "C" fn(*mut LibusbDeviceHandle, i32) -> i32>(
                     b"libusb_claim_interface\0",
+                )
+                .map_err(|e| FnoxError::Provider(format!("libusb symbol error: {e}")))?;
+            let release_interface = *lib
+                .get::<unsafe extern "C" fn(*mut LibusbDeviceHandle, i32) -> i32>(
+                    b"libusb_release_interface\0",
                 )
                 .map_err(|e| FnoxError::Provider(format!("libusb symbol error: {e}")))?;
 
@@ -198,7 +210,9 @@ impl LibUsb {
                 control_transfer,
                 kernel_driver_active,
                 detach_kernel_driver,
+                attach_kernel_driver,
                 claim_interface,
+                release_interface,
             })
         }
     }
@@ -304,6 +318,7 @@ impl UsbContext {
                     // Without this, control transfers fail with LIBUSB_ERROR_ACCESS (-3)
                     // or LIBUSB_ERROR_BUSY (-6) because the kernel driver owns the device.
                     // On macOS/Windows this is not needed (returns LIBUSB_ERROR_NOT_SUPPORTED).
+                    let mut driver_was_detached = false;
                     unsafe {
                         let active = (self.lib.kernel_driver_active)(handle, 0);
                         if active == 1 {
@@ -315,9 +330,16 @@ impl UsbContext {
                                     "Failed to detach kernel driver from YubiKey (libusb error {rc})"
                                 )));
                             }
+                            if rc == 0 {
+                                driver_was_detached = true;
+                            }
                         }
                         let rc = (self.lib.claim_interface)(handle, 0);
                         if rc < 0 && rc != -12 {
+                            // Re-attach if we detached before failing
+                            if driver_was_detached {
+                                (self.lib.attach_kernel_driver)(handle, 0);
+                            }
                             (self.lib.close)(handle);
                             return Err(FnoxError::Provider(format!(
                                 "Failed to claim YubiKey interface (libusb error {rc})"
@@ -328,6 +350,7 @@ impl UsbContext {
                     return Ok(DeviceHandle {
                         lib: &self.lib,
                         handle,
+                        driver_was_detached,
                     });
                 }
             }
@@ -351,6 +374,7 @@ impl Drop for UsbContext {
 struct DeviceHandle<'a> {
     lib: &'a LibUsb,
     handle: *mut LibusbDeviceHandle,
+    driver_was_detached: bool,
 }
 
 impl DeviceHandle<'_> {
@@ -492,7 +516,13 @@ impl DeviceHandle<'_> {
 
 impl Drop for DeviceHandle<'_> {
     fn drop(&mut self) {
-        unsafe { (self.lib.close)(self.handle) };
+        unsafe {
+            (self.lib.release_interface)(self.handle, 0);
+            if self.driver_was_detached {
+                (self.lib.attach_kernel_driver)(self.handle, 0);
+            }
+            (self.lib.close)(self.handle);
+        }
     }
 }
 

--- a/src/providers/yubikey_usb.rs
+++ b/src/providers/yubikey_usb.rs
@@ -1,0 +1,492 @@
+//! Dynamic libusb loading for YubiKey HMAC-SHA1 challenge-response.
+//!
+//! This module replaces the `yubico_manager` crate with a minimal implementation
+//! that loads libusb at runtime via `libloading`. If libusb is not installed,
+//! the binary still starts — the YubiKey provider returns a clear error when used.
+
+use std::ptr;
+use std::thread;
+use std::time::Duration;
+
+use crate::error::{FnoxError, Result};
+
+const VENDOR_ID: u16 = 0x1050;
+
+// HID constants
+const HID_GET_REPORT: u8 = 0x01;
+const HID_SET_REPORT: u8 = 0x09;
+const REPORT_TYPE_FEATURE: u16 = 0x03;
+
+// USB request type components
+const REQTYPE_IN_CLASS_INTERFACE: u8 = 0x80 | 0x20 | 0x01; // Direction::In | RequestType::Class | Recipient::Interface
+const REQTYPE_OUT_CLASS_INTERFACE: u8 = 0x20 | 0x01; // Direction::Out | RequestType::Class | Recipient::Interface
+
+// Frame constants
+const DATA_SIZE: usize = 64;
+const FRAME_SIZE: usize = 70;
+
+// CRC constants
+const CRC_PRESET: u16 = 0xFFFF;
+const CRC_POLYNOMIAL: u16 = 0x8408;
+const CRC_RESIDUAL_OK: u16 = 0xF0B8;
+
+// Flags
+const SLOT_WRITE_FLAG: u8 = 0x80;
+const RESP_PENDING_FLAG: u8 = 0x40;
+
+// Commands
+const CHALLENGE_HMAC1: u8 = 0x30;
+const CHALLENGE_HMAC2: u8 = 0x38;
+
+// Opaque libusb types
+enum LibusbContext {}
+enum LibusbDevice {}
+enum LibusbDeviceHandle {}
+
+#[repr(C)]
+#[derive(Default)]
+struct LibusbDeviceDescriptor {
+    b_length: u8,
+    b_descriptor_type: u8,
+    bcd_usb: u16,
+    b_device_class: u8,
+    b_device_sub_class: u8,
+    b_device_protocol: u8,
+    b_max_packet_size0: u8,
+    id_vendor: u16,
+    id_product: u16,
+    bcd_device: u16,
+    i_manufacturer: u8,
+    i_product: u8,
+    i_serial_number: u8,
+    b_num_configurations: u8,
+}
+
+/// Loaded libusb function pointers.
+struct LibUsb {
+    _lib: libloading::Library,
+    init: unsafe extern "C" fn(*mut *mut LibusbContext) -> i32,
+    exit: unsafe extern "C" fn(*mut LibusbContext),
+    get_device_list: unsafe extern "C" fn(*mut LibusbContext, *mut *mut *mut LibusbDevice) -> isize,
+    free_device_list: unsafe extern "C" fn(*mut *mut LibusbDevice, i32),
+    get_device_descriptor:
+        unsafe extern "C" fn(*mut LibusbDevice, *mut LibusbDeviceDescriptor) -> i32,
+    open: unsafe extern "C" fn(*mut LibusbDevice, *mut *mut LibusbDeviceHandle) -> i32,
+    close: unsafe extern "C" fn(*mut LibusbDeviceHandle),
+    control_transfer:
+        unsafe extern "C" fn(*mut LibusbDeviceHandle, u8, u8, u16, u16, *mut u8, u16, u32) -> i32,
+}
+
+impl LibUsb {
+    fn load() -> Result<Self> {
+        let lib_names: &[&str] = if cfg!(target_os = "macos") {
+            &[
+                "libusb-1.0.dylib",
+                "libusb-1.0.0.dylib",
+                "/opt/homebrew/lib/libusb-1.0.0.dylib",
+                "/usr/local/lib/libusb-1.0.0.dylib",
+            ]
+        } else if cfg!(target_os = "windows") {
+            &["libusb-1.0.dll"]
+        } else {
+            // Linux / other Unix
+            &["libusb-1.0.so", "libusb-1.0.so.0"]
+        };
+
+        let lib = lib_names
+            .iter()
+            .find_map(|name| unsafe { libloading::Library::new(name).ok() })
+            .ok_or_else(|| {
+                let install_hint = if cfg!(target_os = "macos") {
+                    "Install it with: brew install libusb"
+                } else if cfg!(target_os = "windows") {
+                    "Install libusb from https://libusb.info"
+                } else {
+                    "Install it with: sudo apt install libusb-1.0-0 (Debian/Ubuntu) or sudo dnf install libusb1 (Fedora)"
+                };
+                FnoxError::Provider(format!(
+                    "YubiKey support requires libusb, but it is not installed. {install_hint}"
+                ))
+            })?;
+
+        unsafe {
+            let init = *lib
+                .get::<unsafe extern "C" fn(*mut *mut LibusbContext) -> i32>(b"libusb_init\0")
+                .map_err(|e| FnoxError::Provider(format!("libusb symbol error: {e}")))?;
+            let exit = *lib
+                .get::<unsafe extern "C" fn(*mut LibusbContext)>(b"libusb_exit\0")
+                .map_err(|e| FnoxError::Provider(format!("libusb symbol error: {e}")))?;
+            let get_device_list = *lib
+                .get::<unsafe extern "C" fn(*mut LibusbContext, *mut *mut *mut LibusbDevice) -> isize>(
+                    b"libusb_get_device_list\0",
+                )
+                .map_err(|e| FnoxError::Provider(format!("libusb symbol error: {e}")))?;
+            let free_device_list = *lib
+                .get::<unsafe extern "C" fn(*mut *mut LibusbDevice, i32)>(
+                    b"libusb_free_device_list\0",
+                )
+                .map_err(|e| FnoxError::Provider(format!("libusb symbol error: {e}")))?;
+            let get_device_descriptor = *lib
+                .get::<unsafe extern "C" fn(*mut LibusbDevice, *mut LibusbDeviceDescriptor) -> i32>(
+                    b"libusb_get_device_descriptor\0",
+                )
+                .map_err(|e| FnoxError::Provider(format!("libusb symbol error: {e}")))?;
+            let open = *lib
+                .get::<unsafe extern "C" fn(*mut LibusbDevice, *mut *mut LibusbDeviceHandle) -> i32>(
+                    b"libusb_open\0",
+                )
+                .map_err(|e| FnoxError::Provider(format!("libusb symbol error: {e}")))?;
+            let close = *lib
+                .get::<unsafe extern "C" fn(*mut LibusbDeviceHandle)>(b"libusb_close\0")
+                .map_err(|e| FnoxError::Provider(format!("libusb symbol error: {e}")))?;
+            let control_transfer = *lib
+                .get::<unsafe extern "C" fn(
+                    *mut LibusbDeviceHandle,
+                    u8,
+                    u8,
+                    u16,
+                    u16,
+                    *mut u8,
+                    u16,
+                    u32,
+                ) -> i32>(b"libusb_control_transfer\0")
+                .map_err(|e| FnoxError::Provider(format!("libusb symbol error: {e}")))?;
+
+            Ok(LibUsb {
+                _lib: lib,
+                init,
+                exit,
+                get_device_list,
+                free_device_list,
+                get_device_descriptor,
+                open,
+                close,
+                control_transfer,
+            })
+        }
+    }
+}
+
+/// RAII wrapper for a libusb context.
+struct UsbContext {
+    lib: LibUsb,
+    ctx: *mut LibusbContext,
+}
+
+impl UsbContext {
+    fn new() -> Result<Self> {
+        let lib = LibUsb::load()?;
+        let mut ctx: *mut LibusbContext = ptr::null_mut();
+        let rc = unsafe { (lib.init)(&mut ctx) };
+        if rc < 0 {
+            return Err(FnoxError::Provider(format!(
+                "libusb_init failed (error {rc})"
+            )));
+        }
+        Ok(UsbContext { lib, ctx })
+    }
+
+    fn find_yubikey(&self) -> Result<Device> {
+        let mut list: *mut *mut LibusbDevice = ptr::null_mut();
+        let count = unsafe { (self.lib.get_device_list)(self.ctx, &mut list) };
+        if count < 0 {
+            return Err(FnoxError::Provider(
+                "Failed to enumerate USB devices".to_string(),
+            ));
+        }
+
+        let result = (|| {
+            for i in 0..count as usize {
+                let dev = unsafe { *list.add(i) };
+                if dev.is_null() {
+                    break;
+                }
+                let mut desc = LibusbDeviceDescriptor::default();
+                let rc = unsafe { (self.lib.get_device_descriptor)(dev, &mut desc) };
+                if rc < 0 {
+                    continue;
+                }
+                if desc.id_vendor == VENDOR_ID {
+                    return Ok(Device {
+                        vendor_id: desc.id_vendor,
+                        product_id: desc.id_product,
+                    });
+                }
+            }
+            Err(FnoxError::Provider(
+                "No YubiKey found. Make sure it is plugged in.".to_string(),
+            ))
+        })();
+
+        unsafe { (self.lib.free_device_list)(list, 1) };
+        result
+    }
+
+    fn open_device(&self, vid: u16, pid: u16) -> Result<DeviceHandle<'_>> {
+        let mut list: *mut *mut LibusbDevice = ptr::null_mut();
+        let count = unsafe { (self.lib.get_device_list)(self.ctx, &mut list) };
+        if count < 0 {
+            return Err(FnoxError::Provider(
+                "Failed to enumerate USB devices".to_string(),
+            ));
+        }
+
+        let result = (|| {
+            for i in 0..count as usize {
+                let dev = unsafe { *list.add(i) };
+                if dev.is_null() {
+                    break;
+                }
+                let mut desc = LibusbDeviceDescriptor::default();
+                let rc = unsafe { (self.lib.get_device_descriptor)(dev, &mut desc) };
+                if rc < 0 {
+                    continue;
+                }
+                if desc.id_vendor == vid && desc.id_product == pid {
+                    let mut handle: *mut LibusbDeviceHandle = ptr::null_mut();
+                    let rc = unsafe { (self.lib.open)(dev, &mut handle) };
+                    if rc < 0 {
+                        return Err(FnoxError::Provider(format!(
+                            "Failed to open YubiKey (libusb error {rc})"
+                        )));
+                    }
+                    return Ok(DeviceHandle {
+                        lib: &self.lib,
+                        handle,
+                    });
+                }
+            }
+            Err(FnoxError::Provider(
+                "YubiKey not found during open".to_string(),
+            ))
+        })();
+
+        unsafe { (self.lib.free_device_list)(list, 1) };
+        result
+    }
+}
+
+impl Drop for UsbContext {
+    fn drop(&mut self) {
+        unsafe { (self.lib.exit)(self.ctx) };
+    }
+}
+
+/// RAII wrapper for a libusb device handle.
+struct DeviceHandle<'a> {
+    lib: &'a LibUsb,
+    handle: *mut LibusbDeviceHandle,
+}
+
+impl DeviceHandle<'_> {
+    fn read_report(&self, buf: &mut [u8; 8]) -> Result<usize> {
+        let value = REPORT_TYPE_FEATURE << 8;
+        let rc = unsafe {
+            (self.lib.control_transfer)(
+                self.handle,
+                REQTYPE_IN_CLASS_INTERFACE,
+                HID_GET_REPORT,
+                value,
+                0,
+                buf.as_mut_ptr(),
+                8,
+                2000,
+            )
+        };
+        if rc < 0 {
+            return Err(FnoxError::Provider(format!(
+                "YubiKey USB read failed (error {rc})"
+            )));
+        }
+        Ok(rc as usize)
+    }
+
+    fn write_packet(&self, packet: &[u8; 8]) -> Result<()> {
+        let value = REPORT_TYPE_FEATURE << 8;
+        // Need a mutable copy for the FFI call
+        let mut data = *packet;
+        let rc = unsafe {
+            (self.lib.control_transfer)(
+                self.handle,
+                REQTYPE_OUT_CLASS_INTERFACE,
+                HID_SET_REPORT,
+                value,
+                0,
+                data.as_mut_ptr(),
+                8,
+                2000,
+            )
+        };
+        if rc != 8 {
+            return Err(FnoxError::Provider(format!(
+                "YubiKey USB write failed (wrote {rc}, expected 8)"
+            )));
+        }
+        Ok(())
+    }
+
+    fn wait_for<F: Fn(u8) -> bool>(&self, predicate: F) -> Result<[u8; 8]> {
+        let mut buf = [0u8; 8];
+        loop {
+            self.read_report(&mut buf)?;
+            let flags = buf[7];
+            if predicate(flags) {
+                return Ok(buf);
+            }
+            thread::sleep(Duration::from_millis(1));
+        }
+    }
+
+    fn write_frame(&self, frame: &[u8; FRAME_SIZE]) -> Result<()> {
+        let mut offset = 0;
+        let mut seq: u8 = 0;
+
+        while offset < FRAME_SIZE {
+            let remaining = FRAME_SIZE - offset;
+            let chunk_len = remaining.min(7);
+            let mut packet = [0u8; 8];
+            packet[..chunk_len].copy_from_slice(&frame[offset..offset + chunk_len]);
+            let is_first = seq == 0;
+            let is_last = offset + chunk_len >= FRAME_SIZE;
+            let is_nonzero = packet[..7].iter().any(|&b| b != 0);
+
+            if is_first || is_last || is_nonzero {
+                packet[7] = SLOT_WRITE_FLAG | seq;
+                self.wait_for(|f| f & SLOT_WRITE_FLAG == 0)?;
+                self.write_packet(&packet)?;
+            }
+
+            offset += 7;
+            seq += 1;
+        }
+        Ok(())
+    }
+
+    fn read_response(&self, response: &mut [u8; 36]) -> Result<usize> {
+        // Wait for RESP_PENDING_FLAG, capturing first 8 bytes
+        let first = self.wait_for(|f| f & RESP_PENDING_FLAG != 0)?;
+        response[..8].copy_from_slice(&first);
+        let mut r0: usize = 7;
+
+        loop {
+            let mut buf = [0u8; 8];
+            let n = self.read_report(&mut buf)?;
+            if n < 8 {
+                break;
+            }
+            let end = (r0 + 8).min(36);
+            let copy_len = end - r0;
+            response[r0..r0 + copy_len].copy_from_slice(&buf[..copy_len]);
+
+            let flags = buf[7];
+            if flags & RESP_PENDING_FLAG != 0 {
+                let seq = flags & 0x1F;
+                if r0 > 0 && seq == 0 {
+                    break;
+                }
+            } else {
+                break;
+            }
+            r0 += 7;
+        }
+
+        // Send write_reset
+        let mut reset_packet = [0u8; 8];
+        reset_packet[7] = 0x8F;
+        self.write_packet(&reset_packet)?;
+        self.wait_for(|f| f & SLOT_WRITE_FLAG == 0)?;
+
+        Ok(r0)
+    }
+}
+
+impl Drop for DeviceHandle<'_> {
+    fn drop(&mut self) {
+        unsafe { (self.lib.close)(self.handle) };
+    }
+}
+
+// Ensure the handle types are Send (the raw pointers are only accessed from one thread).
+unsafe impl Send for UsbContext {}
+
+#[derive(Clone, Debug)]
+pub struct Device {
+    pub vendor_id: u16,
+    pub product_id: u16,
+}
+
+fn crc16(data: &[u8]) -> u16 {
+    let mut crc = CRC_PRESET;
+    for &b in data {
+        crc ^= b as u16;
+        for _ in 0..8 {
+            let j = crc & 1;
+            crc >>= 1;
+            if j != 0 {
+                crc ^= CRC_POLYNOMIAL;
+            }
+        }
+    }
+    crc
+}
+
+fn build_frame(payload: &[u8; DATA_SIZE], command: u8) -> [u8; FRAME_SIZE] {
+    let mut frame = [0u8; FRAME_SIZE];
+    frame[..DATA_SIZE].copy_from_slice(payload);
+    frame[DATA_SIZE] = command;
+    let crc = crc16(&frame[..DATA_SIZE]).to_le_bytes();
+    frame[DATA_SIZE + 1] = crc[0];
+    frame[DATA_SIZE + 2] = crc[1];
+    // filler bytes remain 0
+    frame
+}
+
+/// Find a connected YubiKey. Returns device info (VID/PID).
+pub fn find_yubikey() -> Result<Device> {
+    let ctx = UsbContext::new()?;
+    ctx.find_yubikey()
+}
+
+/// Perform HMAC-SHA1 challenge-response with a YubiKey.
+///
+/// `challenge`: the raw challenge bytes (up to 64 bytes)
+/// `device`: the device returned by `find_yubikey()`
+/// `slot`: 1 or 2
+///
+/// Returns the 20-byte HMAC-SHA1 response.
+pub fn challenge_response_hmac(challenge: &[u8], device: &Device, slot: u8) -> Result<[u8; 20]> {
+    let ctx = UsbContext::new()?;
+    let handle = ctx.open_device(device.vendor_id, device.product_id)?;
+
+    let mut payload = [0u8; DATA_SIZE];
+    let len = challenge.len().min(DATA_SIZE);
+    payload[..len].copy_from_slice(&challenge[..len]);
+
+    let command = match slot {
+        1 => CHALLENGE_HMAC1,
+        _ => CHALLENGE_HMAC2,
+    };
+
+    let frame = build_frame(&payload, command);
+
+    // Wait for device ready
+    handle.wait_for(|f| f & SLOT_WRITE_FLAG == 0)?;
+
+    // Send challenge
+    handle.write_frame(&frame)?;
+
+    // Read response
+    let mut response = [0u8; 36];
+    handle.read_response(&mut response)?;
+
+    // Verify CRC
+    if crc16(&response[..22]) != CRC_RESIDUAL_OK {
+        return Err(FnoxError::Provider(
+            "YubiKey HMAC response CRC check failed".to_string(),
+        ));
+    }
+
+    let mut hmac = [0u8; 20];
+    hmac.copy_from_slice(&response[..20]);
+    Ok(hmac)
+}


### PR DESCRIPTION
## Summary

- Replace `yubico_manager` crate with a minimal reimplementation in `yubikey_usb.rs` that loads `libusb-1.0` at runtime via `libloading` (dlopen)
- Eliminates the hard link-time dependency on libusb — the binary starts normally on systems without libusb installed
- When a user actually tries to use the YubiKey provider without libusb, they get a clear error with platform-specific install instructions

Fixes #346

## Details

The `yubico_manager` crate depends on `rusb` → `libusb1-sys`, which links libusb at build time. On macOS, this hardcodes the Homebrew libusb path into the binary, causing a dyld crash at startup for users without Homebrew libusb — even if they never use the YubiKey provider.

The new `yubikey_usb` module:
- Loads libusb dynamically via `libloading::Library::new()`, trying platform-appropriate paths
- Implements just enough of the libusb API (init, device enumeration, control transfers) and YubiKey OTP frame protocol (CRC16, HID feature reports, challenge-response) to support HMAC-SHA1 operations
- Is a drop-in replacement — the `yubikey.rs` provider and setup code work identically

The FIDO2 provider (`ctap-hid-fido2` → `hidapi`) was already fine — `hidapi` uses IOKit on macOS natively, no libusb needed.

## Test plan

- [x] `cargo build` — no warnings
- [x] `otool -L target/debug/fnox | grep libusb` — no matches (no link-time dep)
- [x] `cargo test` — all 118 unit tests pass
- [x] `mise run test:bats` — all 605 integration tests pass
- [ ] Manual: test YubiKey challenge-response with libusb installed
- [ ] Manual: verify clean error message when libusb is not installed


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Introduces a new unsafe, FFI-based libusb implementation for YubiKey HMAC-SHA1 operations and removes the previous dependency stack; bugs here could break YubiKey encryption/decryption or cause platform-specific USB/runtime failures.
> 
> **Overview**
> **Reworks the YubiKey provider to avoid a link-time `libusb` dependency.** The PR removes the `yubico_manager`-based flow and replaces it with a new `yubikey_usb` module that dynamically loads `libusb` via `libloading` and performs the HID feature-report challenge/response directly.
> 
> This updates `yubikey` runtime and setup paths to call `yubikey_usb::challenge_response_hmac`, adds `libloading` to dependencies, and updates the lockfile accordingly so the binary can start even when `libusb` is not installed (failing only when the YubiKey provider is used).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 714764d9e9c296a59df1aa2f71bf1d1119bfb080. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->