### PR TITLE
fix(cli): exit cleanly on SIGPIPE instead of panicking in println!

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -11,9 +11,13 @@ async fn main() -> miette::Result<()> {
     // SIG_DFL makes the process exit on the signal like a normal Unix tool.
     #[cfg(unix)]
     unsafe {
-        let _ = nix::sys::signal::signal(
+        let _ = nix::sys::signal::sigaction(
             nix::sys::signal::Signal::SIGPIPE,
-            nix::sys::signal::SigHandler::SigDfl,
+            &nix::sys::signal::SigAction::new(
+                nix::sys::signal::SigHandler::SigDfl,
+                nix::sys::signal::SaFlags::empty(),
+                nix::sys::signal::SigSet::empty(),
+            ),
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,18 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 #[tokio::main]
 async fn main() -> miette::Result<()> {
+    // Restore the default SIGPIPE handler. Rust inherits SIG_IGN from libc,
+    // so writes to a closed pipe return EPIPE and `println!` panics — e.g.
+    // `fnox get FOO | head -c 0` would crash with "failed printing to stdout".
+    // SIG_DFL makes the process exit on the signal like a normal Unix tool.
+    #[cfg(unix)]
+    unsafe {
+        let _ = nix::sys::signal::signal(
+            nix::sys::signal::Signal::SIGPIPE,
+            nix::sys::signal::SigHandler::SigDfl,
+        );
+    }
+
     miette::set_panic_hook();
 
     // Initialize rustls crypto provider for GCP SDKs

--- a/test/broken_pipe.bats
+++ b/test/broken_pipe.bats
@@ -1,0 +1,41 @@
+#!/usr/bin/env bats
+
+setup() {
+	load 'test_helper/common_setup'
+	_common_setup
+}
+
+teardown() {
+	_common_teardown
+}
+
+# Regression: `fnox get` used to panic with "failed printing to stdout:
+# Broken pipe (os error 32)" when its stdout was closed early — e.g.
+# `fnox get FOO | head -c 0` or any pipeline where the reader exits before
+# fnox writes. Rust inherits SIG_IGN for SIGPIPE from libc, so writes to a
+# closed pipe return EPIPE and `println!` panics. The fix resets SIGPIPE to
+# SIG_DFL in main() so fnox dies from the signal like a normal Unix tool.
+@test "fnox get does not panic when stdout pipe is closed" {
+	cat >fnox.toml <<'EOF'
+root = true
+
+[providers.age]
+type = "age"
+recipients = ["age1exampleexampleexampleexampleexampleexampleexampleexampleexampleexample"]
+
+[secrets]
+PIPE_TEST = { default = "hello" }
+EOF
+
+	# `false` exits immediately, closing the read end of the pipe before
+	# fnox writes. Without the SIGPIPE reset, fnox panics on the write.
+	run bash -c '"$FNOX_BIN" get PIPE_TEST | false; echo "fnox_exit=${PIPESTATUS[0]}"'
+
+	refute_output --partial "Main thread panicked"
+	refute_output --partial "failed printing to stdout"
+	# Buggy behavior exited 1 via the miette panic handler. Fixed behavior
+	# exits 0 (write fit in the pipe buffer before the reader closed) or
+	# 141 (128 + SIGPIPE). Use refute_line so "1" doesn't substring-match
+	# "141".
+	refute_line "fnox_exit=1"
+}


### PR DESCRIPTION
## Summary

`fnox get FOO | <reader-that-exits-early>` panics with "failed printing to stdout: Broken pipe (os error 32)" because Rust inherits `SIG_IGN` for `SIGPIPE` from libc, so writes to a closed pipe return `EPIPE` and `println!` panics. Reset `SIGPIPE` to `SIG_DFL` early in `main()` so fnox dies from the signal like a normal Unix tool.

### Repro

```toml
# fnox.toml
root = true

[providers.age]
type = "age"
recipients = ["age1exampleexampleexampleexampleexampleexampleexampleexampleexampleexample"]

[secrets]
HELLO = { default = "world" }
```

```console
$ fnox get HELLO | false ; echo "pipestatus=${PIPESTATUS[*]}"
# before:
Error:   × Main thread panicked.
  ├─▶ at .../library/std/src/io/stdio.rs:1165:9
  ╰─▶ failed printing to stdout: Broken pipe (os error 32)
pipestatus=101 1

# after:
pipestatus=141 1
```

The original report was `fnox get TRAILING | cat -A` — BSD `cat` rejects `-A`, exits, fnox panics on the next write.

## Test plan

- [x] `bats test/broken_pipe.bats` passes on the fix, fails on `main` with the expected panic message (verified by stashing the fix and re-running)
- [x] `cargo build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)