### PR TITLE
fix(fido2): keep touch prompts off stdout

### DIFF
--- a/crates/fnox-core/src/providers/fido2.rs
+++ b/crates/fnox-core/src/providers/fido2.rs
@@ -11,6 +11,7 @@ pub fn env_dependencies() -> &'static [&'static str] {
 
 /// Cached FIDO2 hmac-secret responses keyed by provider name.
 static CACHED_SECRETS: OnceLock<std::sync::Mutex<HashMap<String, Vec<u8>>>> = OnceLock::new();
+static STDOUT_REDIRECT_LOCK: OnceLock<std::sync::Mutex<()>> = OnceLock::new();
 
 #[derive(Clone)]
 pub struct Fido2Provider {
@@ -103,8 +104,7 @@ impl Fido2Provider {
         }
         let args = builder.build();
 
-        let assertions = device
-            .get_assertion_with_args(&args)
+        let assertions = with_stdout_redirected_to_stderr(|| device.get_assertion_with_args(&args))
             .map_err(|e| FnoxError::Provider(format!("FIDO2 assertion failed: {:?}", e)))?;
 
         let assertion = assertions
@@ -158,6 +158,74 @@ impl crate::providers::Provider for Fido2Provider {
     }
 }
 
+#[cfg(unix)]
+fn with_stdout_redirected_to_stderr<T>(f: impl FnOnce() -> T) -> T {
+    use std::io::Write;
+    use std::os::raw::c_int;
+    use std::sync::MutexGuard;
+
+    const STDOUT_FILENO: c_int = 1;
+    const STDERR_FILENO: c_int = 2;
+
+    unsafe extern "C" {
+        fn close(fd: c_int) -> c_int;
+        fn dup(fd: c_int) -> c_int;
+        fn dup2(oldfd: c_int, newfd: c_int) -> c_int;
+    }
+
+    struct StdoutRedirectGuard {
+        saved_stdout: c_int,
+        _lock: MutexGuard<'static, ()>,
+    }
+
+    impl Drop for StdoutRedirectGuard {
+        fn drop(&mut self) {
+            let _ = std::io::stdout().flush();
+            // SAFETY: saved_stdout is a valid duplicate of STDOUT_FILENO when
+            // the guard is constructed, and dup2 atomically restores fd 1.
+            unsafe {
+                dup2(self.saved_stdout, STDOUT_FILENO);
+                close(self.saved_stdout);
+            }
+        }
+    }
+
+    let lock = STDOUT_REDIRECT_LOCK
+        .get_or_init(|| std::sync::Mutex::new(()))
+        .lock();
+    let Ok(lock) = lock else {
+        return f();
+    };
+
+    let _ = std::io::stdout().flush();
+
+    // SAFETY: dup/dup2 operate on process-standard file descriptors. On
+    // failure we leave stdout untouched and run the CTAP call normally.
+    let saved_stdout = unsafe { dup(STDOUT_FILENO) };
+    if saved_stdout < 0 {
+        return f();
+    }
+
+    if unsafe { dup2(STDERR_FILENO, STDOUT_FILENO) } < 0 {
+        // SAFETY: saved_stdout is an open fd returned by dup above.
+        unsafe {
+            close(saved_stdout);
+        }
+        return f();
+    }
+
+    let _guard = StdoutRedirectGuard {
+        saved_stdout,
+        _lock: lock,
+    };
+    f()
+}
+
+#[cfg(not(unix))]
+fn with_stdout_redirected_to_stderr<T>(f: impl FnOnce() -> T) -> T {
+    f()
+}
+
 /// Setup helpers for `fnox provider add --type fido2`
 pub mod setup {
     use crate::error::{FnoxError, Result};
@@ -198,9 +266,10 @@ pub mod setup {
         }
         let make_args = builder.build();
 
-        let attestation = device.make_credential_with_args(&make_args).map_err(|e| {
-            FnoxError::Provider(format!("FIDO2 credential creation failed: {:?}", e))
-        })?;
+        let attestation = super::with_stdout_redirected_to_stderr(|| {
+            device.make_credential_with_args(&make_args)
+        })
+        .map_err(|e| FnoxError::Provider(format!("FIDO2 credential creation failed: {:?}", e)))?;
 
         // Verify hmac-secret was accepted
         let hmac_ok = attestation.extensions.iter().any(|ext| {
@@ -237,7 +306,9 @@ pub mod setup {
         }
         let get_args = builder2.build();
 
-        let assertions = device.get_assertion_with_args(&get_args).map_err(|e| {
+        let assertion_result =
+            super::with_stdout_redirected_to_stderr(|| device.get_assertion_with_args(&get_args));
+        let assertions = assertion_result.map_err(|e| {
             FnoxError::Provider(format!("FIDO2 verification assertion failed: {:?}", e))
         })?;
 


### PR DESCRIPTION
## Summary

- redirect FIDO2 CTAP library stdout output to stderr while waiting for authenticator interaction
- apply the same redirection to FIDO2 setup and verification calls
- keep `fnox export` stdout suitable for shell sourcing when FIDO2 prompts are emitted

## Context

Discussion #465 reported that `fnox export | source` can fail because the FIDO2 authenticator prompt text is emitted on stdout. The local FIDO2 messages already use stderr, so this contains stdout writes from the CTAP call itself around the hardware interaction.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p fnox-core fido2 --lib`
- `cargo check --workspace`
- `cargo check -p fnox-core`

Note: `mise run build` could not reach the Rust build because mise failed while extracting the 1Password CLI tool before running project checks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces process-wide stdout FD redirection around FIDO2 CTAP calls, which can have subtle side effects in concurrent/multi-threaded scenarios despite the added mutex guard; functional scope is otherwise limited to FIDO2 flows.
> 
> **Overview**
> Prevents FIDO2 authenticator/CTAP library prompt text from leaking to stdout by wrapping FIDO2 `make_credential_with_args` and `get_assertion_with_args` calls in a `with_stdout_redirected_to_stderr` helper.
> 
> On Unix, the helper temporarily `dup2`s stdout to stderr under a global mutex and restores it via a drop guard (non-Unix is a no-op), ensuring commands like `fnox export` keep stdout clean for shell piping while still showing prompts on stderr.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 824ea72e7a3a8890fe79470733e9a2717a4b0174. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->