### PR TITLE
chore(ci): assert mise run render produces no diff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,7 +254,7 @@ jobs:
           if [ -n "$(git status --porcelain)" ]; then
             echo "::error::'mise run render' produced changes. Run it locally and commit."
             git status
-            git diff
+            git diff HEAD
             exit 1
           fi
       - name: Check formatting

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,6 +247,16 @@ jobs:
           fnox run -- sh -c 'echo MY_UNIMPORTANT_SECRET: $MY_UNIMPORTANT_SECRET'
       - name: Run tests
         run: cargo test --workspace
+      - name: mise run render
+        run: mise run render
+      - name: assert render produces no diff
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "::error::'mise run render' produced changes. Run it locally and commit."
+            git status
+            git diff
+            exit 1
+          fi
       - name: Check formatting
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
         with:

--- a/mise.toml
+++ b/mise.toml
@@ -79,7 +79,6 @@ depends = ["build"]
 run = [
   "fnox schema > docs/public/schema.json",
   "prettier --write docs/public/schema.json",
-  "git add docs/public/schema.json",
 ]
 
 [tasks."render:usage"]
@@ -91,5 +90,4 @@ run = [
   "usage g markdown -mf fnox.usage.kdl --out-dir docs/cli --url-prefix /cli",
   "usage g json -f fnox.usage.kdl > docs/cli/commands.json",
   "prettier --write docs/cli",
-  "git add fnox.usage.kdl docs/cli",
 ]


### PR DESCRIPTION
Runs `mise run render` and asserts it produces no diff. Follows up the autofix.ci workflow removal in #478.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only CI workflow/task plumbing changes to enforce committed generated docs, with no runtime or security-sensitive code touched.
> 
> **Overview**
> CI (`.github/workflows/ci.yml`) now runs `mise run render` during `ci-other` and explicitly **fails the job if the repo becomes dirty**, surfacing the diff in logs so generated docs can’t drift.
> 
> `mise.toml` render tasks no longer run `git add`, making generation side-effect-free and relying on the new CI check to ensure outputs are committed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35c6ecb0c6ed99d3aff3a642e067957559e57a03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->