### PR TITLE
chore(ci): add PR autocloser

### DIFF
--- a/.github/workflows/pr-closer.yml
+++ b/.github/workflows/pr-closer.yml
@@ -1,0 +1,54 @@
+name: pr-closer
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # daily at midnight
+  workflow_dispatch:
+
+concurrency:
+  group: pr-closer
+  cancel-in-progress: true
+
+jobs:
+  close-stale-prs:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      checks: read
+      statuses: read
+    steps:
+      - name: Close stale PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -o pipefail
+          CUTOFF=$(date -u -d '6 days ago' +%Y-%m-%d)
+          gh pr list -R "$REPO" --state open --search "updated:<$CUTOFF -author:jdx -label:keep-open draft:false" --json number,mergeStateStatus,statusCheckRollup --limit 500 | \
+          jq -r '
+            def failed_check:
+              (.statusCheckRollup | length > 0) and
+              ([.statusCheckRollup // [] | .[] | ((.conclusion // .state // "") | ascii_upcase)] | any(. == "FAILURE" or . == "ERROR" or . == "TIMED_OUT" or . == "ACTION_REQUIRED"));
+
+            .[]
+            | failed_check as $failed
+            | ([.statusCheckRollup // [] | .[] | ((.conclusion // .state // "") | ascii_upcase)] | any(. == "CANCELLED")) as $cancelled
+            | (.mergeStateStatus == "DIRTY") as $conflicted
+            | (.mergeStateStatus == "UNKNOWN") as $unknown
+            | if $failed and $conflicted then [.number, "failing checks and merge conflicts"]
+              elif $failed then [.number, "failing checks"]
+              elif $conflicted then [.number, "merge conflicts"]
+              elif $cancelled then [.number, "cancelled checks", "warn"]
+              elif $unknown then [.number, "unknown merge state", "warn"]
+              else empty
+              end
+            | @tsv
+          ' | \
+          while IFS=$'\t' read -r pr reason action; do
+            if [ "$action" = "warn" ]; then
+              echo "Skipping PR #$pr ($reason)"
+              continue
+            fi
+            echo "Closing PR #$pr ($reason)"
+            gh pr close "$pr" -R "$REPO" -c "This PR has been inactive for at least 7 days and currently has $reason. Feel free to reopen or create a new PR if you'd like to continue working on this." || echo "Warning: failed to close PR #$pr, skipping"
+          done


### PR DESCRIPTION
## Summary
- add a scheduled PR autocloser workflow
- close inactive PRs after 7 days only when they have failing checks or merge conflicts
- keep exclusions for @jdx-authored and keep-open PRs

## Validation
- actionlint .github/workflows/pr-closer.yml
- git diff --check
- jq filter sample validation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Automates closing pull requests via the GitHub API based on status/merge state; misclassification or query mistakes could close PRs unexpectedly, though it’s limited to stale PRs and excludes `keep-open` and `jdx`-authored PRs.
> 
> **Overview**
> Adds a new scheduled/dispatchable GitHub Actions workflow (`pr-closer`) that scans for open PRs not updated in ~7 days (excluding `jdx`-authored, `keep-open`, and draft PRs) and **automatically closes** those with *failing checks* and/or *merge conflicts*.
> 
> PRs with cancelled checks or unknown merge state are only logged (skipped), and the workflow runs with minimal PR/check/status read/write permissions plus concurrency to prevent overlapping runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcfb2e74d32f82191a135f95b0364bb0d5da4104. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->