### PR TITLE
feat(provider): add Doppler secrets manager provider

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,10 +118,27 @@ jobs:
             -p 4566:4566 \
             -e SERVICES=sts,iam,kms,secretsmanager,ssm \
             localstack/localstack:latest
-          # Wait for services to be ready
-          # Poll LocalStack health endpoint (can take 10-30s on cold runners)
-          for _i in $(seq 1 30); do
-            curl -sf http://localhost:4566/_localstack/health && break
+          # Wait for LocalStack to be ready (can take 10-60s on cold runners)
+          echo "Waiting for LocalStack..."
+          localstack_ready=false
+          for _i in $(seq 1 45); do
+            if curl -sf http://localhost:4566/_localstack/health >/dev/null 2>&1; then
+              localstack_ready=true
+              break
+            fi
+            sleep 2
+          done
+          if [ "$localstack_ready" = false ]; then
+            echo "::error::LocalStack failed to start within 90 seconds"
+            docker logs localstack
+            exit 1
+          fi
+          # Verify individual services are responding
+          echo "Verifying LocalStack services..."
+          for _i in $(seq 1 15); do
+            if aws --endpoint-url http://localhost:4566 sts get-caller-identity --region us-east-1 --no-sign-request >/dev/null 2>&1; then
+              break
+            fi
             sleep 2
           done
           # Wait for Vault to be ready

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
           docker run -d --name localstack \
             -p 4566:4566 \
             -e SERVICES=sts,iam,kms,secretsmanager,ssm \
-            localstack/localstack:4.14.0
+            localstack/localstack:latest
           # Wait for LocalStack to be ready (can take 10-60s on cold runners)
           echo "Waiting for LocalStack..."
           localstack_ready=false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,27 +118,10 @@ jobs:
             -p 4566:4566 \
             -e SERVICES=sts,iam,kms,secretsmanager,ssm \
             localstack/localstack:latest
-          # Wait for LocalStack to be ready (can take 10-60s on cold runners)
-          echo "Waiting for LocalStack..."
-          localstack_ready=false
-          for _i in $(seq 1 45); do
-            if curl -sf http://localhost:4566/_localstack/health >/dev/null 2>&1; then
-              localstack_ready=true
-              break
-            fi
-            sleep 2
-          done
-          if [ "$localstack_ready" = false ]; then
-            echo "::error::LocalStack failed to start within 90 seconds"
-            docker logs localstack
-            exit 1
-          fi
-          # Verify individual services are responding
-          echo "Verifying LocalStack services..."
-          for _i in $(seq 1 15); do
-            if aws --endpoint-url http://localhost:4566 sts get-caller-identity --region us-east-1 --no-sign-request >/dev/null 2>&1; then
-              break
-            fi
+          # Wait for services to be ready
+          # Poll LocalStack health endpoint (can take 10-30s on cold runners)
+          for _i in $(seq 1 30); do
+            curl -sf http://localhost:4566/_localstack/health && break
             sleep 2
           done
           # Wait for Vault to be ready

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
           docker run -d --name localstack \
             -p 4566:4566 \
             -e SERVICES=sts,iam,kms,secretsmanager,ssm \
-            localstack/localstack:latest
+            localstack/localstack:4.14.0
           # Wait for LocalStack to be ready (can take 10-60s on cold runners)
           echo "Waiting for LocalStack..."
           localstack_ready=false

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -106,6 +106,7 @@ export default defineConfig({
               { text: "AWS Parameter Store", link: "/providers/aws-ps" },
               { text: "AWS Secrets Manager", link: "/providers/aws-sm" },
               { text: "Azure Key Vault Secrets", link: "/providers/azure-sm" },
+              { text: "Doppler", link: "/providers/doppler" },
               { text: "GCP Secret Manager", link: "/providers/gcp-sm" },
               {
                 text: "Bitwarden Secrets Manager",

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -809,6 +809,7 @@
                     "gcp-kms",
                     "fido2",
                     "bitwarden",
+                    "doppler",
                     "bitwarden-sm",
                     "infisical",
                     "keepass",

--- a/docs/cli/provider/add.md
+++ b/docs/cli/provider/add.md
@@ -30,8 +30,8 @@ Provider type
 - `gcp-kms`
 - `fido2`
 - `bitwarden`
-- `bitwarden-sm`
 - `doppler`
+- `bitwarden-sm`
 - `infisical`
 - `keepass`
 - `keychain`

--- a/docs/cli/provider/add.md
+++ b/docs/cli/provider/add.md
@@ -31,6 +31,7 @@ Provider type
 - `fido2`
 - `bitwarden`
 - `bitwarden-sm`
+- `doppler`
 - `infisical`
 - `keepass`
 - `keychain`

--- a/docs/index.md
+++ b/docs/index.md
@@ -91,6 +91,7 @@ API_KEY = { default = "dev-key-12345" }  # ← plain default value for local dev
 - **azure-sm** - Azure Key Vault Secrets
 - **gcp-sm** - Google Cloud Secret Manager
 - **bitwarden-sm** - Bitwarden Secrets Manager
+- **doppler** - Doppler secrets manager
 - **vault** - HashiCorp Vault
 
 ### 🔑 Password Managers & Secret Services

--- a/docs/providers/doppler.md
+++ b/docs/providers/doppler.md
@@ -1,0 +1,250 @@
+# Doppler
+
+Integrate with [Doppler](https://www.doppler.com/) to retrieve secrets from your Doppler projects and configs.
+
+## Quick Start
+
+```bash
+# 1. Install Doppler CLI
+brew install dopplerhq/cli/doppler
+
+# 2. Login to Doppler
+doppler login
+
+# 3. Configure Doppler provider
+cat >> fnox.toml << 'EOF'
+[providers]
+doppler = { type = "doppler", project = "my-project", config = "prd" }
+
+[secrets]
+DATABASE_URL = { provider = "doppler", value = "DATABASE_URL" }
+EOF
+
+# 4. Use it
+fnox get DATABASE_URL
+```
+
+## Prerequisites
+
+- [Doppler account](https://www.doppler.com/)
+- [Doppler CLI](https://docs.doppler.com/docs/cli)
+
+## Installation
+
+```bash
+# macOS
+brew install dopplerhq/cli/doppler
+
+# Linux
+curl -sLf --retry 3 --tlsv1.2 --proto "=https" 'https://packages.doppler.com/public/cli/gpg.DE2A7741A397C129.key' | sudo gpg --dearmor -o /usr/share/keyrings/doppler-archive-keyring.gpg
+echo "deb [signed-by=/usr/share/keyrings/doppler-archive-keyring.gpg] https://packages.doppler.com/public/cli/deb/debian any-version main" | sudo tee /etc/apt/sources.list.d/doppler-cli.list
+sudo apt-get update && sudo apt-get install -y doppler
+
+# Or install via mise
+mise use -g "github:DopplerHQ/cli"
+```
+
+## Setup
+
+### 1. Login to Doppler
+
+```bash
+doppler login
+```
+
+### 2. Authentication
+
+#### Option A: Interactive Login (Local Development)
+
+```bash
+doppler login
+```
+
+#### Option B: Service Token (CI/CD)
+
+Create a service token in the Doppler dashboard scoped to a specific project and config:
+
+```bash
+export DOPPLER_TOKEN="dp.st.prd.xxxx"
+```
+
+### 3. Configure Doppler Provider
+
+```toml
+[providers]
+doppler = { type = "doppler", project = "my-project", config = "prd" }
+```
+
+**Configuration Options:**
+
+All fields are optional. If not specified, the Doppler CLI will use its own defaults (from `doppler setup` or environment variables):
+
+- `project` - Doppler project name. If omitted, uses the project configured via `doppler setup`.
+- `config` - Doppler config (environment) name (e.g., "dev", "stg", "prd"). If omitted, uses the config configured via `doppler setup`.
+- `token` - Service token for authentication. If omitted, uses `DOPPLER_TOKEN` or `FNOX_DOPPLER_TOKEN` environment variable, or interactive login session.
+
+## Referencing Secrets
+
+```toml
+[secrets]
+DATABASE_URL = { provider = "doppler", value = "DATABASE_URL" }
+API_KEY = { provider = "doppler", value = "API_KEY" }
+```
+
+The `value` is the secret key name in Doppler. The provider configuration determines the project and config scope.
+
+## Usage
+
+```bash
+# Get a single secret
+fnox get DATABASE_URL
+
+# Run commands with secrets injected
+fnox exec -- npm start
+```
+
+## Multi-Environment Example
+
+Use named provider instances to pull secrets from different Doppler projects or configs:
+
+```toml
+[providers]
+app-prod = { type = "doppler", project = "my-app", config = "prd" }
+app-dev = { type = "doppler", project = "my-app", config = "dev" }
+infra = { type = "doppler", project = "infra", config = "prd" }
+
+[secrets]
+PROD_DB_URL = { provider = "app-prod", value = "DATABASE_URL" }
+DEV_DB_URL = { provider = "app-dev", value = "DATABASE_URL" }
+AWS_KEY = { provider = "infra", value = "AWS_ACCESS_KEY_ID" }
+```
+
+Or use fnox profiles:
+
+```toml
+[providers]
+doppler = { type = "doppler", project = "my-app", config = "dev" }
+
+[secrets]
+DATABASE_URL = { provider = "doppler", value = "DATABASE_URL" }
+
+[profiles.staging.providers]
+doppler = { type = "doppler", project = "my-app", config = "stg" }
+
+[profiles.production.providers]
+doppler = { type = "doppler", project = "my-app", config = "prd" }
+```
+
+Usage:
+
+```bash
+# Development (default)
+fnox exec -- npm start
+
+# Staging
+fnox exec --profile staging -- npm start
+
+# Production
+fnox exec --profile production -- ./deploy.sh
+```
+
+## CI/CD Example
+
+### GitHub Actions
+
+```yaml
+name: Deploy
+on: [push]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jdx/mise-action@v3
+
+      - name: Deploy
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+        run: |
+          fnox exec -- ./deploy.sh
+```
+
+**Setup:**
+
+1. Create a service token in the Doppler dashboard for the target project/config
+2. Add the token to GitHub Secrets as `DOPPLER_TOKEN`
+
+## Token Management
+
+### Environment Variables
+
+fnox checks for tokens in this order:
+
+1. Provider config `token` field
+2. `FNOX_DOPPLER_TOKEN` environment variable
+3. `DOPPLER_TOKEN` environment variable
+4. Interactive login session (from `doppler login`)
+
+### Bootstrap Pattern
+
+Store the Doppler token encrypted for easy bootstrap:
+
+```bash
+# Store token encrypted with age
+fnox set DOPPLER_TOKEN "dp.st.prd.xxxx" --provider age
+
+# Bootstrap from fnox
+export DOPPLER_TOKEN=$(fnox get DOPPLER_TOKEN)
+fnox exec -- npm start
+```
+
+## Pros
+
+- ✅ Developer-friendly dashboard and CLI
+- ✅ Simple project/config/environment model
+- ✅ Automatic secret syncing across environments
+- ✅ Good integrations (GitHub, Vercel, AWS, etc.)
+- ✅ Secret referencing and inheritance between configs
+- ✅ Audit logs and access controls
+- ✅ Free tier available
+
+## Cons
+
+- ❌ Requires network access (cloud-only, no self-hosted option)
+- ❌ No open source option
+
+## Troubleshooting
+
+### "Unauthorized" or "Invalid service token"
+
+```bash
+# Re-login interactively
+doppler login
+
+# Or check your service token
+echo $DOPPLER_TOKEN
+```
+
+### "Could not find project" or "Could not find config"
+
+Verify your project and config exist:
+
+```bash
+doppler projects
+doppler configs --project my-project
+```
+
+### "Secret not found"
+
+Check the secret exists in the correct project/config:
+
+```bash
+doppler secrets --project my-project --config prd
+```
+
+## Next Steps
+
+- [Infisical](/providers/infisical) - Alternative cloud secrets manager
+- [HashiCorp Vault](/providers/vault) - Self-hosted alternative
+- [Real-World Example](/guide/real-world-example) - Complete setup

--- a/docs/providers/overview.md
+++ b/docs/providers/overview.md
@@ -26,6 +26,7 @@ Store secrets remotely in cloud providers. Your `fnox.toml` contains only refere
 | [Azure Key Vault Secrets](/providers/azure-sm)       | Azure secret storage                | Production Azure workloads               |
 | [GCP Secret Manager](/providers/gcp-sm)              | Google Cloud secrets                | Production GCP workloads                 |
 | [Bitwarden Secrets Manager](/providers/bitwarden-sm) | Bitwarden Secrets Manager (bws CLI) | Teams using Bitwarden for DevOps secrets |
+| [Doppler](/providers/doppler)                        | Doppler secrets manager             | Developer-friendly cloud secrets         |
 | [HashiCorp Vault](/providers/vault)                  | Self-hosted or HCP Vault            | Multi-cloud, advanced features           |
 
 ### 🔑 Password Managers & Secret Services

--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -483,6 +483,32 @@
             "auth_command": {
               "type": ["string", "null"]
             },
+            "credential_id": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            },
+            "pin": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "rp_id": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            },
+            "salt": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "fido2"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type", "credential_id", "salt", "rp_id"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "auth_command": {
+              "type": ["string", "null"]
+            },
             "challenge": {
               "$ref": "#/$defs/StringOrSecretRef"
             },
@@ -563,25 +589,16 @@
             "auth_command": {
               "type": ["string", "null"]
             },
-            "credential_id": {
-              "$ref": "#/$defs/StringOrSecretRef"
-            },
-            "pin": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "rp_id": {
-              "$ref": "#/$defs/StringOrSecretRef"
-            },
-            "salt": {
-              "$ref": "#/$defs/StringOrSecretRef"
-            },
             "type": {
               "type": "string",
-              "const": "fido2"
+              "const": "proton-pass"
+            },
+            "vault": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
             }
           },
           "additionalProperties": false,
-          "required": ["type", "credential_id", "salt", "rp_id"]
+          "required": ["type"]
         },
         {
           "type": "object",
@@ -609,41 +626,21 @@
         {
           "type": "object",
           "properties": {
-            "api_key": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
             "auth_command": {
               "type": ["string", "null"]
             },
-            "base_url": {
-              "$ref": "#/$defs/StringOrSecretRef"
+            "environment": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
             },
-            "password_list_id": {
-              "$ref": "#/$defs/StringOrSecretRef"
+            "path": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "project_id": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
             },
             "type": {
               "type": "string",
-              "const": "passwordstate"
-            },
-            "verify_ssl": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["type", "base_url", "password_list_id"]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "auth_command": {
-              "type": ["string", "null"]
-            },
-            "type": {
-              "type": "string",
-              "const": "proton-pass"
-            },
-            "vault": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
+              "const": "infisical"
             }
           },
           "additionalProperties": false,
@@ -685,48 +682,28 @@
         {
           "type": "object",
           "properties": {
+            "api_key": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
             "auth_command": {
               "type": ["string", "null"]
             },
-            "environment": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "path": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "project_id": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "type": {
-              "type": "string",
-              "const": "infisical"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["type"]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "auth_command": {
-              "type": ["string", "null"]
-            },
-            "endpoint": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "key_id": {
+            "base_url": {
               "$ref": "#/$defs/StringOrSecretRef"
             },
-            "region": {
+            "password_list_id": {
               "$ref": "#/$defs/StringOrSecretRef"
             },
             "type": {
               "type": "string",
-              "const": "aws-kms"
+              "const": "passwordstate"
+            },
+            "verify_ssl": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
             }
           },
           "additionalProperties": false,
-          "required": ["type", "key_id", "region"]
+          "required": ["type", "base_url", "password_list_id"]
         },
         {
           "type": "object",
@@ -783,6 +760,95 @@
             "endpoint": {
               "$ref": "#/$defs/OptionStringOrSecretRef"
             },
+            "key_id": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            },
+            "region": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "aws-kms"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type", "key_id", "region"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "auth_command": {
+              "type": ["string", "null"]
+            },
+            "profile": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "project_id": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "bitwarden-sm"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "address": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "auth_command": {
+              "type": ["string", "null"]
+            },
+            "namespace": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "path": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "token": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "vault"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "auth_command": {
+              "type": ["string", "null"]
+            },
+            "prefix": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "project": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "gcp-sm"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type", "project"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "auth_command": {
+              "type": ["string", "null"]
+            },
+            "endpoint": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
             "prefix": {
               "$ref": "#/$defs/OptionStringOrSecretRef"
             },
@@ -829,52 +895,6 @@
         {
           "type": "object",
           "properties": {
-            "address": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "auth_command": {
-              "type": ["string", "null"]
-            },
-            "namespace": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "path": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "token": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "type": {
-              "type": "string",
-              "const": "vault"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["type"]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "auth_command": {
-              "type": ["string", "null"]
-            },
-            "profile": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "project_id": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "type": {
-              "type": "string",
-              "const": "bitwarden-sm"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["type"]
-        },
-        {
-          "type": "object",
-          "properties": {
             "auth_command": {
               "type": ["string", "null"]
             },
@@ -898,19 +918,22 @@
             "auth_command": {
               "type": ["string", "null"]
             },
-            "prefix": {
+            "config": {
               "$ref": "#/$defs/OptionStringOrSecretRef"
             },
             "project": {
-              "$ref": "#/$defs/StringOrSecretRef"
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "token": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
             },
             "type": {
               "type": "string",
-              "const": "gcp-sm"
+              "const": "doppler"
             }
           },
           "additionalProperties": false,
-          "required": ["type", "project"]
+          "required": ["type"]
         },
         {
           "type": "object",

--- a/fnox.usage.kdl
+++ b/fnox.usage.kdl
@@ -138,7 +138,7 @@ cmd provider help="Manage providers (defaults to list)" {
         }
         arg <PROVIDER> help="Provider name"
         arg <PROVIDER_TYPE> help="Provider type" {
-            choices "1password" age aws aws-kms aws-ps azure-kms azure-sm gcp gcp-kms fido2 bitwarden bitwarden-sm infisical keepass keychain password-store passwordstate plain proton-pass vault yubikey
+            choices "1password" age aws aws-kms aws-ps azure-kms azure-sm gcp gcp-kms fido2 bitwarden doppler bitwarden-sm infisical keepass keychain password-store passwordstate plain proton-pass vault yubikey
         }
     }
     cmd list help="List available providers" {

--- a/providers/doppler.toml
+++ b/providers/doppler.toml
@@ -1,0 +1,31 @@
+# Doppler provider - retrieves secrets from Doppler
+display_name = "Doppler"
+serde_rename = "doppler"
+rust_variant = "Doppler"
+category = "CloudSecretsManager"
+description = "Doppler secrets manager"
+default_name = "doppler"
+auth_command = "doppler login"
+setup_instructions = """
+Requires: Doppler CLI (https://docs.doppler.com/docs/cli)
+Install: brew install dopplerhq/cli/doppler
+Authenticate: doppler login
+Set project/config: doppler setup (or specify in provider config)
+Or use a service token: export DOPPLER_TOKEN=dp.st.xxx"""
+
+[fields.project]
+type = "optional"
+placeholder = "my-project"
+label = "Project:"
+wizard = true
+
+[fields.config]
+type = "optional"
+placeholder = "prd"
+label = "Config (environment):"
+wizard = true
+
+[fields.token]
+type = "optional"
+placeholder = ""
+label = "Service token (optional, uses env var if not set):"

--- a/src/commands/provider/add.rs
+++ b/src/commands/provider/add.rs
@@ -182,6 +182,12 @@ impl AddCommand {
                     auth_command: None,
                 }
             }
+            ProviderType::Doppler => crate::config::ProviderConfig::Doppler {
+                project: OptionStringOrSecretRef::literal("my-project"),
+                config: OptionStringOrSecretRef::literal("prd"),
+                token: OptionStringOrSecretRef::none(),
+                auth_command: None,
+            },
             ProviderType::Infisical => crate::config::ProviderConfig::Infisical {
                 project_id: OptionStringOrSecretRef::literal("your-project-id"),
                 environment: OptionStringOrSecretRef::literal("dev"),

--- a/src/commands/provider/mod.rs
+++ b/src/commands/provider/mod.rs
@@ -57,6 +57,9 @@ pub enum ProviderType {
     /// Bitwarden Password Manager
     #[value(name = "bitwarden")]
     Bitwarden,
+    /// Doppler secrets manager
+    #[value(name = "doppler")]
+    Doppler,
     /// Bitwarden Secrets Manager
     #[value(name = "bitwarden-sm")]
     #[strum(serialize = "bitwarden-sm")]

--- a/src/providers/doppler.rs
+++ b/src/providers/doppler.rs
@@ -1,0 +1,478 @@
+use crate::env;
+use crate::error::{FnoxError, Result};
+use async_trait::async_trait;
+use std::collections::HashMap;
+use tokio::process::Command;
+
+const PROVIDER_NAME: &str = "Doppler";
+const PROVIDER_URL: &str = "https://fnox.jdx.dev/providers/doppler";
+
+pub struct DopplerProvider {
+    project: Option<String>,
+    config: Option<String>,
+    token: Option<String>,
+}
+
+impl DopplerProvider {
+    pub fn new(
+        project: Option<String>,
+        config: Option<String>,
+        token: Option<String>,
+    ) -> Result<Self> {
+        Ok(Self {
+            project,
+            config,
+            token,
+        })
+    }
+
+    /// Get authentication token from config or environment
+    fn get_token(&self) -> Option<String> {
+        self.token
+            .clone()
+            .or_else(|| {
+                env::var("FNOX_DOPPLER_TOKEN")
+                    .or_else(|_| env::var("DOPPLER_TOKEN"))
+                    .ok()
+            })
+    }
+
+    /// Build common args for project/config/token
+    fn build_common_args(&self) -> Vec<String> {
+        let mut args = Vec::new();
+
+        if let Some(ref project) = self.project {
+            args.push(format!("--project={}", project));
+        }
+        if let Some(ref config) = self.config {
+            args.push(format!("--config={}", config));
+        }
+        if let Some(ref token) = self.get_token() {
+            args.push(format!("--token={}", token));
+        }
+
+        args
+    }
+
+    /// Execute a doppler CLI command and return stdout
+    async fn execute_doppler_command(
+        &self,
+        args: &[&str],
+        secret_ref: Option<&str>,
+    ) -> Result<String> {
+        tracing::debug!("Executing doppler command with args: {:?}", args);
+
+        let mut cmd = Command::new("doppler");
+        cmd.args(args);
+
+        let common_args = self.build_common_args();
+        for arg in &common_args {
+            cmd.arg(arg);
+        }
+
+        cmd.stdin(std::process::Stdio::null());
+
+        let output = cmd.output().await.map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                FnoxError::ProviderCliNotFound {
+                    provider: PROVIDER_NAME.to_string(),
+                    cli: "doppler".to_string(),
+                    install_hint: "brew install dopplerhq/cli/doppler".to_string(),
+                    url: PROVIDER_URL.to_string(),
+                }
+            } else {
+                FnoxError::ProviderCliFailed {
+                    provider: PROVIDER_NAME.to_string(),
+                    details: e.to_string(),
+                    hint: "Check that the Doppler CLI is installed and accessible".to_string(),
+                    url: PROVIDER_URL.to_string(),
+                }
+            }
+        })?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(classify_cli_error(stderr.trim(), secret_ref));
+        }
+
+        let stdout =
+            String::from_utf8(output.stdout).map_err(|e| FnoxError::ProviderInvalidResponse {
+                provider: PROVIDER_NAME.to_string(),
+                details: format!("Invalid UTF-8 in command output: {}", e),
+                hint: "The secret value contains invalid UTF-8 characters".to_string(),
+                url: PROVIDER_URL.to_string(),
+            })?;
+
+        Ok(stdout.trim().to_string())
+    }
+}
+
+#[async_trait]
+impl crate::providers::Provider for DopplerProvider {
+    async fn get_secret(&self, value: &str) -> Result<String> {
+        tracing::debug!("Getting secret '{}' from Doppler", value);
+
+        let result = self
+            .execute_doppler_command(&["secrets", "get", value, "--plain"], Some(value))
+            .await?;
+
+        if result.is_empty() {
+            return Err(FnoxError::ProviderSecretNotFound {
+                provider: PROVIDER_NAME.to_string(),
+                secret: value.to_string(),
+                hint: "Check that the secret exists in your Doppler project/config".to_string(),
+                url: PROVIDER_URL.to_string(),
+            });
+        }
+
+        Ok(result)
+    }
+
+    async fn get_secrets_batch(
+        &self,
+        secrets: &[(String, String)],
+    ) -> HashMap<String, Result<String>> {
+        if secrets.is_empty() {
+            return HashMap::new();
+        }
+        if secrets.len() == 1 {
+            let (key, value) = &secrets[0];
+            let result = self.get_secret(value).await;
+            let mut map = HashMap::new();
+            map.insert(key.clone(), result);
+            return map;
+        }
+
+        tracing::debug!("Batch fetching {} secrets from Doppler", secrets.len());
+
+        // Build command: doppler secrets get NAME1 NAME2 ... --json
+        let mut args = vec!["secrets", "get"];
+        let secret_names: Vec<&str> = secrets.iter().map(|(_, v)| v.as_str()).collect();
+        args.extend(&secret_names);
+        args.push("--json");
+
+        match self.execute_doppler_command(&args, None).await {
+            Ok(json_output) => {
+                // Doppler --json returns: { "NAME": { "computed": "value", ... }, ... }
+                match serde_json::from_str::<serde_json::Value>(&json_output) {
+                    Ok(json_obj) => {
+                        secrets
+                            .iter()
+                            .map(|(key, secret_name)| {
+                                let result = json_obj
+                                    .get(secret_name)
+                                    .and_then(|entry| entry.get("computed"))
+                                    .and_then(|v| v.as_str())
+                                    .map(|s| s.to_string())
+                                    .ok_or_else(|| FnoxError::ProviderSecretNotFound {
+                                        provider: PROVIDER_NAME.to_string(),
+                                        secret: secret_name.clone(),
+                                        hint: "Check that the secret exists in your Doppler project/config".to_string(),
+                                        url: PROVIDER_URL.to_string(),
+                                    });
+                                (key.clone(), result)
+                            })
+                            .collect()
+                    }
+                    Err(e) => secrets
+                        .iter()
+                        .map(|(key, _)| {
+                            (
+                                key.clone(),
+                                Err(FnoxError::ProviderInvalidResponse {
+                                    provider: PROVIDER_NAME.to_string(),
+                                    details: format!("Failed to parse batch response: {}", e),
+                                    hint: "The Doppler CLI returned an unexpected response format"
+                                        .to_string(),
+                                    url: PROVIDER_URL.to_string(),
+                                }),
+                            )
+                        })
+                        .collect(),
+                }
+            }
+            Err(e) => secrets
+                .iter()
+                .map(|(key, secret_name)| (key.clone(), Err(map_batch_error(&e, secret_name))))
+                .collect(),
+        }
+    }
+
+    async fn test_connection(&self) -> Result<()> {
+        tracing::debug!("Testing connection to Doppler");
+
+        // Use `doppler secrets --only-names` as a lightweight connectivity check
+        self.execute_doppler_command(&["secrets", "--only-names"], None)
+            .await?;
+
+        tracing::debug!("Doppler connection test successful");
+        Ok(())
+    }
+}
+
+pub fn env_dependencies() -> &'static [&'static str] {
+    &["DOPPLER_TOKEN", "FNOX_DOPPLER_TOKEN"]
+}
+
+fn clone_provider_error(error: &FnoxError) -> Option<FnoxError> {
+    Some(match error {
+        FnoxError::ProviderAuthFailed {
+            provider,
+            details,
+            hint,
+            url,
+        } => FnoxError::ProviderAuthFailed {
+            provider: provider.clone(),
+            details: details.clone(),
+            hint: hint.clone(),
+            url: url.clone(),
+        },
+        FnoxError::ProviderCliNotFound {
+            provider,
+            cli,
+            install_hint,
+            url,
+        } => FnoxError::ProviderCliNotFound {
+            provider: provider.clone(),
+            cli: cli.clone(),
+            install_hint: install_hint.clone(),
+            url: url.clone(),
+        },
+        FnoxError::ProviderInvalidResponse {
+            provider,
+            details,
+            hint,
+            url,
+        } => FnoxError::ProviderInvalidResponse {
+            provider: provider.clone(),
+            details: details.clone(),
+            hint: hint.clone(),
+            url: url.clone(),
+        },
+        FnoxError::ProviderApiError {
+            provider,
+            details,
+            hint,
+            url,
+        } => FnoxError::ProviderApiError {
+            provider: provider.clone(),
+            details: details.clone(),
+            hint: hint.clone(),
+            url: url.clone(),
+        },
+        FnoxError::ProviderCliFailed {
+            provider,
+            details,
+            hint,
+            url,
+        } => FnoxError::ProviderCliFailed {
+            provider: provider.clone(),
+            details: details.clone(),
+            hint: hint.clone(),
+            url: url.clone(),
+        },
+        _ => return None,
+    })
+}
+
+/// Map a batch-level error to a per-secret error, preserving structured variants.
+fn map_batch_error(e: &FnoxError, secret_name: &str) -> FnoxError {
+    if let FnoxError::ProviderSecretNotFound {
+        provider,
+        hint,
+        url,
+        ..
+    } = e
+    {
+        return FnoxError::ProviderSecretNotFound {
+            provider: provider.clone(),
+            secret: secret_name.to_string(),
+            hint: hint.clone(),
+            url: url.clone(),
+        };
+    }
+
+    clone_provider_error(e).unwrap_or_else(|| FnoxError::ProviderCliFailed {
+        provider: PROVIDER_NAME.to_string(),
+        details: e.to_string(),
+        hint: "Check your Doppler configuration".to_string(),
+        url: PROVIDER_URL.to_string(),
+    })
+}
+
+const AUTH_ERROR_PATTERNS: &[&str] = &[
+    "unauthorized",
+    "token expired",
+    "invalid token",
+    "authentication failed",
+    "forbidden",
+    "invalid service token",
+    "missing token",
+];
+
+const SECRET_NOT_FOUND_PATTERNS: &[&str] = &[
+    "could not find secret",
+    "secret not found",
+    "does not exist",
+    "not found",
+];
+
+const RESOURCE_NOT_FOUND_PATTERNS: &[&str] = &[
+    "project not found",
+    "config not found",
+    "could not find project",
+    "could not find config",
+    "could not find environment",
+];
+
+fn contains_any(haystack: &str, patterns: &[&str]) -> bool {
+    patterns.iter().any(|pattern| haystack.contains(pattern))
+}
+
+/// Classify CLI stderr output into the appropriate FnoxError variant.
+fn classify_cli_error(stderr: &str, secret_ref: Option<&str>) -> FnoxError {
+    let stderr_lower = stderr.to_lowercase();
+
+    if contains_any(&stderr_lower, AUTH_ERROR_PATTERNS) {
+        return FnoxError::ProviderAuthFailed {
+            provider: PROVIDER_NAME.to_string(),
+            details: stderr.to_string(),
+            hint: "Run 'doppler login' or check your DOPPLER_TOKEN".to_string(),
+            url: PROVIDER_URL.to_string(),
+        };
+    }
+
+    if contains_any(&stderr_lower, RESOURCE_NOT_FOUND_PATTERNS) {
+        return FnoxError::ProviderApiError {
+            provider: PROVIDER_NAME.to_string(),
+            details: stderr.to_string(),
+            hint: "Check project/config settings in your Doppler provider config".to_string(),
+            url: PROVIDER_URL.to_string(),
+        };
+    }
+
+    if let Some(secret_name) = secret_ref {
+        if contains_any(&stderr_lower, SECRET_NOT_FOUND_PATTERNS) {
+            return FnoxError::ProviderSecretNotFound {
+                provider: PROVIDER_NAME.to_string(),
+                secret: secret_name.to_string(),
+                hint: "Check that the secret exists in your Doppler project/config".to_string(),
+                url: PROVIDER_URL.to_string(),
+            };
+        }
+    }
+
+    FnoxError::ProviderCliFailed {
+        provider: PROVIDER_NAME.to_string(),
+        details: stderr.to_string(),
+        hint: "Check your Doppler configuration and authentication".to_string(),
+        url: PROVIDER_URL.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_cli_error_unauthorized() {
+        let err = classify_cli_error("Error: Unauthorized access", Some("MY_SECRET"));
+        assert!(
+            matches!(err, FnoxError::ProviderAuthFailed { .. }),
+            "Expected ProviderAuthFailed, got {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn classify_cli_error_invalid_service_token() {
+        let err = classify_cli_error("Invalid service token", None);
+        assert!(matches!(err, FnoxError::ProviderAuthFailed { .. }));
+    }
+
+    #[test]
+    fn classify_cli_error_project_not_found() {
+        let err = classify_cli_error("Could not find project", Some("SECRET"));
+        assert!(
+            matches!(err, FnoxError::ProviderApiError { .. }),
+            "Expected ProviderApiError, got {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn classify_cli_error_config_not_found() {
+        let err = classify_cli_error("Could not find config", Some("SECRET"));
+        assert!(
+            matches!(err, FnoxError::ProviderApiError { .. }),
+            "Expected ProviderApiError, got {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn classify_cli_error_secret_not_found() {
+        let err = classify_cli_error("Could not find secret NAME", Some("NAME"));
+        match err {
+            FnoxError::ProviderSecretNotFound { secret, .. } => {
+                assert_eq!(secret, "NAME");
+            }
+            other => panic!("Expected ProviderSecretNotFound, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn classify_cli_error_secret_not_found_without_ref() {
+        let err = classify_cli_error("Could not find secret", None);
+        assert!(
+            matches!(err, FnoxError::ProviderCliFailed { .. }),
+            "Expected ProviderCliFailed, got {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn classify_cli_error_generic() {
+        let err = classify_cli_error("some unexpected error", Some("SECRET"));
+        assert!(
+            matches!(err, FnoxError::ProviderCliFailed { .. }),
+            "Expected ProviderCliFailed, got {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn map_batch_error_preserves_auth_failed() {
+        let error = FnoxError::ProviderAuthFailed {
+            provider: PROVIDER_NAME.to_string(),
+            details: "unauthorized".to_string(),
+            hint: "login".to_string(),
+            url: PROVIDER_URL.to_string(),
+        };
+
+        let result = map_batch_error(&error, "secret1");
+        assert!(
+            matches!(result, FnoxError::ProviderAuthFailed { .. }),
+            "Expected ProviderAuthFailed, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn map_batch_error_preserves_secret_not_found_with_per_secret_name() {
+        let error = FnoxError::ProviderSecretNotFound {
+            provider: PROVIDER_NAME.to_string(),
+            secret: "original".to_string(),
+            hint: "check".to_string(),
+            url: PROVIDER_URL.to_string(),
+        };
+
+        let result = map_batch_error(&error, "secret_a");
+        match result {
+            FnoxError::ProviderSecretNotFound { secret, .. } => {
+                assert_eq!(secret, "secret_a");
+            }
+            other => panic!("Expected ProviderSecretNotFound, got {:?}", other),
+        }
+    }
+}

--- a/src/providers/doppler.rs
+++ b/src/providers/doppler.rs
@@ -35,7 +35,7 @@ impl DopplerProvider {
         })
     }
 
-    /// Build common args for project/config/token
+    /// Build common args for project/config
     fn build_common_args(&self) -> Vec<String> {
         let mut args = Vec::new();
 
@@ -44,9 +44,6 @@ impl DopplerProvider {
         }
         if let Some(ref config) = self.config {
             args.push(format!("--config={}", config));
-        }
-        if let Some(ref token) = self.get_token() {
-            args.push(format!("--token={}", token));
         }
 
         args
@@ -66,6 +63,10 @@ impl DopplerProvider {
         let common_args = self.build_common_args();
         for arg in &common_args {
             cmd.arg(arg);
+        }
+
+        if let Some(token) = self.get_token() {
+            cmd.env("DOPPLER_TOKEN", token);
         }
 
         cmd.stdin(std::process::Stdio::null());
@@ -110,20 +111,8 @@ impl crate::providers::Provider for DopplerProvider {
     async fn get_secret(&self, value: &str) -> Result<String> {
         tracing::debug!("Getting secret '{}' from Doppler", value);
 
-        let result = self
-            .execute_doppler_command(&["secrets", "get", value, "--plain"], Some(value))
-            .await?;
-
-        if result.is_empty() {
-            return Err(FnoxError::ProviderSecretNotFound {
-                provider: PROVIDER_NAME.to_string(),
-                secret: value.to_string(),
-                hint: "Check that the secret exists in your Doppler project/config".to_string(),
-                url: PROVIDER_URL.to_string(),
-            });
-        }
-
-        Ok(result)
+        self.execute_doppler_command(&["secrets", "get", value, "--plain"], Some(value))
+            .await
     }
 
     async fn get_secrets_batch(
@@ -312,7 +301,6 @@ const SECRET_NOT_FOUND_PATTERNS: &[&str] = &[
     "could not find secret",
     "secret not found",
     "does not exist",
-    "not found",
 ];
 
 const RESOURCE_NOT_FOUND_PATTERNS: &[&str] = &[

--- a/src/providers/doppler.rs
+++ b/src/providers/doppler.rs
@@ -351,15 +351,15 @@ fn classify_cli_error(stderr: &str, secret_ref: Option<&str>) -> FnoxError {
         };
     }
 
-    if let Some(secret_name) = secret_ref {
-        if contains_any(&stderr_lower, SECRET_NOT_FOUND_PATTERNS) {
-            return FnoxError::ProviderSecretNotFound {
-                provider: PROVIDER_NAME.to_string(),
-                secret: secret_name.to_string(),
-                hint: "Check that the secret exists in your Doppler project/config".to_string(),
-                url: PROVIDER_URL.to_string(),
-            };
-        }
+    if let Some(secret_name) = secret_ref
+        && contains_any(&stderr_lower, SECRET_NOT_FOUND_PATTERNS)
+    {
+        return FnoxError::ProviderSecretNotFound {
+            provider: PROVIDER_NAME.to_string(),
+            secret: secret_name.to_string(),
+            hint: "Check that the secret exists in your Doppler project/config".to_string(),
+            url: PROVIDER_URL.to_string(),
+        };
     }
 
     FnoxError::ProviderCliFailed {

--- a/src/providers/doppler.rs
+++ b/src/providers/doppler.rs
@@ -28,13 +28,11 @@ impl DopplerProvider {
 
     /// Get authentication token from config or environment
     fn get_token(&self) -> Option<String> {
-        self.token
-            .clone()
-            .or_else(|| {
-                env::var("FNOX_DOPPLER_TOKEN")
-                    .or_else(|_| env::var("DOPPLER_TOKEN"))
-                    .ok()
-            })
+        self.token.clone().or_else(|| {
+            env::var("FNOX_DOPPLER_TOKEN")
+                .or_else(|_| env::var("DOPPLER_TOKEN"))
+                .ok()
+        })
     }
 
     /// Build common args for project/config/token

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -11,6 +11,7 @@ pub mod azure_kms;
 pub mod azure_sm;
 pub mod bitwarden;
 pub mod bitwarden_sm;
+pub mod doppler;
 pub mod fido2;
 pub mod gcp_kms;
 pub mod gcp_sm;
@@ -137,8 +138,8 @@ mod generated {
     pub(super) mod providers_instantiate {
         // Need to import provider modules for instantiation
         use super::super::{
-            age, aws_kms, aws_ps, aws_sm, azure_kms, azure_sm, bitwarden, bitwarden_sm, fido2,
-            gcp_kms, gcp_sm, infisical, keepass, keychain, onepassword, password_store,
+            age, aws_kms, aws_ps, aws_sm, azure_kms, azure_sm, bitwarden, bitwarden_sm, doppler,
+            fido2, gcp_kms, gcp_sm, infisical, keepass, keychain, onepassword, password_store,
             passwordstate, plain, proton_pass, vault, yubikey,
         };
         include!(concat!(


### PR DESCRIPTION
## Summary

- Adds a new Doppler secrets manager provider (`type = "doppler"`)
- Supports `project`, `config`, and `token` fields (all optional, falls back to CLI defaults / env vars)
- Uses `doppler secrets get <name> --plain` for single secrets and `--json` for batch fetching
- Includes `ProviderType::Doppler` enum variant and `fnox provider add doppler` support
- Full documentation page and updates to overview, sidebar, index, and CLI reference

## Configuration

```toml
[providers]
app-prod = { type = "doppler", project = "my-app", config = "prd" }
app-dev  = { type = "doppler", project = "my-app", config = "dev" }

[secrets]
PROD_DB_URL = { provider = "app-prod", value = "DATABASE_URL" }
DEV_DB_URL  = { provider = "app-dev",  value = "DATABASE_URL" }
```

## Test plan

- [x] All 141 lib tests pass (including `provider_add_types_match_provider_definitions`)
- [x] `cargo clippy -- -D warnings` passes clean
- [x] Manually tested with live Doppler projects (multiple providers, different projects/configs)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)