### PR TITLE
docs: clarify mise env plugin status

### DIFF
--- a/docs/guide/mise-integration.md
+++ b/docs/guide/mise-integration.md
@@ -1,8 +1,53 @@
 # Mise Integration
 
-fnox integrates with [mise](https://mise.jdx.dev) through the `jdx/mise-env-fnox` env plugin, allowing you to automatically load secrets into your development environment.
+fnox works well with [mise](https://mise.jdx.dev) as a tool installer and task
+runner. The recommended setup is to install the fnox CLI with mise, then use
+fnox directly through shell integration, `fnox exec`, or mise tasks.
+
+::: warning Experimental plugin
+We do not recommend using fnox through the
+[`jdx/mise-env-fnox`](https://github.com/jdx/mise-env-fnox) env plugin. It is an
+incomplete experiment and does not track every fnox feature.
+:::
 
 ## Installation
+
+Install fnox globally with mise:
+
+```bash
+mise use -g fnox
+```
+
+Then enable fnox shell integration if you want secrets to load automatically when
+you enter a project directory:
+
+```bash
+eval "$(fnox activate bash)"
+```
+
+See [Shell Integration](/guide/shell-integration) for zsh, fish, Nushell, and
+PowerShell setup.
+
+## Using fnox in mise Tasks
+
+For commands launched through mise, run them through `fnox exec`:
+
+```toml
+[tasks.dev]
+run = "fnox exec -- npm run dev"
+
+[tasks.deploy]
+run = "fnox exec --profile production -- ./deploy.sh"
+```
+
+This keeps secret resolution inside fnox, so options such as `env = false`,
+`as_file`, leases, profiles, and provider-specific behavior all work the same as
+they do outside mise.
+
+## Experimental Env Plugin
+
+The `jdx/mise-env-fnox` env plugin is documented here only for existing users.
+For new setups, prefer shell integration or `fnox exec`.
 
 Add the plugin to your project's `mise.toml`:
 
@@ -17,11 +62,14 @@ fnox = "latest"
 _.fnox-env = { tools = true }
 ```
 
-> [!IMPORTANT] > `tools = true` is required so the plugin can access the mise-managed fnox binary. Without it, the plugin runs before mise tools are added to PATH and won't be able to find fnox.
+> [!IMPORTANT]
+> `tools = true` is required so the plugin can access the mise-managed fnox
+> binary. Without it, the plugin runs before mise tools are added to PATH and
+> won't be able to find fnox.
 
 ## How It Works
 
-When mise activates your environment, the fnox plugin:
+When mise activates your environment, the experimental fnox plugin:
 
 1. Searches for `fnox.toml` in the current directory and parent directories
 2. Resolves secrets using your configured providers
@@ -125,15 +173,17 @@ export MISE_ENV_CACHE=1
 
 ## Comparison with Shell Integration
 
-| Feature                   | Shell Integration | Mise Integration     |
-| ------------------------- | ----------------- | -------------------- |
-| Automatic loading on `cd` | Yes               | Yes (via mise)       |
-| Works without mise        | Yes               | No                   |
-| Caching                   | No                | Yes (with env cache) |
-| Task integration          | No                | Yes                  |
-| Tool version management   | No                | Yes                  |
+| Feature                   | Shell Integration | Experimental mise env plugin |
+| ------------------------- | ----------------- | ---------------------------- |
+| Automatic loading on `cd` | Yes               | Yes (via mise)               |
+| Works without mise        | Yes               | No                           |
+| Caching                   | No                | Yes (with env cache)         |
+| Task integration          | No                | Yes                          |
+| Tool version management   | No                | Yes                          |
+| Full fnox feature support | Yes               | No                           |
 
-Use shell integration if you want fnox-only secret loading. Use mise integration if you're already using mise for tool/environment management.
+Use shell integration or `fnox exec` for the maintained fnox behavior. Use the
+mise env plugin only when its current feature set is enough for your project.
 
 ## Troubleshooting
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
         "current",
         "glibc"
       ]
+    },
+    "allowBuilds": {
+      "esbuild": true
     }
   }
 }


### PR DESCRIPTION
## Summary

- Reframe the mise integration guide around installing fnox with mise and using fnox directly.
- Add a warning admonition that `jdx/mise-env-fnox` is not recommended and is an incomplete experimental plugin.
- Keep the plugin docs for existing users while steering new setups toward shell integration or `fnox exec`.

## Validation

- `git diff --check`
- `aube run docs:build`

_This PR description was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are primarily documentation guidance plus a small `pnpm` config tweak to allow `esbuild` builds, with no runtime/product code changes.
> 
> **Overview**
> Reframes the `Mise Integration` guide to recommend installing fnox via mise and using **shell integration** or `fnox exec`/mise tasks, and adds a prominent warning that `jdx/mise-env-fnox` is an *experimental, incomplete* env plugin retained mainly for existing users.
> 
> Updates the comparison table and wording to emphasize limited feature support in the plugin, and adjusts `package.json` `pnpm` settings to explicitly allow building `esbuild`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86459cfa8bb551c9a8b68f0102d4c70394f461c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->