### PR TITLE
docs: link to all sponsors

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Manage secrets with encryption or cloud providers—or both! fnox gives you a un
 
 fnox is sponsored by [37signals](https://37signals.com).
 
+[View all sponsors](https://en.dev/sponsors.html).
+
 ## Quick Start
 
 ```bash


### PR DESCRIPTION
## Summary
- add a README link to the full en.dev sponsors page

## Tests
- not run (README-only change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> README-only documentation change with no code or security impact.
> 
> **Overview**
> The **Sponsors** section now includes a **[View all sponsors](https://en.dev/sponsors.html)** link so readers can see the full sponsor list on en.dev, in addition to the existing 37signals mention.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 367e94c40d201bba547649633a674384277c2059. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a "View all sponsors" link in the Sponsors section of the README for easy access to the complete list of sponsors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->