### PR TITLE
fix(deps): add age macos x64 lock entry

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -93,6 +93,11 @@ checksum = "sha256:01120ea2cbf0463d4c6bd767f99f3271bbed1cdc8a9aa718a76ba1fe4f019
 url = "https://github.com/FiloSottile/age/releases/download/v1.3.1/age-v1.3.1-darwin-arm64.tar.gz"
 provenance = "github-attestations"
 
+[tools.age."platforms.macos-x64"]
+checksum = "sha256:2b233301ad21ab7b1eabd9ae1198a164005fa4928fcdd745d47c39f8593209d7"
+url = "https://github.com/FiloSottile/age/releases/download/v1.3.1/age-v1.3.1-darwin-amd64.tar.gz"
+provenance = "github-attestations"
+
 [tools.age."platforms.windows-x64"]
 checksum = "sha256:c56e8ce22f7e80cb85ad946cc82d198767b056366201d3e1a2b93d865be38154"
 url = "https://github.com/FiloSottile/age/releases/download/v1.3.1/age-v1.3.1-windows-amd64.zip"


### PR DESCRIPTION
## Summary
- add the missing `age` macOS x64 entry to `mise.lock`
- fix CI render guard failures where `mise run render` updates the lockfile on runners

## Validation
- `git diff --check`
- `cargo test --workspace`
- attempted `mise run render`, but local tool setup stopped before render because `mise` resolved Infisical `latest` to a macOS arm64 asset that is not available; CI previously showed the needed generated diff was only this `mise.lock` entry

_This PR was generated by Claude Code._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Auto-generated lockfile pin only; no application or runtime logic changes.
> 
> **Overview**
> Adds the missing **`age` macOS Intel (`macos-x64`)** platform block to `mise.lock` (checksum, download URL, GitHub attestations provenance), aligning `age` with other tools that already list every supported platform.
> 
> This stops CI **render guard** failures where `mise run render` on **macOS x64** runners rewrites the lockfile because that platform entry was absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b6c9f8044c9f617f1ba5fe930aecc88496d7b82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->