### PR TITLE
docs: respect banner expires field

### DIFF
--- a/docs/.vitepress/theme/banner.js
+++ b/docs/.vitepress/theme/banner.js
@@ -9,10 +9,18 @@ export function initBanner() {
     .then((r) => (r.ok ? r.json() : null))
     .then((b) => {
       if (!b || !b.enabled) return;
+      if (isExpired(b.expires)) return;
       if (localStorage.getItem(STORAGE_KEY) === b.id) return;
       render(b);
     })
     .catch(() => {});
+}
+
+function isExpired(expires) {
+  if (!expires) return false;
+  const t = Date.parse(expires);
+  if (Number.isNaN(t)) return false;
+  return Date.now() >= t;
 }
 
 function isHttpUrl(value) {


### PR DESCRIPTION
## Summary
- Honors the new optional `expires` (ISO-8601) field in [jdx.dev/banner.json](https://jdx.dev/banner.json)
- Banner is hidden once `Date.now() >= Date.parse(expires)`
- No-op when `expires` is absent (preserves existing behavior)
- Requires [jdx/blog#65](https://github.com/jdx/blog/pull/65) to populate the field

## Test plan
- [ ] Set an `expires` in the past → banner hidden
- [ ] Set an `expires` in the future → banner shown
- [ ] No `expires` field → banner shown as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small docs-site UI tweak that only gates banner rendering based on an optional timestamp, with safe fallbacks for missing/invalid values.
> 
> **Overview**
> The docs site banner now *honors an optional* `expires` field from `banner.json`, skipping rendering when the parsed expiry time is in the past.
> 
> Adds an `isExpired()` helper that treats missing or invalid `expires` values as non-expired to preserve existing behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91f9c9c88a877d2c50fe83a2d9fd589c21613f46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->