### PR TITLE
fix(keychain): run blocking calls on spawn_blocking; batch serially

### DIFF
--- a/crates/fnox-core/src/providers/keychain.rs
+++ b/crates/fnox-core/src/providers/keychain.rs
@@ -1,6 +1,7 @@
 use crate::error::{FnoxError, Result};
 use async_trait::async_trait;
 use keyring_core::Entry;
+use std::collections::HashMap;
 
 pub fn env_dependencies() -> &'static [&'static str] {
     &[]
@@ -51,10 +52,17 @@ impl KeychainProvider {
         })
     }
 
-    /// Store a secret in the OS keychain
+    /// Store a secret in the OS keychain.
+    ///
+    /// The underlying `keyring-core` call is synchronous and on macOS may
+    /// present a Security framework dialog that blocks until the user
+    /// responds. We run it on a blocking thread pool so the tokio runtime
+    /// keeps making progress (and so concurrent calls don't pin every worker
+    /// thread).
     pub async fn put_secret(&self, key: &str, value: &str) -> Result<()> {
         let entry = self.create_entry(key)?;
         let full_key = self.build_key_name(key);
+        let service = self.service.clone();
 
         tracing::debug!(
             "Storing secret '{}' in OS keychain (service: '{}', key: '{}')",
@@ -63,13 +71,16 @@ impl KeychainProvider {
             full_key
         );
 
-        entry
-            .set_password(value)
+        let value = value.to_string();
+        let set_full_key = full_key.clone();
+        let set_service = service.clone();
+        spawn_keychain_blocking(move || entry.set_password(&value))
+            .await?
             .map_err(|e| FnoxError::ProviderApiError {
                 provider: "Keychain".to_string(),
                 details: format!(
                     "Failed to store secret '{}' (service: '{}'): {}",
-                    full_key, self.service, e
+                    set_full_key, set_service, e
                 ),
                 hint: "Check that the keychain is accessible and writable".to_string(),
                 url: "https://fnox.jdx.dev/providers/keychain".to_string(),
@@ -93,76 +104,85 @@ impl crate::providers::Provider for KeychainProvider {
     async fn get_secret(&self, value: &str) -> Result<String> {
         let entry = self.create_entry(value)?;
         let full_key = self.build_key_name(value);
+        let service = self.service.clone();
 
         tracing::debug!(
             "Getting secret '{}' from OS keychain (service: '{}')",
             full_key,
-            self.service
+            service
         );
 
-        entry.get_password().map_err(|e| match e {
-            keyring_core::Error::NoEntry => FnoxError::ProviderSecretNotFound {
-                provider: "Keychain".to_string(),
-                secret: full_key.clone(),
-                hint: format!(
-                    "Check that the secret exists in the keychain (service: '{}')",
-                    self.service
-                ),
-                url: "https://fnox.jdx.dev/providers/keychain".to_string(),
-            },
-            keyring_core::Error::NoStorageAccess(_) => FnoxError::ProviderAuthFailed {
-                provider: "Keychain".to_string(),
-                details: e.to_string(),
-                hint: "Check that the keychain is unlocked and accessible".to_string(),
-                url: "https://fnox.jdx.dev/providers/keychain".to_string(),
-            },
-            _ => FnoxError::ProviderApiError {
-                provider: "Keychain".to_string(),
-                details: e.to_string(),
-                hint: format!(
-                    "Failed to get secret from keychain (service: '{}')",
-                    self.service
-                ),
-                url: "https://fnox.jdx.dev/providers/keychain".to_string(),
-            },
-        })
+        spawn_keychain_blocking(move || entry.get_password())
+            .await?
+            .map_err(|e| match e {
+                keyring_core::Error::NoEntry => FnoxError::ProviderSecretNotFound {
+                    provider: "Keychain".to_string(),
+                    secret: full_key.clone(),
+                    hint: format!(
+                        "Check that the secret exists in the keychain (service: '{}')",
+                        service
+                    ),
+                    url: "https://fnox.jdx.dev/providers/keychain".to_string(),
+                },
+                keyring_core::Error::NoStorageAccess(_) => FnoxError::ProviderAuthFailed {
+                    provider: "Keychain".to_string(),
+                    details: e.to_string(),
+                    hint: "Check that the keychain is unlocked and accessible".to_string(),
+                    url: "https://fnox.jdx.dev/providers/keychain".to_string(),
+                },
+                _ => FnoxError::ProviderApiError {
+                    provider: "Keychain".to_string(),
+                    details: e.to_string(),
+                    hint: format!(
+                        "Failed to get secret from keychain (service: '{}')",
+                        service
+                    ),
+                    url: "https://fnox.jdx.dev/providers/keychain".to_string(),
+                },
+            })
+    }
+
+    /// Override the default parallel `get_secrets_batch` to fetch keychain
+    /// entries sequentially.
+    ///
+    /// The OS keychain API is synchronous and can pop a confirmation dialog
+    /// per access. Running them concurrently would surface several
+    /// overlapping dialogs and — once the number of secrets reaches the
+    /// tokio worker-thread count — would also deadlock the runtime even with
+    /// `spawn_blocking`, since the runtime still needs at least one free
+    /// thread to drive completions.
+    async fn get_secrets_batch(
+        &self,
+        secrets: &[(String, String)],
+    ) -> HashMap<String, Result<String>> {
+        let mut results = HashMap::with_capacity(secrets.len());
+        for (key, value) in secrets {
+            results.insert(key.clone(), self.get_secret(value).await);
+        }
+        results
     }
 
     async fn test_connection(&self) -> Result<()> {
         // Try to create an entry with a test key to verify keychain access
         let test_key = "__fnox_test__";
         let entry = self.create_entry(test_key)?;
+        let service = self.service.clone();
 
-        // Try to set a test value to verify we have keychain access
-        entry
-            .set_password("test")
-            .map_err(|e| FnoxError::ProviderAuthFailed {
-                provider: "Keychain".to_string(),
-                details: format!(
-                    "Failed to access keychain (service: '{}'): {}",
-                    self.service, e
-                ),
-                hint: "Check that you have permission to access the OS keychain".to_string(),
-                url: "https://fnox.jdx.dev/providers/keychain".to_string(),
-            })?;
-
-        // Try to read it back to verify it worked
-        entry
-            .get_password()
-            .map_err(|e| FnoxError::ProviderAuthFailed {
-                provider: "Keychain".to_string(),
-                details: format!(
-                    "Failed to verify keychain access (service: '{}'): {}",
-                    self.service, e
-                ),
-                hint: "Check that you have permission to access the OS keychain".to_string(),
-                url: "https://fnox.jdx.dev/providers/keychain".to_string(),
-            })?;
-
-        // Clean up the test entry
-        let _ = entry.delete_credential();
-
-        Ok(())
+        // Run all three blocking operations on a single background thread to
+        // avoid hopping through the runtime three times.
+        spawn_keychain_blocking(move || {
+            entry.set_password("test")?;
+            entry.get_password()?;
+            let _ = entry.delete_credential();
+            Ok(())
+        })
+        .await?
+        .map_err(|e: keyring_core::Error| FnoxError::ProviderAuthFailed {
+            provider: "Keychain".to_string(),
+            details: format!("Failed to access keychain (service: '{service}'): {e}"),
+            hint: "Check that you have permission to access the OS keychain".to_string(),
+            url: "https://fnox.jdx.dev/providers/keychain".to_string(),
+        })
     }
 
     async fn put_secret(&self, key: &str, value: &str) -> Result<String> {
@@ -170,6 +190,26 @@ impl crate::providers::Provider for KeychainProvider {
         // Return the key name to store in config
         Ok(key.to_string())
     }
+}
+
+/// Run a blocking keyring call on tokio's blocking thread pool.
+///
+/// The OS keychain APIs are synchronous and may present a system dialog that
+/// blocks until the user responds. Calling them directly on a tokio worker
+/// thread pins that thread — concurrent calls can deadlock the runtime.
+async fn spawn_keychain_blocking<F, T>(f: F) -> Result<T>
+where
+    F: FnOnce() -> T + Send + 'static,
+    T: Send + 'static,
+{
+    tokio::task::spawn_blocking(f)
+        .await
+        .map_err(|e| FnoxError::ProviderApiError {
+            provider: "Keychain".to_string(),
+            details: format!("Keychain task failed to complete: {e}"),
+            hint: "This is a bug; please report it".to_string(),
+            url: "https://fnox.jdx.dev/providers/keychain".to_string(),
+        })
 }
 
 fn platform_backend_hint() -> &'static str {

--- a/docs/providers/keychain.md
+++ b/docs/providers/keychain.md
@@ -114,6 +114,33 @@ fnox get DATABASE_URL
 fnox exec -- npm run dev
 ```
 
+## Recommended: Use With Age, Not As Bulk Storage
+
+The OS keychain is designed for **a few** long-lived secrets, not as the storage backend for every secret in a project. On macOS in particular, the system pops a Security dialog the first time each application accesses each keychain item — so if you store ten secrets directly in the keychain, you'll get up to ten "Always Allow / Allow / Deny" prompts the first time `fnox exec` runs.
+
+The pattern that scales much better is to store a single **age private key** in the keychain and encrypt all your secrets with age:
+
+```toml
+[providers]
+keychain = { type = "keychain", service = "fnox" }
+age = { type = "age", recipients = ["age1..."], identity = { provider = "keychain", value = "age-key" } }
+
+[secrets]
+# Many secrets, all encrypted with age — only one keychain access (the age key)
+DATABASE_URL = { provider = "age", value = "encrypted..." }
+API_KEY      = { provider = "age", value = "encrypted..." }
+STRIPE_KEY   = { provider = "age", value = "encrypted..." }
+# ...
+```
+
+This way:
+
+- **One keychain item, one dialog.** Hitting "Always Allow" once authorizes the age key for that machine.
+- Adding more secrets is free — they go into the encrypted config, not into the keychain.
+- Loss of the keychain item is recoverable from any other machine that holds the same age identity.
+
+Reach for direct `provider = "keychain"` only for the handful of bootstrap secrets that don't have anything else to decrypt them (e.g., the age key itself, an OP service account token).
+
 ## Bootstrap Pattern
 
 A common pattern is to store provider tokens in the keychain:


### PR DESCRIPTION
## Summary

Follow-up to #493 addressing the deadlock and multi-dialog UX described in [discussion #489](https://github.com/jdx/fnox/discussions/489).

> When multiple secrets use the keychain provider and the macOS security dialog hasn't been permanently authorized ("Always Allow"), fnox hangs indefinitely. Up to 10 security dialogs appear simultaneously, and the tokio async runtime deadlocks because all worker threads are blocked waiting for user interaction.

### What changed

- **`spawn_blocking` for every blocking keyring call.** A new `spawn_keychain_blocking` helper hands `set_password` / `get_password` / `delete_credential` to tokio's blocking thread pool. Previously these ran directly on a tokio worker thread, so an unresponsive Security-framework dialog could pin a worker and a handful could deadlock the runtime.
- **Override `get_secrets_batch` with a serial loop.** The default fans out 10 concurrent reads. On macOS that surfaces up to 10 overlapping security dialogs and can starve every worker thread at once. Serial resolution presents one dialog at a time and keeps the runtime responsive.

### Notes

- Based on `feat/keyring-v4-migration` (#493) so the file context matches the new `keyring-core` API. Will retarget to `main` if #493 lands first.
- The inherent `KeychainProvider::put_secret` is also routed through `spawn_blocking`, so `fnox set` against the keychain stops blocking the runtime too.
- `test_connection` does set + get + delete inside a single blocking task to keep the round trip cheap.

## Test plan

- [x] `cargo build` clean
- [x] `cargo clippy --workspace --all-targets` clean
- [x] `cargo test --lib -p fnox-core` — 169 pass, 1 pre-existing local-env failure (`test_keychain_set_and_get`) unchanged from main
- [ ] CI green
- [ ] On a fresh macOS keychain (or after `tccutil reset`), `fnox exec` with several keychain-backed secrets produces dialogs one at a time and remains Ctrl-C responsive

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes keychain provider concurrency/threading behavior; while localized, it affects secret retrieval/storage timing and could surface new blocking-task errors or performance regressions on large secret sets.
> 
> **Overview**
> Prevents `KeychainProvider` from pinning tokio worker threads by running all `keyring-core` calls (`get_password`, `set_password`, `delete_credential`) via a new `spawn_keychain_blocking` helper and improving associated error messages.
> 
> Overrides `get_secrets_batch` for the keychain provider to resolve entries **sequentially** (instead of the default parallel fan-out) to avoid overlapping OS security dialogs and runtime deadlocks.
> 
> Updates keychain provider docs to recommend using the OS keychain only for a small bootstrap secret (e.g., an age identity) and keeping bulk secrets encrypted with `age`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e22ac3095eab31242b2f48a2f3a0cc4e9eda70e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->