### PR TITLE
fix(docs): read version from [workspace.package] in Cargo.toml

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -27,7 +27,7 @@ const commands = getCommands(spec.cmd);
 const configDir = dirname(fileURLToPath(import.meta.url));
 const cargoToml = readFileSync(resolve(configDir, "../../Cargo.toml"), "utf8");
 const versionMatch = cargoToml.match(
-  /^\[package\][\s\S]*?^\s*version\s*=\s*"([^"]+)"/m,
+  /^\[workspace\.package\][\s\S]*?^\s*version\s*=\s*"([^"]+)"/m,
 );
 if (!versionMatch) {
   console.warn("Unable to find package version in Cargo.toml");


### PR DESCRIPTION
## Summary
- The docs site was showing `v0.0.0` in the nav (https://fnox.jdx.dev/) because the VitePress config's regex still looked for a literal `version = "..."` under `[package]`.
- After the workspace conversion, the literal version lives under `[workspace.package]` and `[package]` uses `version.workspace = true`, so the match failed and the `"0.0.0"` fallback was used.
- Updated the regex to match `[workspace.package]`.

## Test plan
- [x] `node -e` snippet against the new regex returns `1.24.1`
- [ ] Verify `v1.24.1` appears in the nav once docs are rebuilt/deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a docs-only regex change that affects how the nav version label is derived, with no runtime impact on the core product.
> 
> **Overview**
> Updates the VitePress docs config (`docs/.vitepress/config.mjs`) to extract the displayed version from the `[workspace.package]` section of `Cargo.toml` instead of `[package]`, preventing the navbar from falling back to `v0.0.0` after the workspace migration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcd70a03b962f0b92a035753a5238fb1e5ecae52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->