### PR TITLE
fix(sync): skip post-processing when resolving secrets for sync

### DIFF
--- a/src/commands/reencrypt.rs
+++ b/src/commands/reencrypt.rs
@@ -210,18 +210,12 @@ impl ReencryptCommand {
             }
         }
 
-        // Build a SecretConfig map for batch resolution (decrypt step).
-        // Strip json_path so we get the full encrypted value, not the extracted field.
-        // Strip sync cache so we decrypt from the main provider/value, not a stale cache.
+        // Resolve raw values from the original provider:
+        // - Cached sync values would reencrypt stale data instead of the latest.
+        // - Post-processed values (e.g. from json_path) would cause future reads to fail.
         let secrets_for_resolve: IndexMap<String, SecretConfig> = secrets_to_reencrypt
             .iter()
-            .map(|(key, (_, sc))| {
-                let mut resolve_config = sc.clone();
-                resolve_config.json_path = None;
-                resolve_config.sync = None;
-                resolve_config.default = None;
-                (key.clone(), resolve_config)
-            })
+            .map(|(key, (_, sc))| (key.clone(), sc.for_raw_resolve()))
             .collect();
 
         let resolved = resolve_secrets_batch(&merged_config, &profile, &secrets_for_resolve).await;

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -1,5 +1,5 @@
 use crate::commands::Cli;
-use crate::config::{self, Config, SyncConfig, local_override_filename};
+use crate::config::{self, Config, SecretConfig, SyncConfig, local_override_filename};
 use crate::error::{FnoxError, Result};
 use crate::secret_resolver::resolve_secrets_batch;
 use clap::Args;
@@ -223,12 +223,14 @@ impl SyncCommand {
             }
         }
 
-        // Resolve plaintext values from source providers (strip sync cache so we
-        // re-fetch from the original provider rather than the cached sync value)
-        let mut secrets_for_resolve = secrets_to_sync.clone();
-        for secret_config in secrets_for_resolve.values_mut() {
-            secret_config.sync = None;
-        }
+        // Resolve raw values from the original provider:
+        // - Cached sync values would prevent picking up changes after the first sync.
+        // - Post-processed values (e.g. from json_path) would cause future reads to fail.
+        let secrets_for_resolve: IndexMap<String, SecretConfig> = secrets_to_sync
+            .iter()
+            .map(|(key, sc)| (key.clone(), sc.for_raw_resolve()))
+            .collect();
+
         let resolved =
             resolve_secrets_batch(&merged_config, &profile, &secrets_for_resolve).await?;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1458,6 +1458,16 @@ impl SecretConfig {
         }
     }
 
+    /// Return a copy that will resolve to the original provider value,
+    /// skipping post-processing and cached sync values.
+    pub fn for_raw_resolve(&self) -> Self {
+        let mut config = self.clone();
+        config.json_path = None;
+        config.sync = None;
+        config.default = None;
+        config
+    }
+
     /// Convert this secret config to a TOML inline table for saving
     pub fn to_inline_table(&self) -> toml_edit::InlineTable {
         let mut inline = toml_edit::InlineTable::new();
@@ -1968,5 +1978,72 @@ mod tests {
         };
         let merged = Config::merge_configs(base, overlay).unwrap();
         assert_eq!(merged.mcp.unwrap().secrets, Some(vec!["A".into()]));
+    }
+
+    #[test]
+    fn test_for_raw_resolve_strips_post_processing_fields() {
+        let mut secret = SecretConfig::new();
+        secret.set_provider(Some("plain".to_string()));
+        secret.set_value(Some(r#"{"user":"admin"}"#.to_string()));
+        secret.default = Some("fallback".to_string());
+        secret.json_path = Some("user".to_string());
+        secret.sync = Some(SyncConfig {
+            provider: "age".to_string(),
+            value: "encrypted-blob".to_string(),
+        });
+
+        let raw = secret.for_raw_resolve();
+
+        assert!(raw.default.is_none());
+        assert!(raw.json_path.is_none());
+        assert!(raw.sync.is_none());
+    }
+
+    #[test]
+    fn test_for_raw_resolve_preserves_non_post_processing_fields() {
+        let mut secret = SecretConfig::new();
+        secret.set_provider(Some("plain".to_string()));
+        secret.set_value(Some("my-secret".to_string()));
+        secret.description = Some("A test secret".to_string());
+        secret.if_missing = Some(IfMissing::Warn);
+        secret.env = false;
+        secret.as_file = true;
+        secret.source_path = Some(PathBuf::from("/tmp/fnox.toml"));
+        secret.source_is_profile = true;
+        secret.default = Some("default-val".to_string());
+        secret.json_path = Some("key".to_string());
+        secret.sync = Some(SyncConfig {
+            provider: "age".to_string(),
+            value: "blob".to_string(),
+        });
+
+        let raw = secret.for_raw_resolve();
+
+        assert_eq!(raw.provider(), Some("plain"));
+        assert_eq!(raw.value(), Some("my-secret"));
+        assert_eq!(raw.description.as_deref(), Some("A test secret"));
+        assert_eq!(raw.if_missing, Some(IfMissing::Warn));
+        assert!(!raw.env);
+        assert!(raw.as_file);
+        assert_eq!(
+            raw.source_path.as_deref(),
+            Some(Path::new("/tmp/fnox.toml"))
+        );
+        assert!(raw.source_is_profile);
+    }
+
+    #[test]
+    fn test_for_raw_resolve_with_no_post_processing_fields() {
+        let mut secret = SecretConfig::new();
+        secret.set_provider(Some("plain".to_string()));
+        secret.set_value(Some("simple-value".to_string()));
+
+        let raw = secret.for_raw_resolve();
+
+        assert_eq!(raw.provider(), Some("plain"));
+        assert_eq!(raw.value(), Some("simple-value"));
+        assert!(raw.default.is_none());
+        assert!(raw.json_path.is_none());
+        assert!(raw.sync.is_none());
     }
 }

--- a/test/reencrypt.bats
+++ b/test/reencrypt.bats
@@ -1,0 +1,113 @@
+#!/usr/bin/env bats
+
+setup() {
+	load 'test_helper/common_setup'
+	_common_setup
+}
+
+teardown() {
+	_common_teardown
+}
+
+@test "fnox reencrypt encrypts with new recipients" {
+	if ! command -v age-keygen >/dev/null 2>&1; then
+		skip "age-keygen not installed"
+	fi
+
+	# Generate first keypair
+	local keygen_output1
+	keygen_output1=$(age-keygen -o key1.txt 2>&1)
+	local public_key1
+	public_key1=$(echo "$keygen_output1" | grep "^Public key:" | cut -d' ' -f3)
+
+	# Generate second keypair
+	local keygen_output2
+	keygen_output2=$(age-keygen -o key2.txt 2>&1)
+	local public_key2
+	public_key2=$(echo "$keygen_output2" | grep "^Public key:" | cut -d' ' -f3)
+
+	# Encrypt with first recipient only
+	cat >fnox.toml <<EOF
+root = true
+
+[providers.age]
+type = "age"
+recipients = ["$public_key1"]
+
+[secrets]
+EOF
+
+	assert_fnox_success set MY_SECRET "hello-world" --age-key-file key1.txt
+
+	# Secret can be read by Key1 before reencrypt
+	assert_fnox_success get MY_SECRET --age-key-file key1.txt
+	assert_output "hello-world"
+
+	# Secret cannot be read by Key2 before reencrypt
+	assert_fnox_failure get MY_SECRET --age-key-file key2.txt
+
+	# Add second recipient and reencrypt
+	perl -i -pe "s/recipients = \\[\"$public_key1\"\\]/recipients = [\"$public_key1\", \"$public_key2\"]/" fnox.toml
+	assert_fnox_success reencrypt --force --age-key-file key1.txt
+
+	# Secret can still be read by Key1
+	assert_fnox_success get MY_SECRET --age-key-file key1.txt
+	assert_output "hello-world"
+
+	# Secret can now be read by Key2
+	assert_fnox_success get MY_SECRET --age-key-file key2.txt
+	assert_output "hello-world"
+}
+
+@test "fnox reencrypt works with secrets that use json_path" {
+	if ! command -v age-keygen >/dev/null 2>&1; then
+		skip "age-keygen not installed"
+	fi
+
+	# Generate first keypair
+	local keygen_output1
+	keygen_output1=$(age-keygen -o key1.txt 2>&1)
+	local public_key1
+	public_key1=$(echo "$keygen_output1" | grep "^Public key:" | cut -d' ' -f3)
+
+	# Generate second keypair
+	local keygen_output2
+	keygen_output2=$(age-keygen -o key2.txt 2>&1)
+	local public_key2
+	public_key2=$(echo "$keygen_output2" | grep "^Public key:" | cut -d' ' -f3)
+
+	# Encrypt with first recipient only
+	cat >fnox.toml <<EOF
+root = true
+
+[providers.age]
+type = "age"
+recipients = ["$public_key1"]
+
+[secrets]
+EOF
+
+	assert_fnox_success set JSON_SECRET '{"username":"admin","password":"secret123"}' --age-key-file key1.txt
+
+	# Add json_path to the secret
+	perl -i -pe 's/^(JSON_SECRET\s*=\s*\{.*)\}/$1, json_path = "username" }/' fnox.toml
+
+	# Secret can be read by Key1 before reencrypt
+	assert_fnox_success get JSON_SECRET --age-key-file key1.txt
+	assert_output "admin"
+
+	# Secret cannot be read by Key2 before reencrypt
+	assert_fnox_failure get JSON_SECRET --age-key-file key2.txt
+
+	# Add second recipient and reencrypt
+	perl -i -pe "s/recipients = \\[\"$public_key1\"\\]/recipients = [\"$public_key1\", \"$public_key2\"]/" fnox.toml
+	assert_fnox_success reencrypt --force --age-key-file key1.txt
+
+	# Secret can still be read by Key1
+	assert_fnox_success get JSON_SECRET --age-key-file key1.txt
+	assert_output "admin"
+
+	# Secret can now be read by Key2
+	assert_fnox_success get JSON_SECRET --age-key-file key2.txt
+	assert_output "admin"
+}

--- a/test/sync.bats
+++ b/test/sync.bats
@@ -351,6 +351,97 @@ EOF
 	assert_output "updated-remote-value"
 }
 
+@test "fnox sync works with secrets that use json_path" {
+	if ! command -v age-keygen >/dev/null 2>&1; then
+		skip "age-keygen not installed"
+	fi
+
+	local keygen_output
+	keygen_output=$(age-keygen -o key.txt 2>&1)
+	local public_key
+	public_key=$(echo "$keygen_output" | grep "^Public key:" | cut -d' ' -f3)
+
+	cat >fnox.toml <<EOF
+root = true
+
+[providers.plain]
+type = "plain"
+
+[providers.age]
+type = "age"
+recipients = ["$public_key"]
+
+[secrets]
+DB_USER = { provider = "plain", value = '{"username":"admin","password":"secret123"}', json_path = "username" }
+DB_PASS = { provider = "plain", value = '{"username":"admin","password":"secret123"}', json_path = "password" }
+EOF
+
+	# Pre-sync: json_path extraction works
+	assert_fnox_success get DB_USER
+	assert_output "admin"
+	assert_fnox_success get DB_PASS
+	assert_output "secret123"
+
+	# Sync to age
+	assert_fnox_success sync -p age --force --age-key-file key.txt
+
+	# Post-sync: json_path extraction still works on the cached value
+	assert_fnox_success get DB_USER --age-key-file key.txt
+	assert_output "admin"
+	assert_fnox_success get DB_PASS --age-key-file key.txt
+	assert_output "secret123"
+}
+
+@test "fnox sync skips secrets that fall back to a default value" {
+	if ! command -v age-keygen >/dev/null 2>&1; then
+		skip "age-keygen not installed"
+	fi
+
+	local keygen_output
+	keygen_output=$(age-keygen -o key.txt 2>&1)
+	local public_key
+	public_key=$(echo "$keygen_output" | grep "^Public key:" | cut -d' ' -f3)
+
+	cat >fnox.toml <<EOF
+root = true
+
+[providers.plain]
+type = "plain"
+
+[providers.age]
+type = "age"
+recipients = ["$public_key"]
+
+[secrets]
+HAS_VALUE = { provider = "plain", value = "real-value" }
+HAS_DEFAULT_ONLY = { provider = "plain", default = "fallback" }
+EOF
+
+	# Pre-sync: secrets can be resolved
+	assert_fnox_success get HAS_VALUE
+	assert_output "real-value"
+	assert_fnox_success get HAS_DEFAULT_ONLY
+	assert_output "fallback"
+
+	# Sync — HAS_DEFAULT_ONLY should be skipped (no provider value to cache)
+	assert_fnox_success sync -p age --force --age-key-file key.txt
+	assert_output --partial "Skipped 1 secrets"
+
+	# Post-sync: secrets can still be resolved
+	assert_fnox_success get HAS_VALUE --age-key-file key.txt
+	assert_output "real-value"
+	assert_fnox_success get HAS_DEFAULT_ONLY
+	assert_output "fallback"
+
+	# HAS_VALUE should have a sync section in the config
+	run grep 'HAS_VALUE.*sync' fnox.toml
+	assert_success
+
+	# HAS_DEFAULT_ONLY should not have a sync section in the config
+	run grep 'HAS_DEFAULT_ONLY.*sync' fnox.toml
+	assert_failure
+}
+
 @test "fnox sync with no eligible secrets shows message" {
 	if ! command -v age-keygen >/dev/null 2>&1; then
 		skip "age-keygen not installed"


### PR DESCRIPTION
## Summary

When syncing secrets that use `json_path`, `resolve_secrets_batch` was applying `json_path` extraction before storing the result, caching the extracted value instead of the full raw secret. When reading the secret after that sync, `json_path` would be applied again to the already-extracted value, failing with "Failed to parse JSON secret".

## Fix

Add `SecretConfig::for_raw_resolve()` which strips post-processing fields (`json_path`, `sync`, `default`) so callers that need raw provider values have a single, consistent method to use. Both `sync` and `reencrypt` now use it, ensuring new post-processing steps only need updating in one place.

## Test plan

- [x] `cargo test` — unit tests for `for_raw_resolve()`
- [x] `mise run test:bats -- test/sync.bats` — added tests for syncing secrets with `json_path`
- [x] `mise run test:bats -- test/reencrypt.bats` — added tests for reencrypt (with and without `json_path`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)