### PR TITLE
feat(config): load imports from global and explicit config paths

### DIFF
--- a/src/commands/config_files.rs
+++ b/src/commands/config_files.rs
@@ -110,14 +110,13 @@ fn normalize_path(path: PathBuf) -> PathBuf {
         match component {
             Component::Prefix(_) | Component::RootDir => out.push(component),
             Component::CurDir => {}
-            Component::ParentDir => {
-                let can_pop = matches!(out.components().next_back(), Some(Component::Normal(_)));
-                if can_pop {
+            Component::ParentDir => match out.components().next_back() {
+                Some(Component::Normal(_)) => {
                     out.pop();
-                } else {
-                    out.push("..");
                 }
-            }
+                Some(Component::RootDir) => {}
+                _ => out.push(".."),
+            },
             Component::Normal(c) => out.push(c),
         }
     }
@@ -160,6 +159,15 @@ mod tests {
     #[test]
     fn empty_becomes_cur_dir() {
         assert_eq!(normalize_path(PathBuf::from("a/..")), PathBuf::from("."));
+    }
+
+    #[test]
+    fn parent_of_root_is_root() {
+        assert_eq!(normalize_path(PathBuf::from("/..")), PathBuf::from("/"));
+        assert_eq!(
+            normalize_path(PathBuf::from("/../../a")),
+            PathBuf::from("/a")
+        );
     }
 
     #[test]

--- a/src/commands/config_files.rs
+++ b/src/commands/config_files.rs
@@ -2,7 +2,7 @@ use crate::config::{Config, all_config_filenames};
 use crate::env;
 use crate::error::Result;
 use std::collections::HashSet;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use crate::commands::Cli;
 
@@ -30,9 +30,13 @@ impl ConfigFilesCommand {
         self.collect_recursive(&current_dir, &filenames, &mut printed)?;
 
         // Global config is always checked
-        let global = Config::global_config_path();
+        let global = normalize_path(Config::global_config_path());
         if global.exists() && printed.insert(global.clone()) {
             println!("{}", global.display());
+            if let Some(partial) = self.read_partial_config(&global) {
+                let base_dir = global.parent().unwrap_or_else(|| Path::new("."));
+                self.print_imports_from_partial(base_dir, &partial, &mut printed);
+            }
         }
 
         Ok(())
@@ -47,25 +51,12 @@ impl ConfigFilesCommand {
         let mut found_root = false;
 
         for filename in filenames {
-            let path = dir.join(filename);
+            let path = normalize_path(dir.join(filename));
             if path.exists() && printed.insert(path.clone()) {
                 println!("{}", path.display());
 
-                if let Ok(content) = std::fs::read_to_string(&path)
-                    && let Ok(partial) = toml_edit::de::from_str::<PartialConfig>(&content)
-                {
-                    // Print imported config files
-                    for import_path in &partial.import {
-                        let import = if Path::new(import_path).is_absolute() {
-                            PathBuf::from(import_path)
-                        } else {
-                            dir.join(import_path)
-                        };
-                        if import.exists() && printed.insert(import.clone()) {
-                            println!("{}", import.display());
-                        }
-                    }
-
+                if let Some(partial) = self.read_partial_config(&path) {
+                    self.print_imports_from_partial(dir, &partial, printed);
                     if partial.root {
                         found_root = true;
                     }
@@ -82,5 +73,100 @@ impl ConfigFilesCommand {
         }
 
         Ok(())
+    }
+
+    fn read_partial_config(&self, path: &Path) -> Option<PartialConfig> {
+        let content = std::fs::read_to_string(path).ok()?;
+        toml_edit::de::from_str::<PartialConfig>(&content).ok()
+    }
+
+    fn print_imports_from_partial(
+        &self,
+        base_dir: &Path,
+        partial: &PartialConfig,
+        printed: &mut HashSet<PathBuf>,
+    ) {
+        for import_path in &partial.import {
+            let import = if Path::new(import_path).is_absolute() {
+                PathBuf::from(import_path)
+            } else {
+                base_dir.join(import_path)
+            };
+            if import.exists() {
+                let normalized = normalize_path(import);
+                if printed.insert(normalized.clone()) {
+                    println!("{}", normalized.display());
+                }
+            }
+        }
+    }
+}
+
+/// Lexically normalize a path: collapse `.` and `..` segments without touching
+/// the filesystem or resolving symlinks.
+fn normalize_path(path: PathBuf) -> PathBuf {
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Prefix(_) | Component::RootDir => out.push(component),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                let can_pop = matches!(out.components().next_back(), Some(Component::Normal(_)));
+                if can_pop {
+                    out.pop();
+                } else {
+                    out.push("..");
+                }
+            }
+            Component::Normal(c) => out.push(c),
+        }
+    }
+    if out.as_os_str().is_empty() {
+        PathBuf::from(".")
+    } else {
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_path;
+    use std::path::PathBuf;
+
+    #[test]
+    fn collapses_cur_dir() {
+        assert_eq!(
+            normalize_path(PathBuf::from("/a/./b/./c")),
+            PathBuf::from("/a/b/c")
+        );
+    }
+
+    #[test]
+    fn collapses_parent_dir() {
+        assert_eq!(
+            normalize_path(PathBuf::from("/a/b/../c")),
+            PathBuf::from("/a/c")
+        );
+    }
+
+    #[test]
+    fn preserves_leading_parent_dir() {
+        assert_eq!(
+            normalize_path(PathBuf::from("../a/b")),
+            PathBuf::from("../a/b")
+        );
+    }
+
+    #[test]
+    fn empty_becomes_cur_dir() {
+        assert_eq!(normalize_path(PathBuf::from("a/..")), PathBuf::from("."));
+    }
+
+    #[test]
+    fn relative_import_pattern() {
+        assert_eq!(
+            normalize_path(PathBuf::from("/home/user/.config/fnox/./providers.toml")),
+            PathBuf::from("/home/user/.config/fnox/providers.toml")
+        );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -363,8 +363,8 @@ impl Config {
             } else {
                 path_ref.to_path_buf()
             };
-            // For explicit paths, use direct loading
-            Self::load(resolved_path)
+            // For explicit paths, load the file and its imports relative to that file
+            Self::load_with_imports(&resolved_path)
         }
     }
 
@@ -400,6 +400,19 @@ impl Config {
 
         // Set source paths for all secrets and providers
         config.set_source_paths(path);
+
+        Ok(config)
+    }
+
+    /// Load configuration from a file and merge any direct imports declared by that file.
+    fn load_with_imports(path: &Path) -> Result<Self> {
+        let mut config = Self::load(path)?;
+        let base_dir = path.parent().unwrap_or_else(|| Path::new("."));
+
+        for import_path in &config.import.clone() {
+            let import_config = Self::load_import(import_path, base_dir)?;
+            config = Self::merge_configs(import_config, config)?;
+        }
 
         Ok(config)
     }
@@ -445,7 +458,7 @@ impl Config {
         for filename in &filenames {
             let path = dir.join(filename);
             if path.exists() {
-                let file_config = Self::load(&path)?;
+                let file_config = Self::load_with_imports(&path)?;
                 config = Self::merge_configs(config, file_config)?;
                 found = true;
             }
@@ -453,11 +466,6 @@ impl Config {
 
         // If this config marks root, stop recursion but still load global config
         if config.root {
-            // Load imports if any
-            for import_path in &config.import.clone() {
-                let import_config = Self::load_import(import_path, dir)?;
-                config = Self::merge_configs(import_config, config)?;
-            }
             // Load global config as the base even for root configs
             let (global_config, global_found) = Self::load_global()?;
             if global_found {
@@ -465,12 +473,6 @@ impl Config {
                 found = true;
             }
             return Ok((config, found));
-        }
-
-        // Load imports first (they get overridden by local config)
-        for import_path in &config.import.clone() {
-            let import_config = Self::load_import(import_path, dir)?;
-            config = Self::merge_configs(import_config, config)?;
         }
 
         // If we have a parent directory, recurse up and merge
@@ -522,7 +524,7 @@ impl Config {
                 "Loading global config from {}",
                 global_config_path.display()
             );
-            let config = Self::load(&global_config_path)?;
+            let config = Self::load_with_imports(&global_config_path)?;
             Ok((config, true))
         } else {
             Ok((Self::new(), false))

--- a/test/config_recursion.bats
+++ b/test/config_recursion.bats
@@ -167,6 +167,23 @@ EOF
 	assert_output --partial "abs-import-value"
 }
 
+@test "explicit --config paths load imports" {
+	cat >imported.toml <<EOF
+[providers.imported_provider]
+type = "plain"
+EOF
+
+	cat >explicit.toml <<EOF
+default_provider = "imported_provider"
+import = ["./imported.toml"]
+EOF
+
+	run "$FNOX_BIN" --config explicit.toml doctor
+	assert_success
+	assert_output --partial "Loaded successfully"
+	assert_output --partial "imported_provider (plain)"
+}
+
 @test "config import errors are handled gracefully" {
 	# Create main config with non-existent import
 	cat >fnox.toml <<EOF

--- a/test/global_config.bats
+++ b/test/global_config.bats
@@ -136,6 +136,50 @@ EOF
 	assert_output --partial "fallback-value"
 }
 
+@test "global config imports are loaded" {
+	mkdir -p "$HOME/.config/fnox"
+	cat >"$HOME/.config/fnox/providers.toml" <<EOF
+[providers.imported_provider]
+type = "plain"
+EOF
+	cat >"$HOME/.config/fnox/config.toml" <<EOF
+default_provider = "imported_provider"
+import = ["./providers.toml"]
+EOF
+
+	cat >fnox.toml <<EOF
+root = true
+EOF
+
+	run "$FNOX_BIN" doctor
+	assert_success
+	assert_output --partial "Loaded successfully"
+	assert_output --partial "imported_provider (plain)"
+}
+
+@test "config-files includes global config imports" {
+	mkdir -p "$HOME/.config/fnox"
+	cat >"$HOME/.config/fnox/providers.toml" <<EOF
+[providers.imported_provider]
+type = "plain"
+EOF
+	cat >"$HOME/.config/fnox/config.toml" <<EOF
+import = ["./providers.toml"]
+EOF
+
+	cat >fnox.toml <<EOF
+root = true
+EOF
+
+	local config_dir
+	config_dir="$(cd "$HOME/.config/fnox" && pwd -P)"
+
+	run "$FNOX_BIN" config-files
+	assert_success
+	assert_output --partial "$config_dir/config.toml"
+	assert_output --partial "$config_dir/providers.toml"
+}
+
 @test "project provider overrides global provider" {
 	# Create global config with a provider
 	mkdir -p "$HOME/.config/fnox"


### PR DESCRIPTION
Previously, the import directive was only honored during recursive project config discovery. Now the global config and explicitly provided --config paths also resolve their imports, and config-files surfaces global imports too.