### PR TITLE
chore(docs): remove shrill.en.dev analytics script

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -221,14 +221,5 @@ export default defineConfig({
       "meta",
       { name: "twitter:image", content: "https://fnox.jdx.dev/logo.png" },
     ],
-    [
-      "script",
-      {
-        defer: "",
-        "data-domain": "fnox.jdx.dev",
-        "data-api": "https://shrill.en.dev/f5f1/event",
-        src: "https://shrill.en.dev/shrill/script.js",
-      },
-    ],
   ],
 });


### PR DESCRIPTION
Removes the proxied shrill.en.dev analytics snippet from the VitePress docs config — the endpoint is going away.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes a docs-site analytics script tag only, with no impact on application logic or data handling.
> 
> **Overview**
> Removes the `shrill.en.dev` analytics `script` injection from the VitePress docs `head` config, stopping the docs site from loading and sending events to that endpoint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08592fcda91a5457134336cba2d6c666365c9c84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->