### PR TITLE
ci(release-plz): use crates.io trusted publishing

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -3,6 +3,7 @@ name: release-plz
 permissions:
   pull-requests: write
   contents: write
+  id-token: write # crates.io trusted publishing
 
 on:
   workflow_dispatch: {}
@@ -38,8 +39,10 @@ jobs:
       - run: mise trust --all
       - name: Install Claude Code CLI
         run: npm install -g @anthropic-ai/claude-code
+      - uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
+        id: crates-io-auth
       - run: mise run release-plz
         env:
           GITHUB_TOKEN: ${{ secrets.FNOX_GH_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary
- Switch the release-plz workflow to mint a short-lived crates.io token via OIDC using `rust-lang/crates-io-auth-action`, pinned to v1.0.4.
- Drop the long-lived `CARGO_REGISTRY_TOKEN` secret reference in favor of the action's `outputs.token`.
- Add `id-token: write` to the job permissions so OIDC can sign the token request.

Trusted publishers for `fnox` and `fnox-core` are already configured on crates.io against this workflow file.

## Notes
- v1.25.0 publish failed under the old token; the tag and GitHub release exist but the crate is not on crates.io. Plan to either publish it manually or skip and let v1.25.1+ be the first OIDC-published release.
- After the next successful publish, the `CARGO_REGISTRY_TOKEN` repo secret can be deleted.

## Test plan
- [ ] Merge and confirm the next release-plz run requests an OIDC token and publishes successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the crates.io publish authentication path in CI by minting an OIDC-based short-lived token, which could break releases if permissions or crates.io trusted publisher config are misaligned.
> 
> **Overview**
> Updates the `release-plz` GitHub Actions workflow to publish to crates.io using *trusted publishing*.
> 
> Adds `id-token: write` permission, runs `rust-lang/crates-io-auth-action` to mint a short-lived crates.io token, and switches `CARGO_REGISTRY_TOKEN` from a long-lived repository secret to the action’s `outputs.token`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbdc9fee1ebf050e0305e499e6cade723359dc3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->