### PR TITLE
fix(set): panic when using --if-missing flag on set subcommand

### DIFF
--- a/crates/fnox-core/src/settings.rs
+++ b/crates/fnox-core/src/settings.rs
@@ -12,6 +12,8 @@ use miette::Result;
 use std::sync::Arc;
 use std::sync::{LazyLock, Mutex};
 
+use crate::config::IfMissing;
+
 // Include generated settings code
 mod generated {
     pub(super) mod settings {
@@ -43,7 +45,7 @@ static INITIALIZED: LazyLock<Mutex<bool>> = LazyLock::new(|| Mutex::new(false));
 pub struct CliSnapshot {
     pub age_key_file: Option<std::path::PathBuf>,
     pub profile: Option<String>,
-    pub if_missing: Option<String>,
+    pub if_missing: Option<IfMissing>,
     pub no_defaults: bool,
 }
 
@@ -153,7 +155,13 @@ impl Settings {
             }
 
             if let Some(if_missing) = snapshot.if_missing {
-                map.insert("if_missing", SettingValue::OptionString(Some(if_missing)));
+                let s = match if_missing {
+                    IfMissing::Error => "error",
+                    IfMissing::Warn => "warn",
+                    IfMissing::Ignore => "ignore",
+                }
+                .to_string();
+                map.insert("if_missing", SettingValue::OptionString(Some(s)));
             }
 
             if snapshot.no_defaults {

--- a/crates/fnox-core/src/settings.rs
+++ b/crates/fnox-core/src/settings.rs
@@ -43,9 +43,13 @@ static INITIALIZED: LazyLock<Mutex<bool>> = LazyLock::new(|| Mutex::new(false));
 /// CLI snapshot captured from parsed command-line arguments
 #[derive(Debug, Clone, Default)]
 pub struct CliSnapshot {
+    /// Path to age key file, overrides provider config.
     pub age_key_file: Option<std::path::PathBuf>,
+    /// Active profile name, overrides `FNOX_PROFILE`.
     pub profile: Option<String>,
+    /// Global override for missing-secret behavior.
     pub if_missing: Option<IfMissing>,
+    /// Skip merging top-level secrets into the selected profile.
     pub no_defaults: bool,
 }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use crate::error::{FnoxError, Result};
 use clap::{Parser, Subcommand};
 
-use crate::config::Config;
+use crate::config::{Config, IfMissing};
 
 pub mod activate;
 pub mod check;
@@ -59,7 +59,7 @@ pub struct Cli {
 
     /// What to do if a secret is missing (error, warn, ignore)
     #[arg(long, global = true)]
-    pub if_missing: Option<String>,
+    pub if_missing: Option<IfMissing>,
 
     /// Disable colored output
     #[arg(long, global = true)]

--- a/test/set_if_missing.bats
+++ b/test/set_if_missing.bats
@@ -1,0 +1,42 @@
+#!/usr/bin/env bats
+
+load 'test_helper/common_setup'
+
+setup() {
+	_common_setup
+}
+
+@test "fnox set --if-missing error does not panic" {
+	run "$FNOX_BIN" set MY_VAR --if-missing error
+	assert_success
+}
+
+@test "fnox set --if-missing warn does not panic" {
+	run "$FNOX_BIN" set MY_VAR --if-missing warn
+	assert_success
+}
+
+@test "fnox set --if-missing ignore does not panic" {
+	run "$FNOX_BIN" set MY_VAR --if-missing ignore
+	assert_success
+}
+
+@test "fnox set --if-missing rejects invalid value" {
+	run "$FNOX_BIN" set MY_VAR --if-missing invalid
+	assert_failure
+	assert_output --partial "possible values: error, warn, ignore"
+}
+
+@test "fnox set --if-missing error writes if_missing to config" {
+	run "$FNOX_BIN" set MY_VAR --if-missing error
+	assert_success
+	assert [ -f fnox.toml ]
+	run grep "if_missing" fnox.toml
+	assert_success
+	assert_output --partial 'if_missing = "error"'
+}
+
+@test "fnox set --if-missing combined with --description does not panic" {
+	run "$FNOX_BIN" set MY_VAR --description "test secret" --if-missing warn
+	assert_success
+}


### PR DESCRIPTION
## Summary

`fnox set MY_VAR --if-missing error` panicked with a clap TypeId downcast
error on any valid value. Validation of invalid values was unaffected.

### Root cause

`Cli.if_missing` (global flag) was declared as `Option<String>` while
`SetCommand.if_missing` used `Option<IfMissing>`. Clap stores global args
in a shared TypeMap keyed by TypeId — when the same flag name appears in
both the parent struct and a subcommand, the types must match. They didn't,
causing a panic in `FromArgMatches::from_arg_matches_mut`.

### Fix

Align `Cli.if_missing` and `CliSnapshot.if_missing` to `Option<IfMissing>`,
convert to string when inserting into the settings map.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved handling and validation of the --if-missing flag in the CLI, enforcing supported modes (error, warn, ignore) and ensuring the selected mode is stored correctly in settings.

* **Tests**
  * Added end-to-end tests covering all modes, invalid-value validation, persistence of the chosen mode, and combination with other flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->