### PR TITLE
refactor(providers): extract shared error helpers to FnoxError methods

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -672,6 +672,106 @@ impl FnoxError {
     pub fn is_auth_error(&self) -> bool {
         matches!(self, FnoxError::ProviderAuthFailed { .. })
     }
+
+    /// Clone a provider error variant (all fields are `String`, so always cloneable).
+    ///
+    /// Returns `None` for non-provider error variants.
+    pub fn clone_provider_error(&self) -> Option<FnoxError> {
+        Some(match self {
+            FnoxError::ProviderAuthFailed {
+                provider,
+                details,
+                hint,
+                url,
+            } => FnoxError::ProviderAuthFailed {
+                provider: provider.clone(),
+                details: details.clone(),
+                hint: hint.clone(),
+                url: url.clone(),
+            },
+            FnoxError::ProviderCliNotFound {
+                provider,
+                cli,
+                install_hint,
+                url,
+            } => FnoxError::ProviderCliNotFound {
+                provider: provider.clone(),
+                cli: cli.clone(),
+                install_hint: install_hint.clone(),
+                url: url.clone(),
+            },
+            FnoxError::ProviderInvalidResponse {
+                provider,
+                details,
+                hint,
+                url,
+            } => FnoxError::ProviderInvalidResponse {
+                provider: provider.clone(),
+                details: details.clone(),
+                hint: hint.clone(),
+                url: url.clone(),
+            },
+            FnoxError::ProviderApiError {
+                provider,
+                details,
+                hint,
+                url,
+            } => FnoxError::ProviderApiError {
+                provider: provider.clone(),
+                details: details.clone(),
+                hint: hint.clone(),
+                url: url.clone(),
+            },
+            FnoxError::ProviderCliFailed {
+                provider,
+                details,
+                hint,
+                url,
+            } => FnoxError::ProviderCliFailed {
+                provider: provider.clone(),
+                details: details.clone(),
+                hint: hint.clone(),
+                url: url.clone(),
+            },
+            _ => return None,
+        })
+    }
+
+    /// Map a batch-level error to a per-secret error, preserving structured variants.
+    ///
+    /// If the error is `ProviderSecretNotFound`, the secret name is replaced with the given name.
+    /// Other provider error variants are cloned as-is. Non-provider errors fall back to
+    /// `ProviderCliFailed` with the given provider name, hint, and URL.
+    pub fn map_batch_error(
+        &self,
+        secret_name: &str,
+        fallback_provider: &str,
+        fallback_hint: &str,
+        fallback_url: &str,
+    ) -> FnoxError {
+        if let FnoxError::ProviderSecretNotFound {
+            provider,
+            hint,
+            url,
+            ..
+        } = self
+        {
+            return FnoxError::ProviderSecretNotFound {
+                provider: provider.clone(),
+                secret: secret_name.to_string(),
+                hint: hint.clone(),
+                url: url.clone(),
+            };
+        }
+
+        self.clone_provider_error()
+            .unwrap_or_else(|| FnoxError::ProviderCliFailed {
+                provider: fallback_provider.to_string(),
+                details: self.to_string(),
+                hint: fallback_hint.to_string(),
+                url: fallback_url.to_string(),
+            })
+    }
 }
 
 pub type Result<T> = std::result::Result<T, FnoxError>;
@@ -723,6 +823,56 @@ mod tests {
 
         for err in cases {
             assert!(!err.is_auth_error(), "Expected false for {:?}", err);
+        }
+    }
+
+    #[test]
+    fn clone_provider_error_clones_auth_failed() {
+        let err = FnoxError::ProviderAuthFailed {
+            provider: "test".to_string(),
+            details: "unauthorized".to_string(),
+            hint: "login".to_string(),
+            url: "https://example.com".to_string(),
+        };
+        assert!(matches!(
+            err.clone_provider_error(),
+            Some(FnoxError::ProviderAuthFailed { .. })
+        ));
+    }
+
+    #[test]
+    fn clone_provider_error_returns_none_for_non_provider() {
+        let err = FnoxError::Provider("generic".to_string());
+        assert!(err.clone_provider_error().is_none());
+    }
+
+    #[test]
+    fn map_batch_error_replaces_secret_name() {
+        let err = FnoxError::ProviderSecretNotFound {
+            provider: "test".to_string(),
+            secret: "original".to_string(),
+            hint: "check".to_string(),
+            url: "https://example.com".to_string(),
+        };
+        let mapped = err.map_batch_error("new_secret", "test", "hint", "url");
+        match mapped {
+            FnoxError::ProviderSecretNotFound { secret, .. } => {
+                assert_eq!(secret, "new_secret");
+            }
+            other => panic!("Expected ProviderSecretNotFound, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn map_batch_error_falls_back_for_non_provider() {
+        let err = FnoxError::Provider("generic".to_string());
+        let mapped = err.map_batch_error("secret", "MyProvider", "check config", "https://x.com");
+        match mapped {
+            FnoxError::ProviderCliFailed { provider, hint, .. } => {
+                assert_eq!(provider, "MyProvider");
+                assert_eq!(hint, "check config");
+            }
+            other => panic!("Expected ProviderCliFailed, got {:?}", other),
         }
     }
 }

--- a/src/providers/infisical.rs
+++ b/src/providers/infisical.rs
@@ -398,7 +398,17 @@ impl crate::providers::Provider for InfisicalProvider {
                 // Preserve the structured error variant for each secret
                 secrets
                     .iter()
-                    .map(|(key, secret_name)| (key.clone(), Err(map_batch_error(&e, secret_name))))
+                    .map(|(key, secret_name)| {
+                        (
+                            key.clone(),
+                            Err(e.map_batch_error(
+                                secret_name,
+                                PROVIDER_NAME,
+                                "Check your Infisical configuration",
+                                PROVIDER_URL,
+                            )),
+                        )
+                    })
                     .collect()
             }
         }
@@ -455,92 +465,6 @@ fn infisical_api_url() -> Option<String> {
 
 // Cache login token to avoid repeated login calls
 static CACHED_LOGIN_TOKEN: LazyLock<Mutex<Option<String>>> = LazyLock::new(|| Mutex::new(None));
-
-fn clone_provider_error(error: &FnoxError) -> Option<FnoxError> {
-    Some(match error {
-        FnoxError::ProviderAuthFailed {
-            provider,
-            details,
-            hint,
-            url,
-        } => FnoxError::ProviderAuthFailed {
-            provider: provider.clone(),
-            details: details.clone(),
-            hint: hint.clone(),
-            url: url.clone(),
-        },
-        FnoxError::ProviderCliNotFound {
-            provider,
-            cli,
-            install_hint,
-            url,
-        } => FnoxError::ProviderCliNotFound {
-            provider: provider.clone(),
-            cli: cli.clone(),
-            install_hint: install_hint.clone(),
-            url: url.clone(),
-        },
-        FnoxError::ProviderInvalidResponse {
-            provider,
-            details,
-            hint,
-            url,
-        } => FnoxError::ProviderInvalidResponse {
-            provider: provider.clone(),
-            details: details.clone(),
-            hint: hint.clone(),
-            url: url.clone(),
-        },
-        FnoxError::ProviderApiError {
-            provider,
-            details,
-            hint,
-            url,
-        } => FnoxError::ProviderApiError {
-            provider: provider.clone(),
-            details: details.clone(),
-            hint: hint.clone(),
-            url: url.clone(),
-        },
-        FnoxError::ProviderCliFailed {
-            provider,
-            details,
-            hint,
-            url,
-        } => FnoxError::ProviderCliFailed {
-            provider: provider.clone(),
-            details: details.clone(),
-            hint: hint.clone(),
-            url: url.clone(),
-        },
-        _ => return None,
-    })
-}
-
-/// Map a batch-level error to a per-secret error, preserving structured variants.
-fn map_batch_error(e: &FnoxError, secret_name: &str) -> FnoxError {
-    if let FnoxError::ProviderSecretNotFound {
-        provider,
-        hint,
-        url,
-        ..
-    } = e
-    {
-        return FnoxError::ProviderSecretNotFound {
-            provider: provider.clone(),
-            secret: secret_name.to_string(),
-            hint: hint.clone(),
-            url: url.clone(),
-        };
-    }
-
-    clone_provider_error(e).unwrap_or_else(|| FnoxError::ProviderCliFailed {
-        provider: PROVIDER_NAME.to_string(),
-        details: e.to_string(),
-        hint: "Check your Infisical configuration".to_string(),
-        url: PROVIDER_URL.to_string(),
-    })
-}
 
 const AUTH_ERROR_PATTERNS: &[&str] = &[
     "unauthorized",
@@ -701,7 +625,8 @@ mod tests {
             url: PROVIDER_URL.to_string(),
         };
 
-        let result = map_batch_error(&error, "secret1");
+        let result =
+            error.map_batch_error("secret1", PROVIDER_NAME, "Check your config", PROVIDER_URL);
         assert!(
             matches!(result, FnoxError::ProviderAuthFailed { .. }),
             "Expected ProviderAuthFailed, got {:?}",
@@ -718,7 +643,8 @@ mod tests {
             url: PROVIDER_URL.to_string(),
         };
 
-        let result = map_batch_error(&error, "secret1");
+        let result =
+            error.map_batch_error("secret1", PROVIDER_NAME, "Check your config", PROVIDER_URL);
         assert!(
             matches!(result, FnoxError::ProviderCliNotFound { .. }),
             "Expected ProviderCliNotFound, got {:?}",
@@ -735,7 +661,8 @@ mod tests {
             url: PROVIDER_URL.to_string(),
         };
 
-        let result = map_batch_error(&error, "secret_a");
+        let result =
+            error.map_batch_error("secret_a", PROVIDER_NAME, "Check your config", PROVIDER_URL);
         match result {
             FnoxError::ProviderSecretNotFound { secret, .. } => {
                 assert_eq!(secret, "secret_a");
@@ -753,7 +680,8 @@ mod tests {
             url: PROVIDER_URL.to_string(),
         };
 
-        let result = map_batch_error(&error, "secret1");
+        let result =
+            error.map_batch_error("secret1", PROVIDER_NAME, "Check your config", PROVIDER_URL);
         match result {
             FnoxError::ProviderCliFailed { details, hint, .. } => {
                 assert_eq!(details, "some error");


### PR DESCRIPTION
## Summary
- Move `clone_provider_error` and `map_batch_error` from per-provider free functions to methods on `FnoxError`
- Eliminates boilerplate that would otherwise be duplicated by every CLI-based provider (currently in infisical, and duplicated in the incoming Doppler PR #376)
- Adds unit tests for the new methods on `FnoxError`

## Test plan
- [x] All 12 infisical provider tests pass
- [x] All 6 error module tests pass (including 4 new ones)
- [x] Full `cargo test` passes (131/132, pre-existing keychain skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that centralizes provider error cloning/mapping logic; behavior should remain equivalent but could subtly affect provider error formatting if the fallback parameters are misused.
> 
> **Overview**
> Moves provider-specific error helper functions into `FnoxError` as `clone_provider_error` and `map_batch_error`, so providers can reuse the same structured error cloning/mapping behavior.
> 
> Updates the Infisical batch secret fetch path to call `e.map_batch_error(...)` and removes the now-duplicated local helper functions, adding/adjusting unit tests to cover the new `FnoxError` methods and updated Infisical behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fe23431dd1f5ad38359c8cb84dda7e86f9ff0f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->