### PR TITLE
chore(ci): use !cancelled() instead of always() for final job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,7 +281,9 @@ jobs:
       - msrv
     runs-on: ubuntu-latest
     timeout-minutes: 1
-    if: always()
+    # Run on success or upstream failure but skip when the workflow is cancelled
+    # — `always()` would override `cancel-in-progress` and waste a runner.
+    if: ${{ !cancelled() }}
     steps:
       - name: Check job results
         if: |


### PR DESCRIPTION
## Summary
- Combined with the workflow's `cancel-in-progress` group, `if: always()` overrides cancellation and runs the `final` aggregator even on superseded commits.
- `!cancelled()` still runs on upstream success or failure but skips when the workflow is cancelled — saves a runner and avoids confusing error annotations on already-superseded shas.
- Caught by Cursor Bugbot on a sibling repo (endevco/pitchfork#413). Same `final`-aggregator pattern + `cancel-in-progress: true` here, so the same fix applies.

## Test plan
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that only affects when the `final` aggregator job runs; no product code is modified.
> 
> **Overview**
> Updates the CI workflow so the `final` aggregator job runs for upstream success/failure but **does not run when the workflow is cancelled**, replacing `if: always()` with `if: ${{ !cancelled() }}` to avoid consuming runners and reporting failures on superseded commits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2f7240b08ef98dc596fe92fed278fd32d48dbab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->