### PR TITLE
chore(release-plz): drop cargo update from release PR

### DIFF
--- a/mise-tasks/release-plz
+++ b/mise-tasks/release-plz
@@ -42,7 +42,6 @@ cargo set-version --workspace "${version#v}"
 
 git config user.name mise-en-dev
 git config user.email 123107610+mise-en-dev@users.noreply.github.com
-cargo update
 mise run render ::: lint-fix
 
 # Generate changelog using git-cliff (LLM editorialization happens in release.yml after merge)


### PR DESCRIPTION
## Summary

Remove `cargo update` from `mise-tasks/release-plz` so the release PR only contains the version bump + changelog refresh.

## Why

- Dependency churn is unrelated to the release and makes release diffs noisy.
- A release shouldn't quietly pick up a fresh transitive dep that no one explicitly reviewed.
- Renovate already opens dependency-update PRs that get triaged on their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only removes the `cargo update` step from the release automation, reducing dependency-lockfile churn without affecting build or publish logic.
> 
> **Overview**
> Release PR automation in `mise-tasks/release-plz` no longer runs `cargo update` when preparing a release branch.
> 
> As a result, release PRs should contain only the workspace version bump, regenerated artifacts/lint fixes, and the refreshed `CHANGELOG.md`, avoiding unreviewed transitive dependency changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f252419a2f11c0a7c6061d31288c8238b4adc82b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->