### PR TITLE
ci: remove caching from publishing workflows

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -25,10 +25,6 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.FNOX_GH_TOKEN }}
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          shared-key: debug-ubuntu-latest
-          save-if: false
       - name: Install system dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,9 +53,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           token: ${{ secrets.FNOX_GH_TOKEN }}
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          shared-key: rust-${{ matrix.target }}
       - if: matrix.os == 'macos-latest'
         uses: apple-actions/import-codesign-certs@5142e029c445c10ffc7149d172e540235a065466 # v7
         with:


### PR DESCRIPTION
## Summary
- Strips cache actions (`nscloud-cache-action`, `Swatinem/rust-cache`, `actions/cache`) from release / release-plz / publishing workflows.
- These workflows have elevated permissions (write tokens, signing keys, registry credentials). Even with Namespace's protected-branches setting and GHA's ref-scoped cache enforcement, the simplest defense for the publishing surface is to not depend on any cache at all — builds re-run from clean each time.
- For mise's `release-plz.yml`, also removes the now-pointless sccache install/configure since it had no persistent backing store without the nscloud cache.

## Test plan
- [ ] Releases still build successfully (cold cache; expect slower but functional).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only CI workflow changes, primarily affecting build time and determinism; main failure mode is slower or unexpectedly missing cached build artifacts during release runs.
> 
> **Overview**
> Publishing workflows now run **without any Rust cache**: the `Swatinem/rust-cache` steps were removed from both `release-plz.yml` and `release.yml`, ensuring release builds execute from a clean state even when using elevated credentials.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 817c184e1ce134ee0c285bccb496765d5a7b59d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->