### PR TITLE
feat(mcp): add secret allowlist to limit agent access

### DIFF
--- a/docs/guide/mcp.md
+++ b/docs/guide/mcp.md
@@ -29,6 +29,23 @@ tools = ["get_secret", "exec"]  # default: both enabled
 
 The `tools` array controls which tools are available to the agent. For example, to only allow executing commands without exposing raw secrets, set `tools = ["exec"]`. To only allow retrieving secrets directly, set `tools = ["get_secret"]`.
 
+### Secret allowlist
+
+By default, all profile secrets are available to the MCP server. You can restrict which secrets are visible:
+
+```toml
+[mcp]
+secrets = ["GITHUB_TOKEN", "NPM_TOKEN"]  # only these are available
+```
+
+When `secrets` is set:
+
+- `get_secret` can only retrieve listed secrets; other names return "not found"
+- `exec` only injects listed secrets as environment variables
+- Unlisted secrets are never resolved (no unnecessary auth prompts)
+
+When `secrets` is omitted, all profile secrets are available (the default).
+
 ### 3. Configure your AI agent
 
 For Claude Code, add to `.claude/settings.json`:
@@ -82,4 +99,5 @@ Executes a command with all secrets injected as environment variables. The agent
 - Non-interactive mode prevents provider auth prompts from interfering with the protocol
 - The `exec` tool redacts resolved secret values from stdout/stderr before returning output to the agent — commands like `printenv` or `echo $SECRET` will show `[REDACTED]` instead of the raw value. Redaction performs literal string matching and does not detect base64-encoded or otherwise transformed values. To disable (not recommended): `mcp.redact_output = false`
 - With `tools = ["exec"]` and redaction enabled (default), agents cannot retrieve raw secret values through either `get_secret` or subprocess output
+- Use `mcp.secrets` to limit which secrets the agent can access — unlisted secrets are never resolved or injected
 - Disabled tools are not advertised in `tools/list` — agents only see tools they can actually call

--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -380,6 +380,13 @@
           "description": "Whether to redact secret values from exec tool output (default: true).\nWhen enabled, resolved secret values are replaced with [REDACTED] in\nstdout/stderr before returning to the agent.",
           "type": ["boolean", "null"]
         },
+        "secrets": {
+          "description": "Optional allowlist of secret names visible to the MCP server.\nWhen set, only these secrets are resolved and available via get_secret/exec.\nWhen None, all profile secrets are available.",
+          "type": ["array", "null"],
+          "items": {
+            "type": "string"
+          }
+        },
         "tools": {
           "description": "Which MCP tools to expose (default: [\"get_secret\", \"exec\"])",
           "type": ["array", "null"],

--- a/src/commands/mcp.rs
+++ b/src/commands/mcp.rs
@@ -27,11 +27,31 @@ impl McpCommand {
                     "mcp.secrets is set to an empty list — no secrets will be available to the MCP server"
                 );
             }
+            let allowed_set: std::collections::HashSet<&str> =
+                allowlist.iter().map(|s| s.as_str()).collect();
+            let providers = config.get_providers(&profile);
             for name in allowlist {
                 if !all_secrets.contains_key(name) {
                     tracing::warn!(
                         "mcp.secrets allowlist contains '{name}' which is not a configured secret"
                     );
+                    continue;
+                }
+                // Warn if this secret's provider depends on another fnox secret
+                // that is not in the allowlist (would cause silent auth failure).
+                if let Some(sc) = all_secrets.get(name)
+                    && let Some(provider_name) = sc.provider()
+                    && let Some(pc) = providers.get(provider_name)
+                {
+                    for dep in pc.env_dependencies() {
+                        if all_secrets.contains_key(*dep) && !allowed_set.contains(*dep) {
+                            tracing::warn!(
+                                "mcp.secrets: '{name}' uses provider '{provider_name}' which \
+                                 depends on '{dep}' — add '{dep}' to mcp.secrets or its provider \
+                                 may fail to authenticate"
+                            );
+                        }
+                    }
                 }
             }
         }

--- a/src/commands/mcp.rs
+++ b/src/commands/mcp.rs
@@ -17,8 +17,22 @@ impl McpCommand {
         env::set_non_interactive(true);
 
         let profile = Config::get_profile(cli.profile.as_deref());
-        let profile_secrets = config.get_secrets(&profile)?;
         let mcp_config = config.mcp.clone().unwrap_or_default();
+
+        // Warn about allowlist entries that don't match any configured secret
+        let all_secrets = config.get_secrets(&profile)?;
+        if let Some(ref allowlist) = mcp_config.secrets {
+            for name in allowlist {
+                if !all_secrets.contains_key(name) {
+                    tracing::warn!(
+                        "mcp.secrets allowlist contains '{name}' which is not a configured secret"
+                    );
+                }
+            }
+        }
+
+        // Apply MCP secret allowlist (no-op if not set)
+        let profile_secrets = mcp_config.filter_secrets(all_secrets);
 
         if mcp_config.exec_timeout_secs == Some(0) {
             return Err(FnoxError::Config(

--- a/src/commands/mcp.rs
+++ b/src/commands/mcp.rs
@@ -22,6 +22,11 @@ impl McpCommand {
         // Warn about allowlist entries that don't match any configured secret
         let all_secrets = config.get_secrets(&profile)?;
         if let Some(ref allowlist) = mcp_config.secrets {
+            if allowlist.is_empty() {
+                tracing::warn!(
+                    "mcp.secrets is set to an empty list — no secrets will be available to the MCP server"
+                );
+            }
             for name in allowlist {
                 if !all_secrets.contains_key(name) {
                     tracing::warn!(

--- a/src/config.rs
+++ b/src/config.rs
@@ -1868,4 +1868,55 @@ mod tests {
         let result = super::find_local_config(dir.path(), None);
         assert_eq!(result, dir.path().join("fnox.local.toml"));
     }
+
+    #[test]
+    fn filter_secrets_none_allowlist_returns_all() {
+        let cfg = McpConfig::default(); // secrets: None
+        let mut m = IndexMap::new();
+        m.insert("A".to_string(), SecretConfig::new());
+        m.insert("B".to_string(), SecretConfig::new());
+        let result = cfg.filter_secrets(m.clone());
+        assert_eq!(
+            result.keys().collect::<Vec<_>>(),
+            m.keys().collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn filter_secrets_empty_allowlist_returns_empty() {
+        let cfg = McpConfig {
+            secrets: Some(vec![]),
+            ..Default::default()
+        };
+        let mut m = IndexMap::new();
+        m.insert("A".to_string(), SecretConfig::new());
+        assert!(cfg.filter_secrets(m).is_empty());
+    }
+
+    #[test]
+    fn filter_secrets_subset() {
+        let cfg = McpConfig {
+            secrets: Some(vec!["A".into()]),
+            ..Default::default()
+        };
+        let mut m = IndexMap::new();
+        m.insert("A".to_string(), SecretConfig::new());
+        m.insert("B".to_string(), SecretConfig::new());
+        let result = cfg.filter_secrets(m);
+        assert!(result.contains_key("A"));
+        assert!(!result.contains_key("B"));
+    }
+
+    #[test]
+    fn filter_secrets_unknown_allowlist_entry_ignored() {
+        let cfg = McpConfig {
+            secrets: Some(vec!["A".into(), "NONEXISTENT".into()]),
+            ..Default::default()
+        };
+        let mut m = IndexMap::new();
+        m.insert("A".to_string(), SecretConfig::new());
+        let result = cfg.filter_secrets(m);
+        assert_eq!(result.len(), 1);
+        assert!(result.contains_key("A"));
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -275,6 +275,12 @@ pub struct McpConfig {
     /// stdout/stderr before returning to the agent.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub redact_output: Option<bool>,
+
+    /// Optional allowlist of secret names visible to the MCP server.
+    /// When set, only these secrets are resolved and available via get_secret/exec.
+    /// When None, all profile secrets are available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub secrets: Option<Vec<String>>,
 }
 
 impl McpConfig {
@@ -300,6 +306,25 @@ impl McpConfig {
     /// Whether exec output redaction is enabled (default: true)
     pub fn redact_output(&self) -> bool {
         self.redact_output.unwrap_or(true)
+    }
+
+    /// Filter a secrets map to only include allowed secrets.
+    /// Returns the map unchanged if no allowlist is set.
+    pub fn filter_secrets(
+        &self,
+        secrets: IndexMap<String, SecretConfig>,
+    ) -> IndexMap<String, SecretConfig> {
+        match &self.secrets {
+            None => secrets,
+            Some(allowlist) => {
+                let allowed: std::collections::HashSet<&str> =
+                    allowlist.iter().map(|s| s.as_str()).collect();
+                secrets
+                    .into_iter()
+                    .filter(|(k, _)| allowed.contains(k.as_str()))
+                    .collect()
+            }
+        }
     }
 }
 
@@ -561,6 +586,11 @@ impl Config {
             }
             if overlay_mcp.redact_output.is_some() {
                 base_mcp.redact_output = overlay_mcp.redact_output;
+            }
+            // Replace entirely — a partial overlay should not silently
+            // re-expose secrets that the base config restricted.
+            if overlay_mcp.secrets.is_some() {
+                base_mcp.secrets = overlay_mcp.secrets;
             }
         }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1919,4 +1919,47 @@ mod tests {
         assert_eq!(result.len(), 1);
         assert!(result.contains_key("A"));
     }
+
+    #[test]
+    fn mcp_secrets_overlay_replaces_base_not_appends() {
+        let base = Config {
+            mcp: Some(McpConfig {
+                secrets: Some(vec!["A".into()]),
+                ..Default::default()
+            }),
+            ..Config::new()
+        };
+        let overlay = Config {
+            mcp: Some(McpConfig {
+                secrets: Some(vec!["B".into()]),
+                ..Default::default()
+            }),
+            ..Config::new()
+        };
+        let merged = Config::merge_configs(base, overlay).unwrap();
+        assert_eq!(
+            merged.mcp.unwrap().secrets,
+            Some(vec!["B".into()]),
+            "overlay must replace, not append, the base allowlist"
+        );
+    }
+
+    #[test]
+    fn mcp_secrets_overlay_without_secrets_preserves_base() {
+        let base = Config {
+            mcp: Some(McpConfig {
+                secrets: Some(vec!["A".into()]),
+                ..Default::default()
+            }),
+            ..Config::new()
+        };
+        let overlay = Config {
+            mcp: Some(McpConfig {
+                ..Default::default()
+            }),
+            ..Config::new()
+        };
+        let merged = Config::merge_configs(base, overlay).unwrap();
+        assert_eq!(merged.mcp.unwrap().secrets, Some(vec!["A".into()]));
+    }
 }


### PR DESCRIPTION
## Summary

- Add `mcp.secrets` config option to restrict which secrets the MCP server exposes to AI agents
- When set, only listed secrets are resolved and available via `get_secret`/`exec`; unlisted secrets are never resolved (no unnecessary auth prompts)
- When omitted, all profile secrets are available (current behavior)
- Warns at startup if allowlist contains names that don't match any configured secret

Example:
```toml
[mcp]
secrets = ["GITHUB_TOKEN", "NPM_TOKEN"]  # only these are available
```

Closes discussion https://github.com/jdx/fnox/discussions/350

## Test plan

- [ ] Manual test: configure multiple secrets, set `mcp.secrets` to a subset, verify only those are accessible via `get_secret`
- [ ] Manual test: verify `exec` only injects allowlisted secrets
- [ ] Manual test: verify warning logged for unknown allowlist entries
- [ ] Manual test: verify omitting `mcp.secrets` exposes all secrets (backward compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the MCP server selects and resolves secrets, which can affect agent workflows and provider authentication (especially when providers require dependent env secrets). Scope is contained to MCP config parsing/merging plus startup validation and docs/schema updates.
> 
> **Overview**
> Adds an optional `mcp.secrets` allowlist to restrict which profile secrets the MCP server exposes, so `get_secret` and `exec` only resolve/inject the listed names (default remains *all* secrets when omitted).
> 
> On `fnox mcp` startup, it now logs warnings for empty allowlists, unknown secret names, and allowlisted secrets whose provider depends on other configured secrets not included in the allowlist. Config merging is updated so an overlay `mcp.secrets` **replaces** the base allowlist (to avoid accidentally re-exposing secrets), with unit tests added for filtering and merge behavior; docs and the public JSON schema are updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f71f603d97dfaa91723ba1833d9d81474f08887. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->