### PR TITLE
fix(config): preserve secret table formatting

### DIFF
--- a/crates/fnox-core/src/config.rs
+++ b/crates/fnox-core/src/config.rs
@@ -821,13 +821,19 @@ impl Config {
             profile_table["secrets"].as_table_mut().unwrap()
         };
 
-        // Update/insert the secret as inline table
-        let inline = secret_config.to_inline_table();
-        secrets_table[secret_name] = Item::Value(Value::InlineTable(inline));
+        if let Some(item) = secrets_table.get_mut(secret_name) {
+            secret_config.update_toml_item(item);
+            if let Some(mut key) = secrets_table.key_mut(secret_name) {
+                key.leaf_decor_mut().set_suffix("");
+            }
+        } else {
+            secrets_table[secret_name] =
+                Item::Value(Value::InlineTable(secret_config.to_inline_table()));
 
-        // Remove trailing space from key to match format: KEY= { ... } instead of KEY = { ... }
-        if let Some(mut key) = secrets_table.key_mut(secret_name) {
-            key.leaf_decor_mut().set_suffix("");
+            // Remove trailing space from key to match format: KEY= { ... } instead of KEY = { ... }
+            if let Some(mut key) = secrets_table.key_mut(secret_name) {
+                key.leaf_decor_mut().set_suffix("");
+            }
         }
 
         // Write back (preserves all comments and formatting)
@@ -943,21 +949,20 @@ impl Config {
             profile_table["secrets"].as_table_mut().unwrap()
         };
 
-        // Insert/update each secret as an inline table
+        // Insert/update each secret, preserving existing inline-vs-table style.
         for (name, config) in secrets {
-            let inline = config.to_inline_table();
+            let name_str = name.as_str();
 
             // Update existing values in-place to preserve decor/comments on the entry
-            if let Some(item) = secrets_table.get_mut(name.as_str()) {
-                if let Item::Value(Value::InlineTable(existing_inline)) = item {
-                    *existing_inline = inline;
-                } else {
-                    *item = Item::Value(Value::InlineTable(inline));
+            if let Some(item) = secrets_table.get_mut(name_str) {
+                config.update_toml_item(item);
+                if let Some(mut key) = secrets_table.key_mut(name_str) {
+                    key.leaf_decor_mut().set_suffix("");
                 }
             } else {
-                secrets_table[name.as_str()] = Item::Value(Value::InlineTable(inline));
+                secrets_table[name_str] = Item::Value(Value::InlineTable(config.to_inline_table()));
 
-                if let Some(mut key) = secrets_table.key_mut(name.as_str()) {
+                if let Some(mut key) = secrets_table.key_mut(name_str) {
                     key.leaf_decor_mut().set_suffix("");
                 }
             }
@@ -1544,6 +1549,79 @@ impl SecretConfig {
 
         inline.fmt();
         inline
+    }
+
+    /// Write this secret config into an existing TOML table while preserving
+    /// that table's header/decor and table-style representation.
+    pub fn write_to_table(&self, table: &mut toml_edit::Table) {
+        use toml_edit::{Item, Value};
+
+        fn set_or_remove(table: &mut toml_edit::Table, key: &str, value: Option<Value>) {
+            if let Some(value) = value {
+                table[key] = Item::Value(value);
+            } else {
+                table.remove(key);
+            }
+        }
+
+        set_or_remove(table, "provider", self.provider().map(Value::from));
+        set_or_remove(table, "value", self.value().map(Value::from));
+        set_or_remove(
+            table,
+            "json_path",
+            self.json_path.as_deref().map(Value::from),
+        );
+        set_or_remove(
+            table,
+            "line",
+            self.line.map(|line| Value::from(line as i64)),
+        );
+        set_or_remove(
+            table,
+            "description",
+            self.description.as_deref().map(Value::from),
+        );
+        set_or_remove(table, "default", self.default.as_deref().map(Value::from));
+        set_or_remove(
+            table,
+            "if_missing",
+            self.if_missing.map(|if_missing| {
+                Value::from(match if_missing {
+                    IfMissing::Error => "error",
+                    IfMissing::Warn => "warn",
+                    IfMissing::Ignore => "ignore",
+                })
+            }),
+        );
+        set_or_remove(table, "env", (!self.env).then(|| Value::from(false)));
+        set_or_remove(table, "as_file", self.as_file.then(|| Value::from(true)));
+        set_or_remove(
+            table,
+            "sync",
+            self.sync.as_ref().map(|sync| {
+                let mut sync_table = toml_edit::InlineTable::new();
+                sync_table.insert("provider", Value::from(sync.provider.as_str()));
+                sync_table.insert("value", Value::from(sync.value.as_str()));
+                sync_table.fmt();
+                Value::InlineTable(sync_table)
+            }),
+        );
+    }
+
+    /// Update a TOML item with this secret config while preserving the
+    /// item's existing table-vs-inline-table style.
+    pub fn update_toml_item(&self, item: &mut toml_edit::Item) {
+        use toml_edit::{Item, Value};
+
+        match item {
+            Item::Table(table) => self.write_to_table(table),
+            Item::Value(Value::InlineTable(existing_inline)) => {
+                *existing_inline = self.to_inline_table();
+            }
+            _ => {
+                *item = Item::Value(Value::InlineTable(self.to_inline_table()));
+            }
+        }
     }
 
     /// Check if this secret has any value (provider, value, or default)

--- a/test/toml-formatting.bats
+++ b/test/toml-formatting.bats
@@ -182,3 +182,75 @@ EOF
 	assert_output --partial "# End of secrets"
 	assert_output --partial "API_KEY"
 }
+
+@test "fnox set preserves existing table-style secret format" {
+	if ! command -v age-keygen >/dev/null 2>&1; then
+		skip "age-keygen not installed"
+	fi
+	mkdir -p "$HOME/.config/fnox"
+	local keygen_output
+	keygen_output=$(age-keygen -o "$HOME/.config/fnox/age.txt" 2>&1)
+	local public_key
+	public_key=$(echo "$keygen_output" | grep "^Public key:" | cut -d' ' -f3)
+
+	cat >fnox.toml <<EOF
+root = true
+
+[providers.age]
+type = "age"
+recipients = ["$public_key"]
+
+[secrets."SEKRIT_PASSWORD"]
+provider = "age"
+value = "old-encrypted-value"
+if_missing = "error"
+EOF
+
+	run fnox set SEKRIT_PASSWORD "new-value" --provider age
+	assert_success
+
+	run cat fnox.toml
+	assert_output --partial '[secrets."SEKRIT_PASSWORD"]'
+	assert_output --partial 'provider = "age"'
+	assert_output --partial 'if_missing = "error"'
+	refute_output --partial '"SEKRIT_PASSWORD"= {'
+	refute_output --partial '"SEKRIT_PASSWORD" = {'
+}
+
+@test "fnox import preserves existing table-style secret format" {
+	if ! command -v age-keygen >/dev/null 2>&1; then
+		skip "age-keygen not installed"
+	fi
+
+	local keygen_output
+	keygen_output=$(age-keygen -o key.txt 2>&1)
+	local public_key
+	public_key=$(echo "$keygen_output" | grep "^Public key:" | cut -d' ' -f3)
+
+	cat >fnox.toml <<EOF
+root = true
+
+[providers.age]
+type = "age"
+recipients = ["$public_key"]
+
+[secrets."SEKRIT_PASSWORD"]
+provider = "age"
+value = "old-encrypted-value"
+if_missing = "error"
+EOF
+
+	cat >.env <<'EOF'
+SEKRIT_PASSWORD=new-value
+EOF
+
+	run fnox import -i .env --provider age --force
+	assert_success
+
+	run cat fnox.toml
+	assert_output --partial '[secrets."SEKRIT_PASSWORD"]'
+	assert_output --partial 'provider = "age"'
+	assert_output --partial 'if_missing = "error"'
+	refute_output --partial '"SEKRIT_PASSWORD"= {'
+	refute_output --partial '"SEKRIT_PASSWORD" = {'
+}


### PR DESCRIPTION
## Summary

- preserve existing table-style secret entries when `fnox set` updates a secret
- preserve existing table-style secret entries when `fnox import` updates a secret
- keep inline-table formatting for newly created secrets and existing inline-table secrets
- add focused Bats coverage for table-style `set` and `import` updates

## Context

Discussion #135 has already been mostly addressed for comment preservation, but the remaining open report is that table-style secrets such as `[secrets."SEKRIT_PASSWORD"]` are rewritten into inline entries after `fnox set`. This updates the TOML document mutation path to keep the existing inline-vs-table shape when modifying an existing secret.

`toml_edit` is already on the current crates.io release (`0.25.11+spec-1.1.0`), so no dependency bump was available or needed.

## Validation

- `cargo fmt --check`
- `cargo check -p fnox-core`
- `cargo build`
- `test/bats/bin/bats test/toml-formatting.bats`

Note: `mise run test:bats -- test/toml-formatting.bats` still fails before tests start because mise cannot extract the local 1Password CLI tool. The Bats file was run directly after building `target/debug/fnox`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the TOML mutation path used by `fnox set`/`fnox import`; while intended to be formatting-preserving, it changes how secret fields are written/removed and could subtly affect emitted config structure.
> 
> **Overview**
> Updating secrets via `fnox set` and `fnox import` now **preserves the existing TOML representation** of each secret (table-style `[secrets."NAME"]` vs inline table `NAME = { ... }`) instead of always rewriting updated entries as inline tables.
> 
> This introduces `SecretConfig::update_toml_item`/`write_to_table` to update an existing TOML `Item` in-place (including removing keys when fields are unset) and adds Bats tests to assert table-style secrets remain table-style after `set` and `import`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63041054dd190b8cbf42b8db7b2f17f522453af1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->