### PR TITLE
docs: prefix star count with ★ glyph and populate it on deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,6 +37,8 @@ jobs:
         run: aube install
 
       - name: Build with VitePress
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: aube run docs:build
 
       - name: Upload artifact

--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -30,7 +30,7 @@ export default {
           if (!githubLink.querySelector(".star-count")) {
             const starBadge = document.createElement("span");
             starBadge.className = "star-count";
-            starBadge.textContent = starsData.stars;
+            starBadge.textContent = `★ ${starsData.stars}`;
             starBadge.title = "GitHub Stars";
             githubLink.appendChild(starBadge);
           }

--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -30,8 +30,12 @@ export default {
           if (!githubLink.querySelector(".star-count")) {
             const starBadge = document.createElement("span");
             starBadge.className = "star-count";
-            starBadge.textContent = `★ ${starsData.stars}`;
             starBadge.title = "GitHub Stars";
+            const glyph = document.createElement("span");
+            glyph.className = "star-glyph";
+            glyph.textContent = "★";
+            glyph.setAttribute("aria-hidden", "true");
+            starBadge.append(glyph, starsData.stars);
             githubLink.appendChild(starBadge);
           }
         });

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -190,6 +190,12 @@
   line-height: 1;
 }
 
+.VPSocialLinks .star-count .star-glyph {
+  font-family: -apple-system, "Segoe UI Symbol", sans-serif;
+  line-height: 1;
+  margin-right: 0.2em;
+}
+
 .VPSocialLinks a[href*="github.com/jdx/fnox"]:hover .star-count {
   color: var(--vp-c-brand-1);
 }


### PR DESCRIPTION
## Summary

Two small changes to the docs:

- **Prefix the GitHub star count with ★** (U+2605) in the top-nav social link, so it reads "★ 4" instead of just "4".
- **Pass `GITHUB_TOKEN` to the VitePress build step.** Without it, the build-time data loader in `docs/.vitepress/stars.data.ts` falls back to 0 and returns an empty string, so the badge currently renders blank on the live site (curl-verified). With the token set, the loader can hit the GitHub API and populate the count.

## Test plan

- [ ] Merge → docs deploy runs → reload https://fnox.jdx.dev/ → top-nav GitHub icon shows "★ N"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only change that tweaks UI rendering and CI environment for the VitePress build. Main risk is minor visual/CSS regressions or unexpected behavior if `GITHUB_TOKEN` use affects build-time API calls/rate limits.
> 
> **Overview**
> Improves the docs navbar GitHub star badge by prefixing the count with a `★` glyph (added as a separate `.star-glyph` element) and styling it for consistent symbol rendering.
> 
> Updates the GitHub Pages docs workflow to pass `GITHUB_TOKEN` into the VitePress build step so `stars.data.ts` can query the GitHub API during deploy and avoid an empty/zero star count on the live site.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3490ece626f7353a337811b65898b324ab80b630. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->