### PR TITLE
fix(set): prompt for secret value when -k flag is used

### DIFF
--- a/src/commands/set.rs
+++ b/src/commands/set.rs
@@ -58,12 +58,8 @@ impl SetCommand {
         tracing::debug!("Setting secret '{}' in profile '{}'", self.key, profile);
 
         // Check if we're only setting metadata (no actual secret value)
-        // Note: provider is not considered "metadata only" because we need it for encryption
-        // key_name is metadata-only because it just sets the reference without encrypting
-        let has_metadata = self.description.is_some()
-            || self.if_missing.is_some()
-            || self.default.is_some()
-            || self.key_name.is_some();
+        let has_metadata =
+            self.description.is_some() || self.if_missing.is_some() || self.default.is_some();
 
         // Get the secret value if provided
         let secret_value = if let Some(ref v) = self.value {
@@ -217,9 +213,7 @@ impl SetCommand {
             secret_config.set_provider(provider_name_to_use.clone());
         }
 
-        if let Some(ref key_name) = self.key_name {
-            secret_config.set_value(Some(key_name.clone()));
-        } else if let Some(ref value) = secret_value {
+        if let Some(ref value) = secret_value {
             // Priority order: remote key name, encrypted value, then plaintext
             if let Some(remote_key) = remote_key_name {
                 // Store the key name for remote storage providers

--- a/src/commands/set.rs
+++ b/src/commands/set.rs
@@ -65,7 +65,7 @@ impl SetCommand {
         let secret_value = if let Some(ref v) = self.value {
             // Value provided as argument
             Some(v.clone())
-        } else if has_metadata {
+        } else if has_metadata && self.key_name.is_none() {
             // Only metadata is being set, no secret value needed
             None
         } else if !atty::is(atty::Stream::Stdin) {

--- a/test/set_key_name.bats
+++ b/test/set_key_name.bats
@@ -1,0 +1,68 @@
+#!/usr/bin/env bats
+
+setup() {
+	load 'test_helper/common_setup'
+	_common_setup
+}
+
+teardown() {
+	_common_teardown
+}
+
+@test "fnox set -k prompts for secret value (reads from stdin)" {
+	# Generate age key
+	if ! command -v age-keygen >/dev/null 2>&1; then
+		skip "age-keygen not installed"
+	fi
+
+	local keygen_output
+	keygen_output=$(age-keygen -o key.txt 2>&1)
+	local public_key
+	public_key=$(echo "$keygen_output" | grep "^Public key:" | cut -d' ' -f3)
+
+	cat >test-config.toml <<EOF
+[providers.age]
+type = "age"
+recipients = ["$public_key"]
+
+[secrets]
+EOF
+
+	# Pipe secret value via stdin with -k flag — should encrypt and store
+	run bash -c 'echo "my-secret-value" | "$FNOX_BIN" --config test-config.toml set -p age -k custom-key-name MY_SECRET'
+	assert_success
+
+	# The config should reference the secret
+	assert_file_contains test-config.toml "MY_SECRET"
+	# The plaintext secret value should NOT appear in the config (it should be encrypted)
+	assert_file_not_contains test-config.toml "my-secret-value"
+}
+
+@test "fnox set -k with explicit value stores the secret" {
+	# Generate age key
+	if ! command -v age-keygen >/dev/null 2>&1; then
+		skip "age-keygen not installed"
+	fi
+
+	local keygen_output
+	keygen_output=$(age-keygen -o key.txt 2>&1)
+	local public_key
+	public_key=$(echo "$keygen_output" | grep "^Public key:" | cut -d' ' -f3)
+
+	cat >test-config.toml <<EOF
+[providers.age]
+type = "age"
+recipients = ["$public_key"]
+
+[secrets]
+EOF
+
+	# Provide value as argument with -k flag
+	run "$FNOX_BIN" --config test-config.toml set -p age -k custom-key-name MY_SECRET "my-secret-value"
+	assert_success
+
+	# The config should reference the secret
+	assert_file_contains test-config.toml "MY_SECRET"
+	# The plaintext secret value should NOT appear (it should be encrypted)
+	assert_file_not_contains test-config.toml "my-secret-value"
+}

--- a/test/set_key_name.bats
+++ b/test/set_key_name.bats
@@ -3,14 +3,7 @@
 setup() {
 	load 'test_helper/common_setup'
 	_common_setup
-}
 
-teardown() {
-	_common_teardown
-}
-
-@test "fnox set -k prompts for secret value (reads from stdin)" {
-	# Generate age key
 	if ! command -v age-keygen >/dev/null 2>&1; then
 		skip "age-keygen not installed"
 	fi
@@ -27,7 +20,13 @@ recipients = ["$public_key"]
 
 [secrets]
 EOF
+}
 
+teardown() {
+	_common_teardown
+}
+
+@test "fnox set -k prompts for secret value (reads from stdin)" {
 	# Pipe secret value via stdin with -k flag — should encrypt and store
 	run bash -c 'echo "my-secret-value" | "$FNOX_BIN" --config test-config.toml set -p age -k custom-key-name MY_SECRET'
 	assert_success
@@ -36,27 +35,11 @@ EOF
 	assert_file_contains test-config.toml "MY_SECRET"
 	# The plaintext secret value should NOT appear in the config (it should be encrypted)
 	assert_file_not_contains test-config.toml "my-secret-value"
+	# key_name is silently ignored for encryption providers — it should not appear in config
+	assert_file_not_contains test-config.toml "custom-key-name"
 }
 
 @test "fnox set -k with explicit value stores the secret" {
-	# Generate age key
-	if ! command -v age-keygen >/dev/null 2>&1; then
-		skip "age-keygen not installed"
-	fi
-
-	local keygen_output
-	keygen_output=$(age-keygen -o key.txt 2>&1)
-	local public_key
-	public_key=$(echo "$keygen_output" | grep "^Public key:" | cut -d' ' -f3)
-
-	cat >test-config.toml <<EOF
-[providers.age]
-type = "age"
-recipients = ["$public_key"]
-
-[secrets]
-EOF
-
 	# Provide value as argument with -k flag
 	run "$FNOX_BIN" --config test-config.toml set -p age -k custom-key-name MY_SECRET "my-secret-value"
 	assert_success
@@ -65,4 +48,6 @@ EOF
 	assert_file_contains test-config.toml "MY_SECRET"
 	# The plaintext secret value should NOT appear (it should be encrypted)
 	assert_file_not_contains test-config.toml "my-secret-value"
+	# key_name is silently ignored for encryption providers — it should not appear in config
+	assert_file_not_contains test-config.toml "custom-key-name"
 }

--- a/test/set_key_name.bats
+++ b/test/set_key_name.bats
@@ -51,3 +51,16 @@ teardown() {
 	# key_name is silently ignored for encryption providers — it should not appear in config
 	assert_file_not_contains test-config.toml "custom-key-name"
 }
+
+@test "fnox set -k combined with -d still prompts for secret value" {
+	# When -k is combined with metadata flags like -d, the secret value should
+	# still be read (not skipped by the metadata-only path)
+	run bash -c 'echo "my-secret-value" | "$FNOX_BIN" --config test-config.toml set -p age -k custom-key-name -d "my description" MY_SECRET'
+	assert_success
+
+	# The config should reference the secret with description and encrypted value
+	assert_file_contains test-config.toml "MY_SECRET"
+	assert_file_contains test-config.toml "my description"
+	# The plaintext secret value should NOT appear (it should be encrypted)
+	assert_file_not_contains test-config.toml "my-secret-value"
+}


### PR DESCRIPTION
## Summary
- Removed `key_name` from the `has_metadata` check in `set.rs` — `-k` specifies the provider key name, not a metadata-only operation, so users should still be prompted for the secret value
- Removed code that wrote `key_name` directly as the config value, bypassing provider storage
- Added bats tests verifying `-k` correctly reads secrets from stdin and explicit arguments

Fixes #366

## Test plan
- [x] `mise run test:bats -- test/set_key_name.bats` passes
- [ ] Verify `fnox set -g -p provider -k keyname SECRET` prompts for value interactively
- [ ] Verify `echo "val" | fnox set -p provider -k keyname SECRET` reads from stdin

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `fnox set` secret-value acquisition and persistence logic when `-k/--key-name` is present, which can affect whether secrets are prompted/read and what ultimately gets stored. While scoped, mistakes here could lead to missing secrets or incorrect config values.
> 
> **Overview**
> Fixes `fnox set` so `-k/--key-name` no longer triggers the *metadata-only* path: when `-k` is used without an explicit value, the command will still read from stdin or prompt interactively for the secret value.
> 
> Removes the behavior that wrote `key_name` directly into the secret `value` field, ensuring provider/encryption handling determines what is persisted instead. Adds Bats coverage (`test/set_key_name.bats`) to verify stdin and explicit-value flows with `-k` (including when combined with `-d`) don’t store plaintext or the key name for encryption providers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f5d4f6e4111ad40c197409758309e3c3871e235. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->