### PR TITLE
feat: Powershell integration

### DIFF
--- a/docs/cli/activate.md
+++ b/docs/cli/activate.md
@@ -10,7 +10,7 @@ Output shell activation code to enable automatic secret loading
 
 ### `[SHELL]`
 
-Shell to generate activation code for (bash, zsh, fish, nu)
+Shell to generate activation code for (bash, zsh, fish, nu, pwsh)
 
 ## Flags
 

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -13,8 +13,8 @@
           {
             "name": "SHELL",
             "usage": "[SHELL]",
-            "help": "Shell to generate activation code for (bash, zsh, fish, nu)",
-            "help_first_line": "Shell to generate activation code for (bash, zsh, fish, nu)",
+            "help": "Shell to generate activation code for (bash, zsh, fish, nu, pwsh)",
+            "help_first_line": "Shell to generate activation code for (bash, zsh, fish, nu, pwsh)",
             "required": false,
             "double_dash": "Optional",
             "hide": false
@@ -291,8 +291,8 @@
           {
             "name": "shell",
             "usage": "-s --shell <SHELL>",
-            "help": "Shell type (bash, zsh, fish, nu)",
-            "help_first_line": "Shell type (bash, zsh, fish, nu)",
+            "help": "Shell type (bash, zsh, fish, nu, pwsh)",
+            "help_first_line": "Shell type (bash, zsh, fish, nu, pwsh)",
             "short": ["s"],
             "long": ["shell"],
             "hide": false,

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -50,7 +50,7 @@ eval "$(fnox activate bash)"  # or zsh, fish
 echo 'eval "$(fnox activate bash)"' >> ~/.bashrc
 ```
 
-For Nushell setup, see the [Shell Integration](/guide/shell-integration) guide.
+To enable integration in other shells (Nushell, Powershell), see the [Shell Integration](/guide/shell-integration) guide.
 
 Now secrets auto-load:
 

--- a/docs/guide/shell-integration.md
+++ b/docs/guide/shell-integration.md
@@ -31,6 +31,12 @@ mkdir ($nu.data-dir | path join "vendor/autoload")
 fnox activate nu | save -f ($nu.data-dir | path join "vendor/autoload/fnox.nu")
 ```
 
+```powershell [Powershell]
+# Add this to your Powershell profile.
+# To find your profile, see https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_profiles
+(&fnox activate pwsh) | Out-String | Invoke-Expression
+```
+
 :::
 
 ## How It Works

--- a/fnox.usage.kdl
+++ b/fnox.usage.kdl
@@ -21,7 +21,7 @@ flag --no-color help="Disable colored output" global=#true
 flag --no-defaults help="Do not merge top-level secrets into the selected profile" global=#true
 cmd activate help="Output shell activation code to enable automatic secret loading" {
     flag --no-hook-env help="Don't automatically invoke hook-env (for testing)"
-    arg "[SHELL]" help="Shell to generate activation code for (bash, zsh, fish, nu)" required=#false
+    arg "[SHELL]" help="Shell to generate activation code for (bash, zsh, fish, nu, pwsh)" required=#false
 }
 cmd check help="Check if all required secrets are defined and configured" {
     alias c
@@ -60,7 +60,7 @@ cmd get help="Get a secret value" {
     arg <KEY> help="Secret key to retrieve"
 }
 cmd hook-env hide=#true help="Internal command used by shell hooks to load secrets" {
-    flag "-s --shell" help="Shell type (bash, zsh, fish, nu)" {
+    flag "-s --shell" help="Shell type (bash, zsh, fish, nu, pwsh)" {
         arg <SHELL>
     }
 }

--- a/src/commands/activate.rs
+++ b/src/commands/activate.rs
@@ -5,7 +5,7 @@ use clap::Parser;
 #[derive(Debug, Parser)]
 #[command(about = "Output shell activation code to enable automatic secret loading")]
 pub struct ActivateCommand {
-    /// Shell to generate activation code for (bash, zsh, fish, nu)
+    /// Shell to generate activation code for (bash, zsh, fish, nu, pwsh)
     #[arg(value_name = "SHELL")]
     pub shell: Option<String>,
 

--- a/src/commands/hook_env.rs
+++ b/src/commands/hook_env.rs
@@ -37,7 +37,7 @@ impl OutputMode {
 #[derive(Debug, Parser)]
 #[command(about = "Internal command used by shell hooks to load secrets")]
 pub struct HookEnvCommand {
-    /// Shell type (bash, zsh, fish, nu)
+    /// Shell type (bash, zsh, fish, nu, pwsh)
     #[arg(short = 's', long)]
     pub shell: Option<String>,
 }

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -3,11 +3,13 @@ use std::fmt;
 mod bash;
 mod fish;
 mod nushell;
+mod pwsh;
 mod zsh;
 
 pub use bash::Bash;
 pub use fish::Fish;
 pub use nushell::Nushell;
+pub use pwsh::Pwsh;
 pub use zsh::Zsh;
 
 /// Options for shell activation
@@ -84,6 +86,7 @@ pub fn get_shell(name: Option<&str>) -> anyhow::Result<Box<dyn Shell>> {
         "zsh" => Ok(Box::new(Zsh)),
         "fish" => Ok(Box::new(Fish)),
         "nu" => Ok(Box::new(Nushell)),
+        "pwsh" | "powershell" => Ok(Box::new(Pwsh)),
         _ => anyhow::bail!("unsupported shell: {}", shell_name),
     }
 }

--- a/src/shell/pwsh.rs
+++ b/src/shell/pwsh.rs
@@ -1,0 +1,180 @@
+use super::{ActivateOptions, Shell};
+use std::borrow::Cow;
+use std::fmt;
+
+pub struct Pwsh;
+
+impl Shell for Pwsh {
+    fn activate(&self, opts: ActivateOptions) -> String {
+        let exe = opts.exe.to_string_lossy();
+        let mut out = String::new();
+
+        out.push_str("$env:FNOX_SHELL='pwsh'\n");
+
+        out.push_str(&format!(r#"
+function fnox {{
+    [CmdletBinding()]
+    param(
+        [Parameter(ValueFromRemainingArguments=$true)]
+        [string[]] $arguments
+    )
+
+    if ($arguments.count -eq 0) {{
+        & "{exe}"
+        return
+    }}
+
+    $command = $arguments[0]
+    if ($arguments.Length -gt 1) {{
+        $remainingArgs = $arguments[1..($arguments.Length - 1)]
+    }} else {{
+        $remainingArgs = @()
+    }}
+
+    switch ($command) {{
+        {{ $_ -in 'deactivate', 'shell' }} {{
+            & "{exe}" $command @remainingArgs | Out-String | Invoke-Expression -ErrorAction SilentlyContinue
+        }}
+        default {{
+            & "{exe}" $command @remainingArgs
+        }}
+    }}
+}}
+"#,
+        ));
+
+        if !opts.no_hook_env {
+            out.push_str(&format!(r#"
+function Global:_fnox_hook {{
+    if ($env:FNOX_SHELL -eq 'pwsh') {{
+        $output = & "{exe}" hook-env -s pwsh | Out-String
+        if ($output -and $output.Trim()) {{
+            $output | Invoke-Expression
+            if (Test-Path -Path Function:\__fnox_print_changes) {{
+                __fnox_print_changes
+                Remove-Item -Path Function:\__fnox_print_changes
+            }}
+        }}
+    }}
+}}
+
+function __enable_fnox_prompt {{
+    if (-not $__fnox_pwsh_previous_prompt_function) {{
+        $Global:__fnox_pwsh_previous_prompt_function = $function:prompt
+        function global:prompt {{
+            if (Test-Path -Path Function:\_fnox_hook) {{
+                _fnox_hook
+            }}
+            & $__fnox_pwsh_previous_prompt_function
+        }}
+    }}
+}}
+__enable_fnox_prompt
+Remove-Item -ErrorAction SilentlyContinue -Path Function:\__enable_fnox_prompt
+
+_fnox_hook"#,
+            ));
+        }
+
+        out
+    }
+
+    fn deactivate(&self) -> String {
+        r#"
+Remove-Item -ErrorAction SilentlyContinue Function:fnox
+Remove-Item -ErrorAction SilentlyContinue Function:_fnox_hook
+Remove-Item -ErrorAction SilentlyContinue -Path Env:FNOX_SHELL
+Remove-Item -ErrorAction SilentlyContinue -Path Env:__FNOX_SESSION
+        "#
+        .to_string()
+    }
+
+    fn hook_env_output(
+        &self,
+        added: &[(String, String)],
+        removed: &[String],
+        session_encoded: &str,
+    ) -> String {
+        let mut output = String::new();
+
+        if !added.is_empty() || !removed.is_empty() {
+            let mut count_parts = Vec::new();
+            if !added.is_empty() {
+                count_parts.push(format!("+{}", added.len()));
+            }
+            if !removed.is_empty() {
+                count_parts.push(format!("-{}", removed.len()));
+            }
+            let counts = count_parts.join(" ");
+
+            let all_keys: Vec<&str> = added
+                .iter()
+                .map(|(k, _)| k.as_str())
+                .chain(removed.iter().map(|k| k.as_str()))
+                .collect();
+            let keys = powershell_escape(all_keys.join(", ").into());
+            let prefix = powershell_escape(format!("fnox: {} ", counts).into());
+
+            /*
+                Because of the way activate/deactivate call hook-env, any calls to Write-Host get eaten.
+                To get around this, we package the Write-Host calls into a function to be executed in the context
+                of the rest of the activate/deactivate code.
+            */
+            output.push_str("function __fnox_print_changes {\n");
+            output.push_str(&format!(
+                "    Write-Host '{prefix}' -NoNewline -ForegroundColor DarkGray\n"
+            ));
+            output.push_str(&format!(
+                "    Write-Host '{keys}' -ForegroundColor Cyan\n"
+            ));
+            output.push_str("}\n");
+        }
+
+        for (key, value) in added {
+            output.push_str(&self.set_env(key, value));
+        }
+        for key in removed {
+            output.push_str(&self.unset_env(key));
+        }
+        output.push_str(&self.set_env("__FNOX_SESSION", session_encoded));
+        output
+    }
+
+    fn set_env(&self, key: &str, value: &str) -> String {
+        let k = powershell_escape(key.into());
+        let v = powershell_escape(value.into());
+        format!("$Env:{k}='{v}'\n")
+    }
+
+    fn unset_env(&self, key: &str) -> String {
+        let k = powershell_escape(key.into());
+        format!("Remove-Item -ErrorAction SilentlyContinue -Path Env:\\{k}\n")
+    }
+}
+
+impl fmt::Display for Pwsh {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "pwsh")
+    }
+}
+
+fn powershell_escape(s: Cow<str>) -> Cow<str> {
+    let needs_escape = s.chars().any(|c| matches!(c, '\t' | '\n' | '\r' | '\'' | '`'));
+
+    if !needs_escape {
+        return s;
+    }
+
+    let mut es = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '\t' => es.push_str("`t"),
+            '\n' => es.push_str("`n"),
+            '\r' => es.push_str("`r"),
+            '\'' => es.push_str("''"),
+            '`' => es.push_str("``"),
+            c => es.push(c),
+        }
+    }
+    es.into()
+}

--- a/src/shell/pwsh.rs
+++ b/src/shell/pwsh.rs
@@ -44,7 +44,8 @@ function fnox {{
         ));
 
         if !opts.no_hook_env {
-            out.push_str(&format!(r#"
+            out.push_str(&format!(
+                r#"
 function Global:_fnox_hook {{
     if ($env:FNOX_SHELL -eq 'pwsh') {{
         $output = & "{exe}" hook-env -s pwsh | Out-String
@@ -124,9 +125,7 @@ Remove-Item -ErrorAction SilentlyContinue -Path Env:__FNOX_SESSION
             output.push_str(&format!(
                 "    Write-Host '{prefix}' -NoNewline -ForegroundColor DarkGray\n"
             ));
-            output.push_str(&format!(
-                "    Write-Host '{keys}' -ForegroundColor Cyan\n"
-            ));
+            output.push_str(&format!("    Write-Host '{keys}' -ForegroundColor Cyan\n"));
             output.push_str("}\n");
         }
 
@@ -159,7 +158,9 @@ impl fmt::Display for Pwsh {
 }
 
 fn powershell_escape(s: Cow<str>) -> Cow<str> {
-    let needs_escape = s.chars().any(|c| matches!(c, '\t' | '\n' | '\r' | '\'' | '`'));
+    let needs_escape = s
+        .chars()
+        .any(|c| matches!(c, '\t' | '\n' | '\r' | '\'' | '`'));
 
     if !needs_escape {
         return s;

--- a/src/shell/pwsh.rs
+++ b/src/shell/pwsh.rs
@@ -19,14 +19,14 @@ function fnox {{
         [string[]] $arguments
     )
 
-    if ($arguments.count -eq 0) {{
+    if ($arguments.Count -eq 0) {{
         & "{exe}"
         return
     }}
 
     $command = $arguments[0]
-    if ($arguments.Length -gt 1) {{
-        $remainingArgs = $arguments[1..($arguments.Length - 1)]
+    if ($arguments.Count -gt 1) {{
+        $remainingArgs = $arguments[1..($arguments.Count - 1)]
     }} else {{
         $remainingArgs = @()
     }}
@@ -82,10 +82,14 @@ _fnox_hook"#,
 
     fn deactivate(&self) -> String {
         r#"
-Remove-Item -ErrorAction SilentlyContinue Function:fnox
-Remove-Item -ErrorAction SilentlyContinue Function:_fnox_hook
-Remove-Item -ErrorAction SilentlyContinue -Path Env:FNOX_SHELL
-Remove-Item -ErrorAction SilentlyContinue -Path Env:__FNOX_SESSION
+if ($Global:__fnox_pwsh_previous_prompt_function) {
+    $function:prompt = $Global:__fnox_pwsh_previous_prompt_function
+    Remove-Variable -Name __fnox_pwsh_previous_prompt_function -Scope Global -ErrorAction SilentlyContinue
+}
+Remove-Item -ErrorAction SilentlyContinue -Path Function:\fnox
+Remove-Item -ErrorAction SilentlyContinue -Path Function:\_fnox_hook
+Remove-Item -ErrorAction SilentlyContinue -LiteralPath 'Env:FNOX_SHELL'
+Remove-Item -ErrorAction SilentlyContinue -LiteralPath 'Env:__FNOX_SESSION'
         "#
         .to_string()
     }
@@ -140,14 +144,13 @@ Remove-Item -ErrorAction SilentlyContinue -Path Env:__FNOX_SESSION
     }
 
     fn set_env(&self, key: &str, value: &str) -> String {
-        let k = powershell_escape(key.into());
         let v = powershell_escape(value.into());
-        format!("$Env:{k}='{v}'\n")
+        format!("${{Env:{key}}}='{v}'\n")
     }
 
     fn unset_env(&self, key: &str) -> String {
         let k = powershell_escape(key.into());
-        format!("Remove-Item -ErrorAction SilentlyContinue -Path Env:\\{k}\n")
+        format!("Remove-Item -ErrorAction SilentlyContinue -LiteralPath 'Env:{k}'\n")
     }
 }
 
@@ -158,24 +161,8 @@ impl fmt::Display for Pwsh {
 }
 
 fn powershell_escape(s: Cow<str>) -> Cow<str> {
-    let needs_escape = s
-        .chars()
-        .any(|c| matches!(c, '\t' | '\n' | '\r' | '\'' | '`'));
-
-    if !needs_escape {
+    if !s.contains('\'') {
         return s;
     }
-
-    let mut es = String::with_capacity(s.len());
-    for c in s.chars() {
-        match c {
-            '\t' => es.push_str("`t"),
-            '\n' => es.push_str("`n"),
-            '\r' => es.push_str("`r"),
-            '\'' => es.push_str("''"),
-            '`' => es.push_str("``"),
-            c => es.push(c),
-        }
-    }
-    es.into()
+    s.replace('\'', "''").into()
 }

--- a/test/shell-integration.bats
+++ b/test/shell-integration.bats
@@ -44,6 +44,16 @@ teardown() {
 	assert_output --partial "function __fnox_cd_hook --on-variable PWD"
 }
 
+@test "fnox activate pwsh generates valid powershell code" {
+	run "$FNOX_BIN" activate pwsh
+
+	assert_success
+	assert_output --partial "\$env:FNOX_SHELL='pwsh'"
+	assert_output --partial "function fnox {"
+	assert_output --partial "function Global:_fnox_hook {"
+	assert_output --partial "__enable_fnox_prompt"
+}
+
 @test "fnox activate nu generates valid nushell code" {
 	run "$FNOX_BIN" activate nu
 
@@ -62,6 +72,16 @@ teardown() {
 	assert_output --partial "fnox()"
 	refute_output --partial "_fnox_hook()"
 	refute_output --partial "PROMPT_COMMAND"
+}
+
+@test "fnox activate pwsh --no-hook-env skips hook setup" {
+	run "$FNOX_BIN" activate pwsh --no-hook-env
+
+	assert_success
+	assert_output --partial "\$env:FNOX_SHELL='pwsh'"
+	assert_output --partial "function fnox {"
+	refute_output --partial "_fnox_hook"
+	refute_output --partial "__enable_fnox_prompt"
 }
 
 @test "fnox activate with invalid shell fails" {
@@ -175,6 +195,41 @@ teardown() {
 	assert_success
 	assert_output --partial 'set -gx FISH_SECRET "fish-value"'
 	assert_output --partial 'set -gx __FNOX_SESSION'
+}
+
+@test "fnox hook-env generates powershell-compatible output" {
+	cd "$TEST_TEMP_DIR"
+	cat >fnox.toml <<-EOF
+		[providers.plain]
+		type = "plain"
+
+		[secrets.PWSH_SECRET]
+		provider = "plain"
+		value = "pwsh-value"
+	EOF
+
+	run "$FNOX_BIN" hook-env -s pwsh
+
+	assert_success
+	assert_output --partial "\$Env:PWSH_SECRET='pwsh-value'"
+	assert_output --partial "\$Env:__FNOX_SESSION="
+}
+
+@test "fnox hook-env escapes single quotes for powershell" {
+	cd "$TEST_TEMP_DIR"
+	cat >fnox.toml <<-'EOF'
+		[providers.plain]
+		type = "plain"
+
+		[secrets.PWSH_QUOTE]
+		provider = "plain"
+		value = "it's a value"
+	EOF
+
+	run "$FNOX_BIN" hook-env -s pwsh
+
+	assert_success
+	assert_output --partial "\$Env:PWSH_QUOTE='it''s a value'"
 }
 
 @test "fnox hook-env finds config in parent directory" {

--- a/test/shell-integration.bats
+++ b/test/shell-integration.bats
@@ -211,8 +211,8 @@ teardown() {
 	run "$FNOX_BIN" hook-env -s pwsh
 
 	assert_success
-	assert_output --partial "\$Env:PWSH_SECRET='pwsh-value'"
-	assert_output --partial "\$Env:__FNOX_SESSION="
+	assert_output --partial "\${Env:PWSH_SECRET}='pwsh-value'"
+	assert_output --partial '${Env:__FNOX_SESSION}='
 }
 
 @test "fnox hook-env escapes single quotes for powershell" {
@@ -229,7 +229,7 @@ teardown() {
 	run "$FNOX_BIN" hook-env -s pwsh
 
 	assert_success
-	assert_output --partial "\$Env:PWSH_QUOTE='it''s a value'"
+	assert_output --partial "\${Env:PWSH_QUOTE}='it''s a value'"
 }
 
 @test "fnox hook-env finds config in parent directory" {


### PR DESCRIPTION
See earlier discussion: https://github.com/jdx/fnox/discussions/412

This PR adds Powershell support for the `activate`/`deactivate`/`hook-env` commands, allowing support for auto loading like all the existing shells.

Copilot was used to generate a starting point by referencing the `src/shell/bash.rs` file from fnox and the `src/shell/pwsh.rs` file from mise. From there, I cleaned up the escaping and added support for displaying the env diff (`fnox: +1 FOO` / `fnox: -1 FOO`).

There are 2 possible names for the powershell binary, `powershell` and `pwsh`. I elected to use `pwsh` in the help, in order to avoid lines wrapping around on smaller terminal windows.

For bash/zsh/fish the flow is: eval the output of the activate command, which sets up a hook, which evaluates the output of the hook-env command, which generates code to both set the env variables and also print the env diff. I wanted the powershell to stick to this general flow. However, due to the way powershell evaluates code from the output of a command ( `(& cmd) | Out-String | Invoke-Expression`) the printed diff gets lost because printing in evaluated commands doesn't bubble up to the parent shell. To solve this `hook-env` creates a function `__fnox_print_changes` that contains the `Write-Host` statements. The powershell code generated by the `activate`/`deactivate` command then checks for the existence of that function, evaluates it if it exists, then deletes it.

I tested the powershell integration on the following platforms:
- MacOS 26.4.1 aarch64, powershell 7.6.0
- Windows 10 x86_64, powershell 7.6.0
- Windows 10 x86_64, powershell 5.1.0

Since powershell is different enough from the usual shells (bash,fish,zsh) I left it off the quick start page and lumped it in with nushell in pointing towards the Shell Integration page.

Thank you for your work on this great project!