### PR TITLE
chore: release v1.25.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [1.25.1](https://github.com/jdx/fnox/compare/v1.25.0..v1.25.1) - 2026-05-17
+
+### 🔍 Other Changes
+
+- **(ci)** add PR autocloser by [@jdx](https://github.com/jdx) in [#490](https://github.com/jdx/fnox/pull/490)
+- **(release-plz)** use crates.io trusted publishing by [@jdx](https://github.com/jdx) in [#491](https://github.com/jdx/fnox/pull/491)
+
+### 📦️ Dependency Updates
+
+- update keepass to 0.12 and migrate provider to new API by [@jdx](https://github.com/jdx) in [#494](https://github.com/jdx/fnox/pull/494)
+- migrate from keyring v3 to keyring-core v1 by [@jdx](https://github.com/jdx) in [#493](https://github.com/jdx/fnox/pull/493)
+
 ## [1.25.0](https://github.com/jdx/fnox/compare/v1.24.1..v1.25.0) - 2026-05-14
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1906,9 +1906,9 @@ checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
 
 [[package]]
 name = "demand"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e75be0d8a6175692cd9f9e7a7e18acd14612be09e166391a8093b7823295cd4"
+checksum = "9e42d12bfa3506597636b814d58b3f540f6ee71aefd795da37892c45759cdbad"
 dependencies = [
  "console",
  "fuzzy-matcher",
@@ -2399,7 +2399,7 @@ dependencies = [
 
 [[package]]
 name = "fnox"
-version = "1.25.0"
+version = "1.25.1"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -2444,7 +2444,7 @@ dependencies = [
 
 [[package]]
 name = "fnox-core"
-version = "1.25.0"
+version = "1.25.1"
 dependencies = [
  "aes-gcm 0.11.0-rc.3",
  "age",
@@ -3205,9 +3205,9 @@ checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
 
 [[package]]
 name = "hidapi"
-version = "2.6.5"
+version = "2.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1b71e1f4791fb9e93b9d7ee03d70b501ab48f6151432fbcadeabc30fe15396e"
+checksum = "c78dadfc12f865bc3fcac3897e64533b930737ceb9ef245c8277de98d0b010e9"
 dependencies = [
  "cc",
  "cfg-if",
@@ -4563,9 +4563,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.79"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
@@ -4603,9 +4603,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.115"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "crates/fnox-core"]
 resolver = "3"
 
 [workspace.package]
-version = "1.25.0"
+version = "1.25.1"
 edition = "2024"
 authors = ["@jdx"]
 license = "MIT"
@@ -110,7 +110,7 @@ name = "fnox"
 path = "src/main.rs"
 
 [dependencies]
-fnox-core = { path = "crates/fnox-core", version = "1.25.0" }
+fnox-core = { path = "crates/fnox-core", version = "1.25.1" }
 
 # Direct dependencies of the CLI binary (commands, MCP server, TUI, hook-env,
 # shell integration). Provider/config/secret-resolver crates are pulled in

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -1593,7 +1593,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.25.0",
+  "version": "1.25.1",
   "usage": "Usage: fnox [OPTIONS] <COMMAND>",
   "complete": {
     "key": {

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -4,7 +4,7 @@
 
 **Usage**: `fnox [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.25.0
+**Version**: 1.25.1
 
 - **Usage**: `fnox [FLAGS] <SUBCOMMAND>`
 

--- a/fnox.usage.kdl
+++ b/fnox.usage.kdl
@@ -1,7 +1,7 @@
 min_usage_version "1.3"
 name fnox
 bin fnox
-version "1.25.0"
+version "1.25.1"
 about "A flexible secret management tool by @jdx"
 usage "Usage: fnox [OPTIONS] <COMMAND>"
 flag "-c --config" help="Path to the configuration file (default: fnox.toml, searches parent directories)" global=#true default=fnox.toml {


### PR DESCRIPTION
### 🔍 Other Changes

- **(ci)** add PR autocloser by [@jdx](https://github.com/jdx) in [#490](https://github.com/jdx/fnox/pull/490)
- **(release-plz)** use crates.io trusted publishing by [@jdx](https://github.com/jdx) in [#491](https://github.com/jdx/fnox/pull/491)

### 📦️ Dependency Updates

- update keepass to 0.12 and migrate provider to new API by [@jdx](https://github.com/jdx) in [#494](https://github.com/jdx/fnox/pull/494)
- migrate from keyring v3 to keyring-core v1 by [@jdx](https://github.com/jdx) in [#493](https://github.com/jdx/fnox/pull/493)