### PR TITLE
docs: document BatchGetSecretValue IAM permission requirement

### DIFF
--- a/docs/providers/aws-sm.md
+++ b/docs/providers/aws-sm.md
@@ -43,7 +43,10 @@ fnox get DATABASE_URL
     {
       "Sid": "ListSecrets",
       "Effect": "Allow",
-      "Action": "secretsmanager:ListSecrets",
+      "Action": [
+        "secretsmanager:ListSecrets",
+        "secretsmanager:BatchGetSecretValue"
+      ],
       "Resource": "*"
     },
     {
@@ -59,8 +62,8 @@ fnox get DATABASE_URL
 }
 ```
 
-::: warning ListSecrets Permission
-The `secretsmanager:ListSecrets` action **must** use `"Resource": "*"` and cannot be scoped to specific ARNs.
+::: warning ListSecrets and BatchGetSecretValue Permissions
+The `secretsmanager:ListSecrets` and `secretsmanager:BatchGetSecretValue` actions **must** use `"Resource": "*"` and cannot be scoped to specific ARNs.
 :::
 
 ### Full Access (For Testing)
@@ -72,7 +75,10 @@ The `secretsmanager:ListSecrets` action **must** use `"Resource": "*"` and canno
     {
       "Sid": "ListSecretsPermission",
       "Effect": "Allow",
-      "Action": "secretsmanager:ListSecrets",
+      "Action": [
+        "secretsmanager:ListSecrets",
+        "secretsmanager:BatchGetSecretValue"
+      ],
       "Resource": "*"
     },
     {


### PR DESCRIPTION
It was introduced in 8f31cc8 but not documented

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated AWS Secrets Manager IAM policy examples with important corrections. Clarified that both `ListSecrets` and `BatchGetSecretValue` actions must be granted with wildcard resource permissions and cannot be limited to specific resource ARNs. Enhanced documentation callouts for proper implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->