### PR TITLE
chore: set dev profile debug to 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,3 +153,6 @@ which = { workspace = true }
 [dev-dependencies]
 clap-sort = "1"
 tempfile = { workspace = true }
+
+[profile.dev]
+debug = 1


### PR DESCRIPTION
## Summary

Reduces `target/` disk usage by setting `[profile.dev] debug = 1`, while keeping backtrace file:line info intact.

The default `debug = 2` writes full DWARF — including variable/type info that's only needed when stepping through code in a debugger (lldb/gdb). With `debug = 1`, panics, `RUST_BACKTRACE=1`, and error chains still resolve to file:line; only debugger variable inspection is reduced.

In practice this typically shrinks `target/` by a meaningful percentage, which adds up across worktrees.

## Test plan

- [ ] `cargo build` still succeeds
- [ ] CI is green

---
*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes the Cargo dev build profile’s debug info level and should not affect runtime behavior; the main risk is reduced debugger variable/type inspection during local development.
> 
> **Overview**
> Reduces dev build debug info by adding `[profile.dev] debug = 1` in `Cargo.toml`, which can shrink `target/` artifacts while preserving file/line backtraces.
> 
> No application code changes; this only affects local/CI dev compilation settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d5a607648c42ed20d0a90da6c5600432c09935f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->