### PR TITLE
fix(set): fall back to current provider when updating secrets

### DIFF
--- a/src/commands/set.rs
+++ b/src/commands/set.rs
@@ -89,6 +89,12 @@ impl SetCommand {
         // Determine which provider to use
         let provider_name_to_use = if let Some(ref provider_name) = self.provider {
             Some(provider_name.clone())
+        } else if let Some(existing) = config
+            .get_secrets(&profile)?
+            .get(&self.key)
+            .and_then(|s| s.provider().map(str::to_string))
+        {
+            Some(existing)
         } else {
             // Try to use default provider if available, but it's OK if there isn't one
             // (will store as plaintext)

--- a/src/commands/set.rs
+++ b/src/commands/set.rs
@@ -90,8 +90,7 @@ impl SetCommand {
         let provider_name_to_use = if let Some(ref provider_name) = self.provider {
             Some(provider_name.clone())
         } else if let Some(existing) = config
-            .get_secrets(&profile)?
-            .get(&self.key)
+            .get_secret(&profile, &self.key)
             .and_then(|s| s.provider().map(str::to_string))
         {
             Some(existing)

--- a/src/config.rs
+++ b/src/config.rs
@@ -1052,6 +1052,26 @@ impl Config {
         Ok(secrets)
     }
 
+    /// Look up a single secret by key without cloning the secrets map.
+    ///
+    /// Mirrors the precedence used by [`Self::get_secrets`]: profile-specific
+    /// secrets take precedence, falling back to top-level secrets unless
+    /// `no_defaults` is set.
+    pub fn get_secret(&self, profile: &str, key: &str) -> Option<&SecretConfig> {
+        if profile != "default"
+            && let Some(profile_config) = self.profiles.get(profile)
+            && let Some(secret) = profile_config.secrets.get(key)
+        {
+            return Some(secret);
+        }
+
+        if profile != "default" && Settings::get().no_defaults {
+            return None;
+        }
+
+        self.secrets.get(key)
+    }
+
     /// Get effective secrets (default or profile, mutable)
     pub fn get_secrets_mut(&mut self, profile: &str) -> &mut IndexMap<String, SecretConfig> {
         if profile == "default" {

--- a/test/set_no_provider.bats
+++ b/test/set_no_provider.bats
@@ -122,3 +122,58 @@ EOF
 	assert_file_contains test-config5.toml 'provider = "age"'
 	assert_file_not_contains test-config5.toml "default-value"
 }
+
+@test "fnox set falls back to current provider when updating secrets" {
+	# With multiple providers configured and no default_provider, `fnox set`
+	# previously stored the new value as plaintext while leaving the original
+	# `provider` key in place. Subsequent `fnox get` calls then failed, since
+	# fnox would try to decrypt a value that was no longer encrypted.
+	#
+	# This test ensures `fnox set` reuses the secret's existing provider before
+	# falling back to `default_provider` or plaintext.
+
+	if ! command -v age-keygen >/dev/null 2>&1; then
+		skip "age-keygen not installed"
+	fi
+
+	local keygen_output1
+	keygen_output1=$(age-keygen -o key1.txt 2>&1)
+	local public_key1
+	public_key1=$(echo "$keygen_output1" | grep "^Public key:" | cut -d' ' -f3)
+
+	local keygen_output2
+	keygen_output2=$(age-keygen -o key2.txt 2>&1)
+	local public_key2
+	public_key2=$(echo "$keygen_output2" | grep "^Public key:" | cut -d' ' -f3)
+
+	cat >test-config-multi.toml <<EOF
+root = true
+
+[providers.provider1]
+type = "age"
+recipients = ["$public_key1"]
+
+[providers.provider2]
+type = "age"
+recipients = ["$public_key2"]
+
+[secrets]
+EOF
+
+	# Explicitly create MY_SECRET using --provider provider1.
+	run "$FNOX_BIN" --config test-config-multi.toml set --provider provider1 MY_SECRET "original-value"
+	assert_success
+	assert_file_contains test-config-multi.toml 'provider = "provider1"'
+	assert_file_not_contains test-config-multi.toml "original-value"
+
+	# Update without --provider: should reuse the secret's existing provider.
+	run "$FNOX_BIN" --config test-config-multi.toml set MY_SECRET "new-value"
+	assert_success
+	assert_file_contains test-config-multi.toml 'provider = "provider1"'
+	assert_file_not_contains test-config-multi.toml "new-value"
+
+	# Round-trip decrypts to the new value with the provider1 key.
+	run "$FNOX_BIN" --config test-config-multi.toml get MY_SECRET --age-key-file key1.txt
+	assert_success
+	assert_output "new-value"
+}


### PR DESCRIPTION
When multiple providers were configured without a `default_provider`, running `fnox set` on an existing secret without `--provider` stored the new value as plaintext while leaving the original `provider` key in place. Subsequent `fnox get` calls then failed, since fnox would try to decrypt a value that was no longer encrypted.

Before falling back to `default_provider` or plaintext, we now reuse the secret's existing provider. This allows updates to stay encrypted and readable without requiring `--provider` on every call.