### PR TITLE
chore(deps): migrate from keyring v3 to keyring-core v1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,6 +239,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "apple-native-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7be2f067ccd8d4b4d4a66ddafe0f32a5dff31732f32dbff85fefc40929b1f72"
+dependencies = [
+ "keyring-core",
+ "log",
+ "security-framework",
+]
+
+[[package]]
 name = "arboard"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1570,16 +1581,6 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -1874,8 +1875,27 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
 dependencies = [
+ "aes 0.8.4",
+ "block-padding 0.3.3",
+ "cbc 0.1.2",
  "dbus",
+ "fastrand",
+ "hkdf 0.12.4",
+ "num",
+ "once_cell",
+ "openssl",
+ "sha2 0.10.9",
  "zeroize",
+]
+
+[[package]]
+name = "dbus-secret-service-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21d8f54da401bb5eb2a4d873ac4b359f4a599df2ca8634bb5b8c045e5ee78757"
+dependencies = [
+ "dbus-secret-service",
+ "keyring-core",
 ]
 
 [[package]]
@@ -2428,6 +2448,7 @@ version = "1.25.0"
 dependencies = [
  "aes-gcm 0.11.0-rc.3",
  "age",
+ "apple-native-keyring-store",
  "arc-swap",
  "async-trait",
  "atty",
@@ -2446,6 +2467,7 @@ dependencies = [
  "clap",
  "ctap-hid-fido2",
  "dbus",
+ "dbus-secret-service-keyring-store",
  "demand",
  "dirs",
  "fslock",
@@ -2458,7 +2480,7 @@ dependencies = [
  "indexmap 2.14.0",
  "jsonwebtoken 10.4.0",
  "keepass",
- "keyring",
+ "keyring-core",
  "libloading",
  "miette",
  "openssl-sys",
@@ -2484,6 +2506,7 @@ dependencies = [
  "tracing",
  "urlencoding",
  "which",
+ "windows-native-keyring-store",
  "xx",
 ]
 
@@ -3981,18 +4004,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "keyring"
-version = "3.6.3"
+name = "keyring-core"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+checksum = "fb1e621458ca9c51aa110bd0339d4751a056b9576bf1253aee1aa560dda0fc9d"
 dependencies = [
- "byteorder",
- "dbus-secret-service",
  "log",
- "security-framework 2.11.1",
- "security-framework 3.7.0",
- "windows-sys 0.60.2",
- "zeroize",
 ]
 
 [[package]]
@@ -4249,7 +4266,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework 3.7.0",
+ "security-framework",
  "security-framework-sys",
  "tempfile",
 ]
@@ -5787,7 +5804,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.7.0",
+ "security-framework",
 ]
 
 [[package]]
@@ -5815,7 +5832,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "jni",
  "log",
@@ -5824,7 +5841,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.103.13",
- "security-framework 3.7.0",
+ "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -6012,25 +6029,12 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags 2.11.1",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.11.1",
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -7938,6 +7942,19 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-native-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5fd986f648459dd29aa252ed3a5ad11a60c0b1251bf81625fb03a86c69d274e"
+dependencies = [
+ "byteorder",
+ "keyring-core",
+ "regex",
+ "windows-sys 0.61.2",
+ "zeroize",
+]
 
 [[package]]
 name = "windows-numerics"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,10 @@ hkdf = "0.13"
 indexmap = { version = "2", features = ["serde"] }
 jsonwebtoken = { version = "10", features = ["aws_lc_rs"] }
 keepass = { version = "0.12", features = ["save_kdbx4"] }
-keyring = { version = "3", features = ["apple-native", "windows-native", "sync-secret-service"] }
+keyring-core = "1"
+apple-native-keyring-store = { version = "1", features = ["keychain"] }
+windows-native-keyring-store = "1"
+dbus-secret-service-keyring-store = { version = "1", features = ["crypto-rust", "vendored"] }
 libloading = "0.9"
 miette = { version = "7", features = ["fancy"] }
 miniz_oxide = "0.9"

--- a/crates/fnox-core/Cargo.toml
+++ b/crates/fnox-core/Cargo.toml
@@ -40,7 +40,7 @@ hkdf = { workspace = true }
 indexmap = { workspace = true }
 jsonwebtoken = { workspace = true }
 keepass = { workspace = true }
-keyring = { workspace = true }
+keyring-core = { workspace = true }
 libloading = { workspace = true }
 miette = { workspace = true }
 pluralizer = { workspace = true }
@@ -72,7 +72,14 @@ ctap-hid-fido2 = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 dbus = { workspace = true }
+dbus-secret-service-keyring-store = { workspace = true }
 openssl-sys = { workspace = true }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+apple-native-keyring-store = { workspace = true }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+windows-native-keyring-store = { workspace = true }
 
 [build-dependencies]
 indexmap = { workspace = true }

--- a/crates/fnox-core/src/keyring_store.rs
+++ b/crates/fnox-core/src/keyring_store.rs
@@ -1,0 +1,42 @@
+//! Initialize the keyring-core default credential store once per process.
+//!
+//! `keyring-core` (the v4 successor to the old `keyring` crate) no longer
+//! auto-selects a platform store via cargo features. Clients have to register
+//! a store with `set_default_store` before creating any `Entry`. This module
+//! does that lazily on first use so both the keychain provider and the
+//! github_oauth lease backend can call `init()` without worrying about order.
+
+use std::sync::Once;
+
+static INIT: Once = Once::new();
+
+pub fn init() {
+    INIT.call_once(|| {
+        if let Err(e) = try_init() {
+            tracing::warn!("Failed to initialize OS keyring store: {e}");
+        }
+    });
+}
+
+#[cfg(target_os = "macos")]
+fn try_init() -> keyring_core::Result<()> {
+    keyring_core::set_default_store(apple_native_keyring_store::keychain::Store::new()?);
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+fn try_init() -> keyring_core::Result<()> {
+    keyring_core::set_default_store(windows_native_keyring_store::Store::new()?);
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn try_init() -> keyring_core::Result<()> {
+    keyring_core::set_default_store(dbus_secret_service_keyring_store::Store::new()?);
+    Ok(())
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+fn try_init() -> keyring_core::Result<()> {
+    Ok(())
+}

--- a/crates/fnox-core/src/keyring_store.rs
+++ b/crates/fnox-core/src/keyring_store.rs
@@ -6,16 +6,25 @@
 //! does that lazily on first use so both the keychain provider and the
 //! github_oauth lease backend can call `init()` without worrying about order.
 
-use std::sync::Once;
+use std::sync::Mutex;
 
-static INIT: Once = Once::new();
+// Only flips to `true` once `try_init` succeeds. A `Mutex<bool>` (rather than
+// `std::sync::Once`) lets a transient failure — e.g. D-Bus not yet ready on
+// Linux — be retried on the next call instead of being latched in for the
+// process lifetime.
+static INITIALIZED: Mutex<bool> = Mutex::new(false);
 
-pub fn init() {
-    INIT.call_once(|| {
-        if let Err(e) = try_init() {
-            tracing::warn!("Failed to initialize OS keyring store: {e}");
-        }
-    });
+pub(crate) fn init() {
+    let mut done = INITIALIZED
+        .lock()
+        .expect("keyring store init mutex poisoned");
+    if *done {
+        return;
+    }
+    match try_init() {
+        Ok(()) => *done = true,
+        Err(e) => tracing::warn!("Failed to initialize OS keyring store: {e}"),
+    }
 }
 
 #[cfg(target_os = "macos")]

--- a/crates/fnox-core/src/lease_backends/github_oauth.rs
+++ b/crates/fnox-core/src/lease_backends/github_oauth.rs
@@ -2,7 +2,7 @@ use crate::error::{FnoxError, Result};
 use crate::lease_backends::{Lease, LeaseBackend};
 use async_trait::async_trait;
 use indexmap::IndexMap;
-use keyring::Entry;
+use keyring_core::Entry;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
@@ -109,6 +109,7 @@ impl GitHubOauthBackend {
     }
 
     fn keyring_entry(&self) -> Result<Entry> {
+        crate::keyring_store::init();
         Entry::new(&self.keyring_service, &self.cache_key()).map_err(|e| {
             FnoxError::ProviderApiError {
                 provider: PROVIDER.to_string(),

--- a/crates/fnox-core/src/lib.rs
+++ b/crates/fnox-core/src/lib.rs
@@ -13,7 +13,7 @@ pub mod config;
 pub mod env;
 pub mod error;
 pub mod http;
-pub mod keyring_store;
+pub(crate) mod keyring_store;
 pub mod lease;
 pub mod lease_backends;
 pub mod library;

--- a/crates/fnox-core/src/lib.rs
+++ b/crates/fnox-core/src/lib.rs
@@ -13,6 +13,7 @@ pub mod config;
 pub mod env;
 pub mod error;
 pub mod http;
+pub mod keyring_store;
 pub mod lease;
 pub mod lease_backends;
 pub mod library;

--- a/crates/fnox-core/src/providers/keychain.rs
+++ b/crates/fnox-core/src/providers/keychain.rs
@@ -104,6 +104,12 @@ impl crate::providers::Provider for KeychainProvider {
                 hint: "Check that the keychain is unlocked and accessible".to_string(),
                 url: "https://fnox.jdx.dev/providers/keychain".to_string(),
             },
+            keyring_core::Error::NoDefaultStore => FnoxError::ProviderAuthFailed {
+                provider: "Keychain".to_string(),
+                details: e.to_string(),
+                hint: platform_backend_hint().to_string(),
+                url: "https://fnox.jdx.dev/providers/keychain".to_string(),
+            },
             _ => FnoxError::ProviderApiError {
                 provider: "Keychain".to_string(),
                 details: e.to_string(),
@@ -157,6 +163,27 @@ impl crate::providers::Provider for KeychainProvider {
         self.put_secret(key, value).await?;
         // Return the key name to store in config
         Ok(key.to_string())
+    }
+}
+
+fn platform_backend_hint() -> &'static str {
+    #[cfg(target_os = "linux")]
+    {
+        "No OS keyring backend is available. Start a Secret Service provider \
+         (e.g. gnome-keyring or KeePassXC) and make sure DBUS_SESSION_BUS_ADDRESS \
+         is set."
+    }
+    #[cfg(target_os = "macos")]
+    {
+        "Failed to initialize the macOS Keychain backend."
+    }
+    #[cfg(target_os = "windows")]
+    {
+        "Failed to initialize the Windows Credential Manager backend."
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+    {
+        "The keychain provider is not supported on this platform."
     }
 }
 

--- a/crates/fnox-core/src/providers/keychain.rs
+++ b/crates/fnox-core/src/providers/keychain.rs
@@ -147,7 +147,7 @@ impl crate::providers::Provider for KeychainProvider {
                 url: "https://fnox.jdx.dev/providers/keychain".to_string(),
             })?;
 
-        // Clean up the test entry (delete_credential in keyring v3)
+        // Clean up the test entry
         let _ = entry.delete_credential();
 
         Ok(())

--- a/crates/fnox-core/src/providers/keychain.rs
+++ b/crates/fnox-core/src/providers/keychain.rs
@@ -1,6 +1,6 @@
 use crate::error::{FnoxError, Result};
 use async_trait::async_trait;
-use keyring::Entry;
+use keyring_core::Entry;
 
 pub fn env_dependencies() -> &'static [&'static str] {
     &[]
@@ -26,6 +26,7 @@ impl KeychainProvider {
 
     /// Create a keyring entry
     fn create_entry(&self, key: &str) -> Result<Entry> {
+        crate::keyring_store::init();
         let full_key = self.build_key_name(key);
         Entry::new(&self.service, &full_key).map_err(|e| FnoxError::ProviderApiError {
             provider: "Keychain".to_string(),
@@ -87,45 +88,31 @@ impl crate::providers::Provider for KeychainProvider {
             self.service
         );
 
-        entry.get_password().map_err(|e| {
-            let err_str = e.to_string();
-            // keyring errors can be: NoEntry, NoStorageAccess, PlatformFailure, etc.
-            // Linux Secret Service returns "No matching entry found in secure storage"
-            if err_str.contains("No entry")
-                || err_str.contains("No matching entry")
-                || err_str.contains("not found")
-                || err_str.contains("ItemNotFound")
-            {
-                FnoxError::ProviderSecretNotFound {
-                    provider: "Keychain".to_string(),
-                    secret: full_key.clone(),
-                    hint: format!(
-                        "Check that the secret exists in the keychain (service: '{}')",
-                        self.service
-                    ),
-                    url: "https://fnox.jdx.dev/providers/keychain".to_string(),
-                }
-            } else if err_str.contains("access")
-                || err_str.contains("permission")
-                || err_str.contains("locked")
-            {
-                FnoxError::ProviderAuthFailed {
-                    provider: "Keychain".to_string(),
-                    details: err_str,
-                    hint: "Check that the keychain is unlocked and accessible".to_string(),
-                    url: "https://fnox.jdx.dev/providers/keychain".to_string(),
-                }
-            } else {
-                FnoxError::ProviderApiError {
-                    provider: "Keychain".to_string(),
-                    details: err_str,
-                    hint: format!(
-                        "Failed to get secret from keychain (service: '{}')",
-                        self.service
-                    ),
-                    url: "https://fnox.jdx.dev/providers/keychain".to_string(),
-                }
-            }
+        entry.get_password().map_err(|e| match e {
+            keyring_core::Error::NoEntry => FnoxError::ProviderSecretNotFound {
+                provider: "Keychain".to_string(),
+                secret: full_key.clone(),
+                hint: format!(
+                    "Check that the secret exists in the keychain (service: '{}')",
+                    self.service
+                ),
+                url: "https://fnox.jdx.dev/providers/keychain".to_string(),
+            },
+            keyring_core::Error::NoStorageAccess(_) => FnoxError::ProviderAuthFailed {
+                provider: "Keychain".to_string(),
+                details: e.to_string(),
+                hint: "Check that the keychain is unlocked and accessible".to_string(),
+                url: "https://fnox.jdx.dev/providers/keychain".to_string(),
+            },
+            _ => FnoxError::ProviderApiError {
+                provider: "Keychain".to_string(),
+                details: e.to_string(),
+                hint: format!(
+                    "Failed to get secret from keychain (service: '{}')",
+                    self.service
+                ),
+                url: "https://fnox.jdx.dev/providers/keychain".to_string(),
+            },
         })
     }
 

--- a/crates/fnox-core/src/providers/keychain.rs
+++ b/crates/fnox-core/src/providers/keychain.rs
@@ -28,14 +28,26 @@ impl KeychainProvider {
     fn create_entry(&self, key: &str) -> Result<Entry> {
         crate::keyring_store::init();
         let full_key = self.build_key_name(key);
-        Entry::new(&self.service, &full_key).map_err(|e| FnoxError::ProviderApiError {
-            provider: "Keychain".to_string(),
-            details: format!(
-                "Failed to create entry for service '{}', key '{}': {}",
-                self.service, full_key, e
-            ),
-            hint: "Check that the keychain is accessible".to_string(),
-            url: "https://fnox.jdx.dev/providers/keychain".to_string(),
+        Entry::new(&self.service, &full_key).map_err(|e| match e {
+            // `Entry::new` itself fails with `NoDefaultStore` when the platform
+            // backend couldn't be registered (e.g. headless Linux without
+            // Secret Service). Surface a backend-specific hint here, since the
+            // call never reaches `get_password`/`set_password`.
+            keyring_core::Error::NoDefaultStore => FnoxError::ProviderAuthFailed {
+                provider: "Keychain".to_string(),
+                details: e.to_string(),
+                hint: platform_backend_hint().to_string(),
+                url: "https://fnox.jdx.dev/providers/keychain".to_string(),
+            },
+            _ => FnoxError::ProviderApiError {
+                provider: "Keychain".to_string(),
+                details: format!(
+                    "Failed to create entry for service '{}', key '{}': {}",
+                    self.service, full_key, e
+                ),
+                hint: "Check that the keychain is accessible".to_string(),
+                url: "https://fnox.jdx.dev/providers/keychain".to_string(),
+            },
         })
     }
 
@@ -102,12 +114,6 @@ impl crate::providers::Provider for KeychainProvider {
                 provider: "Keychain".to_string(),
                 details: e.to_string(),
                 hint: "Check that the keychain is unlocked and accessible".to_string(),
-                url: "https://fnox.jdx.dev/providers/keychain".to_string(),
-            },
-            keyring_core::Error::NoDefaultStore => FnoxError::ProviderAuthFailed {
-                provider: "Keychain".to_string(),
-                details: e.to_string(),
-                hint: platform_backend_hint().to_string(),
                 url: "https://fnox.jdx.dev/providers/keychain".to_string(),
             },
             _ => FnoxError::ProviderApiError {


### PR DESCRIPTION
## Summary

The upstream `keyring` crate v4 is now just a CLI/sample app — the library moved to a new `keyring-core` crate plus per-platform credential-store crates. This is the proper migration in response to Renovate PR #470, which is just a version bump and breaks the build.

### What changed

- Replace the `keyring` workspace dep with:
  - `keyring-core = "1"`
  - `apple-native-keyring-store` (with the `keychain` feature) — macOS only, target-conditional
  - `windows-native-keyring-store` — Windows only, target-conditional
  - `dbus-secret-service-keyring-store` (with `crypto-rust` + `vendored`) — Linux only, target-conditional
- New `fnox_core::keyring_store::init()` lazily calls `keyring_core::set_default_store` once per process via `std::sync::Once`. Both the keychain provider and the github-oauth lease backend invoke it before creating an `Entry`.
- `get_password` error classification now matches on the proper `keyring_core::Error::{NoEntry, NoStorageAccess(_)}` enum variants instead of string-matching.

### Notes

- No public config or CLI surface changes — the `keychain` provider and `github_oauth` lease backend keep the same TOML fields and behavior.
- Closes #470 (Renovate's blind v3→v4 bump).

## Test plan

- [x] `cargo build` clean on Linux
- [x] `cargo clippy --workspace --all-targets` clean
- [x] `cargo test --lib` — only pre-existing failure is the keychain integration test, which fails the same way on `main` due to local Secret Service quirks; CI should be green
- [ ] CI builds on macOS, Linux, Windows
- [ ] Smoke test: `fnox set` / `fnox get` against a `keychain` provider on a real machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OS credential storage setup and error handling; misconfiguration or platform-specific store init issues could break keychain-backed providers or token caching on some environments.
> 
> **Overview**
> Migrates from `keyring` v3 to `keyring-core` v1, switching dependencies to explicit per-OS store crates (macOS Keychain, Windows Credential Manager, Linux Secret Service) and updating the lockfile accordingly.
> 
> Adds `fnox-core` `keyring_store::init()` to register a default store on first use, and wires it into both the `keychain` provider and the `github_oauth` lease backend before creating `Entry`s.
> 
> Updates keychain error handling to use `keyring_core::Error` variants (e.g., `NoDefaultStore`, `NoEntry`, `NoStorageAccess`) instead of string matching, including more platform-specific hints when no backend is available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a616ec6855b1b2c444373331ea06f7c27211746f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->