### PR TITLE
chore: release v1.24.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## [1.24.1](https://github.com/jdx/fnox/compare/v1.24.0..v1.24.1) - 2026-05-12
+
+### 🐛 Bug Fixes
+
+- **(config)** preserve secret table formatting by [@jdx](https://github.com/jdx) in [#467](https://github.com/jdx/fnox/pull/467)
+- **(shell)** prevent shell expansion of secret values in bash/zsh activation by [@jdx](https://github.com/jdx) in [#473](https://github.com/jdx/fnox/pull/473)
+
+### 📚 Documentation
+
+- clarify mise env plugin status by [@jdx](https://github.com/jdx) in [#472](https://github.com/jdx/fnox/pull/472)
+
+### 🛡️ Security
+
+- **(ci)** assert mise run render produces no diff by [@jdx](https://github.com/jdx) in [#479](https://github.com/jdx/fnox/pull/479)
+- **(ci)** add zizmor workflow for github actions security analysis by [@jdx](https://github.com/jdx) in [#480](https://github.com/jdx/fnox/pull/480)
+
+### 🔍 Other Changes
+
+- **(ci)** remove autofix.ci workflow by [@jdx](https://github.com/jdx) in [#478](https://github.com/jdx/fnox/pull/478)
+- remove pull_request_target workflow by [@jdx](https://github.com/jdx) in [#476](https://github.com/jdx/fnox/pull/476)
+- remove caching from publishing workflows by [@jdx](https://github.com/jdx) in [#477](https://github.com/jdx/fnox/pull/477)
+
+### 📦️ Dependency Updates
+
+- lock file maintenance by [@renovate[bot]](https://github.com/renovate[bot]) in [#475](https://github.com/jdx/fnox/pull/475)
+
 ## [1.24.0](https://github.com/jdx/fnox/compare/v1.23.1..v1.24.0) - 2026-05-06
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2379,7 +2379,7 @@ dependencies = [
 
 [[package]]
 name = "fnox"
-version = "1.24.0"
+version = "1.24.1"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -2399,7 +2399,7 @@ dependencies = [
  "indexmap 2.14.0",
  "miette",
  "miniz_oxide 0.9.1",
- "nix 0.31.2",
+ "nix 0.31.3",
  "ratatui",
  "regex",
  "rmcp",
@@ -2424,7 +2424,7 @@ dependencies = [
 
 [[package]]
 name = "fnox-core"
-version = "1.24.0"
+version = "1.24.1"
 dependencies = [
  "aes-gcm 0.11.0-rc.3",
  "age",
@@ -2456,7 +2456,7 @@ dependencies = [
  "hex",
  "hkdf 0.13.0",
  "indexmap 2.14.0",
- "jsonwebtoken 10.3.0",
+ "jsonwebtoken 10.4.0",
  "keepass",
  "keyring",
  "libloading",
@@ -3909,9 +3909,9 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "10.3.0"
+version = "10.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",
@@ -3922,6 +3922,7 @@ dependencies = [
  "serde_json",
  "signature 2.2.0",
  "simple_asn1",
+ "zeroize",
 ]
 
 [[package]]
@@ -4280,9 +4281,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.31.2"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
@@ -8383,9 +8384,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "crates/fnox-core"]
 resolver = "3"
 
 [workspace.package]
-version = "1.24.0"
+version = "1.24.1"
 edition = "2024"
 authors = ["@jdx"]
 license = "MIT"
@@ -107,7 +107,7 @@ name = "fnox"
 path = "src/main.rs"
 
 [dependencies]
-fnox-core = { path = "crates/fnox-core", version = "1.24.0" }
+fnox-core = { path = "crates/fnox-core", version = "1.24.1" }
 
 # Direct dependencies of the CLI binary (commands, MCP server, TUI, hook-env,
 # shell integration). Provider/config/secret-resolver crates are pulled in

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -1592,7 +1592,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.24.0",
+  "version": "1.24.1",
   "usage": "Usage: fnox [OPTIONS] <COMMAND>",
   "complete": {
     "key": {

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -4,7 +4,7 @@
 
 **Usage**: `fnox [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.24.0
+**Version**: 1.24.1
 
 - **Usage**: `fnox [FLAGS] <SUBCOMMAND>`
 

--- a/fnox.usage.kdl
+++ b/fnox.usage.kdl
@@ -1,7 +1,7 @@
 min_usage_version "1.3"
 name fnox
 bin fnox
-version "1.24.0"
+version "1.24.1"
 about "A flexible secret management tool by @jdx"
 usage "Usage: fnox [OPTIONS] <COMMAND>"
 flag "-c --config" help="Path to the configuration file (default: fnox.toml, searches parent directories)" global=#true default=fnox.toml {


### PR DESCRIPTION
### 🐛 Bug Fixes

- **(config)** preserve secret table formatting by [@jdx](https://github.com/jdx) in [#467](https://github.com/jdx/fnox/pull/467)
- **(shell)** prevent shell expansion of secret values in bash/zsh activation by [@jdx](https://github.com/jdx) in [#473](https://github.com/jdx/fnox/pull/473)

### 📚 Documentation

- clarify mise env plugin status by [@jdx](https://github.com/jdx) in [#472](https://github.com/jdx/fnox/pull/472)

### 🛡️ Security

- **(ci)** assert mise run render produces no diff by [@jdx](https://github.com/jdx) in [#479](https://github.com/jdx/fnox/pull/479)
- **(ci)** add zizmor workflow for github actions security analysis by [@jdx](https://github.com/jdx) in [#480](https://github.com/jdx/fnox/pull/480)

### 🔍 Other Changes

- **(ci)** remove autofix.ci workflow by [@jdx](https://github.com/jdx) in [#478](https://github.com/jdx/fnox/pull/478)
- remove pull_request_target workflow by [@jdx](https://github.com/jdx) in [#476](https://github.com/jdx/fnox/pull/476)
- remove caching from publishing workflows by [@jdx](https://github.com/jdx) in [#477](https://github.com/jdx/fnox/pull/477)

### 📦️ Dependency Updates

- lock file maintenance by [@renovate[bot]](https://github.com/renovate[bot]) in [#475](https://github.com/jdx/fnox/pull/475)