### PR TITLE
chore(deps): refresh mise lock attestations

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -344,7 +344,6 @@ url_api = "https://api.github.com/repos/Infisical/cli/releases/assets/398851172"
 checksum = "sha256:a9dbb398ba6538c4583b418854df8b6f3dd2c2fc6c7592042fbfc1f49de97b41"
 url = "https://github.com/Infisical/cli/releases/download/v0.43.76/cli_0.43.76_linux_amd64.tar.gz"
 url_api = "https://api.github.com/repos/Infisical/cli/releases/assets/398851234"
-github_attestations = "unavailable"
 
 [tools.infisical."platforms.linux-x64-musl"]
 checksum = "sha256:a9dbb398ba6538c4583b418854df8b6f3dd2c2fc6c7592042fbfc1f49de97b41"
@@ -355,7 +354,6 @@ url_api = "https://api.github.com/repos/Infisical/cli/releases/assets/398851234"
 checksum = "sha256:a3a38a34ca32822beb59d6ef9458e29b39611e42ac3aa149575beea1172252aa"
 url = "https://github.com/Infisical/cli/releases/download/v0.43.76/cli_0.43.76_darwin_arm64.tar.gz"
 url_api = "https://api.github.com/repos/Infisical/cli/releases/assets/398851174"
-github_attestations = "unavailable"
 
 [tools.infisical."platforms.macos-x64"]
 checksum = "sha256:41f6b3c1a8b879ad564329f43f803436e2b3e8621d97c43e561e718dca767235"


### PR DESCRIPTION
## Summary
- refresh mise.lock after mise dropped stale Infisical github_attestations entries
- keep render output clean for CI

## Validation
- mise run render
- reran mise run render and confirmed git status stayed clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only metadata cleanup; Infisical download URLs and checksums are unchanged.
> 
> **Overview**
> Updates **`mise.lock`** so Infisical **linux-x64** and **macos-arm64** entries no longer carry stale **`github_attestations = "unavailable"`** lines after a **`mise lock`** refresh. **Checksums**, **URLs**, and **Infisical** version **0.43.76** are unchanged.
> 
> This is lockfile hygiene so **`mise run render`** stays idempotent and CI does not keep rewriting the lockfile for dropped attestation metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b5ed8fab496d8e04bdcd9829bf2997f82c53f0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->