### PR TITLE
docs: Add Doppler in Cloud Secret Manager list

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Your `fnox.toml` config file either contains encrypted secrets or references to 
 - [**gcp-sm**](https://fnox.jdx.dev/providers/gcp-sm) - Google Cloud Secret Manager
 - [**bitwarden-sm**](https://fnox.jdx.dev/providers/bitwarden-sm) - Bitwarden Secrets Manager
 - [**vault**](https://fnox.jdx.dev/providers/vault) - HashiCorp Vault
+- [**doppler**](https://fnox.jdx.dev/providers/doppler) - Doppler
 
 ### 🔑 Password Managers & Secret Services
 


### PR DESCRIPTION
Adds doppler to README.md, already listed in fnox docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Doppler as a supported cloud secret storage provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->