### PR TITLE
chore(ci): use shared coderabbit config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+remote_config:
+  repository: "jdx/coderabbit"
+  ref: "main"
+  path: ".coderabbit.yaml"


### PR DESCRIPTION
## Summary
- Point this repository's CodeRabbit YAML at the shared `jdx/coderabbit` configuration.
- Keep CodeRabbit settings centralized across the en.dev CLI repositories.

## Validation
- YAML-only configuration change; not run.

*This PR was created by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> YAML-only CI/tooling config with no runtime, auth, or application logic changes.
> 
> **Overview**
> Adds a **`.coderabbit.yaml`** that pulls review settings from the shared **`jdx/coderabbit`** repo (`main`, path `.coderabbit.yaml`) via **`remote_config`**, instead of maintaining a full local CodeRabbit config in this repo.
> 
> Includes the CodeRabbit **schema** comment for editor validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58c84bb800514899bdb84f49ef9f7c3362841ee7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->