### PR TITLE
fix: Respect $COLUMNS when not connected to a tty

### DIFF
--- a/crates/fnox-core/src/env.rs
+++ b/crates/fnox-core/src/env.rs
@@ -30,6 +30,15 @@ pub fn set_var<K: AsRef<OsStr>, V: AsRef<OsStr>>(key: K, val: V) {
     }
 }
 
+/// Remove an environment variable, serializing access via ENV_MUTEX.
+pub fn remove_var<K: AsRef<OsStr>>(key: K) {
+    let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+    // SAFETY: remove_var is unsafe in Rust 2024 edition. Access is serialized via ENV_MUTEX.
+    unsafe {
+        std::env::remove_var(key);
+    }
+}
+
 // Directory configuration
 pub static HOME_DIR: LazyLock<PathBuf> = LazyLock::new(|| dirs::home_dir().unwrap_or_default());
 pub static FNOX_CONFIG_DIR: LazyLock<PathBuf> = LazyLock::new(|| {
@@ -126,20 +135,18 @@ mod tests {
 
     #[test]
     fn test_var_path() {
-        unsafe {
-            set_var("FNOX_TEST_PATH", "/foo/bar");
-            assert_eq!(
-                var_path("FNOX_TEST_PATH").unwrap(),
-                PathBuf::from("/foo/bar")
-            );
-            // Empty values are treated as unset per XDG spec
-            set_var("FNOX_TEST_PATH", "");
-            assert_eq!(var_path("FNOX_TEST_PATH"), None);
-            // Relative paths are rejected per XDG spec
-            set_var("FNOX_TEST_PATH", "relative/path");
-            assert_eq!(var_path("FNOX_TEST_PATH"), None);
-            remove_var("FNOX_TEST_PATH");
-        }
+        set_var("FNOX_TEST_PATH", "/foo/bar");
+        assert_eq!(
+            var_path("FNOX_TEST_PATH").unwrap(),
+            PathBuf::from("/foo/bar")
+        );
+        // Empty values are treated as unset per XDG spec
+        set_var("FNOX_TEST_PATH", "");
+        assert_eq!(var_path("FNOX_TEST_PATH"), None);
+        // Relative paths are rejected per XDG spec
+        set_var("FNOX_TEST_PATH", "relative/path");
+        assert_eq!(var_path("FNOX_TEST_PATH"), None);
+        remove_var("FNOX_TEST_PATH");
     }
 
     #[test]

--- a/src/commands/hook_env.rs
+++ b/src/commands/hook_env.rs
@@ -300,6 +300,15 @@ fn cleanup_old_temp_files(
     }
 }
 
+/// Terminal width in columns: the TTY width when available, otherwise the
+/// COLUMNS environment variable (stderr is not a TTY when shell hooks capture
+/// it), otherwise 80.
+fn terminal_width(tty_width: Option<usize>) -> usize {
+    tty_width
+        .or_else(|| crate::env::var("COLUMNS").ok().and_then(|v| v.parse().ok()))
+        .unwrap_or(80)
+}
+
 /// Display a summary of environment changes
 fn display_changes(added: &[(String, String)], removed: &[String], mode: OutputMode) {
     use console::{Style, Term};
@@ -327,7 +336,7 @@ fn display_changes(added: &[(String, String)], removed: &[String], mode: OutputM
         }
     } else {
         // Normal mode: compact single-line summary with keys
-        let term_width = term.size().1 as usize;
+        let term_width = terminal_width(term.size_checked().map(|(_, w)| w as usize));
 
         let mut parts = Vec::new();
 
@@ -416,5 +425,29 @@ fn display_changes(added: &[(String, String)], removed: &[String], mode: OutputM
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_terminal_width_fallback() {
+        // TTY width wins regardless of COLUMNS
+        crate::env::set_var("COLUMNS", "120");
+        assert_eq!(terminal_width(Some(100)), 100);
+
+        // No TTY: fall back to COLUMNS
+        assert_eq!(terminal_width(None), 120);
+
+        // No TTY and unparseable COLUMNS: fall back to 80
+        crate::env::set_var("COLUMNS", "abc");
+        assert_eq!(terminal_width(None), 80);
+
+        // No TTY and no COLUMNS: fall back to 80
+        // SAFETY: serialized via ENV_MUTEX, same as set_var above.
+        crate::env::remove_var("COLUMNS");
+        assert_eq!(terminal_width(None), 80);
     }
 }

--- a/src/commands/hook_env.rs
+++ b/src/commands/hook_env.rs
@@ -446,7 +446,6 @@ mod tests {
         assert_eq!(terminal_width(None), 80);
 
         // No TTY and no COLUMNS: fall back to 80
-        // SAFETY: serialized via ENV_MUTEX, same as set_var above.
         crate::env::remove_var("COLUMNS");
         assert_eq!(terminal_width(None), 80);
     }

--- a/test/hook_env_columns.bats
+++ b/test/hook_env_columns.bats
@@ -1,0 +1,86 @@
+#!/usr/bin/env bats
+#
+# Test that hook-env falls back to the COLUMNS environment variable for
+# terminal width when stderr is not a TTY (the usual case in shell hooks)
+#
+
+setup() {
+	load 'test_helper/common_setup'
+	_common_setup
+
+	# Eight secrets with 20-char names: the full key list is ~174 chars wide
+	# root = true stops config recursion into parent directories (the test
+	# temp dir lives inside the fnox repo, which has its own fnox.toml)
+	cat >fnox.toml <<EOF
+root = true
+
+[providers.plain]
+type = "plain"
+
+[secrets.SECRET_AAAAAAAAAAAAA]
+provider = "plain"
+value = "value-a"
+
+[secrets.SECRET_BBBBBBBBBBBBB]
+provider = "plain"
+value = "value-b"
+
+[secrets.SECRET_CCCCCCCCCCCCC]
+provider = "plain"
+value = "value-c"
+
+[secrets.SECRET_DDDDDDDDDDDDD]
+provider = "plain"
+value = "value-d"
+
+[secrets.SECRET_EEEEEEEEEEEEE]
+provider = "plain"
+value = "value-e"
+
+[secrets.SECRET_FFFFFFFFFFFFF]
+provider = "plain"
+value = "value-f"
+
+[secrets.SECRET_GGGGGGGGGGGGG]
+provider = "plain"
+value = "value-g"
+
+[secrets.SECRET_HHHHHHHHHHHHH]
+provider = "plain"
+value = "value-h"
+EOF
+}
+
+teardown() {
+	_common_teardown
+}
+
+@test "hook-env summary uses COLUMNS when stderr is not a tty (wide)" {
+	# All 8 keys fit within 200 columns: no truncation
+	# Capture only the stderr summary line; stdout carries the shell code
+	run bash -c "COLUMNS=200 '$FNOX_BIN' hook-env -s bash 2>&1 >/dev/null"
+	assert_success
+	assert_output --partial "fnox: +8"
+	assert_output --partial "SECRET_AAAAAAAAAAAAA"
+	assert_output --partial "SECRET_HHHHHHHHHHHHH"
+	refute_output --partial "..."
+}
+
+@test "hook-env summary uses COLUMNS when stderr is not a tty (narrow)" {
+	# Only 2 of the 8 keys fit within 60 columns: the rest are truncated
+	# (key order in the summary is not deterministic, so count keys instead)
+	run bash -c "COLUMNS=60 '$FNOX_BIN' hook-env -s bash 2>&1 >/dev/null"
+	assert_success
+	assert_output --partial "fnox: +8"
+	assert_output --partial "..."
+	assert_equal "$(grep -o 'SECRET_' <<<"$output" | wc -l | tr -d ' ')" 2
+}
+
+@test "hook-env summary defaults to 80 columns without a tty or COLUMNS" {
+	# At the default of 80 columns only 3 of the 8 keys fit
+	run env -u COLUMNS bash -c "'$FNOX_BIN' hook-env -s bash 2>&1 >/dev/null"
+	assert_success
+	assert_output --partial "fnox: +8"
+	assert_output --partial "..."
+	assert_equal "$(grep -o 'SECRET_' <<<"$output" | wc -l | tr -d ' ')" 3
+}


### PR DESCRIPTION
When no tty is connected fnox now respects `$COLUMNS` or fallbacks to 80 which was the previous default.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Environment-change summaries now respect the COLUMNS setting when terminal size is unavailable and reliably fall back to an 80-column default for consistent truncation.

* **Tests**
  * Added tests verifying terminal-width detection and summary truncation across wide, narrow, and unset COLUMNS scenarios.

* **Chores**
  * Improved internal environment-variable handling for safer, more robust behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->