### PR TITLE
ci: add musl Linux targets to release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,12 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
             build-tool: cross
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            build-tool: cross
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-latest
+            build-tool: cross
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             build-tool: cargo

--- a/Cross.toml
+++ b/Cross.toml
@@ -10,3 +10,16 @@ pre-build = [
     "apt-get update",
     "apt-get install -y libudev-dev:$CROSS_DEB_ARCH",
 ]
+
+[target.x86_64-unknown-linux-musl]
+pre-build = [
+    "apt-get update",
+    "apt-get install -y libudev-dev",
+]
+
+[target.aarch64-unknown-linux-musl]
+pre-build = [
+    "dpkg --add-architecture $CROSS_DEB_ARCH",
+    "apt-get update",
+    "apt-get install -y libudev-dev:$CROSS_DEB_ARCH",
+]

--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -460,25 +460,22 @@
             "auth_command": {
               "type": ["string", "null"]
             },
-            "credential_id": {
+            "database": {
               "$ref": "#/$defs/StringOrSecretRef"
             },
-            "pin": {
+            "keyfile": {
               "$ref": "#/$defs/OptionStringOrSecretRef"
             },
-            "rp_id": {
-              "$ref": "#/$defs/StringOrSecretRef"
-            },
-            "salt": {
-              "$ref": "#/$defs/StringOrSecretRef"
+            "password": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
             },
             "type": {
               "type": "string",
-              "const": "fido2"
+              "const": "keepass"
             }
           },
           "additionalProperties": false,
-          "required": ["type", "credential_id", "salt", "rp_id"]
+          "required": ["type", "database"]
         },
         {
           "type": "object",
@@ -523,6 +520,32 @@
             "auth_command": {
               "type": ["string", "null"]
             },
+            "credential_id": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            },
+            "pin": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "rp_id": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            },
+            "salt": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "fido2"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type", "credential_id", "salt", "rp_id"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "auth_command": {
+              "type": ["string", "null"]
+            },
             "key_file": {
               "$ref": "#/$defs/OptionStringOrSecretRef"
             },
@@ -546,29 +569,6 @@
             "auth_command": {
               "type": ["string", "null"]
             },
-            "database": {
-              "$ref": "#/$defs/StringOrSecretRef"
-            },
-            "keyfile": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "password": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "type": {
-              "type": "string",
-              "const": "keepass"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["type", "database"]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "auth_command": {
-              "type": ["string", "null"]
-            },
             "challenge": {
               "$ref": "#/$defs/StringOrSecretRef"
             },
@@ -582,49 +582,6 @@
           },
           "additionalProperties": false,
           "required": ["type", "challenge", "slot"]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "api_key": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "auth_command": {
-              "type": ["string", "null"]
-            },
-            "base_url": {
-              "$ref": "#/$defs/StringOrSecretRef"
-            },
-            "password_list_id": {
-              "$ref": "#/$defs/StringOrSecretRef"
-            },
-            "type": {
-              "type": "string",
-              "const": "passwordstate"
-            },
-            "verify_ssl": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["type", "base_url", "password_list_id"]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "auth_command": {
-              "type": ["string", "null"]
-            },
-            "type": {
-              "type": "string",
-              "const": "proton-pass"
-            },
-            "vault": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["type"]
         },
         {
           "type": "object",
@@ -662,6 +619,23 @@
         {
           "type": "object",
           "properties": {
+            "auth_command": {
+              "type": ["string", "null"]
+            },
+            "type": {
+              "type": "string",
+              "const": "proton-pass"
+            },
+            "vault": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type"]
+        },
+        {
+          "type": "object",
+          "properties": {
             "account": {
               "$ref": "#/$defs/OptionStringOrSecretRef"
             },
@@ -685,6 +659,32 @@
         {
           "type": "object",
           "properties": {
+            "api_key": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "auth_command": {
+              "type": ["string", "null"]
+            },
+            "base_url": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            },
+            "password_list_id": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "passwordstate"
+            },
+            "verify_ssl": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type", "base_url", "password_list_id"]
+        },
+        {
+          "type": "object",
+          "properties": {
             "auth_command": {
               "type": ["string", "null"]
             },
@@ -704,6 +704,26 @@
           },
           "additionalProperties": false,
           "required": ["type"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "auth_command": {
+              "type": ["string", "null"]
+            },
+            "key_name": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "azure-kms"
+            },
+            "vault_url": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type", "vault_url", "key_name"]
         },
         {
           "type": "object",
@@ -760,26 +780,6 @@
             "auth_command": {
               "type": ["string", "null"]
             },
-            "key_name": {
-              "$ref": "#/$defs/StringOrSecretRef"
-            },
-            "type": {
-              "type": "string",
-              "const": "azure-kms"
-            },
-            "vault_url": {
-              "$ref": "#/$defs/StringOrSecretRef"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["type", "vault_url", "key_name"]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "auth_command": {
-              "type": ["string", "null"]
-            },
             "endpoint": {
               "$ref": "#/$defs/OptionStringOrSecretRef"
             },
@@ -829,6 +829,32 @@
         {
           "type": "object",
           "properties": {
+            "address": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "auth_command": {
+              "type": ["string", "null"]
+            },
+            "namespace": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "path": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "token": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "vault"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type"]
+        },
+        {
+          "type": "object",
+          "properties": {
             "auth_command": {
               "type": ["string", "null"]
             },
@@ -845,26 +871,6 @@
           },
           "additionalProperties": false,
           "required": ["type", "vault_url"]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "auth_command": {
-              "type": ["string", "null"]
-            },
-            "prefix": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "project": {
-              "$ref": "#/$defs/StringOrSecretRef"
-            },
-            "type": {
-              "type": "string",
-              "const": "gcp-sm"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["type", "project"]
         },
         {
           "type": "object",
@@ -895,6 +901,26 @@
             "auth_command": {
               "type": ["string", "null"]
             },
+            "prefix": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "project": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "gcp-sm"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type", "project"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "auth_command": {
+              "type": ["string", "null"]
+            },
             "profile": {
               "$ref": "#/$defs/OptionStringOrSecretRef"
             },
@@ -904,32 +930,6 @@
             "type": {
               "type": "string",
               "const": "bitwarden-sm"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["type"]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "address": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "auth_command": {
-              "type": ["string", "null"]
-            },
-            "namespace": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "path": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "token": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "type": {
-              "type": "string",
-              "const": "vault"
             }
           },
           "additionalProperties": false,

--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -460,22 +460,25 @@
             "auth_command": {
               "type": ["string", "null"]
             },
-            "database": {
+            "credential_id": {
               "$ref": "#/$defs/StringOrSecretRef"
             },
-            "keyfile": {
+            "pin": {
               "$ref": "#/$defs/OptionStringOrSecretRef"
             },
-            "password": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
+            "rp_id": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            },
+            "salt": {
+              "$ref": "#/$defs/StringOrSecretRef"
             },
             "type": {
               "type": "string",
-              "const": "keepass"
+              "const": "fido2"
             }
           },
           "additionalProperties": false,
-          "required": ["type", "database"]
+          "required": ["type", "credential_id", "salt", "rp_id"]
         },
         {
           "type": "object",
@@ -520,32 +523,6 @@
             "auth_command": {
               "type": ["string", "null"]
             },
-            "credential_id": {
-              "$ref": "#/$defs/StringOrSecretRef"
-            },
-            "pin": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "rp_id": {
-              "$ref": "#/$defs/StringOrSecretRef"
-            },
-            "salt": {
-              "$ref": "#/$defs/StringOrSecretRef"
-            },
-            "type": {
-              "type": "string",
-              "const": "fido2"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["type", "credential_id", "salt", "rp_id"]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "auth_command": {
-              "type": ["string", "null"]
-            },
             "key_file": {
               "$ref": "#/$defs/OptionStringOrSecretRef"
             },
@@ -569,6 +546,29 @@
             "auth_command": {
               "type": ["string", "null"]
             },
+            "database": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            },
+            "keyfile": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "password": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "keepass"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type", "database"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "auth_command": {
+              "type": ["string", "null"]
+            },
             "challenge": {
               "$ref": "#/$defs/StringOrSecretRef"
             },
@@ -582,6 +582,49 @@
           },
           "additionalProperties": false,
           "required": ["type", "challenge", "slot"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "api_key": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "auth_command": {
+              "type": ["string", "null"]
+            },
+            "base_url": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            },
+            "password_list_id": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "passwordstate"
+            },
+            "verify_ssl": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type", "base_url", "password_list_id"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "auth_command": {
+              "type": ["string", "null"]
+            },
+            "type": {
+              "type": "string",
+              "const": "proton-pass"
+            },
+            "vault": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type"]
         },
         {
           "type": "object",
@@ -619,23 +662,6 @@
         {
           "type": "object",
           "properties": {
-            "auth_command": {
-              "type": ["string", "null"]
-            },
-            "type": {
-              "type": "string",
-              "const": "proton-pass"
-            },
-            "vault": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["type"]
-        },
-        {
-          "type": "object",
-          "properties": {
             "account": {
               "$ref": "#/$defs/OptionStringOrSecretRef"
             },
@@ -659,32 +685,6 @@
         {
           "type": "object",
           "properties": {
-            "api_key": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "auth_command": {
-              "type": ["string", "null"]
-            },
-            "base_url": {
-              "$ref": "#/$defs/StringOrSecretRef"
-            },
-            "password_list_id": {
-              "$ref": "#/$defs/StringOrSecretRef"
-            },
-            "type": {
-              "type": "string",
-              "const": "passwordstate"
-            },
-            "verify_ssl": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["type", "base_url", "password_list_id"]
-        },
-        {
-          "type": "object",
-          "properties": {
             "auth_command": {
               "type": ["string", "null"]
             },
@@ -704,26 +704,6 @@
           },
           "additionalProperties": false,
           "required": ["type"]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "auth_command": {
-              "type": ["string", "null"]
-            },
-            "key_name": {
-              "$ref": "#/$defs/StringOrSecretRef"
-            },
-            "type": {
-              "type": "string",
-              "const": "azure-kms"
-            },
-            "vault_url": {
-              "$ref": "#/$defs/StringOrSecretRef"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["type", "vault_url", "key_name"]
         },
         {
           "type": "object",
@@ -780,6 +760,26 @@
             "auth_command": {
               "type": ["string", "null"]
             },
+            "key_name": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "azure-kms"
+            },
+            "vault_url": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type", "vault_url", "key_name"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "auth_command": {
+              "type": ["string", "null"]
+            },
             "endpoint": {
               "$ref": "#/$defs/OptionStringOrSecretRef"
             },
@@ -829,32 +829,6 @@
         {
           "type": "object",
           "properties": {
-            "address": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "auth_command": {
-              "type": ["string", "null"]
-            },
-            "namespace": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "path": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "token": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "type": {
-              "type": "string",
-              "const": "vault"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["type"]
-        },
-        {
-          "type": "object",
-          "properties": {
             "auth_command": {
               "type": ["string", "null"]
             },
@@ -871,6 +845,26 @@
           },
           "additionalProperties": false,
           "required": ["type", "vault_url"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "auth_command": {
+              "type": ["string", "null"]
+            },
+            "prefix": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "project": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "gcp-sm"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type", "project"]
         },
         {
           "type": "object",
@@ -901,26 +895,6 @@
             "auth_command": {
               "type": ["string", "null"]
             },
-            "prefix": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "project": {
-              "$ref": "#/$defs/StringOrSecretRef"
-            },
-            "type": {
-              "type": "string",
-              "const": "gcp-sm"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["type", "project"]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "auth_command": {
-              "type": ["string", "null"]
-            },
             "profile": {
               "$ref": "#/$defs/OptionStringOrSecretRef"
             },
@@ -930,6 +904,32 @@
             "type": {
               "type": "string",
               "const": "bitwarden-sm"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "address": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "auth_command": {
+              "type": ["string", "null"]
+            },
+            "namespace": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "path": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "token": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "vault"
             }
           },
           "additionalProperties": false,

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -635,15 +635,13 @@ impl App {
                 self.resolved_values.insert(key.clone(), Some(value));
                 self.status_message = Some(format!("Updated {} (in memory only)", key));
             }
-            KeyCode::Backspace
-                if state.cursor > 0 => {
-                    Self::remove_char_at(&mut state.value, state.cursor - 1);
-                    state.cursor -= 1;
-                }
-            KeyCode::Delete
-                if state.cursor < state.value.chars().count() => {
-                    Self::remove_char_at(&mut state.value, state.cursor);
-                }
+            KeyCode::Backspace if state.cursor > 0 => {
+                Self::remove_char_at(&mut state.value, state.cursor - 1);
+                state.cursor -= 1;
+            }
+            KeyCode::Delete if state.cursor < state.value.chars().count() => {
+                Self::remove_char_at(&mut state.value, state.cursor);
+            }
             KeyCode::Left => {
                 state.cursor = state.cursor.saturating_sub(1);
             }
@@ -711,15 +709,14 @@ impl App {
                 self.resolved_values.insert(key.clone(), Some(value));
                 self.status_message = Some(format!("Set {} (in memory only)", key));
             }
-            KeyCode::Backspace
-                if state.cursor > 0 => {
-                    let field = match state.field {
-                        SetField::Key => &mut state.key,
-                        SetField::Value => &mut state.value,
-                    };
-                    Self::remove_char_at(field, state.cursor - 1);
-                    state.cursor -= 1;
-                }
+            KeyCode::Backspace if state.cursor > 0 => {
+                let field = match state.field {
+                    SetField::Key => &mut state.key,
+                    SetField::Value => &mut state.value,
+                };
+                Self::remove_char_at(field, state.cursor - 1);
+                state.cursor -= 1;
+            }
             KeyCode::Delete => {
                 let field = match state.field {
                     SetField::Key => &mut state.key,
@@ -764,18 +761,16 @@ impl App {
                 }
                 self.popup = Popup::None;
             }
-            KeyCode::Down | KeyCode::Char('j')
-                if !self.available_profiles.is_empty() => {
-                    self.profile_picker_index =
-                        (self.profile_picker_index + 1) % self.available_profiles.len();
-                }
-            KeyCode::Up | KeyCode::Char('k')
-                if !self.available_profiles.is_empty() => {
-                    self.profile_picker_index = self
-                        .profile_picker_index
-                        .checked_sub(1)
-                        .unwrap_or(self.available_profiles.len() - 1);
-                }
+            KeyCode::Down | KeyCode::Char('j') if !self.available_profiles.is_empty() => {
+                self.profile_picker_index =
+                    (self.profile_picker_index + 1) % self.available_profiles.len();
+            }
+            KeyCode::Up | KeyCode::Char('k') if !self.available_profiles.is_empty() => {
+                self.profile_picker_index = self
+                    .profile_picker_index
+                    .checked_sub(1)
+                    .unwrap_or(self.available_profiles.len() - 1);
+            }
             _ => {}
         }
     }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -463,12 +463,11 @@ impl App {
                     self.popup = Popup::ConfirmDelete(key.clone());
                 }
             }
-            KeyCode::Char('e') => {
+            KeyCode::Char('e')
                 // Edit selected secret value
-                if self.focus == Focus::Secrets {
+                if self.focus == Focus::Secrets => {
                     self.open_edit_secret();
                 }
-            }
             KeyCode::Char('s') => {
                 // Set/create a new secret
                 self.popup = Popup::SetSecret(SetState {
@@ -636,17 +635,15 @@ impl App {
                 self.resolved_values.insert(key.clone(), Some(value));
                 self.status_message = Some(format!("Updated {} (in memory only)", key));
             }
-            KeyCode::Backspace => {
-                if state.cursor > 0 {
+            KeyCode::Backspace
+                if state.cursor > 0 => {
                     Self::remove_char_at(&mut state.value, state.cursor - 1);
                     state.cursor -= 1;
                 }
-            }
-            KeyCode::Delete => {
-                if state.cursor < state.value.chars().count() {
+            KeyCode::Delete
+                if state.cursor < state.value.chars().count() => {
                     Self::remove_char_at(&mut state.value, state.cursor);
                 }
-            }
             KeyCode::Left => {
                 state.cursor = state.cursor.saturating_sub(1);
             }
@@ -714,8 +711,8 @@ impl App {
                 self.resolved_values.insert(key.clone(), Some(value));
                 self.status_message = Some(format!("Set {} (in memory only)", key));
             }
-            KeyCode::Backspace => {
-                if state.cursor > 0 {
+            KeyCode::Backspace
+                if state.cursor > 0 => {
                     let field = match state.field {
                         SetField::Key => &mut state.key,
                         SetField::Value => &mut state.value,
@@ -723,7 +720,6 @@ impl App {
                     Self::remove_char_at(field, state.cursor - 1);
                     state.cursor -= 1;
                 }
-            }
             KeyCode::Delete => {
                 let field = match state.field {
                     SetField::Key => &mut state.key,
@@ -768,20 +764,18 @@ impl App {
                 }
                 self.popup = Popup::None;
             }
-            KeyCode::Down | KeyCode::Char('j') => {
-                if !self.available_profiles.is_empty() {
+            KeyCode::Down | KeyCode::Char('j')
+                if !self.available_profiles.is_empty() => {
                     self.profile_picker_index =
                         (self.profile_picker_index + 1) % self.available_profiles.len();
                 }
-            }
-            KeyCode::Up | KeyCode::Char('k') => {
-                if !self.available_profiles.is_empty() {
+            KeyCode::Up | KeyCode::Char('k')
+                if !self.available_profiles.is_empty() => {
                     self.profile_picker_index = self
                         .profile_picker_index
                         .checked_sub(1)
                         .unwrap_or(self.available_profiles.len() - 1);
                 }
-            }
             _ => {}
         }
     }

--- a/src/tui/event.rs
+++ b/src/tui/event.rs
@@ -41,22 +41,19 @@ impl EventHandler {
                 if event::poll(tick_rate).unwrap_or(false) {
                     if let Ok(evt) = event::read() {
                         match evt {
-                            CrosstermEvent::Key(key) => {
-                                if tx_clone.send(Event::Key(key)).is_err() {
+                            CrosstermEvent::Key(key)
+                                if tx_clone.send(Event::Key(key)).is_err() => {
                                     break;
                                 }
-                            }
-                            CrosstermEvent::Mouse(mouse) => {
-                                if tx_clone.send(Event::Mouse(mouse)).is_err() {
+                            CrosstermEvent::Mouse(mouse)
+                                if tx_clone.send(Event::Mouse(mouse)).is_err() => {
                                     break;
                                 }
-                            }
-                            CrosstermEvent::Resize(_, _) => {
+                            CrosstermEvent::Resize(_, _)
                                 // Terminal resize - send tick to trigger redraw
-                                if tx_clone.send(Event::Tick).is_err() {
+                                if tx_clone.send(Event::Tick).is_err() => {
                                     break;
                                 }
-                            }
                             _ => {}
                         }
                     }


### PR DESCRIPTION
## Summary

- Adds `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl` to the release matrix so fnox can run on Alpine Linux and other musl-based distros
- Uses the existing `cross` build-tool path (same as the glibc targets)

## Why

Discussion [#428](https://github.com/jdx/fnox/discussions/428) reports that `fnox` fails on Alpine with `cannot execute: required file not found` — the error you get when a dynamically-linked glibc binary is run on a musl system. The current release only ships `linux-gnu` binaries, so mise-installed fnox can't run on Alpine.

The project is already set up for this: [Cargo.toml](Cargo.toml) already vendors OpenSSL and dbus for Linux cross-compilation, and `taiki-e/upload-rust-binary-action` handles musl targets via `cross`.

## Reviewer notes

- `keyring` pulls in libdbus via `sync-secret-service` — already vendored, so it should build; users on Alpine who want the keychain provider will still need libsecret at runtime
- `arboard` (TUI clipboard) won't have X11/Wayland in a headless Alpine container — clipboard copy will no-op there, which is fine
- Worth watching the first release run to confirm both musl targets build cleanly before closing #428

## Test plan

- [ ] Release workflow builds both musl targets successfully
- [ ] Download the musl tarball and verify `fnox --version` runs on an Alpine container

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the release build matrix and cross-compilation setup, which could cause CI failures or missing/incorrect release artifacts if the new targets don’t build cleanly.
> 
> **Overview**
> Adds `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl` to the GitHub Actions release build matrix so releases produce musl-linked Linux artifacts alongside existing glibc builds.
> 
> Updates `Cross.toml` with per-target `pre-build` steps for the new musl targets (installing `libudev-dev`, including multi-arch setup for aarch64) to support successful `cross` compilation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1f004ab163325003c44bc115299abf55810f064. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->