### PR TITLE
feat(gcp-sm): implement put_secret_value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2412,6 +2412,7 @@ dependencies = [
  "azure_security_keyvault_secrets",
  "base64 0.22.1",
  "blake3",
+ "bytes",
  "chrono",
  "clap",
  "ctap-hid-fido2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ azure_security_keyvault_keys = { version = "1" }
 azure_security_keyvault_secrets = { version = "1" }
 base64 = "0.22"
 blake3 = "1"
+bytes = "1"
 chrono = "0.4"
 ci_info = "0.14"
 clap = { version = "4", features = ["derive", "env"] }

--- a/crates/fnox-core/Cargo.toml
+++ b/crates/fnox-core/Cargo.toml
@@ -26,6 +26,7 @@ azure_security_keyvault_keys = { workspace = true }
 azure_security_keyvault_secrets = { workspace = true }
 base64 = { workspace = true }
 blake3 = { workspace = true }
+bytes = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }
 demand = { workspace = true }

--- a/crates/fnox-core/src/providers/gcp_sm.rs
+++ b/crates/fnox-core/src/providers/gcp_sm.rs
@@ -81,14 +81,14 @@ impl GoogleSecretManagerProvider {
                 if let Err(e) = create_secret(&client, &parent, secret_id, &name).await
                     && e.http_status_code() != Some(409)
                 {
-                    return Err(convert_provider_error(e));
+                    return Err(convert_provider_error(e, "secretmanager.secrets.create"));
                 }
 
                 add_secret_version(&client, &name, secret_value)
                     .await
-                    .map_err(convert_provider_error)
+                    .map_err(|e| convert_provider_error(e, "secretmanager.versions.add"))
             }
-            Err(e) => Err(convert_provider_error(e)),
+            Err(e) => Err(convert_provider_error(e, "secretmanager.versions.add")),
         }
     }
 }
@@ -129,7 +129,11 @@ async fn add_secret_version(
     Ok(())
 }
 
-fn convert_secret_error(e: google_cloud_secretmanager_v1::Error, secret_id: &str) -> FnoxError {
+fn convert_secret_error(
+    e: google_cloud_secretmanager_v1::Error,
+    secret_id: &str,
+    permission: &str,
+) -> FnoxError {
     let err_str = e.to_string();
 
     if err_str.contains("NOT_FOUND") || err_str.contains("not found") {
@@ -140,18 +144,18 @@ fn convert_secret_error(e: google_cloud_secretmanager_v1::Error, secret_id: &str
             url: URL.to_string(),
         }
     } else {
-        convert_provider_error(e)
+        convert_provider_error(e, permission)
     }
 }
 
-fn convert_provider_error(e: google_cloud_secretmanager_v1::Error) -> FnoxError {
+fn convert_provider_error(e: google_cloud_secretmanager_v1::Error, permission: &str) -> FnoxError {
     let err_str = e.to_string();
 
     if err_str.contains("PERMISSION_DENIED") || err_str.contains("permission") {
         FnoxError::ProviderAuthFailed {
             provider: PROVIDER_NAME.to_string(),
             details: err_str,
-            hint: "Check IAM permissions for secretmanager.versions.access".to_string(),
+            hint: format!("Check IAM permissions for {permission}"),
             url: URL.to_string(),
         }
     } else {
@@ -179,7 +183,7 @@ impl crate::providers::Provider for GoogleSecretManagerProvider {
             .set_name(secret_name)
             .send()
             .await
-            .map_err(|e| convert_secret_error(e, value))?;
+            .map_err(|e| convert_secret_error(e, value, "secretmanager.versions.access"))?;
 
         // Extract the payload data
         let payload = response
@@ -209,7 +213,27 @@ impl crate::providers::Provider for GoogleSecretManagerProvider {
             .set_parent(format!("projects/{}", self.project))
             .send()
             .await
-            .map_err(convert_provider_error)?;
+            .map_err(|e| {
+                let err_str = e.to_string();
+                if err_str.contains("PERMISSION_DENIED") || err_str.contains("permission") {
+                    FnoxError::ProviderAuthFailed {
+                        provider: "GCP Secret Manager".to_string(),
+                        details: err_str,
+                        hint: "Check IAM permissions for secretmanager.secrets.list".to_string(),
+                        url: URL.to_string(),
+                    }
+                } else {
+                    FnoxError::ProviderApiError {
+                        provider: "GCP Secret Manager".to_string(),
+                        details: format!(
+                            "Failed to access project '{}': {}",
+                            self.project, err_str
+                        ),
+                        hint: "Check that the project exists and you have access".to_string(),
+                        url: URL.to_string(),
+                    }
+                }
+            })?;
 
         Ok(())
     }

--- a/crates/fnox-core/src/providers/gcp_sm.rs
+++ b/crates/fnox-core/src/providers/gcp_sm.rs
@@ -1,12 +1,18 @@
 use crate::error::{FnoxError, Result};
 use async_trait::async_trait;
-use google_cloud_secretmanager_v1::client::SecretManagerService;
+use bytes::Bytes;
+use google_cloud_secretmanager_v1::{
+    client::SecretManagerService,
+    model::{Replication, Secret, SecretPayload, replication::Automatic},
+};
 
 pub fn env_dependencies() -> &'static [&'static str] {
     &[]
 }
 
 const URL: &str = "https://fnox.jdx.dev/providers/gcp-sm";
+
+const PROVIDER_NAME: &str = "GCP Secret Manager";
 
 pub struct GoogleSecretManagerProvider {
     project: String,
@@ -20,15 +26,10 @@ impl GoogleSecretManagerProvider {
 
     /// Build the full secret name with optional prefix
     fn build_secret_name(&self, value: &str) -> String {
-        let secret_name = if let Some(prefix) = &self.prefix {
-            format!("{}{}", prefix, value)
-        } else {
-            value.to_string()
-        };
-
         format!(
             "projects/{}/secrets/{}/versions/latest",
-            self.project, secret_name
+            self.project,
+            self.get_secret_id(value)
         )
     }
 
@@ -41,14 +42,14 @@ impl GoogleSecretManagerProvider {
                 || err_str.contains("GOOGLE_APPLICATION_CREDENTIALS")
             {
                 FnoxError::ProviderAuthFailed {
-                    provider: "GCP Secret Manager".to_string(),
+                    provider: PROVIDER_NAME.to_string(),
                     details: err_str,
                     hint: "Run 'gcloud auth application-default login' or set GOOGLE_APPLICATION_CREDENTIALS".to_string(),
                     url: URL.to_string(),
                 }
             } else {
                 FnoxError::ProviderApiError {
-                    provider: "GCP Secret Manager".to_string(),
+                    provider: PROVIDER_NAME.to_string(),
                     details: err_str,
                     hint: "Check your GCP project configuration".to_string(),
                     url: URL.to_string(),
@@ -67,15 +68,99 @@ impl GoogleSecretManagerProvider {
     }
 
     /// Create or update a secret in GCP Secret Manager
-    /// Note: This is a placeholder - full implementation requires determining
-    /// the correct API for setting payload data in google-cloud-secretmanager-v1 crate
-    async fn put_secret_value(&self, _secret_id: &str, _secret_value: &str) -> Result<()> {
-        Err(FnoxError::ProviderApiError {
-            provider: "GCP Secret Manager".to_string(),
-            details: "put_secret not yet implemented".to_string(),
-            hint: "Contributions welcome to implement payload data setting".to_string(),
+    async fn put_secret_value(&self, secret_id: &str, secret_value: &str) -> Result<()> {
+        let client = self.create_client().await?;
+
+        let project = self.project.as_str();
+        let parent = format!("projects/{project}");
+        let name = format!("{parent}/secrets/{secret_id}");
+
+        match add_secret_version(&client, &name, secret_value).await {
+            Ok(_) => Ok(()),
+            Err(e) if e.http_status_code() == Some(404) => {
+                if let Err(e) = create_secret(&client, &parent, secret_id, &name).await
+                    && e.http_status_code() != Some(409)
+                {
+                    return Err(convert_provider_error(e));
+                }
+
+                add_secret_version(&client, &name, secret_value)
+                    .await
+                    .map_err(convert_provider_error)
+            }
+            Err(e) => Err(convert_provider_error(e)),
+        }
+    }
+}
+
+async fn create_secret(
+    client: &SecretManagerService,
+    parent: &str,
+    secret_id: &str,
+    name: &str,
+) -> google_cloud_secretmanager_v1::Result<()> {
+    client
+        .create_secret()
+        .set_parent(parent)
+        .set_secret_id(secret_id)
+        .set_secret(
+            Secret::new()
+                .set_name(name)
+                .set_replication(Replication::new().set_automatic(Automatic::new())),
+        )
+        .send()
+        .await?;
+
+    Ok(())
+}
+
+async fn add_secret_version(
+    client: &SecretManagerService,
+    qualified_secret_name: &str,
+    secret_value: &str,
+) -> google_cloud_secretmanager_v1::Result<()> {
+    client
+        .add_secret_version()
+        .set_parent(qualified_secret_name)
+        .set_payload(SecretPayload::new().set_data(Bytes::copy_from_slice(secret_value.as_bytes())))
+        .send()
+        .await?;
+
+    Ok(())
+}
+
+fn convert_secret_error(e: google_cloud_secretmanager_v1::Error, secret_id: &str) -> FnoxError {
+    let err_str = e.to_string();
+
+    if err_str.contains("NOT_FOUND") || err_str.contains("not found") {
+        FnoxError::ProviderSecretNotFound {
+            provider: PROVIDER_NAME.to_string(),
+            secret: secret_id.to_string(),
+            hint: "Check that the secret exists in the GCP project".to_string(),
             url: URL.to_string(),
-        })
+        }
+    } else {
+        convert_provider_error(e)
+    }
+}
+
+fn convert_provider_error(e: google_cloud_secretmanager_v1::Error) -> FnoxError {
+    let err_str = e.to_string();
+
+    if err_str.contains("PERMISSION_DENIED") || err_str.contains("permission") {
+        FnoxError::ProviderAuthFailed {
+            provider: PROVIDER_NAME.to_string(),
+            details: err_str,
+            hint: "Check IAM permissions for secretmanager.versions.access".to_string(),
+            url: URL.to_string(),
+        }
+    } else {
+        FnoxError::ProviderApiError {
+            provider: PROVIDER_NAME.to_string(),
+            details: err_str,
+            hint: "Check your GCP configuration".to_string(),
+            url: URL.to_string(),
+        }
     }
 }
 
@@ -94,37 +179,13 @@ impl crate::providers::Provider for GoogleSecretManagerProvider {
             .set_name(secret_name)
             .send()
             .await
-            .map_err(|e| {
-                let err_str = e.to_string();
-                if err_str.contains("NOT_FOUND") || err_str.contains("not found") {
-                    FnoxError::ProviderSecretNotFound {
-                        provider: "GCP Secret Manager".to_string(),
-                        secret: value.to_string(),
-                        hint: "Check that the secret exists in the GCP project".to_string(),
-                        url: URL.to_string(),
-                    }
-                } else if err_str.contains("PERMISSION_DENIED") || err_str.contains("permission") {
-                    FnoxError::ProviderAuthFailed {
-                        provider: "GCP Secret Manager".to_string(),
-                        details: err_str,
-                        hint: "Check IAM permissions for secretmanager.versions.access".to_string(),
-                        url: URL.to_string(),
-                    }
-                } else {
-                    FnoxError::ProviderApiError {
-                        provider: "GCP Secret Manager".to_string(),
-                        details: err_str,
-                        hint: "Check your GCP configuration".to_string(),
-                        url: URL.to_string(),
-                    }
-                }
-            })?;
+            .map_err(|e| convert_secret_error(e, value))?;
 
         // Extract the payload data
         let payload = response
             .payload
             .ok_or_else(|| FnoxError::ProviderInvalidResponse {
-                provider: "GCP Secret Manager".to_string(),
+                provider: PROVIDER_NAME.to_string(),
                 details: "Secret has no payload".to_string(),
                 hint: "The secret exists but has no value".to_string(),
                 url: URL.to_string(),
@@ -132,7 +193,7 @@ impl crate::providers::Provider for GoogleSecretManagerProvider {
 
         // Convert bytes to string
         String::from_utf8(payload.data.to_vec()).map_err(|e| FnoxError::ProviderInvalidResponse {
-            provider: "GCP Secret Manager".to_string(),
+            provider: PROVIDER_NAME.to_string(),
             details: format!("Secret value is not valid UTF-8: {}", e),
             hint: "The secret contains binary data that cannot be decoded as UTF-8".to_string(),
             url: URL.to_string(),
@@ -148,27 +209,7 @@ impl crate::providers::Provider for GoogleSecretManagerProvider {
             .set_parent(format!("projects/{}", self.project))
             .send()
             .await
-            .map_err(|e| {
-                let err_str = e.to_string();
-                if err_str.contains("PERMISSION_DENIED") || err_str.contains("permission") {
-                    FnoxError::ProviderAuthFailed {
-                        provider: "GCP Secret Manager".to_string(),
-                        details: err_str,
-                        hint: "Check IAM permissions for secretmanager.secrets.list".to_string(),
-                        url: URL.to_string(),
-                    }
-                } else {
-                    FnoxError::ProviderApiError {
-                        provider: "GCP Secret Manager".to_string(),
-                        details: format!(
-                            "Failed to access project '{}': {}",
-                            self.project, err_str
-                        ),
-                        hint: "Check that the project exists and you have access".to_string(),
-                        url: URL.to_string(),
-                    }
-                }
-            })?;
+            .map_err(convert_provider_error)?;
 
         Ok(())
     }


### PR DESCRIPTION
Currently the implementation of put_secret_value for gcp-sm only provides a stub that returns an error when called. This PR create the actual implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Writing secrets to Google Cloud Secret Manager now works: missing secrets are created automatically and writes are retried.
  * Secret read/write error handling has been centralized for consistent responses; retrieval now returns explicit errors for empty or non‑UTF‑8 payloads.

* **Chores**
  * Added a workspace dependency for improved byte handling used by the core crate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->