### PR TITLE
fix(Windows): Nushell integration

### DIFF
--- a/src/shell/nushell.rs
+++ b/src/shell/nushell.rs
@@ -6,7 +6,7 @@ pub struct Nushell;
 impl Shell for Nushell {
     fn activate(&self, opts: ActivateOptions) -> String {
         let mut out = String::new();
-        let exe = opts.exe.display().to_string();
+        let exe = opts.exe.to_string_lossy().replace('\\', "/");
 
         out.push_str("$env.FNOX_SHELL = \"nu\"\n");
 

--- a/src/shell/nushell.rs
+++ b/src/shell/nushell.rs
@@ -37,7 +37,7 @@ def --env --wrapped fnox [...rest] {{
     let command = ($rest | first | default "")
     match $command {{
         "deactivate" => {{
-            let result = (do -i {{ ^'{exe}' $command ...($rest | skip 1) }} | complete)
+            let result = (do -i {{ ^"{exe}" $command ...($rest | skip 1) }} | complete)
             if ($result.stderr | str trim | is-not-empty) {{
                 print -e $result.stderr
             }}
@@ -50,7 +50,7 @@ def --env --wrapped fnox [...rest] {{
                 hide-env -i __FNOX_SESSION
             }}
         }}
-        _ => {{ ^'{exe}' ...$rest }}
+        _ => {{ ^"{exe}" ...$rest }}
     }}
 }}
 "#,
@@ -62,7 +62,7 @@ def --env --wrapped fnox [...rest] {{
             out.push_str(&format!(
                 r#"
 def --env _fnox_hook [] {{
-    let result = (do -i {{ ^'{exe}' hook-env -s nu }} | complete)
+    let result = (do -i {{ ^"{exe}" hook-env -s nu }} | complete)
     if ($result.stderr | str trim | is-not-empty) {{
         print -e $result.stderr
     }}

--- a/src/shell/nushell.rs
+++ b/src/shell/nushell.rs
@@ -37,7 +37,7 @@ def --env --wrapped fnox [...rest] {{
     let command = ($rest | first | default "")
     match $command {{
         "deactivate" => {{
-            let result = (do -i {{ ^"{exe}" $command ...($rest | skip 1) }} | complete)
+            let result = (do -i {{ ^'{exe}' $command ...($rest | skip 1) }} | complete)
             if ($result.stderr | str trim | is-not-empty) {{
                 print -e $result.stderr
             }}
@@ -50,7 +50,7 @@ def --env --wrapped fnox [...rest] {{
                 hide-env -i __FNOX_SESSION
             }}
         }}
-        _ => {{ ^"{exe}" ...$rest }}
+        _ => {{ ^'{exe}' ...$rest }}
     }}
 }}
 "#,
@@ -62,7 +62,7 @@ def --env --wrapped fnox [...rest] {{
             out.push_str(&format!(
                 r#"
 def --env _fnox_hook [] {{
-    let result = (do -i {{ ^"{exe}" hook-env -s nu }} | complete)
+    let result = (do -i {{ ^'{exe}' hook-env -s nu }} | complete)
     if ($result.stderr | str trim | is-not-empty) {{
         print -e $result.stderr
     }}


### PR DESCRIPTION
``
let exe = opts.exe.display().to_string();
``
display() on Windows outputs backslashes eg. "C:\Users\john"

Nushell treats backslashes in [double-quoted strings](https://www.nushell.sh/book/working_with_strings.html#double-quoted-strings) as escape characters.


You get this error when running fnox in nushell on Windows:
unrecognized escape after "\\" in string

Update opts.exe.display to use 
``
.to_string_lossy().replace('\\', "/"); 
``
fixes issue.