### PR TITLE
fix(ci): de-duplicate sponsor section in release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,9 +142,17 @@ jobs:
           else
             TAG_NAME="${{ github.ref_name }}"
           fi
-          {
-            gh release view "$TAG_NAME" --json body --jq .body
-            cat <<'EOF'
+          # Strip any pre-existing "Sponsor fnox" section from the body so the
+          # canonical block we append below isn't duplicated. Matches headings
+          # like "## Sponsor fnox" or "## 💚 Sponsor fnox" and drops everything
+          # through the next top-level heading.
+          gh release view "$TAG_NAME" --json body --jq .body \
+            | awk '
+                /^## .*Sponsor fnox[[:space:]]*$/ { skip=1; next }
+                skip && /^## / { skip=0; print; next }
+                !skip { print }
+              ' > /tmp/release-notes.md
+          cat >> /tmp/release-notes.md <<'EOF'
 
           ## 💚 Sponsor fnox
 
@@ -152,5 +160,4 @@ jobs:
 
           If fnox is handling secrets or config for you or your team, please consider [sponsoring at en.dev](https://en.dev). Sponsorships are what let fnox stay independent and the project keep moving.
           EOF
-          } > /tmp/release-notes.md
           gh release edit "$TAG_NAME" --notes-file /tmp/release-notes.md

--- a/communique.toml
+++ b/communique.toml
@@ -1,4 +1,8 @@
 context = "fnox is a secrets management CLI that encrypts and manages secrets in config files, supporting multiple providers (1Password, AWS, Azure, GCP, Bitwarden, etc.)."
 
+system_extra = """
+Do NOT include a "Sponsor fnox" / "Sponsor" / "Sponsorship" / "Support" section, donation links, or any en.dev / GitHub Sponsors blurb in the release body. The release workflow appends a canonical sponsor section after generation; including one here produces a duplicate. Style references from prior releases that contain a sponsor section are showing you the appended block — ignore that block when matching tone and structure.
+"""
+
 [defaults]
 emoji = false


### PR DESCRIPTION
## Summary

[v1.23.1](https://github.com/jdx/fnox/releases/tag/v1.23.1) shipped with two `Sponsor fnox` sections back-to-back. Cause: the `enhance-release` job in `release.yml` always appends a canonical sponsor block, **and** communique had also written one into the body — it picked up the pattern from prior releases passed in as "Style Reference" (which themselves contain the appended block).

Two changes:

- `communique.toml`: add a `system_extra` directive telling the LLM not to include a sponsor section in the body — that's the workflow's job.
- `.github/workflows/release.yml`: make the append step idempotent. Strip any pre-existing `## ... Sponsor fnox` section from the generated body (heading through next `## `, or to EOF) before appending the canonical block. Even if a future generation slips one in, the published release ends up with exactly one.

The v1.23.1 release notes have already been edited to remove the duplicate.

## Test plan

- [ ] Awk filter strips both `## Sponsor fnox` and `## 💚 Sponsor fnox` sections (verified locally against a synthetic body).
- [ ] Awk filter is a no-op on a body with no sponsor section (verified locally).
- [ ] `mise run lint` clean (actionlint + prettier).
- [ ] Next release produces a single sponsor section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI/release-workflow changes only; main risk is accidentally stripping unintended sections from release notes if headings match the awk pattern.
> 
> **Overview**
> Prevents duplicate sponsor blurbs in published GitHub releases by making the `enhance-release` append step idempotent: it now removes any existing `## … Sponsor fnox` section from the current release body before appending the canonical block.
> 
> Updates `communique.toml` with extra system instructions to *avoid generating* any sponsorship/support section in the first place, since the workflow is responsible for adding it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86b336e2804e5f6a5748bac23e2099190efb6e94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->