### PR TITLE
feat(provider): add FOKS (Federated Open Key Service) provider

### DIFF
--- a/crates/fnox-core/providers/foks.toml
+++ b/crates/fnox-core/providers/foks.toml
@@ -1,0 +1,45 @@
+# FOKS provider - Federated Open Key Service
+display_name = "FOKS"
+serde_rename = "foks"
+rust_variant = "Foks"
+category = "CloudSecretsManager"
+description = "End-to-end encrypted, federated/self-hostable KV store"
+default_name = "foks"
+auth_command = "foks ctl start"
+setup_instructions = """
+Requires the foks CLI: see https://foks.pub for install options
+  macOS:           brew install foks
+  Debian/Ubuntu:   curl -fsSL https://pkgs.foks.pub/install.sh | sh && apt-get install foks
+  Static binary:   curl -fsSL https://pkgs.foks.pub/install-static.sh | sh
+Start the agent: foks ctl start
+Sign up or log in: foks signup (or foks login)"""
+
+[fields.prefix]
+type = "optional"
+placeholder = "fnox/"
+label = "KV path prefix (optional):"
+wizard = true
+
+[fields.team]
+type = "optional"
+placeholder = ""
+label = "FOKS team (optional, defaults to personal):"
+wizard = true
+
+[fields.home]
+type = "optional"
+placeholder = ""
+label = "FOKS home directory (optional):"
+wizard = false
+
+[fields.host]
+type = "optional"
+placeholder = "foks.app"
+label = "FOKS host (required when using bot_token, e.g. CI):"
+wizard = false
+
+[fields.bot_token]
+type = "optional"
+placeholder = ""
+label = "Bot token for non-interactive auth (CI; falls back to FOKS_BOT_TOKEN):"
+wizard = false

--- a/crates/fnox-core/src/providers/foks.rs
+++ b/crates/fnox-core/src/providers/foks.rs
@@ -1,0 +1,589 @@
+use crate::env;
+use crate::error::{FnoxError, Result};
+use async_trait::async_trait;
+use tokio::process::Command;
+use tokio::sync::Mutex;
+
+const PROVIDER_NAME: &str = "FOKS";
+const PROVIDER_URL: &str = "https://fnox.jdx.dev/providers/foks";
+
+/// Provider that integrates with FOKS (https://foks.pub) via the `foks` CLI.
+///
+/// Secrets are stored as values in the FOKS encrypted key-value store, either
+/// in the user's personal namespace or under a team. fnox shells out to the
+/// `foks` CLI; the FOKS agent (`foks ctl start`) handles authentication and
+/// end-to-end encryption.
+///
+/// For non-interactive environments (CI), set `bot_token` (or pass it via the
+/// `FOKS_BOT_TOKEN` / `FNOX_FOKS_BOT_TOKEN` env var) along with `host`. On the
+/// first auth failure during a fnox run, the provider transparently calls
+/// `foks bot use --host <host>` with the token, then retries the operation.
+pub struct FoksProvider {
+    prefix: Option<String>,
+    team: Option<String>,
+    home: Option<String>,
+    host: Option<String>,
+    bot_token: Option<String>,
+    /// One-shot guard: ensures the bot-token auto-login is attempted at most
+    /// once per provider instance, no matter how many concurrent secrets are
+    /// being fetched. Stores `true` once we've tried (success or failure).
+    login_attempted: Mutex<bool>,
+}
+
+impl FoksProvider {
+    pub fn new(
+        prefix: Option<String>,
+        team: Option<String>,
+        home: Option<String>,
+        host: Option<String>,
+        bot_token: Option<String>,
+    ) -> Result<Self> {
+        Ok(Self {
+            prefix,
+            team,
+            home,
+            host,
+            bot_token,
+            login_attempted: Mutex::new(false),
+        })
+    }
+
+    /// Build the full KV path with optional prefix.
+    fn build_secret_path(&self, key: &str) -> String {
+        match &self.prefix {
+            Some(prefix) => format!("{prefix}{key}"),
+            None => key.to_string(),
+        }
+    }
+
+    /// Resolve the FOKS home directory: explicit config wins, otherwise fall
+    /// back to FNOX_FOKS_HOME / FOKS_HOME, otherwise `None` (foks uses its
+    /// default).
+    fn resolved_home(&self) -> Option<String> {
+        resolve_with_env(self.home.as_deref(), &["FNOX_FOKS_HOME", "FOKS_HOME"])
+    }
+
+    /// Resolve the FOKS host: explicit config wins, otherwise FNOX_FOKS_HOST /
+    /// FOKS_HOST. Required for bot-token auto-login; for normal interactive
+    /// use it can be omitted (the agent already knows the active host).
+    fn resolved_host(&self) -> Option<String> {
+        resolve_with_env(self.host.as_deref(), &["FNOX_FOKS_HOST", "FOKS_HOST"])
+    }
+
+    /// Resolve the bot token: explicit config wins, otherwise
+    /// FNOX_FOKS_BOT_TOKEN / FOKS_BOT_TOKEN. Returning `None` here disables
+    /// the auto-login retry path entirely.
+    fn resolved_bot_token(&self) -> Option<String> {
+        resolve_with_env(
+            self.bot_token.as_deref(),
+            &["FNOX_FOKS_BOT_TOKEN", "FOKS_BOT_TOKEN"],
+        )
+    }
+
+    /// Args common to every `foks kv ...` invocation: -H/--home (if set) and
+    /// -t/--team (if set). Returned as owned strings so the caller can borrow
+    /// them as &str.
+    fn common_args(&self) -> Vec<String> {
+        let mut args = Vec::new();
+        if let Some(home) = self.resolved_home() {
+            args.push("--home".to_string());
+            args.push(home);
+        }
+        if let Some(team) = self.team.as_deref()
+            && !team.is_empty()
+        {
+            args.push("--team".to_string());
+            args.push(team.to_string());
+        }
+        args
+    }
+
+    fn new_command(&self) -> Command {
+        let mut cmd = Command::new("foks");
+        for arg in self.common_args() {
+            cmd.arg(arg);
+        }
+        cmd
+    }
+
+    /// Single attempt at running `foks kv ...` with no stdin. Returns trimmed
+    /// stdout on success; classifies the stderr on failure. Does not retry.
+    async fn execute_foks_kv_once(
+        &self,
+        args: &[&str],
+        secret_ref: Option<&str>,
+    ) -> Result<String> {
+        tracing::debug!("Executing foks kv command with args: {args:?}");
+
+        let mut cmd = self.new_command();
+        cmd.arg("kv");
+        cmd.args(args);
+        cmd.stdin(std::process::Stdio::null());
+        cmd.stdout(std::process::Stdio::piped());
+        cmd.stderr(std::process::Stdio::piped());
+
+        let output = cmd.output().await.map_err(map_spawn_error)?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(classify_cli_error(stderr.trim(), secret_ref));
+        }
+
+        let stdout =
+            String::from_utf8(output.stdout).map_err(|e| FnoxError::ProviderInvalidResponse {
+                provider: PROVIDER_NAME.to_string(),
+                details: format!("Invalid UTF-8 in command output: {e}"),
+                hint: "The secret value contains invalid UTF-8 characters".to_string(),
+                url: PROVIDER_URL.to_string(),
+            })?;
+
+        Ok(stdout.trim().to_string())
+    }
+
+    /// Run a `foks kv ...` command, transparently retrying once after a
+    /// successful bot-token auto-login if the first attempt failed with an
+    /// auth error and a bot token is configured.
+    async fn execute_foks_kv(&self, args: &[&str], secret_ref: Option<&str>) -> Result<String> {
+        match self.execute_foks_kv_once(args, secret_ref).await {
+            Ok(v) => Ok(v),
+            Err(err) => {
+                if self.try_auto_login_for(&err).await? {
+                    self.execute_foks_kv_once(args, secret_ref).await
+                } else {
+                    Err(err)
+                }
+            }
+        }
+    }
+
+    /// Single attempt at running `foks kv put <path>` with `value` written to
+    /// stdin. Used by `put_secret`; the retry wrapper lives in `put_secret`
+    /// itself.
+    async fn execute_foks_kv_put_once(&self, path: &str, value: &str) -> Result<()> {
+        let mut cmd = self.new_command();
+        cmd.arg("kv")
+            .arg("put")
+            .arg("--force")
+            .arg("--mkdir-p")
+            .arg(path)
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped());
+
+        let mut child = cmd.spawn().map_err(map_spawn_error)?;
+
+        if let Some(mut stdin) = child.stdin.take() {
+            use tokio::io::AsyncWriteExt;
+            stdin
+                .write_all(value.as_bytes())
+                .await
+                .map_err(|e| FnoxError::ProviderCliFailed {
+                    provider: PROVIDER_NAME.to_string(),
+                    details: format!("Failed to write secret to foks stdin: {e}"),
+                    hint: "This is an internal error".to_string(),
+                    url: PROVIDER_URL.to_string(),
+                })?;
+            // Closing stdin signals EOF; foks treats EOF as end-of-value.
+            drop(stdin);
+        }
+
+        let output = child
+            .wait_with_output()
+            .await
+            .map_err(|e| FnoxError::ProviderCliFailed {
+                provider: PROVIDER_NAME.to_string(),
+                details: format!("Failed to wait for 'foks kv put': {e}"),
+                hint: "This is an internal error".to_string(),
+                url: PROVIDER_URL.to_string(),
+            })?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(classify_cli_error(stderr.trim(), Some(path)));
+        }
+        Ok(())
+    }
+
+    /// If `err` is an auth failure and a bot token is configured, run
+    /// `foks bot use --host <host>` exactly once for this provider instance.
+    /// Returns `Ok(true)` if a login was performed (caller should retry the
+    /// failing op), `Ok(false)` if no auto-login was attempted (caller should
+    /// surface the original error). A login that itself fails is returned as
+    /// `Err`.
+    async fn try_auto_login_for(&self, err: &FnoxError) -> Result<bool> {
+        if !matches!(err, FnoxError::ProviderAuthFailed { .. }) {
+            return Ok(false);
+        }
+        let Some(token) = self.resolved_bot_token() else {
+            return Ok(false);
+        };
+        let Some(host) = self.resolved_host() else {
+            tracing::warn!(
+                "FOKS bot_token is configured but no host is set; skipping auto-login. \
+                 Set the `host` field or FOKS_HOST env var."
+            );
+            return Ok(false);
+        };
+
+        let mut attempted = self.login_attempted.lock().await;
+        if *attempted {
+            return Ok(false);
+        }
+        *attempted = true;
+
+        tracing::info!("FOKS auth failed; attempting bot-token auto-login on host {host}");
+        self.run_bot_login(&host, &token).await?;
+        Ok(true)
+    }
+
+    /// Run `foks bot use --host <host>` with the bot token piped via the
+    /// FOKS_BOT_TOKEN env var (so it never appears on the command line / in
+    /// `ps` output).
+    async fn run_bot_login(&self, host: &str, token: &str) -> Result<()> {
+        let mut cmd = self.new_command();
+        cmd.arg("bot")
+            .arg("use")
+            .arg("--host")
+            .arg(host)
+            .env("FOKS_BOT_TOKEN", token)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped());
+
+        let output = cmd.output().await.map_err(map_spawn_error)?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(FnoxError::ProviderAuthFailed {
+                provider: PROVIDER_NAME.to_string(),
+                details: format!("foks bot use failed: {}", stderr.trim()),
+                hint: "Check that the bot token is valid and that the host matches the FOKS server it was issued on".to_string(),
+                url: PROVIDER_URL.to_string(),
+            });
+        }
+        tracing::debug!("FOKS bot-token auto-login succeeded");
+        Ok(())
+    }
+}
+
+/// Map a spawn-time IO error from `Command::output` / `Command::spawn` to a
+/// `FnoxError`. Shared by all `foks` invocations so missing-CLI vs other-IO
+/// errors stay consistent.
+fn map_spawn_error(e: std::io::Error) -> FnoxError {
+    if e.kind() == std::io::ErrorKind::NotFound {
+        FnoxError::ProviderCliNotFound {
+            provider: PROVIDER_NAME.to_string(),
+            cli: "foks".to_string(),
+            install_hint: "brew install foks (or see https://foks.pub)".to_string(),
+            url: PROVIDER_URL.to_string(),
+        }
+    } else {
+        FnoxError::ProviderCliFailed {
+            provider: PROVIDER_NAME.to_string(),
+            details: e.to_string(),
+            hint: "Check that the foks CLI is installed and on PATH".to_string(),
+            url: PROVIDER_URL.to_string(),
+        }
+    }
+}
+
+/// Resolve a value: prefer the explicit `Option<&str>` (after trimming empty
+/// strings), then fall back to the first non-empty value among `env_vars`,
+/// then `None`.
+fn resolve_with_env(explicit: Option<&str>, env_vars: &[&str]) -> Option<String> {
+    if let Some(s) = explicit
+        && !s.is_empty()
+    {
+        return Some(s.to_string());
+    }
+    for v in env_vars {
+        if let Ok(s) = env::var(v)
+            && !s.is_empty()
+        {
+            return Some(s);
+        }
+    }
+    None
+}
+
+#[async_trait]
+impl crate::providers::Provider for FoksProvider {
+    fn capabilities(&self) -> Vec<crate::providers::ProviderCapability> {
+        vec![crate::providers::ProviderCapability::RemoteStorage]
+    }
+
+    async fn get_secret(&self, value: &str) -> Result<String> {
+        let path = self.build_secret_path(value);
+        tracing::debug!("Getting secret '{path}' from FOKS");
+        // `foks kv get <path>` prints the value to stdout (no output file).
+        self.execute_foks_kv(&["get", &path], Some(&path)).await
+    }
+
+    async fn put_secret(&self, key: &str, value: &str) -> Result<String> {
+        let path = self.build_secret_path(key);
+        tracing::debug!("Storing secret '{path}' in FOKS");
+
+        match self.execute_foks_kv_put_once(&path, value).await {
+            Ok(()) => {}
+            Err(err) => {
+                if self.try_auto_login_for(&err).await? {
+                    self.execute_foks_kv_put_once(&path, value).await?;
+                } else {
+                    return Err(err);
+                }
+            }
+        }
+
+        tracing::debug!("Successfully stored secret '{path}' in FOKS");
+        Ok(key.to_string())
+    }
+
+    async fn test_connection(&self) -> Result<()> {
+        tracing::debug!("Testing connection to FOKS");
+        // `foks kv ls /` exercises the agent + KV path without touching any
+        // particular key. Output is discarded.
+        self.execute_foks_kv(&["ls", "/"], None).await?;
+        tracing::debug!("FOKS connection test successful");
+        Ok(())
+    }
+}
+
+pub fn env_dependencies() -> &'static [&'static str] {
+    &[
+        "FOKS_HOME",
+        "FNOX_FOKS_HOME",
+        "FOKS_HOST",
+        "FNOX_FOKS_HOST",
+        "FOKS_BOT_TOKEN",
+        "FNOX_FOKS_BOT_TOKEN",
+    ]
+}
+
+/// Patterns that indicate the FOKS agent is unreachable or the user is not
+/// authenticated. The most common cause is forgetting to run `foks ctl start`
+/// or `foks signup` / `foks login`.
+const AUTH_ERROR_PATTERNS: &[&str] = &[
+    "could not connect to the foks agent",
+    "no logged-in user",
+    "no current user",
+    "not logged in",
+    "auth required",
+    "permission denied",
+];
+
+/// Patterns that indicate the requested KV entry does not exist. FOKS uses
+/// "no rows in result set" (a postgres-style message bubbling up from the
+/// server) and the more user-facing "not found" / "no such" wording.
+const SECRET_NOT_FOUND_PATTERNS: &[&str] = &[
+    "no rows in result set",
+    "not found",
+    "no such file or directory",
+    "no such key",
+    "does not exist",
+];
+
+fn contains_any(haystack: &str, patterns: &[&str]) -> bool {
+    patterns.iter().any(|p| haystack.contains(p))
+}
+
+/// Classify FOKS CLI stderr output into the appropriate FnoxError variant.
+fn classify_cli_error(stderr: &str, secret_ref: Option<&str>) -> FnoxError {
+    let stderr_lower = stderr.to_lowercase();
+
+    if contains_any(&stderr_lower, AUTH_ERROR_PATTERNS) {
+        return FnoxError::ProviderAuthFailed {
+            provider: PROVIDER_NAME.to_string(),
+            details: stderr.to_string(),
+            hint: "Start the FOKS agent (`foks ctl start`) and ensure you are signed in (`foks signup` or `foks login`)".to_string(),
+            url: PROVIDER_URL.to_string(),
+        };
+    }
+
+    if let Some(secret_name) = secret_ref
+        && contains_any(&stderr_lower, SECRET_NOT_FOUND_PATTERNS)
+    {
+        return FnoxError::ProviderSecretNotFound {
+            provider: PROVIDER_NAME.to_string(),
+            secret: secret_name.to_string(),
+            hint: "Check that the key exists in the FOKS KV store (try `foks kv ls`)".to_string(),
+            url: PROVIDER_URL.to_string(),
+        };
+    }
+
+    FnoxError::ProviderCliFailed {
+        provider: PROVIDER_NAME.to_string(),
+        details: stderr.to_string(),
+        hint: "Check your FOKS configuration and that the agent is running".to_string(),
+        url: PROVIDER_URL.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn provider(prefix: Option<&str>, team: Option<&str>, home: Option<&str>) -> FoksProvider {
+        FoksProvider::new(
+            prefix.map(String::from),
+            team.map(String::from),
+            home.map(String::from),
+            None,
+            None,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn build_secret_path_with_prefix() {
+        let p = provider(Some("fnox/"), None, None);
+        assert_eq!(p.build_secret_path("MY_SECRET"), "fnox/MY_SECRET");
+    }
+
+    #[test]
+    fn build_secret_path_without_prefix() {
+        let p = provider(None, None, None);
+        assert_eq!(p.build_secret_path("MY_SECRET"), "MY_SECRET");
+    }
+
+    #[test]
+    fn common_args_empty_by_default() {
+        let p = provider(None, None, None);
+        assert!(p.common_args().is_empty());
+    }
+
+    #[test]
+    fn common_args_team_and_home() {
+        let p = provider(None, Some("eng"), Some("/tmp/foks"));
+        assert_eq!(
+            p.common_args(),
+            vec!["--home", "/tmp/foks", "--team", "eng"]
+        );
+    }
+
+    #[test]
+    fn common_args_skips_empty_strings() {
+        // Empty strings can come through from the wizard / config and should
+        // not produce dangling `--team ""` flags.
+        let p = provider(None, Some(""), Some(""));
+        assert!(p.common_args().is_empty());
+    }
+
+    #[test]
+    fn classify_agent_unreachable_is_auth_failed() {
+        let err = classify_cli_error(
+            "Error: could not connect to the FOKS agent; start it via `foks ctl start`",
+            None,
+        );
+        assert!(
+            matches!(err, FnoxError::ProviderAuthFailed { .. }),
+            "Expected ProviderAuthFailed, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn classify_no_logged_in_user_is_auth_failed() {
+        let err = classify_cli_error("no logged-in user", Some("MY_SECRET"));
+        assert!(matches!(err, FnoxError::ProviderAuthFailed { .. }));
+    }
+
+    #[test]
+    fn classify_missing_key_is_secret_not_found() {
+        let err = classify_cli_error("Error: no rows in result set", Some("/fnox/MY_SECRET"));
+        match err {
+            FnoxError::ProviderSecretNotFound { secret, .. } => {
+                assert_eq!(secret, "/fnox/MY_SECRET");
+            }
+            other => panic!("Expected ProviderSecretNotFound, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_missing_key_without_ref_is_cli_failed() {
+        // Without a secret_ref to attach, "not found" should fall through to
+        // the generic CLI-failed bucket rather than a misleading
+        // ProviderSecretNotFound with an empty secret name.
+        let err = classify_cli_error("not found", None);
+        assert!(matches!(err, FnoxError::ProviderCliFailed { .. }));
+    }
+
+    #[test]
+    fn classify_unknown_error_is_cli_failed() {
+        let err = classify_cli_error("kv put failed: disk full", Some("/fnox/MY_SECRET"));
+        assert!(matches!(err, FnoxError::ProviderCliFailed { .. }));
+    }
+
+    #[test]
+    fn env_dependencies_lists_foks_home_and_bot_token() {
+        let deps = env_dependencies();
+        assert!(deps.contains(&"FOKS_HOME"));
+        assert!(deps.contains(&"FNOX_FOKS_HOME"));
+        assert!(deps.contains(&"FOKS_HOST"));
+        assert!(deps.contains(&"FNOX_FOKS_HOST"));
+        assert!(deps.contains(&"FOKS_BOT_TOKEN"));
+        assert!(deps.contains(&"FNOX_FOKS_BOT_TOKEN"));
+    }
+
+    #[test]
+    fn resolve_with_env_prefers_explicit() {
+        // Set the env var to a sentinel; explicit value should still win.
+        // SAFETY: tests run single-threaded for env mutation; this test name
+        // is unique within the suite.
+        // We use a unique env-var name per test to avoid cross-test races.
+        let env_name = "FNOX_FOKS_RESOLVE_TEST_EXPLICIT";
+        // SAFETY: safe in tests; we restore with remove_var on each branch.
+        unsafe { std::env::set_var(env_name, "from-env") };
+        let r = resolve_with_env(Some("from-config"), &[env_name]);
+        unsafe { std::env::remove_var(env_name) };
+        assert_eq!(r.as_deref(), Some("from-config"));
+    }
+
+    #[test]
+    fn resolve_with_env_falls_back_to_first_set_env() {
+        let primary = "FNOX_FOKS_RESOLVE_TEST_PRIMARY";
+        let secondary = "FNOX_FOKS_RESOLVE_TEST_SECONDARY";
+        // SAFETY: see above.
+        unsafe {
+            std::env::remove_var(primary);
+            std::env::set_var(secondary, "fallback");
+        }
+        let r = resolve_with_env(None, &[primary, secondary]);
+        unsafe { std::env::remove_var(secondary) };
+        assert_eq!(r.as_deref(), Some("fallback"));
+    }
+
+    #[test]
+    fn resolve_with_env_treats_empty_string_as_absent() {
+        // Empty string from the wizard should NOT shadow a set env var.
+        let env_name = "FNOX_FOKS_RESOLVE_TEST_EMPTY";
+        // SAFETY: see above.
+        unsafe { std::env::set_var(env_name, "from-env") };
+        let r = resolve_with_env(Some(""), &[env_name]);
+        unsafe { std::env::remove_var(env_name) };
+        assert_eq!(r.as_deref(), Some("from-env"));
+    }
+
+    #[tokio::test]
+    async fn try_auto_login_for_skips_non_auth_errors() {
+        let p = provider(None, None, None);
+        let err = FnoxError::ProviderCliFailed {
+            provider: PROVIDER_NAME.to_string(),
+            details: "kv put failed".to_string(),
+            hint: String::new(),
+            url: PROVIDER_URL.to_string(),
+        };
+        assert!(!p.try_auto_login_for(&err).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn try_auto_login_for_skips_when_no_bot_token() {
+        let p = provider(None, None, None);
+        let err = FnoxError::ProviderAuthFailed {
+            provider: PROVIDER_NAME.to_string(),
+            details: "no logged-in user".to_string(),
+            hint: String::new(),
+            url: PROVIDER_URL.to_string(),
+        };
+        // With no bot_token configured (and no env var set), auto-login is a
+        // no-op and the original error should bubble up unchanged.
+        assert!(!p.try_auto_login_for(&err).await.unwrap());
+    }
+}

--- a/crates/fnox-core/src/providers/mod.rs
+++ b/crates/fnox-core/src/providers/mod.rs
@@ -14,6 +14,7 @@ pub mod bitwarden_sm;
 pub mod doppler;
 #[cfg(not(target_env = "musl"))]
 pub mod fido2;
+pub mod foks;
 pub mod gcp_kms;
 pub mod gcp_sm;
 pub mod hw_encrypt;
@@ -142,7 +143,7 @@ mod generated {
         use super::super::fido2;
         use super::super::{
             age, aws_kms, aws_ps, aws_sm, azure_kms, azure_sm, bitwarden, bitwarden_sm, doppler,
-            gcp_kms, gcp_sm, infisical, keepass, keychain, onepassword, password_store,
+            foks, gcp_kms, gcp_sm, infisical, keepass, keychain, onepassword, password_store,
             passwordstate, plain, proton_pass, vault, yubikey,
         };
         include!(concat!(

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -123,6 +123,7 @@ export default defineConfig({
               { text: "AWS Secrets Manager", link: "/providers/aws-sm" },
               { text: "Azure Key Vault Secrets", link: "/providers/azure-sm" },
               { text: "Doppler", link: "/providers/doppler" },
+              { text: "FOKS", link: "/providers/foks" },
               { text: "GCP Secret Manager", link: "/providers/gcp-sm" },
               {
                 text: "Bitwarden Secrets Manager",

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -810,6 +810,7 @@
                     "fido2",
                     "bitwarden",
                     "doppler",
+                    "foks",
                     "bitwarden-sm",
                     "infisical",
                     "keepass",

--- a/docs/cli/provider/add.md
+++ b/docs/cli/provider/add.md
@@ -31,6 +31,7 @@ Provider type
 - `fido2`
 - `bitwarden`
 - `doppler`
+- `foks`
 - `bitwarden-sm`
 - `infisical`
 - `keepass`

--- a/docs/index.md
+++ b/docs/index.md
@@ -92,6 +92,7 @@ API_KEY = { default = "dev-key-12345" }  # ← plain default value for local dev
 - **gcp-sm** - Google Cloud Secret Manager
 - **bitwarden-sm** - Bitwarden Secrets Manager
 - **doppler** - Doppler secrets manager
+- **foks** - FOKS (Federated Open Key Service)
 - **vault** - HashiCorp Vault
 
 ### 🔑 Password Managers & Secret Services

--- a/docs/providers/foks.md
+++ b/docs/providers/foks.md
@@ -1,0 +1,237 @@
+# FOKS
+
+Integrate with [FOKS](https://foks.pub) — the Federated Open Key Service — to store secrets in an end-to-end encrypted, self-hostable key-value store. Secrets are encrypted on the client; the server only ever sees ciphertext.
+
+FOKS pairs well with fnox for teams that want their secrets manager to be open source, federated, and free of cloud-vendor lock-in. The hosted instance at [foks.app](https://foks.app) and self-hosted FOKS servers behave identically — fnox just shells out to the `foks` CLI either way.
+
+## Quick Start
+
+```bash
+# 1. Install the foks CLI
+brew install foks            # macOS / Linuxbrew
+# or: curl -fsSL https://pkgs.foks.pub/install.sh | sh && apt-get install foks  # Debian/Ubuntu
+
+# 2. Start the agent and sign up (or log in)
+foks ctl start
+foks signup
+
+# 3. Configure the FOKS provider
+cat >> fnox.toml << 'EOF'
+[providers]
+foks = { type = "foks", prefix = "fnox/" }
+
+[secrets]
+DATABASE_URL = { provider = "foks", value = "DATABASE_URL" }
+EOF
+
+# 4. Store a secret and read it back
+fnox set DATABASE_URL "postgres://..." --provider foks
+fnox get DATABASE_URL
+```
+
+## Prerequisites
+
+- The [`foks` CLI](https://foks.pub) on your `PATH`
+- A running FOKS agent (`foks ctl start`)
+- A FOKS account, either on the [hosted service](https://foks.app) or your own server
+
+## Installation
+
+```bash
+# macOS (Homebrew)
+brew install foks
+
+# Debian / Ubuntu
+curl -fsSL https://pkgs.foks.pub/install.sh | sh
+apt-get install foks
+
+# Fedora
+curl -fsSL https://pkgs.foks.pub/install.sh | sh
+dnf install foks
+
+# Arch Linux (AUR)
+yay -Sy go-foks
+
+# Windows
+winget install foks
+
+# Static binary (any platform)
+curl -fsSL https://pkgs.foks.pub/install-static.sh | sh
+```
+
+See [foks.pub](https://foks.pub) for the most up-to-date instructions.
+
+## Setup
+
+### 1. Start the agent
+
+The `foks` CLI talks to a long-running agent that holds your keys in memory (similar to `ssh-agent`). Start it once per machine; it persists across logins via launchd / systemd / the Windows Registry.
+
+```bash
+foks ctl start
+```
+
+### 2. Sign up or log in
+
+```bash
+foks signup    # new user
+foks login     # existing user, new device
+```
+
+### 3. (Optional) Create a team for shared secrets
+
+If you want to share secrets with teammates, create a FOKS team:
+
+```bash
+foks team create my-team
+foks team add my-team alice
+```
+
+Each team has its own KV namespace.
+
+### 4. Configure the provider
+
+```toml
+[providers]
+foks = { type = "foks", prefix = "fnox/" }
+```
+
+**Configuration options** (all optional):
+
+- `prefix` — Path prefix prepended to every key. Use this to keep fnox-managed secrets in their own subtree of the KV store (e.g. `fnox/`, `apps/myapp/`).
+- `team` — A FOKS team name. When set, fnox passes `--team <name>` to every `foks kv` invocation, so secrets read and write to that team's namespace instead of your personal one.
+- `home` — A custom FOKS home directory, passed through as `--home`. Falls back to `FNOX_FOKS_HOME` / `FOKS_HOME` if not set.
+- `host` — The FOKS server hostname (e.g. `foks.app` or your self-hosted server). Required for non-interactive bot-token auth (see [CI/CD](#cicd)). Falls back to `FNOX_FOKS_HOST` / `FOKS_HOST`.
+- `bot_token` — A FOKS bot token for non-interactive auth (CI). Almost always you want to leave this unset and supply it via the `FOKS_BOT_TOKEN` env var instead, so it isn't checked into your config. Also accepts `FNOX_FOKS_BOT_TOKEN`.
+
+## Referencing Secrets
+
+```toml
+[secrets]
+DATABASE_URL = { provider = "foks", value = "DATABASE_URL" }
+API_KEY      = { provider = "foks", value = "API_KEY" }
+```
+
+The `value` is the key path within the FOKS KV store, joined with the provider's `prefix`. With `prefix = "fnox/"`, `value = "DATABASE_URL"` resolves to `foks kv get fnox/DATABASE_URL`.
+
+## Usage
+
+```bash
+# Store a secret (FOKS encrypts it client-side before upload)
+fnox set DATABASE_URL "postgres://..." --provider foks
+
+# Fetch it
+fnox get DATABASE_URL
+
+# Run a command with secrets injected as env vars
+fnox exec -- npm start
+```
+
+## Personal vs Team Secrets
+
+Use named provider instances to mix personal and team-scoped secrets in the same config:
+
+```toml
+[providers]
+me  = { type = "foks", prefix = "fnox/" }
+ops = { type = "foks", prefix = "fnox/", team = "ops" }
+
+[secrets]
+PERSONAL_TOKEN = { provider = "me",  value = "github-token" }
+DATABASE_URL   = { provider = "ops", value = "db/primary" }
+DEPLOY_KEY     = { provider = "ops", value = "deploy/key" }
+```
+
+`PERSONAL_TOKEN` is read from your personal namespace; the rest are read from the `ops` team's namespace and stay accessible to teammates.
+
+## CI/CD
+
+For non-interactive environments, configure the provider with a `host` and let fnox handle authentication via a FOKS bot token. On the first auth failure, the provider runs `foks bot use --host <host>` with the token from the `FOKS_BOT_TOKEN` env var, then transparently retries.
+
+Setup:
+
+1. Create a [bot token](https://docs.foks.pub) for the user or team the runner should act as.
+2. Add the token to your CI provider's secret store as `FOKS_BOT_TOKEN`.
+3. Set `host` in the provider config (or `FOKS_HOST` env var).
+
+```toml
+# fnox.toml
+[providers]
+foks = { type = "foks", prefix = "fnox/", team = "ops", host = "foks.app" }
+
+[secrets]
+DATABASE_URL = { provider = "foks", value = "DATABASE_URL" }
+```
+
+```yaml
+# .github/workflows/deploy.yml
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      FOKS_BOT_TOKEN: ${{ secrets.FOKS_BOT_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - run: brew install foks
+      - run: foks ctl start
+      - run: fnox exec -- ./deploy.sh
+```
+
+That's it — no explicit `foks bot use` step; fnox runs it for you the first time the agent reports it's not authenticated, then retries the failed `kv` call once.
+
+If you'd rather keep `host` out of `fnox.toml`, set it via `FOKS_HOST` in the workflow env. Likewise, `bot_token` can live in the config (encrypted with a bootstrap provider like `age`) instead of the env var, but the env var is usually simpler.
+
+## Pros
+
+- ✅ End-to-end encrypted — the FOKS server never sees plaintext
+- ✅ Open source and self-hostable
+- ✅ Federated: a self-hosted FOKS server interoperates with the hosted service
+- ✅ Teams have first-class shared namespaces
+- ✅ Hierarchical KV paths and multiple devices per identity
+
+## Cons
+
+- ❌ Newer / smaller ecosystem than Vault, AWS Secrets Manager, etc.
+- ❌ Requires the `foks` agent to be running locally
+- ❌ CI integration requires a bot-token bootstrap step
+
+## Troubleshooting
+
+### "could not connect to the FOKS agent"
+
+Start the agent and try again:
+
+```bash
+foks ctl start
+foks ctl status
+```
+
+### "no logged-in user" / "not logged in"
+
+Sign up or log in:
+
+```bash
+foks signup    # new account
+foks login     # existing account
+```
+
+### Secret not found
+
+List the keys to confirm the path is what you expect:
+
+```bash
+foks kv ls /
+foks kv ls /fnox/   # if you set prefix = "fnox/"
+```
+
+If you set a `team` in your provider config, scope the listing to the team:
+
+```bash
+foks kv ls --team my-team /
+```
+
+## Next Steps
+
+- [HashiCorp Vault](/providers/vault) — Closest comparable self-hosted alternative
+- [password-store](/providers/password-store) — GPG-based local alternative
+- [Real-World Example](/guide/real-world-example) — Complete setup walkthrough

--- a/docs/providers/overview.md
+++ b/docs/providers/overview.md
@@ -27,6 +27,7 @@ Store secrets remotely in cloud providers. Your `fnox.toml` contains only refere
 | [GCP Secret Manager](/providers/gcp-sm)              | Google Cloud secrets                | Production GCP workloads                 |
 | [Bitwarden Secrets Manager](/providers/bitwarden-sm) | Bitwarden Secrets Manager (bws CLI) | Teams using Bitwarden for DevOps secrets |
 | [Doppler](/providers/doppler)                        | Doppler secrets manager             | Developer-friendly cloud secrets         |
+| [FOKS](/providers/foks)                              | End-to-end encrypted, federated KV  | Self-hosted, E2EE, team-shared secrets   |
 | [HashiCorp Vault](/providers/vault)                  | Self-hosted or HCP Vault            | Multi-cloud, advanced features           |
 
 ### 🔑 Password Managers & Secret Services

--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -946,6 +946,35 @@
             "auth_command": {
               "type": ["string", "null"]
             },
+            "bot_token": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "home": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "host": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "prefix": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "team": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "foks"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "auth_command": {
+              "type": ["string", "null"]
+            },
             "prefix": {
               "$ref": "#/$defs/OptionStringOrSecretRef"
             },

--- a/fnox.usage.kdl
+++ b/fnox.usage.kdl
@@ -138,7 +138,7 @@ cmd provider help="Manage providers (defaults to list)" {
         }
         arg <PROVIDER> help="Provider name"
         arg <PROVIDER_TYPE> help="Provider type" {
-            choices "1password" age aws aws-kms aws-ps azure-kms azure-sm gcp gcp-kms fido2 bitwarden doppler bitwarden-sm infisical keepass keychain password-store passwordstate plain proton-pass vault yubikey
+            choices "1password" age aws aws-kms aws-ps azure-kms azure-sm gcp gcp-kms fido2 bitwarden doppler foks bitwarden-sm infisical keepass keychain password-store passwordstate plain proton-pass vault yubikey
         }
     }
     cmd list help="List available providers" {

--- a/src/commands/provider/add.rs
+++ b/src/commands/provider/add.rs
@@ -189,6 +189,14 @@ impl AddCommand {
                 token: OptionStringOrSecretRef::none(),
                 auth_command: None,
             },
+            ProviderType::Foks => crate::config::ProviderConfig::Foks {
+                prefix: OptionStringOrSecretRef::literal("fnox/"),
+                team: OptionStringOrSecretRef::none(),
+                home: OptionStringOrSecretRef::none(),
+                host: OptionStringOrSecretRef::none(),
+                bot_token: OptionStringOrSecretRef::none(),
+                auth_command: None,
+            },
             ProviderType::Infisical => crate::config::ProviderConfig::Infisical {
                 project_id: OptionStringOrSecretRef::literal("your-project-id"),
                 environment: OptionStringOrSecretRef::literal("dev"),

--- a/src/commands/provider/mod.rs
+++ b/src/commands/provider/mod.rs
@@ -61,6 +61,9 @@ pub enum ProviderType {
     /// Doppler secrets manager
     #[value(name = "doppler")]
     Doppler,
+    /// FOKS (Federated Open Key Service)
+    #[value(name = "foks")]
+    Foks,
     /// Bitwarden Secrets Manager
     #[value(name = "bitwarden-sm")]
     #[strum(serialize = "bitwarden-sm")]


### PR DESCRIPTION
## Summary

Adds a new `foks` provider that stores secrets in a [FOKS](https://foks.pub) end-to-end encrypted KV store via the `foks` CLI. Addresses jdx/fnox discussion / foks-proj/go-foks#255.

```toml
[providers]
foks = { type = "foks", prefix = "fnox/" }                      # personal
ops  = { type = "foks", prefix = "fnox/", team = "ops" }        # team-shared

[secrets]
DATABASE_URL = { provider = "ops", value = "DATABASE_URL" }
```

Fields:
- `prefix` — path namespace within the FOKS KV store (e.g. `fnox/`)
- `team` — FOKS team to scope to; passes through as `--team`
- `home` — custom FOKS home dir; passes through as `--home`. Falls back to `FNOX_FOKS_HOME` / `FOKS_HOME`
- `host`, `bot_token` — non-interactive auth (see below)

## Non-interactive auth (CI)

When `bot_token` is configured (or `FOKS_BOT_TOKEN` is set in env) **and** `host` is configured (or `FOKS_HOST` in env), the provider transparently runs `foks bot use --host <host>` on the first auth failure and retries the operation. CI workflows just need to drop the bot token in env:

```yaml
env:
  FOKS_BOT_TOKEN: ${{ secrets.FOKS_BOT_TOKEN }}
steps:
  - run: brew install foks
  - run: foks ctl start
  - run: fnox exec -- ./deploy.sh
```

No explicit `foks bot use` step in the workflow. The auto-login fires at most once per provider instance (guarded by a mutex), so concurrent secret fetches don't dogpile and a bad token still surfaces as a clear `ProviderAuthFailed`.

## Files

- `crates/fnox-core/providers/foks.toml` — provider declaration (drives the build-script-generated config/wizard/instantiation)
- `crates/fnox-core/src/providers/foks.rs` — implementation (~330 LoC)
- `crates/fnox-core/src/providers/mod.rs` — module registration
- `src/commands/provider/{mod.rs,add.rs}` — `ProviderType::Foks` variant + `provider add foks` template
- `docs/providers/foks.md` — provider docs page
- `docs/providers/overview.md`, `docs/index.md`, `docs/.vitepress/config.mjs` — list/sidebar entries
- `docs/cli/provider/add.md`, `docs/cli/commands.json`, `fnox.usage.kdl` — CLI choices (regenerated content)
- `docs/public/schema.json` — JSON-schema entry for the new variant

## Test plan

- [x] 16 unit tests for path building, common-args, error classification, env-var resolution, and the auto-login skip paths
- [x] All 163 `fnox-core` tests + 8 `fnox` tests pass (`cargo test`)
- [x] `provider_add_types_match_provider_definitions` still green (the .toml ↔ enum sync test)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `./target/debug/fnox provider add foks foks` produces a sensible default config block
- [ ] CI passes on this PR

## Notes

- I'm new to the fnox codebase — happy to adjust naming, file layout, or any of the design choices. The provider follows the password-store / doppler shape closely (CLI shellout, env-var fallback, classified error mapping).
- The `host` field is documented as the FOKS server hostname (e.g. `foks.app`). Open to adopting whatever wording you prefer there.

_This PR was generated by Claude Code (Opus 4.7) under @maxtaco's direction._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
