### PR TITLE
chore: add plausible analytics

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -225,7 +225,7 @@ export default defineConfig({
       "script",
       {
         defer: "",
-        "data-domain": "pa-Q_O4JS1YOlgteKkhIvxTO",
+        "data-domain": "fnox.jdx.dev",
         "data-api": "https://shrill.en.dev/f5f1/event",
         src: "https://shrill.en.dev/shrill/script.js",
       },

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -221,5 +221,14 @@ export default defineConfig({
       "meta",
       { name: "twitter:image", content: "https://fnox.jdx.dev/logo.png" },
     ],
+    [
+      "script",
+      {
+        defer: "",
+        "data-domain": "pa-Q_O4JS1YOlgteKkhIvxTO",
+        "data-api": "https://shrill.en.dev/f5f1/event",
+        src: "https://shrill.en.dev/shrill/script.js",
+      },
+    ],
   ],
 });


### PR DESCRIPTION
## Summary

- Adds Plausible Analytics to the docs site via the shrill.en.dev Cloudflare worker proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only change that injects a third-party analytics script; primary risk is unintended tracking/script-loading issues in the docs build/runtime.
> 
> **Overview**
> Adds a deferred analytics `<script>` tag to the docs site (`docs/.vitepress/config.mjs`) head configuration, configured with `data-domain=fnox.jdx.dev` and a `shrill.en.dev` worker `data-api` endpoint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0d303a83b0537794b927380ae3eb799942974b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->