### PR TITLE
feat(mcp): redact secret values from exec output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2214,6 +2214,7 @@ version = "1.17.0"
 dependencies = [
  "aes-gcm",
  "age",
+ "aho-corasick",
  "anyhow",
  "arboard",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/main.rs"
 [dependencies]
 aes-gcm = "0.10"
 age = { version = "0.11", features = ["ssh"] }
+aho-corasick = "1.1.4"
 anyhow = "1"
 arboard = "3"
 arc-swap = "1"

--- a/docs/guide/mcp.md
+++ b/docs/guide/mcp.md
@@ -80,5 +80,6 @@ Executes a command with all secrets injected as environment variables. The agent
 - Secrets live only in process memory — except for `as_file = true` secrets, which are written to ephemeral temp files for subprocess injection and deleted when the command completes
 - The `exec` tool captures stdout/stderr (does not inherit stdio, which would corrupt the JSON-RPC stream) and caps output at 1 MiB to prevent unbounded memory usage
 - Non-interactive mode prevents provider auth prompts from interfering with the protocol
-- With `tools = ["exec"]`, agents don't receive secrets via `get_secret`, but can still read injected env vars by running commands like `printenv`. This provides audit visibility rather than strict secret isolation
+- The `exec` tool redacts resolved secret values from stdout/stderr before returning output to the agent — commands like `printenv` or `echo $SECRET` will show `[REDACTED]` instead of the raw value. Redaction performs literal string matching and does not detect base64-encoded or otherwise transformed values. To disable (not recommended): `mcp.redact_output = false`
+- With `tools = ["exec"]` and redaction enabled (default), agents cannot retrieve raw secret values through either `get_secret` or subprocess output
 - Disabled tools are not advertised in `tools/list` — agents only see tools they can actually call

--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -376,6 +376,10 @@
           "format": "uint64",
           "minimum": 1
         },
+        "redact_output": {
+          "description": "Whether to redact secret values from exec tool output (default: true).\nWhen enabled, resolved secret values are replaced with [REDACTED] in\nstdout/stderr before returning to the agent.",
+          "type": ["boolean", "null"]
+        },
         "tools": {
           "description": "Which MCP tools to expose (default: [\"get_secret\", \"exec\"])",
           "type": ["array", "null"],

--- a/src/config.rs
+++ b/src/config.rs
@@ -258,6 +258,12 @@ pub struct McpConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schemars(range(min = 1))]
     pub exec_timeout_secs: Option<u64>,
+
+    /// Whether to redact secret values from exec tool output (default: true).
+    /// When enabled, resolved secret values are replaced with [REDACTED] in
+    /// stdout/stderr before returning to the agent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub redact_output: Option<bool>,
 }
 
 impl McpConfig {
@@ -278,6 +284,11 @@ impl McpConfig {
     /// Set the tools list explicitly
     pub fn set_tools(&mut self, tools: Vec<McpTool>) {
         self.tools_raw = Some(tools);
+    }
+
+    /// Whether exec output redaction is enabled (default: true)
+    pub fn redact_output(&self) -> bool {
+        self.redact_output.unwrap_or(true)
     }
 }
 
@@ -536,6 +547,9 @@ impl Config {
             }
             if overlay_mcp.exec_timeout_secs.is_some() {
                 base_mcp.exec_timeout_secs = overlay_mcp.exec_timeout_secs;
+            }
+            if overlay_mcp.redact_output.is_some() {
+                base_mcp.redact_output = overlay_mcp.redact_output;
             }
         }
 

--- a/src/mcp_server.rs
+++ b/src/mcp_server.rs
@@ -467,32 +467,40 @@ impl FnoxMcpServer {
     }
 }
 
+/// Minimum secret length for redaction. Secrets shorter than this are skipped
+/// to avoid false-positive redaction that corrupts output readability.
+const MIN_REDACT_LENGTH: usize = 3;
+
 /// Replace all occurrences of secret values in `text` with `[REDACTED]`.
 ///
-/// Secrets are sorted longest-first to avoid partial matches (e.g., if secret
-/// "abc" and "abcdef" both exist, "abcdef" is replaced first).
-/// Empty and whitespace-only secrets are skipped to avoid false positives.
+/// Uses Aho-Corasick with leftmost-longest matching for single-pass replacement,
+/// avoiding issues with sequential replacement (e.g., a short secret matching
+/// inside an already-placed `[REDACTED]` marker).
+///
+/// Secrets shorter than `MIN_REDACT_LENGTH` or that are empty/whitespace-only
+/// are skipped to avoid false positives.
 fn redact_secrets(text: &str, secret_values: &[(String, String)]) -> String {
-    let mut values: Vec<&str> = secret_values
+    let values: Vec<&str> = secret_values
         .iter()
         .map(|(_, v)| v.as_str())
-        .filter(|v| !v.trim().is_empty())
+        .filter(|v| {
+            let trimmed = v.trim();
+            !trimmed.is_empty() && trimmed.len() >= MIN_REDACT_LENGTH
+        })
         .collect();
 
     if values.is_empty() {
         return text.to_string();
     }
 
-    values.sort_unstable();
-    values.dedup();
-    // Sort longest first for greedy replacement
-    values.sort_by_key(|v| std::cmp::Reverse(v.len()));
+    let Ok(ac) = aho_corasick::AhoCorasick::builder()
+        .match_kind(aho_corasick::MatchKind::LeftmostLongest)
+        .build(&values)
+    else {
+        return text.to_string();
+    };
 
-    let mut result = text.to_string();
-    for secret in &values {
-        result = result.replace(secret, "[REDACTED]");
-    }
-    result
+    ac.replace_all(text, &vec!["[REDACTED]"; values.len()])
 }
 
 /// Manually implement ServerHandler instead of using #[tool_handler] so we can
@@ -588,7 +596,7 @@ mod tests {
     }
 
     #[test]
-    fn redact_longest_first() {
+    fn redact_longest_match_wins() {
         let secrets = vec![
             ("SHORT".into(), "abc".into()),
             ("LONG".into(), "abcdef".into()),
@@ -599,15 +607,16 @@ mod tests {
     }
 
     #[test]
-    fn redact_skips_empty_secrets() {
+    fn redact_skips_empty_and_short_secrets() {
         let secrets = vec![
             ("EMPTY".into(), "".into()),
             ("SPACES".into(), "   ".into()),
+            ("SHORT".into(), "ab".into()),
             ("REAL".into(), "secret".into()),
         ];
-        let input = "the secret is here";
+        let input = "the secret has ab in it";
         let result = redact_secrets(input, &secrets);
-        assert_eq!(result, "the [REDACTED] is here");
+        assert_eq!(result, "the [REDACTED] has ab in it");
     }
 
     #[test]
@@ -619,9 +628,22 @@ mod tests {
 
     #[test]
     fn redact_multiple_occurrences() {
-        let secrets = vec![("TOKEN".into(), "xyz".into())];
-        let input = "xyz and xyz again";
+        let secrets = vec![("TOKEN".into(), "xyz789".into())];
+        let input = "xyz789 and xyz789 again";
         let result = redact_secrets(input, &secrets);
         assert_eq!(result, "[REDACTED] and [REDACTED] again");
+    }
+
+    #[test]
+    fn redact_does_not_corrupt_markers() {
+        // A secret that is a substring of "[REDACTED]" should not corrupt
+        // already-placed markers (aho-corasick does single-pass replacement).
+        let secrets = vec![
+            ("LONG".into(), "sk-abc123".into()),
+            ("OVERLAP".into(), "DACT".into()),
+        ];
+        let input = "sk-abc123 key";
+        let result = redact_secrets(input, &secrets);
+        assert_eq!(result, "[REDACTED] key");
     }
 }

--- a/src/mcp_server.rs
+++ b/src/mcp_server.rs
@@ -478,15 +478,14 @@ const MIN_REDACT_LENGTH: usize = 3;
 /// inside an already-placed `[REDACTED]` marker).
 ///
 /// Secrets shorter than `MIN_REDACT_LENGTH` or that are empty/whitespace-only
-/// are skipped to avoid false positives.
+/// are skipped to avoid false positives. Values are trimmed before matching
+/// so that trailing newlines (common when secrets are loaded from files) don't
+/// prevent redaction of the core value in output.
 fn redact_secrets(text: &str, secret_values: &[(String, String)]) -> String {
     let values: Vec<&str> = secret_values
         .iter()
-        .map(|(_, v)| v.as_str())
-        .filter(|v| {
-            let trimmed = v.trim();
-            !trimmed.is_empty() && trimmed.len() >= MIN_REDACT_LENGTH
-        })
+        .map(|(_, v)| v.trim())
+        .filter(|v| !v.is_empty() && v.len() >= MIN_REDACT_LENGTH)
         .collect();
 
     if values.is_empty() {

--- a/src/mcp_server.rs
+++ b/src/mcp_server.rs
@@ -426,8 +426,8 @@ impl FnoxMcpServer {
         // commands like `printenv` or `echo $SECRET`.
         let (stdout, stderr) = if self.mcp_config.redact_output() {
             (
-                redact_secrets(&stdout_raw, &env_vars),
-                redact_secrets(&stderr_raw, &env_vars),
+                redact_secrets(&stdout_raw, &env_vars)?,
+                redact_secrets(&stderr_raw, &env_vars)?,
             )
         } else {
             (stdout_raw.to_string(), stderr_raw.to_string())
@@ -481,7 +481,7 @@ const MIN_REDACT_LENGTH: usize = 3;
 /// are skipped to avoid false positives. Values are trimmed before matching
 /// so that trailing newlines (common when secrets are loaded from files) don't
 /// prevent redaction of the core value in output.
-fn redact_secrets(text: &str, secret_values: &[(String, String)]) -> String {
+fn redact_secrets(text: &str, secret_values: &[(String, String)]) -> Result<String, McpError> {
     let values: Vec<&str> = secret_values
         .iter()
         .map(|(_, v)| v.trim())
@@ -489,17 +489,22 @@ fn redact_secrets(text: &str, secret_values: &[(String, String)]) -> String {
         .collect();
 
     if values.is_empty() {
-        return text.to_string();
+        return Ok(text.to_string());
     }
 
-    let Ok(ac) = aho_corasick::AhoCorasick::builder()
+    let ac = aho_corasick::AhoCorasick::builder()
         .match_kind(aho_corasick::MatchKind::LeftmostLongest)
         .build(&values)
-    else {
-        return text.to_string();
-    };
+        .map_err(|e| {
+            McpError::internal_error(
+                format!(
+                    "Failed to build redaction filter: {e}. Refusing to return unredacted output."
+                ),
+                None,
+            )
+        })?;
 
-    ac.replace_all(text, &vec!["[REDACTED]"; values.len()])
+    Ok(ac.replace_all(text, &vec!["[REDACTED]"; values.len()]))
 }
 
 /// Manually implement ServerHandler instead of using #[tool_handler] so we can
@@ -590,7 +595,7 @@ mod tests {
             ("DB_PASS".into(), "hunter2".into()),
         ];
         let input = "API_KEY=sk-abc123\nDB_PASS=hunter2\nOK=public";
-        let result = redact_secrets(input, &secrets);
+        let result = redact_secrets(input, &secrets).unwrap();
         assert_eq!(result, "API_KEY=[REDACTED]\nDB_PASS=[REDACTED]\nOK=public");
     }
 
@@ -601,7 +606,7 @@ mod tests {
             ("LONG".into(), "abcdef".into()),
         ];
         let input = "value is abcdef";
-        let result = redact_secrets(input, &secrets);
+        let result = redact_secrets(input, &secrets).unwrap();
         assert_eq!(result, "value is [REDACTED]");
     }
 
@@ -614,14 +619,14 @@ mod tests {
             ("REAL".into(), "secret".into()),
         ];
         let input = "the secret has ab in it";
-        let result = redact_secrets(input, &secrets);
+        let result = redact_secrets(input, &secrets).unwrap();
         assert_eq!(result, "the [REDACTED] has ab in it");
     }
 
     #[test]
     fn redact_no_secrets_returns_unchanged() {
         let input = "nothing to redact here";
-        let result = redact_secrets(input, &[]);
+        let result = redact_secrets(input, &[]).unwrap();
         assert_eq!(result, input);
     }
 
@@ -629,7 +634,7 @@ mod tests {
     fn redact_multiple_occurrences() {
         let secrets = vec![("TOKEN".into(), "xyz789".into())];
         let input = "xyz789 and xyz789 again";
-        let result = redact_secrets(input, &secrets);
+        let result = redact_secrets(input, &secrets).unwrap();
         assert_eq!(result, "[REDACTED] and [REDACTED] again");
     }
 
@@ -642,7 +647,7 @@ mod tests {
             ("OVERLAP".into(), "DACT".into()),
         ];
         let input = "sk-abc123 key";
-        let result = redact_secrets(input, &secrets);
+        let result = redact_secrets(input, &secrets).unwrap();
         assert_eq!(result, "[REDACTED] key");
     }
 }

--- a/src/mcp_server.rs
+++ b/src/mcp_server.rs
@@ -417,12 +417,25 @@ impl FnoxMcpServer {
         let truncated = stdout_truncated || stderr_truncated || total_collected > MAX_OUTPUT_BYTES;
 
         let display_limit = PER_STREAM_LIMIT - 1;
-        let stdout = String::from_utf8_lossy(&stdout_buf[..stdout_buf.len().min(display_limit)]);
-        let stderr = String::from_utf8_lossy(&stderr_buf[..stderr_buf.len().min(display_limit)]);
+        let stdout_raw =
+            String::from_utf8_lossy(&stdout_buf[..stdout_buf.len().min(display_limit)]);
+        let stderr_raw =
+            String::from_utf8_lossy(&stderr_buf[..stderr_buf.len().min(display_limit)]);
+
+        // Redact secret values from output to prevent exfiltration via
+        // commands like `printenv` or `echo $SECRET`.
+        let (stdout, stderr) = if self.mcp_config.redact_output() {
+            (
+                redact_secrets(&stdout_raw, &env_vars),
+                redact_secrets(&stderr_raw, &env_vars),
+            )
+        } else {
+            (stdout_raw.to_string(), stderr_raw.to_string())
+        };
 
         let mut parts = Vec::new();
         if !stdout.is_empty() {
-            parts.push(stdout.to_string());
+            parts.push(stdout);
         }
         if !stderr.is_empty() {
             parts.push(format!("[stderr]\n{stderr}"));
@@ -452,6 +465,34 @@ impl FnoxMcpServer {
             Ok(CallToolResult::error(vec![Content::text(text)]))
         }
     }
+}
+
+/// Replace all occurrences of secret values in `text` with `[REDACTED]`.
+///
+/// Secrets are sorted longest-first to avoid partial matches (e.g., if secret
+/// "abc" and "abcdef" both exist, "abcdef" is replaced first).
+/// Empty and whitespace-only secrets are skipped to avoid false positives.
+fn redact_secrets(text: &str, secret_values: &[(String, String)]) -> String {
+    let mut values: Vec<&str> = secret_values
+        .iter()
+        .map(|(_, v)| v.as_str())
+        .filter(|v| !v.trim().is_empty())
+        .collect();
+
+    if values.is_empty() {
+        return text.to_string();
+    }
+
+    values.sort_unstable();
+    values.dedup();
+    // Sort longest first for greedy replacement
+    values.sort_by(|a, b| b.len().cmp(&a.len()));
+
+    let mut result = text.to_string();
+    for secret in &values {
+        result = result.replace(secret, "[REDACTED]");
+    }
+    result
 }
 
 /// Manually implement ServerHandler instead of using #[tool_handler] so we can
@@ -528,5 +569,59 @@ impl ServerHandler for FnoxMcpServer {
         }
         let tcc = rmcp::handler::server::tool::ToolCallContext::new(self, request, context);
         self.tool_router.call(tcc).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redact_replaces_secret_values() {
+        let secrets = vec![
+            ("API_KEY".into(), "sk-abc123".into()),
+            ("DB_PASS".into(), "hunter2".into()),
+        ];
+        let input = "API_KEY=sk-abc123\nDB_PASS=hunter2\nOK=public";
+        let result = redact_secrets(input, &secrets);
+        assert_eq!(result, "API_KEY=[REDACTED]\nDB_PASS=[REDACTED]\nOK=public");
+    }
+
+    #[test]
+    fn redact_longest_first() {
+        let secrets = vec![
+            ("SHORT".into(), "abc".into()),
+            ("LONG".into(), "abcdef".into()),
+        ];
+        let input = "value is abcdef";
+        let result = redact_secrets(input, &secrets);
+        assert_eq!(result, "value is [REDACTED]");
+    }
+
+    #[test]
+    fn redact_skips_empty_secrets() {
+        let secrets = vec![
+            ("EMPTY".into(), "".into()),
+            ("SPACES".into(), "   ".into()),
+            ("REAL".into(), "secret".into()),
+        ];
+        let input = "the secret is here";
+        let result = redact_secrets(input, &secrets);
+        assert_eq!(result, "the [REDACTED] is here");
+    }
+
+    #[test]
+    fn redact_no_secrets_returns_unchanged() {
+        let input = "nothing to redact here";
+        let result = redact_secrets(input, &[]);
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn redact_multiple_occurrences() {
+        let secrets = vec![("TOKEN".into(), "xyz".into())];
+        let input = "xyz and xyz again";
+        let result = redact_secrets(input, &secrets);
+        assert_eq!(result, "[REDACTED] and [REDACTED] again");
     }
 }

--- a/src/mcp_server.rs
+++ b/src/mcp_server.rs
@@ -486,7 +486,7 @@ fn redact_secrets(text: &str, secret_values: &[(String, String)]) -> String {
     values.sort_unstable();
     values.dedup();
     // Sort longest first for greedy replacement
-    values.sort_by(|a, b| b.len().cmp(&a.len()));
+    values.sort_by_key(|v| std::cmp::Reverse(v.len()));
 
     let mut result = text.to_string();
     for secret in &values {


### PR DESCRIPTION
## Summary

- Scans stdout/stderr from the MCP `exec` tool for resolved secret values and replaces them with `[REDACTED]` before returning output to the agent
- Prevents agents from exfiltrating secrets via commands like `printenv` or `echo $SECRET`
- Enabled by default; configurable via `mcp.redact_output = false`
- Includes unit tests for the redaction logic (longest-first matching, empty/whitespace skipping, multiple occurrences)

Closes discussion https://github.com/jdx/fnox/discussions/350

## Test plan

- [x] Unit tests for `redact_secrets` function (5 tests, all passing)
- [ ] Manual test: configure secrets, run `fnox mcp`, use exec to run `printenv` and verify values are redacted
- [ ] Manual test: set `mcp.redact_output = false` and verify raw values are returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes MCP `exec` behavior to post-process stdout/stderr and hide resolved secret values by default, which could affect tooling that expects exact output and carries some risk of false-positive/negative redaction.
> 
> **Overview**
> **Prevents secret exfiltration via MCP `exec` output** by scanning captured stdout/stderr for resolved secret values and replacing matches with `[REDACTED]` before returning results to the agent.
> 
> Adds configurable control via `mcp.redact_output` (default **true**), wires it through config merging and the published JSON schema, and documents the new security behavior and limitations. Implements redaction using `aho-corasick` (leftmost-longest) and adds unit tests covering overlap/length/empty handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1b1b528bb672aabb766375d6ffbe9890de8f55c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->