### PR TITLE
chore: release v1.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 # Changelog
 
-## [1.24.1](https://github.com/jdx/fnox/compare/v1.24.0..v1.24.1) - 2026-05-12
+## [1.25.0](https://github.com/jdx/fnox/compare/v1.24.1..v1.25.0) - 2026-05-14
+
+### 🚀 Features
+
+- **(provider)** add FOKS (Federated Open Key Service) provider by [@maxtaco](https://github.com/maxtaco) in [#486](https://github.com/jdx/fnox/pull/486)
+
+### 🐛 Bug Fixes
+
+- **(cli)** exit cleanly on SIGPIPE instead of panicking in println! by [@maxtaco](https://github.com/maxtaco) in [#487](https://github.com/jdx/fnox/pull/487)
+- **(docs)** read version from [workspace.package] in Cargo.toml by [@jdx](https://github.com/jdx) in [#483](https://github.com/jdx/fnox/pull/483)
+
+### New Contributors
+
+- @maxtaco made their first contribution in [#486](https://github.com/jdx/fnox/pull/486)
+
+## [1.24.1](https://github.com/jdx/fnox/compare/v1.24.0..v1.24.1) - 2026-05-13
 
 ### 🐛 Bug Fixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,9 +434,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -445,9 +445,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -2288,9 +2288,9 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.28"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d5b2eef6fafbf69f877e55509ce5b11a760690ac9700a2921be067aa6afaef6"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
  "cfg-if",
  "libc",
@@ -2379,7 +2379,7 @@ dependencies = [
 
 [[package]]
 name = "fnox"
-version = "1.24.1"
+version = "1.25.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -2424,7 +2424,7 @@ dependencies = [
 
 [[package]]
 name = "fnox-core"
-version = "1.24.1"
+version = "1.25.0"
 dependencies = [
  "aes-gcm 0.11.0-rc.3",
  "age",
@@ -4890,18 +4890,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5577,9 +5577,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12ca9067b5ebfbd5b3fcdc4acfceb81aa7d5ab2a879dff7cb75d22434276aad"
+checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5599,9 +5599,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7caa6743cc0888e433105fe1bc551a7f607940b126a37bc97b478e86064627eb"
+checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -6984,7 +6984,7 @@ dependencies = [
  "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -6993,7 +6993,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -8161,9 +8161,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "crates/fnox-core"]
 resolver = "3"
 
 [workspace.package]
-version = "1.24.1"
+version = "1.25.0"
 edition = "2024"
 authors = ["@jdx"]
 license = "MIT"
@@ -107,7 +107,7 @@ name = "fnox"
 path = "src/main.rs"
 
 [dependencies]
-fnox-core = { path = "crates/fnox-core", version = "1.24.1" }
+fnox-core = { path = "crates/fnox-core", version = "1.25.0" }
 
 # Direct dependencies of the CLI binary (commands, MCP server, TUI, hook-env,
 # shell integration). Provider/config/secret-resolver crates are pulled in

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -1593,7 +1593,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.24.1",
+  "version": "1.25.0",
   "usage": "Usage: fnox [OPTIONS] <COMMAND>",
   "complete": {
     "key": {

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -4,7 +4,7 @@
 
 **Usage**: `fnox [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.24.1
+**Version**: 1.25.0
 
 - **Usage**: `fnox [FLAGS] <SUBCOMMAND>`
 

--- a/fnox.usage.kdl
+++ b/fnox.usage.kdl
@@ -1,7 +1,7 @@
 min_usage_version "1.3"
 name fnox
 bin fnox
-version "1.24.1"
+version "1.25.0"
 about "A flexible secret management tool by @jdx"
 usage "Usage: fnox [OPTIONS] <COMMAND>"
 flag "-c --config" help="Path to the configuration file (default: fnox.toml, searches parent directories)" global=#true default=fnox.toml {


### PR DESCRIPTION
### 🚀 Features

- **(provider)** add FOKS (Federated Open Key Service) provider by [@maxtaco](https://github.com/maxtaco) in [#486](https://github.com/jdx/fnox/pull/486)

### 🐛 Bug Fixes

- **(cli)** exit cleanly on SIGPIPE instead of panicking in println! by [@maxtaco](https://github.com/maxtaco) in [#487](https://github.com/jdx/fnox/pull/487)
- **(docs)** read version from [workspace.package] in Cargo.toml by [@jdx](https://github.com/jdx) in [#483](https://github.com/jdx/fnox/pull/483)

### New Contributors

- @maxtaco made their first contribution in [#486](https://github.com/jdx/fnox/pull/486)