### PR TITLE
fix(build): deterministic provider ordering in generated schema

### DIFF
--- a/build/generate_providers.rs
+++ b/build/generate_providers.rs
@@ -176,7 +176,10 @@ fn load_providers() -> Result<Vec<(String, ProviderToml)>, Box<dyn std::error::E
         }
     }
 
-    // Sort by category for consistent ordering
+    // Sort by category, then by name. The secondary name sort is required for
+    // determinism — fs::read_dir returns entries in OS-dependent order, so
+    // sorting by category alone leaves within-category ordering at the mercy of
+    // the filesystem, producing schema.json churn across machines/CI runs.
     providers.sort_by(|a, b| {
         let cat_order = |cat: &str| -> usize {
             match cat {
@@ -188,7 +191,9 @@ fn load_providers() -> Result<Vec<(String, ProviderToml)>, Box<dyn std::error::E
                 _ => 5,
             }
         };
-        cat_order(&a.1.category).cmp(&cat_order(&b.1.category))
+        cat_order(&a.1.category)
+            .cmp(&cat_order(&b.1.category))
+            .then_with(|| a.0.cmp(&b.0))
     });
 
     Ok(providers)

--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -460,6 +460,29 @@
             "auth_command": {
               "type": ["string", "null"]
             },
+            "key_file": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "recipients": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "type": {
+              "type": "string",
+              "const": "age"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type", "recipients"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "auth_command": {
+              "type": ["string", "null"]
+            },
             "credential_id": {
               "$ref": "#/$defs/StringOrSecretRef"
             },
@@ -479,66 +502,6 @@
           },
           "additionalProperties": false,
           "required": ["type", "credential_id", "salt", "rp_id"]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "auth_command": {
-              "type": ["string", "null"]
-            },
-            "type": {
-              "type": "string",
-              "const": "plain"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["type"]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "auth_command": {
-              "type": ["string", "null"]
-            },
-            "gpg_opts": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "prefix": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "store_dir": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "type": {
-              "type": "string",
-              "const": "password-store"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["type"]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "auth_command": {
-              "type": ["string", "null"]
-            },
-            "key_file": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "recipients": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "type": {
-              "type": "string",
-              "const": "age"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["type", "recipients"]
         },
         {
           "type": "object",
@@ -569,6 +532,43 @@
             "auth_command": {
               "type": ["string", "null"]
             },
+            "gpg_opts": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "prefix": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "store_dir": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "password-store"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "auth_command": {
+              "type": ["string", "null"]
+            },
+            "type": {
+              "type": "string",
+              "const": "plain"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "auth_command": {
+              "type": ["string", "null"]
+            },
             "challenge": {
               "$ref": "#/$defs/StringOrSecretRef"
             },
@@ -582,6 +582,85 @@
           },
           "additionalProperties": false,
           "required": ["type", "challenge", "slot"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "account": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "auth_command": {
+              "type": ["string", "null"]
+            },
+            "token": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "1password"
+            },
+            "vault": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "auth_command": {
+              "type": ["string", "null"]
+            },
+            "backend": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BitwardenBackend"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "collection": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "organization_id": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "profile": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "bitwarden"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "auth_command": {
+              "type": ["string", "null"]
+            },
+            "environment": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "path": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "project_id": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "infisical"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type"]
         },
         {
           "type": "object",
@@ -632,85 +711,6 @@
             "auth_command": {
               "type": ["string", "null"]
             },
-            "backend": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/BitwardenBackend"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "collection": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "organization_id": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "profile": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "type": {
-              "type": "string",
-              "const": "bitwarden"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["type"]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "account": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "auth_command": {
-              "type": ["string", "null"]
-            },
-            "token": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "type": {
-              "type": "string",
-              "const": "1password"
-            },
-            "vault": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["type"]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "auth_command": {
-              "type": ["string", "null"]
-            },
-            "environment": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "path": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "project_id": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
-            },
-            "type": {
-              "type": "string",
-              "const": "infisical"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["type"]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "auth_command": {
-              "type": ["string", "null"]
-            },
             "endpoint": {
               "$ref": "#/$defs/OptionStringOrSecretRef"
             },
@@ -727,6 +727,26 @@
           },
           "additionalProperties": false,
           "required": ["type", "key_id", "region"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "auth_command": {
+              "type": ["string", "null"]
+            },
+            "key_name": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "azure-kms"
+            },
+            "vault_url": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type", "vault_url", "key_name"]
         },
         {
           "type": "object",
@@ -753,26 +773,6 @@
           },
           "additionalProperties": false,
           "required": ["type", "project", "location", "keyring", "key"]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "auth_command": {
-              "type": ["string", "null"]
-            },
-            "key_name": {
-              "$ref": "#/$defs/StringOrSecretRef"
-            },
-            "type": {
-              "type": "string",
-              "const": "azure-kms"
-            },
-            "vault_url": {
-              "$ref": "#/$defs/StringOrSecretRef"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["type", "vault_url", "key_name"]
         },
         {
           "type": "object",
@@ -852,19 +852,19 @@
             "auth_command": {
               "type": ["string", "null"]
             },
-            "prefix": {
+            "profile": {
               "$ref": "#/$defs/OptionStringOrSecretRef"
             },
-            "project": {
-              "$ref": "#/$defs/StringOrSecretRef"
+            "project_id": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
             },
             "type": {
               "type": "string",
-              "const": "gcp-sm"
+              "const": "bitwarden-sm"
             }
           },
           "additionalProperties": false,
-          "required": ["type", "project"]
+          "required": ["type"]
         },
         {
           "type": "object",
@@ -895,19 +895,19 @@
             "auth_command": {
               "type": ["string", "null"]
             },
-            "profile": {
+            "prefix": {
               "$ref": "#/$defs/OptionStringOrSecretRef"
             },
-            "project_id": {
-              "$ref": "#/$defs/OptionStringOrSecretRef"
+            "project": {
+              "$ref": "#/$defs/StringOrSecretRef"
             },
             "type": {
               "type": "string",
-              "const": "bitwarden-sm"
+              "const": "gcp-sm"
             }
           },
           "additionalProperties": false,
-          "required": ["type"]
+          "required": ["type", "project"]
         },
         {
           "type": "object",


### PR DESCRIPTION
## Summary

- Providers within a category were ordered by `fs::read_dir` (OS/filesystem-dependent).
- That non-determinism flowed into the generated `ProviderConfig` enum and then into [docs/public/schema.json](docs/public/schema.json), causing [autofix.ci](https://github.com/jdx/fnox/blob/main/.github/workflows/autofix.yml) to keep reshuffling 100+ lines between runs. You can see this on [#431](https://github.com/jdx/fnox/pull/431) — three autofix passes each re-ordered the same `oneOf` variants without converging.
- Adds a secondary sort by provider name in [`build/generate_providers.rs`](build/generate_providers.rs) so within-category ordering is fully deterministic, then regenerates [docs/public/schema.json](docs/public/schema.json) with the stable ordering.

## Root cause

```rust
// before — stable sort on category only; within-category order = read_dir order
providers.sort_by(|a, b| cat_order(&a.1.category).cmp(&cat_order(&b.1.category)));
```

Stable sort preserves input order on ties, and input order comes from `fs::read_dir`, which is not guaranteed to be sorted. Fix is a secondary `.then_with(|| a.0.cmp(&b.0))` on name.

## Test plan

- [x] `mise run render:schema` locally
- [x] Running `fnox schema` twice produces byte-identical output
- [ ] `autofix.ci` on this PR does not re-touch `docs/public/schema.json`
- [ ] Future PRs that don't touch provider definitions should not see schema churn

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes provider sorting during schema generation to add a name tie-breaker, plus a regenerated `schema.json` reflecting stable ordering.
> 
> **Overview**
> Ensures deterministic ordering when generating provider code/schema by sorting providers by *category then name* (instead of category only), avoiding OS/filesystem-dependent churn.
> 
> Regenerates `docs/public/schema.json` so the `ProviderConfig.oneOf` variants appear in the new stable order (no semantic schema changes intended).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcbd331a3a11b3fef75499c50814fc198d3df480. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->