### PR TITLE
feat(config): add line selector for multiline secrets

### DIFF
--- a/docs/providers/password-store.md
+++ b/docs/providers/password-store.md
@@ -212,6 +212,36 @@ API_TOKEN = { provider = "pass", value = "tokens/github" }
 # → Stored at: tokens/github.gpg (no prefix)
 ```
 
+## Selecting a Line
+
+A common `pass` convention is to pack related values into a single entry:
+the password on line 1 and other fields (username, URL, etc.) on the lines
+below. The `pass` CLI exposes this with `pass show <entry> --clip=N` to
+copy the Nth line.
+
+fnox supports the same with the `line` field on a secret. It is **1-indexed**
+and selects a single line from whatever the provider returned:
+
+```toml
+[providers.pass]
+type = "password-store"
+prefix = "fnox/"
+
+[secrets]
+# `pass show fnox/database` returns:
+#   <password>
+#   <username>
+DB_PASSWORD = { provider = "pass", value = "database", line = 1 }
+DB_USERNAME = { provider = "pass", value = "database", line = 2 }
+```
+
+Create a multi-line entry with `pass insert -m` (see [Multiline Secrets](#multiline-secrets)
+below). Without `line`, fnox returns the entire entry unchanged.
+
+`line` is mutually exclusive with `json_path` and is currently a read-only
+view: `fnox set` always overwrites the entire pass entry, so editing a
+single line should still be done with `pass edit <entry>`.
+
 ## Git Integration
 
 password-store has built-in git support:

--- a/docs/providers/password-store.md
+++ b/docs/providers/password-store.md
@@ -238,9 +238,9 @@ DB_USERNAME = { provider = "pass", value = "database", line = 2 }
 Create a multi-line entry with `pass insert -m` (see [Multiline Secrets](#multiline-secrets)
 below). Without `line`, fnox returns the entire entry unchanged.
 
-`line` is mutually exclusive with `json_path` and is currently a read-only
-view: `fnox set` always overwrites the entire pass entry, so editing a
-single line should still be done with `pass edit <entry>`.
+`line` is mutually exclusive with `json_path`. It is also a read-only
+selector — see the warning under [Multiline Secrets](#multiline-secrets)
+for how to edit one line of an existing entry.
 
 ## Git Integration
 
@@ -362,6 +362,14 @@ MIIEpAIBAAKCAQEA...
 -----END RSA PRIVATE KEY-----
 EOF
 ```
+
+::: warning Editing existing multiline entries
+`fnox set` always replaces the entire pass entry — it cannot edit a
+single line in place. To change one field of a multi-line entry without
+losing the others, use `pass edit <entry>` (or `pass insert -m -f` to
+re-write all lines) directly. This applies whether or not the secret
+uses the [`line`](#selecting-a-line) selector.
+:::
 
 ## Environment Variables
 

--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -992,6 +992,12 @@
           "description": "JSON path to extract from the secret value (supports dot notation: \"nested.key\")\nWhen set, the secret value is parsed as JSON and the specified path is extracted.",
           "type": ["string", "null"]
         },
+        "line": {
+          "description": "1-indexed line number to extract from the secret value.\nWhen set, the secret value is split on newlines and the Nth line is returned.\nUseful for providers whose entries pack multiple related values into a\nsingle secret (e.g. one value per line). Mutually exclusive with `json_path`.",
+          "type": ["integer", "null"],
+          "format": "uint",
+          "minimum": 1
+        },
         "provider": {
           "description": "Provider to fetch from (age, aws-kms, 1password, aws, etc.)",
           "anyOf": [

--- a/src/config.rs
+++ b/src/config.rs
@@ -201,6 +201,7 @@ pub struct SecretConfig {
     /// Useful for providers whose entries pack multiple related values into a
     /// single secret (e.g. one value per line). Mutually exclusive with `json_path`.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[schemars(range(min = 1))]
     pub line: Option<usize>,
 
     /// Cached sync data (provider + encrypted value from `fnox sync`)

--- a/src/config.rs
+++ b/src/config.rs
@@ -196,6 +196,13 @@ pub struct SecretConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub json_path: Option<String>,
 
+    /// 1-indexed line number to extract from the secret value.
+    /// When set, the secret value is split on newlines and the Nth line is returned.
+    /// Useful for providers whose entries pack multiple related values into a
+    /// single secret (e.g. one value per line). Mutually exclusive with `json_path`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line: Option<usize>,
+
     /// Cached sync data (provider + encrypted value from `fnox sync`)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sync: Option<SyncConfig>,
@@ -1472,6 +1479,7 @@ impl SecretConfig {
             env: true,
             as_file: false,
             json_path: None,
+            line: None,
             sync: None,
             source_path: None,
             source_is_profile: false,
@@ -1483,6 +1491,7 @@ impl SecretConfig {
     pub fn for_raw_resolve(&self) -> Self {
         let mut config = self.clone();
         config.json_path = None;
+        config.line = None;
         config.sync = None;
         config.default = None;
         config
@@ -1500,6 +1509,9 @@ impl SecretConfig {
         }
         if let Some(ref json_path) = self.json_path {
             inline.insert("json_path", toml_edit::Value::from(json_path.as_str()));
+        }
+        if let Some(line) = self.line {
+            inline.insert("line", toml_edit::Value::from(line as i64));
         }
         if let Some(ref description) = self.description {
             inline.insert("description", toml_edit::Value::from(description.as_str()));
@@ -2007,6 +2019,7 @@ mod tests {
         secret.set_value(Some(r#"{"user":"admin"}"#.to_string()));
         secret.default = Some("fallback".to_string());
         secret.json_path = Some("user".to_string());
+        secret.line = Some(2);
         secret.sync = Some(SyncConfig {
             provider: "age".to_string(),
             value: "encrypted-blob".to_string(),
@@ -2016,7 +2029,26 @@ mod tests {
 
         assert!(raw.default.is_none());
         assert!(raw.json_path.is_none());
+        assert!(raw.line.is_none());
         assert!(raw.sync.is_none());
+    }
+
+    #[test]
+    fn test_secret_config_line_roundtrip() {
+        let toml_input = r#"
+[secrets]
+USERNAME = { provider = "pass", value = "master", line = 2 }
+"#;
+        let parsed: Config = toml_edit::de::from_str(toml_input).unwrap();
+        let secret = parsed.secrets.get("USERNAME").unwrap();
+        assert_eq!(secret.line, Some(2));
+
+        let inline = secret.to_inline_table();
+        let rendered = inline.to_string();
+        assert!(
+            rendered.contains("line = 2"),
+            "expected serialized output to contain `line = 2`, got: {rendered}"
+        );
     }
 
     #[test]

--- a/src/secret_resolver.rs
+++ b/src/secret_resolver.rs
@@ -62,6 +62,9 @@ fn split_key_path(key: &str) -> Vec<String> {
 }
 
 /// Extract the Nth (1-indexed) line from a multi-line value.
+///
+/// Uses `str::lines()` so both `\n` and `\r\n` line endings are handled and a
+/// single trailing newline is not counted as an extra empty line.
 fn extract_line(value: &str, line: usize) -> Result<String> {
     if line == 0 {
         return Err(FnoxError::Config(
@@ -69,7 +72,7 @@ fn extract_line(value: &str, line: usize) -> Result<String> {
         ));
     }
 
-    let lines: Vec<&str> = value.split('\n').collect();
+    let lines: Vec<&str> = value.lines().collect();
     lines.get(line - 1).map(|s| s.to_string()).ok_or_else(|| {
         FnoxError::Config(format!(
             "`line = {line}` is out of range; secret has {} line(s)",
@@ -1104,6 +1107,30 @@ mod tests {
             msg.contains("2 line"),
             "expected line count in error: {msg}"
         );
+    }
+
+    #[test]
+    fn test_extract_line_ignores_trailing_newline() {
+        // A trailing newline must not count as a fourth empty line — otherwise
+        // values from providers that emit "<value>\n" would silently shift.
+        let value = "a\nb\nc\n";
+        assert_eq!(extract_line(value, 3).unwrap(), "c");
+        let err = extract_line(value, 4).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("out of range"), "unexpected error: {msg}");
+        assert!(
+            msg.contains("3 line"),
+            "expected line count in error: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_extract_line_handles_crlf() {
+        // Windows-style line endings should not leak `\r` into the returned line.
+        let value = "first\r\nsecond\r\nthird";
+        assert_eq!(extract_line(value, 1).unwrap(), "first");
+        assert_eq!(extract_line(value, 2).unwrap(), "second");
+        assert_eq!(extract_line(value, 3).unwrap(), "third");
     }
 
     #[test]

--- a/src/secret_resolver.rs
+++ b/src/secret_resolver.rs
@@ -72,13 +72,14 @@ fn extract_line(value: &str, line: usize) -> Result<String> {
         ));
     }
 
-    let lines: Vec<&str> = value.lines().collect();
-    lines.get(line - 1).map(|s| s.to_string()).ok_or_else(|| {
-        FnoxError::Config(format!(
-            "`line = {line}` is out of range; secret has {} line(s)",
-            lines.len()
-        ))
-    })
+    if let Some(l) = value.lines().nth(line - 1) {
+        return Ok(l.to_string());
+    }
+
+    let count = value.lines().count();
+    Err(FnoxError::Config(format!(
+        "`line = {line}` is out of range; secret has {count} line(s)"
+    )))
 }
 
 /// Apply post-processing to a secret value based on SecretConfig settings.

--- a/src/secret_resolver.rs
+++ b/src/secret_resolver.rs
@@ -1100,7 +1100,10 @@ mod tests {
         let err = extract_line("foo\nbar", 5).unwrap_err();
         let msg = format!("{err}");
         assert!(msg.contains("out of range"), "unexpected error: {msg}");
-        assert!(msg.contains("2 line"), "expected line count in error: {msg}");
+        assert!(
+            msg.contains("2 line"),
+            "expected line count in error: {msg}"
+        );
     }
 
     #[test]

--- a/src/secret_resolver.rs
+++ b/src/secret_resolver.rs
@@ -1086,7 +1086,7 @@ mod tests {
 
     #[test]
     fn test_extract_line_preserves_intra_line_whitespace() {
-        // Trimming should not happen — `username: alice` stays intact.
+        // Leading and trailing whitespace within a line must not be trimmed.
         let value = "pw\n  spaced  ";
         assert_eq!(extract_line(value, 2).unwrap(), "  spaced  ");
     }

--- a/src/secret_resolver.rs
+++ b/src/secret_resolver.rs
@@ -61,17 +61,42 @@ fn split_key_path(key: &str) -> Vec<String> {
     parts
 }
 
+/// Extract the Nth (1-indexed) line from a multi-line value.
+fn extract_line(value: &str, line: usize) -> Result<String> {
+    if line == 0 {
+        return Err(FnoxError::Config(
+            "`line` must be a 1-indexed line number (got 0)".to_string(),
+        ));
+    }
+
+    let lines: Vec<&str> = value.split('\n').collect();
+    lines.get(line - 1).map(|s| s.to_string()).ok_or_else(|| {
+        FnoxError::Config(format!(
+            "`line = {line}` is out of range; secret has {} line(s)",
+            lines.len()
+        ))
+    })
+}
+
 /// Apply post-processing to a secret value based on SecretConfig settings.
-/// When json_path is set, extracts the specified path from a JSON value.
+/// `json_path` extracts a path from a JSON value; `line` returns the Nth
+/// line (1-indexed) of the raw value. The two are mutually exclusive.
 fn apply_post_processing(value: String, secret_config: &SecretConfig) -> Result<String> {
+    if secret_config.json_path.is_some() && secret_config.line.is_some() {
+        return Err(FnoxError::Config(
+            "`json_path` and `line` are mutually exclusive on a secret".to_string(),
+        ));
+    }
     if let Some(ref json_path) = secret_config.json_path {
         if json_path.is_empty() {
             return Err(FnoxError::Config("json_path must not be empty".to_string()));
         }
-        extract_json_path(&value, json_path)
-    } else {
-        Ok(value)
+        return extract_json_path(&value, json_path);
     }
+    if let Some(line) = secret_config.line {
+        return extract_line(&value, line);
+    }
+    Ok(value)
 }
 
 /// Creates a ProviderNotConfigured error, using source spans when available for better error display.
@@ -1035,5 +1060,72 @@ mod tests {
         assert_eq!(split_key_path(".foo"), vec!["", "foo"]);
         // Backslash at end (kept as-is)
         assert_eq!(split_key_path(r"foo\"), vec!["foo\\"]);
+    }
+
+    fn secret_with_line(line: Option<usize>) -> SecretConfig {
+        let mut s = SecretConfig::new();
+        s.line = line;
+        s
+    }
+
+    #[test]
+    fn test_extract_line_first_and_subsequent() {
+        let value = "hunter2\nuser: alice\nhttps://example.com";
+        assert_eq!(extract_line(value, 1).unwrap(), "hunter2");
+        assert_eq!(extract_line(value, 2).unwrap(), "user: alice");
+        assert_eq!(extract_line(value, 3).unwrap(), "https://example.com");
+    }
+
+    #[test]
+    fn test_extract_line_single_line_value() {
+        assert_eq!(extract_line("just-one-line", 1).unwrap(), "just-one-line");
+    }
+
+    #[test]
+    fn test_extract_line_preserves_intra_line_whitespace() {
+        // Trimming should not happen — `username: alice` stays intact.
+        let value = "pw\n  spaced  ";
+        assert_eq!(extract_line(value, 2).unwrap(), "  spaced  ");
+    }
+
+    #[test]
+    fn test_extract_line_zero_is_rejected() {
+        let err = extract_line("foo\nbar", 0).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("1-indexed"), "unexpected error: {msg}");
+    }
+
+    #[test]
+    fn test_extract_line_out_of_range() {
+        let err = extract_line("foo\nbar", 5).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("out of range"), "unexpected error: {msg}");
+        assert!(msg.contains("2 line"), "expected line count in error: {msg}");
+    }
+
+    #[test]
+    fn test_apply_post_processing_line() {
+        let cfg = secret_with_line(Some(2));
+        let out = apply_post_processing("a\nb\nc".to_string(), &cfg).unwrap();
+        assert_eq!(out, "b");
+    }
+
+    #[test]
+    fn test_apply_post_processing_unset_returns_value_unchanged() {
+        let cfg = secret_with_line(None);
+        let out = apply_post_processing("a\nb\nc".to_string(), &cfg).unwrap();
+        assert_eq!(out, "a\nb\nc");
+    }
+
+    #[test]
+    fn test_apply_post_processing_line_and_json_path_are_mutually_exclusive() {
+        let mut cfg = secret_with_line(Some(1));
+        cfg.json_path = Some("user".to_string());
+        let err = apply_post_processing(r#"{"user":"x"}"#.to_string(), &cfg).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("mutually exclusive"),
+            "unexpected error: {msg}"
+        );
     }
 }

--- a/test/password_store.bats
+++ b/test/password_store.bats
@@ -467,7 +467,8 @@ EOF
 	assert_success
 	track_secret_path "ONE_LINE"
 
-	# Override the auto-generated entry with a line selector that is out of range.
+	# Add a separate secret that points at the same single-line entry but
+	# requests a line that doesn't exist.
 	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 OUT_OF_RANGE = { provider = "pass", value = "ONE_LINE", line = 5 }
 EOF

--- a/test/password_store.bats
+++ b/test/password_store.bats
@@ -427,3 +427,52 @@ EOF
 	assert_output --partial "database"
 	assert_output --partial "api"
 }
+
+@test "fnox get with line selects a single line of a multiline entry" {
+	create_pass_config
+
+	# Store a multi-line entry directly via `pass insert -m`, mimicking
+	# the `pass` convention of password-on-line-1, metadata below.
+	local multiline_value="hunter2
+alice
+https://example.com"
+	run bash -c "printf '%s' '$multiline_value' | pass insert -m -f db-creds"
+	assert_success
+	track_secret_path "db-creds"
+
+	# Two secrets pointing at the same entry, each selecting a different line.
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
+DB_PASSWORD = { provider = "pass", value = "db-creds", line = 1 }
+DB_USERNAME = { provider = "pass", value = "db-creds", line = 2 }
+DB_URL      = { provider = "pass", value = "db-creds", line = 3 }
+EOF
+
+	run "$FNOX_BIN" get DB_PASSWORD
+	assert_success
+	assert_output "hunter2"
+
+	run "$FNOX_BIN" get DB_USERNAME
+	assert_success
+	assert_output "alice"
+
+	run "$FNOX_BIN" get DB_URL
+	assert_success
+	assert_output "https://example.com"
+}
+
+@test "fnox get with line out of range fails with a clear error" {
+	create_pass_config
+
+	run "$FNOX_BIN" set ONE_LINE "only-line" --provider pass
+	assert_success
+	track_secret_path "ONE_LINE"
+
+	# Override the auto-generated entry with a line selector that is out of range.
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
+OUT_OF_RANGE = { provider = "pass", value = "ONE_LINE", line = 5 }
+EOF
+
+	run "$FNOX_BIN" get OUT_OF_RANGE
+	assert_failure
+	assert_output --partial "out of range"
+}


### PR DESCRIPTION
## Summary

Adds a `line` field on a secret that selects a single 1-indexed line from the resolved value. Mostly useful for the `pass` convention of packing the password on line 1 and metadata (username, URL, etc.) on the lines below - the same pattern that `pass show <entry> --clip=N` exposes.

```toml
[secrets]
DB_PASSWORD = { provider = "pass", value = "database", line = 1 }
DB_USERNAME = { provider = "pass", value = "database", line = 2 }
```

- new `Option<usize>` field on `SecretConfig`, mutually exclusive with `json_path`, schema-constrained to `>= 1`
- post-processing applied uniformly to provider, default, and env-var sources via the existing `apply_post_processing` pipeline
- `for_raw_resolve` strips `line` along with `json_path` so `fnox sync` and `fnox reencrypt` cache the raw provider value, not the
  post-processed view
- uses `str::lines()` so `\r\n` line endings are stripped and a single trailing newline doesn't shift the indexing
- documented under `docs/providers/password-store.md` (cross-linked from the existing Multiline Secrets section), since `pass` is the most natural use case

## Test plan

- [x] `mise run test:cargo` - 146 tests pass, including new unit coverage for happy path, single-line value, whitespace preservation,  zero rejection, out-of-range, trailing newline, CRLF, and `apply_post_processing` mutual exclusion with `json_path`
- [x] `mise run test:bats -- test/password_store.bats` - two new bats tests pass: multiline selection through `pass insert -m` and the out-of-range error path
- [x] `mise run lint` - cargo-fmt and cargo-clippy clean
- [x] `mise run render:schema` - `docs/public/schema.json` reflects the new field with `minimum: 1`

## Notes

`fnox set` still overwrites the entire pass entry - `line` is a read-only view. Editing one line of an existing multi-line entry should still be done via `pass edit <entry>`.

_Related to discussion https://github.com/jdx/fnox/discussions/426_

---

🤖 Generated with Claude Code