### PR TITLE
feat(provider): add vault credential command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2449,6 +2449,7 @@ dependencies = [
  "strsim",
  "strum 0.28.0",
  "tempfile",
+ "tera",
  "thiserror 2.0.18",
  "tokio",
  "toml_edit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ strsim = "0.11"
 strum = { version = "0.28", features = ["derive"] }
 tabled = { version = "0.20", features = ["ansi"] }
 tempfile = "3"
+tera = { version = "1", default-features = false }
 terminal_size = "0.4"
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }

--- a/crates/fnox-core/Cargo.toml
+++ b/crates/fnox-core/Cargo.toml
@@ -57,6 +57,7 @@ shellexpand = { workspace = true }
 strsim = { workspace = true }
 strum = { workspace = true }
 tempfile = { workspace = true }
+tera = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 toml_edit = { workspace = true }

--- a/crates/fnox-core/providers/vault.toml
+++ b/crates/fnox-core/providers/vault.toml
@@ -39,3 +39,4 @@ wizard = true
 type = "optional"
 placeholder = "vault login -method=oidc -token-only"
 label = "Credential command (optional):"
+wizard = true

--- a/crates/fnox-core/providers/vault.toml
+++ b/crates/fnox-core/providers/vault.toml
@@ -34,3 +34,8 @@ type = "optional"
 placeholder = ""
 label = "Namespace (optional, uses env var if not set):"
 wizard = true
+
+[fields.credential_command]
+type = "optional"
+placeholder = "vault login -method=oidc -token-only"
+label = "Credential command (optional):"

--- a/crates/fnox-core/src/credential_command.rs
+++ b/crates/fnox-core/src/credential_command.rs
@@ -1,10 +1,15 @@
 use crate::error::{FnoxError, Result};
 use serde_json::Value;
+use std::collections::HashMap;
+use std::sync::{LazyLock, Mutex};
 use std::time::Duration;
 use tera::{Context, Tera};
 use tokio::process::Command;
 
 pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+
+static CACHE: LazyLock<Mutex<HashMap<String, String>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
 
 pub async fn run(
     provider: &str,
@@ -23,6 +28,16 @@ pub async fn run(
             hint: "Check credential_command template syntax".to_string(),
             url: url.to_string(),
         })?;
+
+    let cache_key = cache_key(provider, &rendered, envs);
+    if let Some(token) = CACHE
+        .lock()
+        .expect("credential cache lock poisoned")
+        .get(&cache_key)
+    {
+        tracing::debug!("Using cached credential_command output for {provider}");
+        return Ok(token.clone());
+    }
 
     tracing::debug!("Running credential_command for {provider}");
 
@@ -73,7 +88,29 @@ pub async fn run(
         });
     }
 
+    CACHE
+        .lock()
+        .expect("credential cache lock poisoned")
+        .insert(cache_key, token.clone());
+
     Ok(token)
+}
+
+fn cache_key(provider: &str, command: &str, envs: &[(&str, String)]) -> String {
+    let mut envs = envs.to_vec();
+    envs.sort_by(|a, b| a.0.cmp(b.0).then_with(|| a.1.cmp(&b.1)));
+
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(provider.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(command.as_bytes());
+    for (key, value) in envs {
+        hasher.update(b"\0");
+        hasher.update(key.as_bytes());
+        hasher.update(b"=");
+        hasher.update(value.as_bytes());
+    }
+    hasher.finalize().to_hex().to_string()
 }
 
 fn shell_command(command: &str) -> Command {
@@ -85,5 +122,46 @@ fn shell_command(command: &str) -> Command {
         let mut cmd = Command::new("sh");
         cmd.args(["-c", command]);
         cmd
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn credential_command_output_is_cached() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let count_file = tempdir.path().join("count");
+        let count_path = count_file.display();
+        let command = format!(
+            "count=$(cat '{count_path}' 2>/dev/null || echo 0); count=$((count + 1)); printf '%s' \"$count\" > '{count_path}'; printf token"
+        );
+
+        let first = run(
+            "Test",
+            &command,
+            json!({}),
+            &[("VAULT_ADDR", "https://vault.example.com".to_string())],
+            DEFAULT_TIMEOUT,
+            "https://example.com",
+        )
+        .await
+        .unwrap();
+        let second = run(
+            "Test",
+            &command,
+            json!({}),
+            &[("VAULT_ADDR", "https://vault.example.com".to_string())],
+            DEFAULT_TIMEOUT,
+            "https://example.com",
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(first, "token");
+        assert_eq!(second, "token");
+        assert_eq!(std::fs::read_to_string(count_file).unwrap(), "1");
     }
 }

--- a/crates/fnox-core/src/credential_command.rs
+++ b/crates/fnox-core/src/credential_command.rs
@@ -114,6 +114,9 @@ fn cache_key(provider: &str, command: &str, envs: &[(&str, String)]) -> String {
 }
 
 fn shell_command(command: &str) -> Command {
+    // `cfg!` selects the shell for the target binary at compile time, which
+    // matches fnox's native build/release flow. Cross-compiled artifacts should
+    // be built per target so Windows binaries use cmd and Unix binaries use sh.
     if cfg!(target_os = "windows") {
         let mut cmd = Command::new("cmd");
         cmd.args(["/C", command]);

--- a/crates/fnox-core/src/credential_command.rs
+++ b/crates/fnox-core/src/credential_command.rs
@@ -1,15 +1,24 @@
 use crate::error::{FnoxError, Result};
 use serde_json::Value;
 use std::collections::HashMap;
-use std::sync::{LazyLock, Mutex};
-use std::time::Duration;
+use std::sync::{Arc, LazyLock, Mutex};
+use std::time::{Duration, Instant};
 use tera::{Context, Tera};
 use tokio::process::Command;
 
 pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+const DEFAULT_CACHE_TTL: Duration = Duration::from_secs(5 * 60);
 
-static CACHE: LazyLock<Mutex<HashMap<String, String>>> =
+type CacheSlot = Arc<tokio::sync::Mutex<Option<CachedToken>>>;
+
+static CACHE: LazyLock<Mutex<HashMap<String, CacheSlot>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
+
+#[derive(Clone)]
+struct CachedToken {
+    token: String,
+    expires_at: Instant,
+}
 
 pub async fn run(
     provider: &str,
@@ -30,18 +39,26 @@ pub async fn run(
         })?;
 
     let cache_key = cache_key(provider, &rendered, envs);
-    if let Some(token) = CACHE
-        .lock()
-        .expect("credential cache lock poisoned")
-        .get(&cache_key)
+    let cache_slot = {
+        let mut cache = CACHE.lock().expect("credential cache lock poisoned");
+        cache
+            .entry(cache_key)
+            .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(None)))
+            .clone()
+    };
+
+    let mut cached = cache_slot.lock().await;
+    if let Some(cached_token) = cached.as_ref()
+        && cached_token.expires_at > Instant::now()
     {
         tracing::debug!("Using cached credential_command output for {provider}");
-        return Ok(token.clone());
+        return Ok(cached_token.token.clone());
     }
 
     tracing::debug!("Running credential_command for {provider}");
 
     let mut cmd = shell_command(&rendered);
+    cmd.kill_on_drop(true);
     for (key, value) in envs {
         cmd.env(key, value);
     }
@@ -88,10 +105,10 @@ pub async fn run(
         });
     }
 
-    CACHE
-        .lock()
-        .expect("credential cache lock poisoned")
-        .insert(cache_key, token.clone());
+    *cached = Some(CachedToken {
+        token: token.clone(),
+        expires_at: Instant::now() + DEFAULT_CACHE_TTL,
+    });
 
     Ok(token)
 }
@@ -133,6 +150,7 @@ mod tests {
     use super::*;
     use serde_json::json;
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn credential_command_output_is_cached() {
         let tempdir = tempfile::tempdir().unwrap();

--- a/crates/fnox-core/src/credential_command.rs
+++ b/crates/fnox-core/src/credential_command.rs
@@ -28,15 +28,7 @@ pub async fn run(
     timeout: Duration,
     url: &str,
 ) -> Result<String> {
-    let tera_context =
-        Context::from_value(context).map_err(|e| FnoxError::Config(e.to_string()))?;
-    let rendered =
-        Tera::one_off(command, &tera_context, false).map_err(|e| FnoxError::ProviderCliFailed {
-            provider: provider.to_string(),
-            details: format!("Failed to render credential_command: {e}"),
-            hint: "Check credential_command template syntax".to_string(),
-            url: url.to_string(),
-        })?;
+    let rendered = render_command(provider, command, context, url)?;
 
     let cache_key = cache_key(provider, &rendered, envs);
     let cache_slot = {
@@ -113,6 +105,31 @@ pub async fn run(
     Ok(token)
 }
 
+pub fn invalidate(
+    provider: &str,
+    command: &str,
+    context: Value,
+    envs: &[(&str, String)],
+    url: &str,
+) -> Result<()> {
+    let rendered = render_command(provider, command, context, url)?;
+    let cache_key = cache_key(provider, &rendered, envs);
+    let mut cache = CACHE.lock().expect("credential cache lock poisoned");
+    cache.remove(&cache_key);
+    Ok(())
+}
+
+fn render_command(provider: &str, command: &str, context: Value, url: &str) -> Result<String> {
+    let tera_context =
+        Context::from_value(context).map_err(|e| FnoxError::Config(e.to_string()))?;
+    Tera::one_off(command, &tera_context, false).map_err(|e| FnoxError::ProviderCliFailed {
+        provider: provider.to_string(),
+        details: format!("Failed to render credential_command: {e}"),
+        hint: "Check credential_command template syntax".to_string(),
+        url: url.to_string(),
+    })
+}
+
 fn cache_key(provider: &str, command: &str, envs: &[(&str, String)]) -> String {
     let mut envs = envs.to_vec();
     envs.sort_by(|a, b| a.0.cmp(b.0).then_with(|| a.1.cmp(&b.1)));
@@ -184,5 +201,60 @@ mod tests {
         assert_eq!(first, "token");
         assert_eq!(second, "token");
         assert_eq!(std::fs::read_to_string(count_file).unwrap(), "1");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn credential_command_cache_can_be_invalidated() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let token_file = tempdir.path().join("token");
+        std::fs::write(&token_file, "first").unwrap();
+        let token_path = token_file.display();
+        let command = format!("cat '{token_path}'");
+        let envs = [("VAULT_ADDR", "https://vault.example.com".to_string())];
+
+        let first = run(
+            "TestInvalidate",
+            &command,
+            json!({}),
+            &envs,
+            DEFAULT_TIMEOUT,
+            "https://example.com",
+        )
+        .await
+        .unwrap();
+        std::fs::write(&token_file, "second").unwrap();
+        let cached = run(
+            "TestInvalidate",
+            &command,
+            json!({}),
+            &envs,
+            DEFAULT_TIMEOUT,
+            "https://example.com",
+        )
+        .await
+        .unwrap();
+        invalidate(
+            "TestInvalidate",
+            &command,
+            json!({}),
+            &envs,
+            "https://example.com",
+        )
+        .unwrap();
+        let refreshed = run(
+            "TestInvalidate",
+            &command,
+            json!({}),
+            &envs,
+            DEFAULT_TIMEOUT,
+            "https://example.com",
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(first, "first");
+        assert_eq!(cached, "first");
+        assert_eq!(refreshed, "second");
     }
 }

--- a/crates/fnox-core/src/credential_command.rs
+++ b/crates/fnox-core/src/credential_command.rs
@@ -1,0 +1,89 @@
+use crate::error::{FnoxError, Result};
+use serde_json::Value;
+use std::time::Duration;
+use tera::{Context, Tera};
+use tokio::process::Command;
+
+pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+
+pub async fn run(
+    provider: &str,
+    command: &str,
+    context: Value,
+    envs: &[(&str, String)],
+    timeout: Duration,
+    url: &str,
+) -> Result<String> {
+    let tera_context =
+        Context::from_value(context).map_err(|e| FnoxError::Config(e.to_string()))?;
+    let rendered =
+        Tera::one_off(command, &tera_context, false).map_err(|e| FnoxError::ProviderCliFailed {
+            provider: provider.to_string(),
+            details: format!("Failed to render credential_command: {e}"),
+            hint: "Check credential_command template syntax".to_string(),
+            url: url.to_string(),
+        })?;
+
+    tracing::debug!("Running credential_command for {provider}");
+
+    let mut cmd = shell_command(&rendered);
+    for (key, value) in envs {
+        cmd.env(key, value);
+    }
+
+    let output = tokio::time::timeout(timeout, cmd.output())
+        .await
+        .map_err(|_| FnoxError::ProviderCliFailed {
+            provider: provider.to_string(),
+            details: format!("credential_command timed out after {}s", timeout.as_secs()),
+            hint: "Check that credential_command completes in time".to_string(),
+            url: url.to_string(),
+        })?
+        .map_err(|e| FnoxError::ProviderCliFailed {
+            provider: provider.to_string(),
+            details: e.to_string(),
+            hint: "Failed to execute credential_command".to_string(),
+            url: url.to_string(),
+        })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(FnoxError::ProviderCliFailed {
+            provider: provider.to_string(),
+            details: stderr.trim().to_string(),
+            hint: format!("credential_command exited with {}", output.status),
+            url: url.to_string(),
+        });
+    }
+
+    let stdout =
+        String::from_utf8(output.stdout).map_err(|e| FnoxError::ProviderInvalidResponse {
+            provider: provider.to_string(),
+            details: format!("Invalid UTF-8 in credential_command output: {e}"),
+            hint: "credential_command must output a UTF-8 token".to_string(),
+            url: url.to_string(),
+        })?;
+    let token = stdout.trim().to_string();
+    if token.is_empty() {
+        return Err(FnoxError::ProviderInvalidResponse {
+            provider: provider.to_string(),
+            details: "credential_command returned empty stdout".to_string(),
+            hint: "Ensure credential_command prints the token to stdout".to_string(),
+            url: url.to_string(),
+        });
+    }
+
+    Ok(token)
+}
+
+fn shell_command(command: &str) -> Command {
+    if cfg!(target_os = "windows") {
+        let mut cmd = Command::new("cmd");
+        cmd.args(["/C", command]);
+        cmd
+    } else {
+        let mut cmd = Command::new("sh");
+        cmd.args(["-c", command]);
+        cmd
+    }
+}

--- a/crates/fnox-core/src/env.rs
+++ b/crates/fnox-core/src/env.rs
@@ -30,6 +30,15 @@ pub fn set_var<K: AsRef<OsStr>, V: AsRef<OsStr>>(key: K, val: V) {
     }
 }
 
+/// Remove an environment variable, serializing access via ENV_MUTEX.
+pub fn remove_var<K: AsRef<OsStr>>(key: K) {
+    let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+    // SAFETY: remove_var is unsafe in Rust 2024 edition. Access is serialized via ENV_MUTEX.
+    unsafe {
+        std::env::remove_var(key);
+    }
+}
+
 // Directory configuration
 pub static HOME_DIR: LazyLock<PathBuf> = LazyLock::new(|| dirs::home_dir().unwrap_or_default());
 pub static FNOX_CONFIG_DIR: LazyLock<PathBuf> = LazyLock::new(|| {
@@ -126,20 +135,18 @@ mod tests {
 
     #[test]
     fn test_var_path() {
-        unsafe {
-            set_var("FNOX_TEST_PATH", "/foo/bar");
-            assert_eq!(
-                var_path("FNOX_TEST_PATH").unwrap(),
-                PathBuf::from("/foo/bar")
-            );
-            // Empty values are treated as unset per XDG spec
-            set_var("FNOX_TEST_PATH", "");
-            assert_eq!(var_path("FNOX_TEST_PATH"), None);
-            // Relative paths are rejected per XDG spec
-            set_var("FNOX_TEST_PATH", "relative/path");
-            assert_eq!(var_path("FNOX_TEST_PATH"), None);
-            remove_var("FNOX_TEST_PATH");
-        }
+        set_var("FNOX_TEST_PATH", "/foo/bar");
+        assert_eq!(
+            var_path("FNOX_TEST_PATH").unwrap(),
+            PathBuf::from("/foo/bar")
+        );
+        // Empty values are treated as unset per XDG spec
+        set_var("FNOX_TEST_PATH", "");
+        assert_eq!(var_path("FNOX_TEST_PATH"), None);
+        // Relative paths are rejected per XDG spec
+        set_var("FNOX_TEST_PATH", "relative/path");
+        assert_eq!(var_path("FNOX_TEST_PATH"), None);
+        remove_var("FNOX_TEST_PATH");
     }
 
     #[test]

--- a/crates/fnox-core/src/lease_backends/mod.rs
+++ b/crates/fnox-core/src/lease_backends/mod.rs
@@ -135,6 +135,8 @@ pub enum LeaseBackendConfig {
         address: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         token: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        credential_command: Option<String>,
         secret_path: String,
         #[serde(skip_serializing_if = "Option::is_none")]
         namespace: Option<String>,
@@ -231,9 +233,12 @@ impl LeaseBackendConfig {
         match self {
             LeaseBackendConfig::AwsSts { profile, .. } => aws_sts::check_prerequisites(profile),
             LeaseBackendConfig::GcpIam { .. } => gcp_iam::check_prerequisites(),
-            LeaseBackendConfig::Vault { address, token, .. } => {
-                vault::check_prerequisites(address, token)
-            }
+            LeaseBackendConfig::Vault {
+                address,
+                token,
+                credential_command,
+                ..
+            } => vault::check_prerequisites(address, token, credential_command),
             LeaseBackendConfig::AzureToken { .. } => azure_token::check_prerequisites(),
             LeaseBackendConfig::Cloudflare { .. } => cloudflare::check_prerequisites(),
             LeaseBackendConfig::GithubApp {
@@ -251,9 +256,12 @@ impl LeaseBackendConfig {
         match self {
             LeaseBackendConfig::AwsSts { .. } => aws_sts::required_env_vars(),
             LeaseBackendConfig::GcpIam { .. } => gcp_iam::required_env_vars(),
-            LeaseBackendConfig::Vault { address, token, .. } => {
-                vault::required_env_vars(address, token)
-            }
+            LeaseBackendConfig::Vault {
+                address,
+                token,
+                credential_command,
+                ..
+            } => vault::required_env_vars(address, token, credential_command),
             LeaseBackendConfig::AzureToken { .. } => azure_token::required_env_vars(),
             LeaseBackendConfig::Cloudflare { .. } => cloudflare::required_env_vars(),
             LeaseBackendConfig::GithubApp { .. } => github_app::required_env_vars(),
@@ -321,6 +329,7 @@ impl LeaseBackendConfig {
             LeaseBackendConfig::Vault {
                 address,
                 token,
+                credential_command,
                 secret_path,
                 namespace,
                 env_map,
@@ -329,6 +338,7 @@ impl LeaseBackendConfig {
             } => Ok(Box::new(vault::VaultBackend::new(
                 address.clone(),
                 token.clone(),
+                credential_command.clone(),
                 secret_path.clone(),
                 namespace.clone(),
                 env_map.clone(),

--- a/crates/fnox-core/src/lease_backends/vault.rs
+++ b/crates/fnox-core/src/lease_backends/vault.rs
@@ -3,6 +3,7 @@ use crate::error::{FnoxError, Result};
 use crate::lease_backends::{Lease, LeaseBackend};
 use async_trait::async_trait;
 use indexmap::IndexMap;
+use serde_json::json;
 use std::time::Duration;
 
 const URL: &str = "https://fnox.jdx.dev/leases/vault";
@@ -22,13 +23,18 @@ pub const CONSUMED_ENV_VARS: &[&str] = &[
     "VAULT_TLS_SERVER_NAME",
 ];
 
-pub fn check_prerequisites(address: &Option<String>, token: &Option<String>) -> Option<String> {
+pub fn check_prerequisites(
+    address: &Option<String>,
+    token: &Option<String>,
+    credential_command: &Option<String>,
+) -> Option<String> {
     let has_addr = address.is_some()
         || std::env::var("VAULT_ADDR").is_ok()
         || std::env::var("FNOX_VAULT_ADDR").is_ok();
     let has_token = token.is_some()
         || std::env::var("VAULT_TOKEN").is_ok()
-        || std::env::var("FNOX_VAULT_TOKEN").is_ok();
+        || std::env::var("FNOX_VAULT_TOKEN").is_ok()
+        || credential_command.is_some();
     match (has_addr, has_token) {
         (false, false) => {
             Some("Vault address and token not found. Set VAULT_ADDR and VAULT_TOKEN.".to_string())
@@ -42,6 +48,7 @@ pub fn check_prerequisites(address: &Option<String>, token: &Option<String>) -> 
 pub fn required_env_vars(
     address: &Option<String>,
     token: &Option<String>,
+    credential_command: &Option<String>,
 ) -> Vec<(&'static str, &'static str)> {
     let mut vars = vec![];
     if address.is_none() {
@@ -50,7 +57,7 @@ pub fn required_env_vars(
             "Vault server address (e.g., http://localhost:8200)",
         ));
     }
-    if token.is_none() {
+    if token.is_none() && credential_command.is_none() {
         vars.push(("VAULT_TOKEN", "Vault authentication token"));
     }
     vars
@@ -58,7 +65,8 @@ pub fn required_env_vars(
 
 pub struct VaultBackend {
     address: String,
-    token: String,
+    token: Option<String>,
+    credential_command: Option<String>,
     secret_path: String,
     namespace: Option<String>,
     env_map: IndexMap<String, String>,
@@ -69,6 +77,7 @@ impl VaultBackend {
     pub fn new(
         address: Option<String>,
         token: Option<String>,
+        credential_command: Option<String>,
         secret_path: String,
         namespace: Option<String>,
         env_map: IndexMap<String, String>,
@@ -84,18 +93,21 @@ impl VaultBackend {
                 "Vault address not configured. Set 'address' in lease config or VAULT_ADDR env var.".to_string(),
             ))?;
 
-        let token = token
-            .or_else(|| {
-                env::var("FNOX_VAULT_TOKEN")
-                    .or_else(|_| env::var("VAULT_TOKEN"))
-                    .ok()
-            })
-            .ok_or_else(|| FnoxError::ProviderAuthFailed {
+        let token = token.or_else(|| {
+            env::var("FNOX_VAULT_TOKEN")
+                .or_else(|_| env::var("VAULT_TOKEN"))
+                .ok()
+        });
+
+        if token.is_none() && credential_command.is_none() {
+            return Err(FnoxError::ProviderAuthFailed {
                 provider: "Vault".to_string(),
                 details: "VAULT_TOKEN not set".to_string(),
-                hint: "Set 'token' in lease config or VAULT_TOKEN env var".to_string(),
+                hint: "Set 'token' in lease config, VAULT_TOKEN env var, or credential_command"
+                    .to_string(),
                 url: URL.to_string(),
-            })?;
+            });
+        }
 
         if env_map.is_empty() {
             return Err(FnoxError::Config(
@@ -108,11 +120,48 @@ impl VaultBackend {
         Ok(Self {
             address,
             token,
+            credential_command,
             secret_path,
             namespace,
             env_map,
             method,
         })
+    }
+
+    async fn token(&self) -> Result<String> {
+        if let Some(token) = &self.token {
+            return Ok(token.clone());
+        }
+
+        let command =
+            self.credential_command
+                .as_ref()
+                .ok_or_else(|| FnoxError::ProviderAuthFailed {
+                    provider: "Vault".to_string(),
+                    details: "VAULT_TOKEN not set".to_string(),
+                    hint: "Set 'token' in lease config, VAULT_TOKEN env var, or credential_command"
+                        .to_string(),
+                    url: URL.to_string(),
+                })?;
+
+        let mut envs = vec![("VAULT_ADDR", self.address.clone())];
+        if let Some(namespace) = &self.namespace {
+            envs.push(("VAULT_NAMESPACE", namespace.clone()));
+        }
+
+        crate::credential_command::run(
+            "Vault",
+            command,
+            json!({
+                "address": self.address,
+                "secret_path": self.secret_path,
+                "namespace": self.namespace,
+            }),
+            &envs,
+            crate::credential_command::DEFAULT_TIMEOUT,
+            URL,
+        )
+        .await
     }
 }
 
@@ -127,17 +176,18 @@ impl LeaseBackend for VaultBackend {
 
         let client = crate::http::http_client();
         let ttl_value = format!("{}s", duration.as_secs());
+        let token = self.token().await?;
         let mut request = if self.method.eq_ignore_ascii_case("post")
             || self.method.eq_ignore_ascii_case("put")
         {
             client
                 .post(&url)
-                .header("X-Vault-Token", &self.token)
+                .header("X-Vault-Token", &token)
                 .json(&serde_json::json!({ "ttl": ttl_value }))
         } else {
             client
                 .get(&url)
-                .header("X-Vault-Token", &self.token)
+                .header("X-Vault-Token", &token)
                 .query(&[("ttl", &ttl_value)])
         };
 
@@ -273,9 +323,10 @@ impl LeaseBackend for VaultBackend {
         );
 
         let client = crate::http::http_client();
+        let token = self.token().await?;
         let mut request = client
             .put(&url)
-            .header("X-Vault-Token", &self.token)
+            .header("X-Vault-Token", &token)
             .json(&serde_json::json!({ "lease_id": lease_id }));
 
         if let Some(ns) = &self.namespace {

--- a/crates/fnox-core/src/lease_backends/vault.rs
+++ b/crates/fnox-core/src/lease_backends/vault.rs
@@ -418,9 +418,7 @@ mod tests {
     #[test]
     fn new_uses_vault_namespace_env_fallback() {
         env::set_var("FNOX_VAULT_NAMESPACE", "admin/test");
-        unsafe {
-            env::remove_var("VAULT_NAMESPACE");
-        }
+        env::remove_var("VAULT_NAMESPACE");
 
         let mut env_map = IndexMap::new();
         env_map.insert("access_key".to_string(), "AWS_ACCESS_KEY_ID".to_string());
@@ -438,8 +436,6 @@ mod tests {
 
         assert_eq!(backend.namespace.as_deref(), Some("admin/test"));
 
-        unsafe {
-            env::remove_var("FNOX_VAULT_NAMESPACE");
-        }
+        env::remove_var("FNOX_VAULT_NAMESPACE");
     }
 }

--- a/crates/fnox-core/src/lease_backends/vault.rs
+++ b/crates/fnox-core/src/lease_backends/vault.rs
@@ -15,6 +15,7 @@ pub const CONSUMED_ENV_VARS: &[&str] = &[
     "VAULT_TOKEN",
     "FNOX_VAULT_TOKEN",
     "VAULT_NAMESPACE",
+    "FNOX_VAULT_NAMESPACE",
     "VAULT_CACERT",
     "VAULT_CAPATH",
     "VAULT_SKIP_VERIFY",
@@ -117,6 +118,8 @@ impl VaultBackend {
             ));
         }
 
+        let namespace = namespace.or_else(vault_namespace);
+
         Ok(Self {
             address,
             token,
@@ -126,6 +129,22 @@ impl VaultBackend {
             env_map,
             method,
         })
+    }
+
+    fn credential_command_context(&self) -> serde_json::Value {
+        json!({
+            "address": self.address,
+            "secret_path": self.secret_path,
+            "namespace": self.namespace,
+        })
+    }
+
+    fn credential_command_envs(&self) -> Vec<(&str, String)> {
+        let mut envs = vec![("VAULT_ADDR", self.address.clone())];
+        if let Some(namespace) = &self.namespace {
+            envs.push(("VAULT_NAMESPACE", namespace.clone()));
+        }
+        envs
     }
 
     async fn token(&self) -> Result<String> {
@@ -144,24 +163,35 @@ impl VaultBackend {
                     url: URL.to_string(),
                 })?;
 
-        let mut envs = vec![("VAULT_ADDR", self.address.clone())];
-        if let Some(namespace) = &self.namespace {
-            envs.push(("VAULT_NAMESPACE", namespace.clone()));
-        }
+        let envs = self.credential_command_envs();
 
         crate::credential_command::run(
             "Vault",
             command,
-            json!({
-                "address": self.address,
-                "secret_path": self.secret_path,
-                "namespace": self.namespace,
-            }),
+            self.credential_command_context(),
             &envs,
             crate::credential_command::DEFAULT_TIMEOUT,
             URL,
         )
         .await
+    }
+
+    fn invalidate_credential_command(&self) -> Result<()> {
+        if self.token.is_some() {
+            return Ok(());
+        }
+
+        let Some(command) = &self.credential_command else {
+            return Ok(());
+        };
+
+        crate::credential_command::invalidate(
+            "Vault",
+            command,
+            self.credential_command_context(),
+            &self.credential_command_envs(),
+            URL,
+        )
     }
 }
 
@@ -209,6 +239,7 @@ impl LeaseBackend for VaultBackend {
             let status = response.status();
             let body_text = response.text().await.unwrap_or_default();
             if status.as_u16() == 403 || status.as_u16() == 401 {
+                self.invalidate_credential_command()?;
                 return Err(FnoxError::ProviderAuthFailed {
                     provider: "Vault".to_string(),
                     details: body_text,
@@ -347,6 +378,7 @@ impl LeaseBackend for VaultBackend {
             let status = response.status();
             let body_text = response.text().await.unwrap_or_default();
             if status.as_u16() == 403 || status.as_u16() == 401 {
+                self.invalidate_credential_command()?;
                 return Err(FnoxError::ProviderAuthFailed {
                     provider: "Vault".to_string(),
                     details: body_text,
@@ -370,5 +402,44 @@ impl LeaseBackend for VaultBackend {
 
     fn max_lease_duration(&self) -> Duration {
         Duration::from_secs(24 * 3600)
+    }
+}
+
+fn vault_namespace() -> Option<String> {
+    env::var("FNOX_VAULT_NAMESPACE")
+        .or_else(|_| env::var("VAULT_NAMESPACE"))
+        .ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_uses_vault_namespace_env_fallback() {
+        env::set_var("FNOX_VAULT_NAMESPACE", "admin/test");
+        unsafe {
+            env::remove_var("VAULT_NAMESPACE");
+        }
+
+        let mut env_map = IndexMap::new();
+        env_map.insert("access_key".to_string(), "AWS_ACCESS_KEY_ID".to_string());
+
+        let backend = VaultBackend::new(
+            Some("https://vault.example.com".to_string()),
+            Some("token".to_string()),
+            None,
+            "secret/data/fnox".to_string(),
+            None,
+            env_map,
+            "get".to_string(),
+        )
+        .unwrap();
+
+        assert_eq!(backend.namespace.as_deref(), Some("admin/test"));
+
+        unsafe {
+            env::remove_var("FNOX_VAULT_NAMESPACE");
+        }
     }
 }

--- a/crates/fnox-core/src/lib.rs
+++ b/crates/fnox-core/src/lib.rs
@@ -10,6 +10,7 @@
 
 pub mod auth_prompt;
 pub mod config;
+pub(crate) mod credential_command;
 pub mod env;
 pub mod error;
 pub mod http;

--- a/crates/fnox-core/src/providers/vault.rs
+++ b/crates/fnox-core/src/providers/vault.rs
@@ -1,13 +1,17 @@
 use crate::env;
 use crate::error::{FnoxError, Result};
 use async_trait::async_trait;
+use serde_json::json;
 use tokio::process::Command;
+
+const URL: &str = "https://fnox.jdx.dev/providers/vault";
 
 pub struct HashiCorpVaultProvider {
     address: Option<String>,
     path: Option<String>,
     token: Option<String>,
     namespace: Option<String>,
+    credential_command: Option<String>,
 }
 
 impl HashiCorpVaultProvider {
@@ -16,12 +20,14 @@ impl HashiCorpVaultProvider {
         path: Option<String>,
         token: Option<String>,
         namespace: Option<String>,
+        credential_command: Option<String>,
     ) -> Result<Self> {
         Ok(Self {
             address,
             path,
             token,
             namespace,
+            credential_command,
         })
     }
 
@@ -36,8 +42,35 @@ impl HashiCorpVaultProvider {
         self.address.clone().or_else(vault_address)
     }
 
-    fn get_token(&self) -> Option<String> {
-        self.token.clone().or_else(vault_token)
+    async fn get_token(&self, address: &str) -> Result<Option<String>> {
+        if let Some(token) = self.token.clone().or_else(vault_token) {
+            return Ok(Some(token));
+        }
+
+        let Some(command) = &self.credential_command else {
+            return Ok(None);
+        };
+
+        let namespace = self.namespace.clone().or_else(vault_namespace);
+        let mut envs = vec![("VAULT_ADDR", address.to_string())];
+        if let Some(namespace) = &namespace {
+            envs.push(("VAULT_NAMESPACE", namespace.clone()));
+        }
+
+        crate::credential_command::run(
+            "HashiCorp Vault",
+            command,
+            json!({
+                "address": address,
+                "path": self.path,
+                "namespace": namespace,
+            }),
+            &envs,
+            crate::credential_command::DEFAULT_TIMEOUT,
+            URL,
+        )
+        .await
+        .map(Some)
     }
 
     /// Execute vault CLI command with proper authentication
@@ -54,22 +87,23 @@ impl HashiCorpVaultProvider {
         })?;
 
         tracing::debug!("Setting VAULT_ADDR to '{}'", address);
-        cmd.env("VAULT_ADDR", address);
+        cmd.env("VAULT_ADDR", &address);
 
         // Set VAULT_NAMESPACE if provided
-        if let Some(namespace) = &self.namespace {
+        if let Some(namespace) = self.namespace.clone().or_else(vault_namespace) {
             tracing::debug!("Setting VAULT_NAMESPACE to '{}'", namespace);
             cmd.env("VAULT_NAMESPACE", namespace);
         }
 
         // Set VAULT_TOKEN from provider config or environment
         let token = self
-            .get_token()
+            .get_token(&address)
+            .await?
             .ok_or_else(|| FnoxError::ProviderAuthFailed {
                 provider: "HashiCorp Vault".to_string(),
                 details: "VAULT_TOKEN not set".to_string(),
-                hint: "Set VAULT_TOKEN in provider config or environment".to_string(),
-                url: "https://fnox.jdx.dev/providers/vault".to_string(),
+                hint: "Set VAULT_TOKEN in provider config or environment, or configure credential_command".to_string(),
+                url: URL.to_string(),
             })?;
 
         tracing::debug!(
@@ -86,14 +120,14 @@ impl HashiCorpVaultProvider {
                     provider: "HashiCorp Vault".to_string(),
                     cli: "vault".to_string(),
                     install_hint: "brew install vault".to_string(),
-                    url: "https://fnox.jdx.dev/providers/vault".to_string(),
+                    url: URL.to_string(),
                 }
             } else {
                 FnoxError::ProviderCliFailed {
                     provider: "HashiCorp Vault".to_string(),
                     details: e.to_string(),
                     hint: "Check that the Vault CLI is installed and accessible".to_string(),
-                    url: "https://fnox.jdx.dev/providers/vault".to_string(),
+                    url: URL.to_string(),
                 }
             }
         })?;
@@ -112,14 +146,14 @@ impl HashiCorpVaultProvider {
                     provider: "HashiCorp Vault".to_string(),
                     details: stderr_str.to_string(),
                     hint: "Check your Vault token has the required permissions".to_string(),
-                    url: "https://fnox.jdx.dev/providers/vault".to_string(),
+                    url: URL.to_string(),
                 });
             }
             return Err(FnoxError::ProviderCliFailed {
                 provider: "HashiCorp Vault".to_string(),
                 details: stderr_str.to_string(),
                 hint: "Check your Vault configuration".to_string(),
-                url: "https://fnox.jdx.dev/providers/vault".to_string(),
+                url: URL.to_string(),
             });
         }
 
@@ -128,7 +162,7 @@ impl HashiCorpVaultProvider {
                 provider: "HashiCorp Vault".to_string(),
                 details: format!("Invalid UTF-8 in command output: {}", e),
                 hint: "The secret value contains invalid UTF-8 characters".to_string(),
-                url: "https://fnox.jdx.dev/providers/vault".to_string(),
+                url: URL.to_string(),
             })?;
 
         Ok(stdout.trim().to_string())
@@ -156,7 +190,7 @@ impl crate::providers::Provider for HashiCorpVaultProvider {
                     provider: "HashiCorp Vault".to_string(),
                     details: format!("Invalid secret reference format: '{}'", value),
                     hint: "Expected 'secret' or 'secret/field'".to_string(),
-                    url: "https://fnox.jdx.dev/providers/vault".to_string(),
+                    url: URL.to_string(),
                 });
             }
         };
@@ -218,6 +252,8 @@ pub fn env_dependencies() -> &'static [&'static str] {
         "FNOX_VAULT_TOKEN",
         "VAULT_ADDR",
         "FNOX_VAULT_ADDR",
+        "VAULT_NAMESPACE",
+        "FNOX_VAULT_NAMESPACE",
     ]
 }
 
@@ -230,5 +266,11 @@ fn vault_token() -> Option<String> {
 fn vault_address() -> Option<String> {
     env::var("FNOX_VAULT_ADDR")
         .or_else(|_| env::var("VAULT_ADDR"))
+        .ok()
+}
+
+fn vault_namespace() -> Option<String> {
+    env::var("FNOX_VAULT_NAMESPACE")
+        .or_else(|_| env::var("VAULT_NAMESPACE"))
         .ok()
 }

--- a/docs/leases/vault.md
+++ b/docs/leases/vault.md
@@ -43,7 +43,7 @@ Vault address not found. Set VAULT_ADDR.
 Vault token not found. Set VAULT_TOKEN.
 ```
 
-When `credential_command` is configured, fnox runs it through the platform shell and uses trimmed stdout as the token. The command is rendered as a Tera template with `address`, `secret_path`, and `namespace`, and fnox sets `VAULT_ADDR` and `VAULT_NAMESPACE` for the command from the lease config. Output is cached for the current fnox process so repeated lease operations do not repeat the login.
+When `credential_command` is configured, fnox runs it through the platform shell and uses trimmed stdout as the token. The command is rendered as a Tera template with `address`, `secret_path`, and `namespace`, and fnox sets `VAULT_ADDR` and `VAULT_NAMESPACE` for the command from the lease config. Output is cached briefly for the current fnox process so repeated lease operations do not repeat the login.
 
 ## Credentials Produced
 

--- a/docs/leases/vault.md
+++ b/docs/leases/vault.md
@@ -15,15 +15,16 @@ username = "DB_USER"
 password = "DB_PASSWORD"
 ```
 
-| Field         | Required | Description                                                |
-| ------------- | -------- | ---------------------------------------------------------- |
-| `secret_path` | Yes      | Vault API path for the dynamic secret                      |
-| `env_map`     | Yes      | Map of Vault response field names to environment variables |
-| `address`     | No       | Vault server URL (falls back to `VAULT_ADDR`)              |
-| `token`       | No       | Vault auth token (falls back to `VAULT_TOKEN`)             |
-| `namespace`   | No       | Vault namespace (for Vault Enterprise / HCP Vault)         |
-| `duration`    | No       | Requested lease TTL (e.g., `"1h"`, `"30m"`)                |
-| `method`      | No       | HTTP method: `"get"` (default) or `"post"` (for pki/issue) |
+| Field                | Required | Description                                                          |
+| -------------------- | -------- | -------------------------------------------------------------------- |
+| `secret_path`        | Yes      | Vault API path for the dynamic secret                                |
+| `env_map`            | Yes      | Map of Vault response field names to environment variables           |
+| `address`            | No       | Vault server URL (falls back to `VAULT_ADDR`)                        |
+| `token`              | No       | Vault auth token (falls back to `VAULT_TOKEN`)                       |
+| `credential_command` | No       | Shell command that prints a Vault token when no token is configured  |
+| `namespace`          | No       | Vault namespace (for Vault Enterprise / HCP Vault)                   |
+| `duration`           | No       | Requested lease TTL (e.g., `"1h"`, `"30m"`)                          |
+| `method`             | No       | HTTP method: `"get"` (default) or `"post"` (for pki/issue)           |
 
 ## Prerequisites
 
@@ -32,6 +33,7 @@ The backend needs a Vault address and token. fnox resolves them in this order:
 1. `address` / `token` fields in config
 2. `FNOX_VAULT_ADDR` / `FNOX_VAULT_TOKEN` environment variables
 3. `VAULT_ADDR` / `VAULT_TOKEN` environment variables
+4. `credential_command` for the token
 
 If the address or token is missing, fnox prints one of:
 
@@ -40,6 +42,8 @@ Vault address and token not found. Set VAULT_ADDR and VAULT_TOKEN.
 Vault address not found. Set VAULT_ADDR.
 Vault token not found. Set VAULT_TOKEN.
 ```
+
+When `credential_command` is configured, fnox runs it through the platform shell and uses trimmed stdout as the token. The command is rendered as a Tera template with `address`, `secret_path`, and `namespace`, and fnox sets `VAULT_ADDR` and `VAULT_NAMESPACE` for the command from the lease config.
 
 ## Credentials Produced
 
@@ -129,6 +133,22 @@ security_token = "AWS_SESSION_TOKEN"
 type = "vault"
 namespace = "admin/my-team"
 secret_path = "database/creds/app-role"
+
+[leases.vault-db.env_map]
+username = "DB_USER"
+password = "DB_PASSWORD"
+```
+
+### With credential command
+
+```toml
+[leases.vault-db]
+type = "vault"
+address = "https://vault.example.com"
+namespace = "team-a"
+credential_command = "vault login -method=oidc -token-only"
+secret_path = "database/creds/readonly"
+method = "post"
 
 [leases.vault-db.env_map]
 username = "DB_USER"

--- a/docs/leases/vault.md
+++ b/docs/leases/vault.md
@@ -43,7 +43,7 @@ Vault address not found. Set VAULT_ADDR.
 Vault token not found. Set VAULT_TOKEN.
 ```
 
-When `credential_command` is configured, fnox runs it through the platform shell and uses trimmed stdout as the token. The command is rendered as a Tera template with `address`, `secret_path`, and `namespace`, and fnox sets `VAULT_ADDR` and `VAULT_NAMESPACE` for the command from the lease config.
+When `credential_command` is configured, fnox runs it through the platform shell and uses trimmed stdout as the token. The command is rendered as a Tera template with `address`, `secret_path`, and `namespace`, and fnox sets `VAULT_ADDR` and `VAULT_NAMESPACE` for the command from the lease config. Output is cached for the current fnox process so repeated lease operations do not repeat the login.
 
 ## Credentials Produced
 

--- a/docs/leases/vault.md
+++ b/docs/leases/vault.md
@@ -15,16 +15,16 @@ username = "DB_USER"
 password = "DB_PASSWORD"
 ```
 
-| Field                | Required | Description                                                          |
-| -------------------- | -------- | -------------------------------------------------------------------- |
-| `secret_path`        | Yes      | Vault API path for the dynamic secret                                |
-| `env_map`            | Yes      | Map of Vault response field names to environment variables           |
-| `address`            | No       | Vault server URL (falls back to `VAULT_ADDR`)                        |
-| `token`              | No       | Vault auth token (falls back to `VAULT_TOKEN`)                       |
-| `credential_command` | No       | Shell command that prints a Vault token when no token is configured  |
-| `namespace`          | No       | Vault namespace (for Vault Enterprise / HCP Vault)                   |
-| `duration`           | No       | Requested lease TTL (e.g., `"1h"`, `"30m"`)                          |
-| `method`             | No       | HTTP method: `"get"` (default) or `"post"` (for pki/issue)           |
+| Field                | Required | Description                                                         |
+| -------------------- | -------- | ------------------------------------------------------------------- |
+| `secret_path`        | Yes      | Vault API path for the dynamic secret                               |
+| `env_map`            | Yes      | Map of Vault response field names to environment variables          |
+| `address`            | No       | Vault server URL (falls back to `VAULT_ADDR`)                       |
+| `token`              | No       | Vault auth token (falls back to `VAULT_TOKEN`)                      |
+| `credential_command` | No       | Shell command that prints a Vault token when no token is configured |
+| `namespace`          | No       | Vault namespace (for Vault Enterprise / HCP Vault)                  |
+| `duration`           | No       | Requested lease TTL (e.g., `"1h"`, `"30m"`)                         |
+| `method`             | No       | HTTP method: `"get"` (default) or `"post"` (for pki/issue)          |
 
 ## Prerequisites
 

--- a/docs/providers/vault.md
+++ b/docs/providers/vault.md
@@ -46,7 +46,7 @@ path = "secret/team-a"
 credential_command = "vault login -method=oidc -token-only"
 ```
 
-fnox sets `VAULT_ADDR` and `VAULT_NAMESPACE` for the command from the provider config. The command runs through the platform shell, so shell features like pipes and redirects work. Output is cached for the current fnox process so resolving multiple secrets from the same provider does not repeat the login.
+fnox sets `VAULT_ADDR` and `VAULT_NAMESPACE` for the command from the provider config. The command runs through the platform shell, so shell features like pipes and redirects work. Output is cached briefly for the current fnox process so resolving multiple secrets from the same provider does not repeat the login.
 
 ## Setup
 

--- a/docs/providers/vault.md
+++ b/docs/providers/vault.md
@@ -46,7 +46,7 @@ path = "secret/team-a"
 credential_command = "vault login -method=oidc -token-only"
 ```
 
-fnox sets `VAULT_ADDR` and `VAULT_NAMESPACE` for the command from the provider config. The command runs through the platform shell, so shell features like pipes and redirects work.
+fnox sets `VAULT_ADDR` and `VAULT_NAMESPACE` for the command from the provider config. The command runs through the platform shell, so shell features like pipes and redirects work. Output is cached for the current fnox process so resolving multiple secrets from the same provider does not repeat the login.
 
 ## Setup
 

--- a/docs/providers/vault.md
+++ b/docs/providers/vault.md
@@ -30,6 +30,23 @@ vault = { type = "vault", path = "secret/myapp" } # address and token are option
 - **address**: (Optional) The Vault server address. Falls back to `FNOX_VAULT_ADDR` or `VAULT_ADDR`.
 - **path**: (Required) The base path for secrets in Vault (e.g., `secret/myapp`).
 - **token**: (Optional) Vault token. Falls back to `FNOX_VAULT_TOKEN` or `VAULT_TOKEN`.
+- **namespace**: (Optional) Vault namespace. Falls back to `FNOX_VAULT_NAMESPACE` or `VAULT_NAMESPACE`.
+- **credential_command**: (Optional) Shell command that prints a Vault token to stdout when no token is configured. The command is rendered as a Tera template and receives `address`, `path`, and `namespace`.
+
+### Provider-scoped Login
+
+Use `credential_command` when different Vault/OpenBao providers need different tokens:
+
+```toml
+[providers.vault_team_a]
+type = "vault"
+address = "https://vault.example.com"
+namespace = "team-a"
+path = "secret/team-a"
+credential_command = "vault login -method=oidc -token-only"
+```
+
+fnox sets `VAULT_ADDR` and `VAULT_NAMESPACE` for the command from the provider config. The command runs through the platform shell, so shell features like pipes and redirects work.
 
 ## Setup
 

--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -213,6 +213,9 @@
             "address": {
               "type": ["string", "null"]
             },
+            "credential_command": {
+              "type": ["string", "null"]
+            },
             "duration": {
               "type": ["string", "null"]
             },
@@ -997,6 +1000,9 @@
             },
             "auth_command": {
               "type": ["string", "null"]
+            },
+            "credential_command": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
             },
             "namespace": {
               "$ref": "#/$defs/OptionStringOrSecretRef"

--- a/src/commands/provider/add.rs
+++ b/src/commands/provider/add.rs
@@ -94,6 +94,7 @@ impl AddCommand {
                 path: OptionStringOrSecretRef::literal("secret"),
                 token: OptionStringOrSecretRef::none(),
                 namespace: OptionStringOrSecretRef::none(),
+                credential_command: OptionStringOrSecretRef::none(),
                 auth_command: None,
             },
             ProviderType::Gcp => crate::config::ProviderConfig::GoogleSecretManager {

--- a/test/lease_vault.bats
+++ b/test/lease_vault.bats
@@ -148,6 +148,25 @@ EOF
 	assert_output --partial "CUSTOM_KEY_VAR=AKIATEST123"
 }
 
+@test "vault lease: uses credential_command when token is not in environment" {
+	cat >"$FNOX_CONFIG_FILE" <<EOF
+root = true
+
+[leases.test_credential_command]
+type = "vault"
+address = "$VAULT_ADDR"
+credential_command = "printf '%s' '$VAULT_TOKEN'"
+secret_path = "secret/data/fnox-lease-test"
+
+[leases.test_credential_command.env_map]
+access_key = "CUSTOM_KEY_VAR"
+EOF
+
+	run env -u VAULT_TOKEN -u FNOX_VAULT_TOKEN "$FNOX_BIN" exec -- env
+	assert_success
+	assert_output --partial "CUSTOM_KEY_VAR=AKIATEST123"
+}
+
 @test "vault lease: auth failure with bad token" {
 	cat >"$FNOX_CONFIG_FILE" <<EOF
 root = true

--- a/test/lease_vault.bats
+++ b/test/lease_vault.bats
@@ -155,14 +155,14 @@ root = true
 [leases.test_credential_command]
 type = "vault"
 address = "$VAULT_ADDR"
-credential_command = "printf '%s' '$VAULT_TOKEN'"
+credential_command = "printf '%s' \"\$TEST_VAULT_TOKEN\""
 secret_path = "secret/data/fnox-lease-test"
 
 [leases.test_credential_command.env_map]
 access_key = "CUSTOM_KEY_VAR"
 EOF
 
-	run env -u VAULT_TOKEN -u FNOX_VAULT_TOKEN "$FNOX_BIN" exec -- env
+	run env -u VAULT_TOKEN -u FNOX_VAULT_TOKEN TEST_VAULT_TOKEN="$VAULT_TOKEN" "$FNOX_BIN" exec -- env
 	assert_success
 	assert_output --partial "CUSTOM_KEY_VAR=AKIATEST123"
 }

--- a/test/vault.bats
+++ b/test/vault.bats
@@ -294,7 +294,7 @@ EOF
 [providers.vault]
 type = "vault"
 address = "http://localhost:8200"
-credential_command = "printf '%s' '$VAULT_TOKEN'"
+credential_command = "printf '%s' \"\$TEST_VAULT_TOKEN\""
 
 [secrets.TEST_CREDENTIAL_COMMAND]
 provider = "vault"
@@ -303,7 +303,7 @@ EOF
 
 	vault kv put "secret/credential-command-test" value="credential-command-value" >/dev/null 2>&1
 
-	run env -u VAULT_TOKEN -u FNOX_VAULT_TOKEN "$FNOX_BIN" get TEST_CREDENTIAL_COMMAND
+	run env -u VAULT_TOKEN -u FNOX_VAULT_TOKEN TEST_VAULT_TOKEN="$VAULT_TOKEN" "$FNOX_BIN" get TEST_CREDENTIAL_COMMAND
 	assert_success
 	assert_output "credential-command-value"
 

--- a/test/vault.bats
+++ b/test/vault.bats
@@ -289,6 +289,27 @@ EOF
 	vault kv delete "secret/test-secret" >/dev/null 2>&1 || true
 }
 
+@test "Vault provider uses credential_command when token is not in environment" {
+	cat >"${FNOX_CONFIG_FILE:-fnox.toml}" <<EOF
+[providers.vault]
+type = "vault"
+address = "http://localhost:8200"
+credential_command = "printf '%s' '$VAULT_TOKEN'"
+
+[secrets.TEST_CREDENTIAL_COMMAND]
+provider = "vault"
+value = "credential-command-test"
+EOF
+
+	vault kv put "secret/credential-command-test" value="credential-command-value" >/dev/null 2>&1
+
+	run env -u VAULT_TOKEN -u FNOX_VAULT_TOKEN "$FNOX_BIN" get TEST_CREDENTIAL_COMMAND
+	assert_success
+	assert_output "credential-command-value"
+
+	vault kv delete "secret/credential-command-test" >/dev/null 2>&1 || true
+}
+
 @test "Vault provider test connection works" {
 	create_vault_config
 


### PR DESCRIPTION
## Summary
- add shared credential_command execution with Tera rendering and shell execution
- allow Vault providers and Vault lease backends to obtain tokens from credential_command when no configured/env token exists
- document provider-scoped Vault/OpenBao login and add Bats coverage for provider and lease flows

## Verification
- cargo check -p fnox-core
- mise run build
- git diff --check
- cargo test -p fnox-core (169 passed; 1 unrelated keychain test failed because no OS keyring/DBus backend is available in this environment)
- mise run test:bats -- test/vault.bats (not run: bats is not installed; test/bats/bin is absent in this environment)

_This PR description was generated with AI assistance._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Runs arbitrary configured shell commands and caches tokens in-process; auth and lease flows depend on command output correctness, but static/env tokens still take precedence.
> 
> **Overview**
> Adds optional **`credential_command`** so Vault tokens can come from a user-defined shell command when config/env tokens are absent, for both the **Vault provider** and **Vault lease backend**.
> 
> A new **`credential_command`** module runs commands via the platform shell, renders them with **Tera** templates, injects `VAULT_ADDR` / `VAULT_NAMESPACE`, caches stdout (5 min) per process, and **invalidates the cache on 401/403** from Vault HTTP calls. **`FNOX_VAULT_NAMESPACE`** is supported alongside existing namespace env fallbacks; **`env::remove_var`** is exposed for tests.
> 
> Config surfaces are updated (provider wizard TOML, JSON schema, `fnox provider add` template) plus lease/provider docs and Bats tests for credential-command auth paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5474633272a737d25ca3fa6e1240def0d5a2e6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Vault tokens can be obtained via an optional external credential_command; the command supports templating, runs with VAULT_ADDR/VAULT_NAMESPACE (with fallback), its output is cached per process, and can be invalidated on auth failure.
  * Provider and lease configs/templates now include an optional credential_command field.

* **Documentation**
  * Vault docs updated with namespace, credential_command usage, examples, and behavior.

* **Tests**
  * Added tests validating credential-command-based token retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->