### PR TITLE
fix(Windows): Command resolution for executables

### DIFF
--- a/src/commands/edit.rs
+++ b/src/commands/edit.rs
@@ -128,11 +128,10 @@ impl EditCommand {
                 }
             });
 
-        let editor_path = if cfg!(windows) {
-            which::which(&editor).unwrap_or_else(|_| editor.clone().into())
-        } else {
-            editor.clone().into()
-        };
+        #[cfg(windows)]
+        let editor_path = which::which(&editor).unwrap_or_else(|_| editor.clone().into());
+        #[cfg(not(windows))]
+        let editor_path = &editor;
 
         let status = Command::new(editor_path)
             .arg(&temp_path)

--- a/src/commands/edit.rs
+++ b/src/commands/edit.rs
@@ -128,7 +128,13 @@ impl EditCommand {
                 }
             });
 
-        let status = Command::new(&editor)
+        let editor_path = if cfg!(windows) {
+            which::which(&editor).unwrap_or_else(|_| editor.clone().into())
+        } else {
+            editor.clone().into()
+        };
+
+        let status = Command::new(editor_path)
             .arg(&temp_path)
             .status()
             .map_err(|e| FnoxError::EditorLaunchFailed {

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -28,11 +28,13 @@ impl ExecCommand {
         // Get the profile secrets
         let profile_secrets = config.get_secrets(&profile)?;
 
+        let cmd_name = &self.command[0];
+
         #[cfg(windows)]
         let cmd_path = which::which(cmd_name).unwrap_or_else(|_| cmd_name.into());
         #[cfg(not(windows))]
         let cmd_path = cmd_name;
-        
+
         let mut cmd = Command::new(cmd_path);
 
         if self.command.len() > 1 {

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -28,7 +28,13 @@ impl ExecCommand {
         // Get the profile secrets
         let profile_secrets = config.get_secrets(&profile)?;
 
-        let mut cmd = Command::new(&self.command[0]);
+        let cmd_name = &self.command[0];
+        let mut cmd = if cfg!(windows) {
+            let resolved = which::which(cmd_name).unwrap_or_else(|_| cmd_name.into());
+            Command::new(resolved)
+        } else {
+            Command::new(cmd_name)
+        };
         if self.command.len() > 1 {
             cmd.args(&self.command[1..]);
         }

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -28,13 +28,13 @@ impl ExecCommand {
         // Get the profile secrets
         let profile_secrets = config.get_secrets(&profile)?;
 
-        let cmd_name = &self.command[0];
-        let mut cmd = if cfg!(windows) {
-            let resolved = which::which(cmd_name).unwrap_or_else(|_| cmd_name.into());
-            Command::new(resolved)
-        } else {
-            Command::new(cmd_name)
-        };
+        #[cfg(windows)]
+        let cmd_path = which::which(cmd_name).unwrap_or_else(|_| cmd_name.into());
+        #[cfg(not(windows))]
+        let cmd_path = cmd_name;
+        
+        let mut cmd = Command::new(cmd_path);
+
         if self.command.len() > 1 {
             cmd.args(&self.command[1..]);
         }

--- a/src/mcp_server.rs
+++ b/src/mcp_server.rs
@@ -302,12 +302,12 @@ impl FnoxMcpServer {
         // file path as the env var. Temp files are kept alive until the
         // subprocess completes (held in _exec_temp_files).
         let mut _exec_temp_files = Vec::new();
-        
+
         let cmd_name = &params.command[0];
 
         #[cfg(windows)]
         let cmd_path = which::which(cmd_name).unwrap_or_else(|_| cmd_name.into());
-        #[cfg(not(windows))]        
+        #[cfg(not(windows))]
         let cmd_path = cmd_name;
 
         let mut cmd = tokio::process::Command::new(cmd_path);

--- a/src/mcp_server.rs
+++ b/src/mcp_server.rs
@@ -303,11 +303,13 @@ impl FnoxMcpServer {
         // subprocess completes (held in _exec_temp_files).
         let mut _exec_temp_files = Vec::new();
         
+        let cmd_name = &params.command[0];
+
         #[cfg(windows)]
         let cmd_path = which::which(cmd_name).unwrap_or_else(|_| cmd_name.into());
         #[cfg(not(windows))]        
         let cmd_path = cmd_name;
-        
+
         let mut cmd = Command::new(cmd_path);
         if params.command.len() > 1 {
             cmd.args(&params.command[1..]);

--- a/src/mcp_server.rs
+++ b/src/mcp_server.rs
@@ -310,7 +310,7 @@ impl FnoxMcpServer {
         #[cfg(not(windows))]        
         let cmd_path = cmd_name;
 
-        let mut cmd = Command::new(cmd_path);
+        let mut cmd = tokio::process::Command::new(cmd_path);
         if params.command.len() > 1 {
             cmd.args(&params.command[1..]);
         }

--- a/src/mcp_server.rs
+++ b/src/mcp_server.rs
@@ -302,13 +302,13 @@ impl FnoxMcpServer {
         // file path as the env var. Temp files are kept alive until the
         // subprocess completes (held in _exec_temp_files).
         let mut _exec_temp_files = Vec::new();
-        let cmd_name = &params.command[0];
-        let mut cmd = if cfg!(windows) {
-            let resolved = which::which(cmd_name).unwrap_or_else(|_| cmd_name.into());
-            tokio::process::Command::new(resolved)
-        } else {
-            tokio::process::Command::new(cmd_name)
-        };
+        
+        #[cfg(windows)]
+        let cmd_path = which::which(cmd_name).unwrap_or_else(|_| cmd_name.into());
+        #[cfg(not(windows))]        
+        let cmd_path = cmd_name;
+        
+        let mut cmd = Command::new(cmd_path);
         if params.command.len() > 1 {
             cmd.args(&params.command[1..]);
         }

--- a/src/mcp_server.rs
+++ b/src/mcp_server.rs
@@ -302,7 +302,13 @@ impl FnoxMcpServer {
         // file path as the env var. Temp files are kept alive until the
         // subprocess completes (held in _exec_temp_files).
         let mut _exec_temp_files = Vec::new();
-        let mut cmd = tokio::process::Command::new(&params.command[0]);
+        let cmd_name = &params.command[0];
+        let mut cmd = if cfg!(windows) {
+            let resolved = which::which(cmd_name).unwrap_or_else(|_| cmd_name.into());
+            tokio::process::Command::new(resolved)
+        } else {
+            tokio::process::Command::new(cmd_name)
+        };
         if params.command.len() > 1 {
             cmd.args(&params.command[1..]);
         }


### PR DESCRIPTION
Some commands on Windows would fail when the actual executable has an extension (e.g npm.cmd).

This fails: 
``fnox exec -- npm install
``
This works: 
``fnox exec -- npm.cmd install
``

Update commands to use Which for better path resolution. 
Now npm install works as expected.