### PR TITLE
fix(export): emit dotenv format for env exports

### DIFF
--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -292,7 +292,7 @@
               "double_dash": "Optional",
               "hide": false,
               "choices": {
-                "choices": ["env", "json", "yaml", "toml"]
+                "choices": ["env", "shell", "json", "yaml", "toml"]
               }
             },
             "default": ["env"]

--- a/docs/cli/export.md
+++ b/docs/cli/export.md
@@ -16,6 +16,7 @@ Export format
 **Choices:**
 
 - `env`
+- `shell`
 - `json`
 - `yaml`
 - `toml`

--- a/docs/guide/import-export.md
+++ b/docs/guide/import-export.md
@@ -123,6 +123,9 @@ fnox import -i .env \
 # Export as .env format (default)
 fnox export
 
+# Export as sourceable POSIX shell
+fnox export --format shell
+
 # Export as JSON
 fnox export --format json
 
@@ -138,6 +141,7 @@ fnox export --format toml
 ```bash
 # Export to file
 fnox export > .env
+fnox export --format shell > secrets.sh
 fnox export --format json > secrets.json
 fnox export --format yaml > secrets.yaml
 fnox export --format toml > secrets.toml

--- a/fnox.usage.kdl
+++ b/fnox.usage.kdl
@@ -55,7 +55,7 @@ cmd export help="Export secrets in various formats" {
     alias ex
     flag "-f --format" help="Export format" default=env {
         arg <FORMAT> {
-            choices env json yaml toml
+            choices env shell json yaml toml
         }
     }
     flag "-n --dry-run" help="Show what would be exported without writing to file"

--- a/src/commands/export.rs
+++ b/src/commands/export.rs
@@ -1,6 +1,7 @@
 use crate::commands::Cli;
 use crate::config::Config;
 use crate::error::{FnoxError, Result};
+use crate::shell;
 use crate::temp_file_secrets::create_persistent_secret_file;
 use clap::{Args, ValueEnum};
 use console;
@@ -15,6 +16,8 @@ use strum::{Display, EnumString, VariantNames};
 pub enum ExportFormat {
     /// Environment variable format (KEY=value)
     Env,
+    /// POSIX shell format (export KEY=value)
+    Shell,
     /// JSON format
     Json,
     /// YAML format
@@ -114,6 +117,7 @@ impl ExportCommand {
 
         let output = match self.format {
             ExportFormat::Env => self.export_as_env(&export_data),
+            ExportFormat::Shell => self.export_as_shell(&export_data),
             ExportFormat::Json => self.export_as_json(&export_data),
             ExportFormat::Yaml => self.export_as_yaml(&export_data),
             ExportFormat::Toml => self.export_as_toml(&export_data),
@@ -163,7 +167,24 @@ impl ExportCommand {
         }
 
         for (key, value) in &data.secrets {
-            output.push_str(&format!("export {}='{}'\n", key, value));
+            output.push_str(&format!("{}={}\n", key, dotenv_quote(value)));
+        }
+
+        Ok(output)
+    }
+
+    fn export_as_shell(&self, data: &ExportData) -> Result<String> {
+        let mut output = String::new();
+
+        if let Some(metadata) = &data.metadata {
+            output.push_str(&format!("# Exported from profile: {}\n", metadata.profile));
+            output.push_str(&format!("# Exported at: {}\n", metadata.exported_at));
+            output.push_str(&format!("# Total secrets: {}\n", metadata.total_secrets));
+            output.push('\n');
+        }
+
+        for (key, value) in &data.secrets {
+            output.push_str(&format!("export {}={}\n", key, shell::posix_quote(value)));
         }
 
         Ok(output)
@@ -179,5 +200,53 @@ impl ExportCommand {
 
     fn export_as_toml(&self, data: &ExportData) -> Result<String> {
         toml_edit::ser::to_string_pretty(data).map_err(|source| FnoxError::Toml { source })
+    }
+}
+
+fn dotenv_quote(value: &str) -> String {
+    if !value.is_empty()
+        && value
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.' | '/' | ':'))
+    {
+        return value.to_string();
+    }
+
+    let mut quoted = String::with_capacity(value.len() + 2);
+    quoted.push('"');
+    for c in value.chars() {
+        match c {
+            '\\' => quoted.push_str("\\\\"),
+            '"' => quoted.push_str("\\\""),
+            '$' => quoted.push_str("\\$"),
+            '`' => quoted.push_str("\\`"),
+            '\n' => quoted.push_str("\\n"),
+            '\r' => quoted.push_str("\\r"),
+            '\t' => quoted.push_str("\\t"),
+            _ => quoted.push(c),
+        }
+    }
+    quoted.push('"');
+    quoted
+}
+
+#[cfg(test)]
+mod tests {
+    use super::dotenv_quote;
+
+    #[test]
+    fn dotenv_quote_leaves_simple_values_unquoted() {
+        assert_eq!(dotenv_quote("kek"), "kek");
+        assert_eq!(
+            dotenv_quote("/tmp/fnox-export-FILE_SECRET-abc"),
+            "/tmp/fnox-export-FILE_SECRET-abc"
+        );
+    }
+
+    #[test]
+    fn dotenv_quote_escapes_special_values() {
+        assert_eq!(dotenv_quote("value with spaces"), "\"value with spaces\"");
+        assert_eq!(dotenv_quote("it's \"fine\""), "\"it's \\\"fine\\\"\"");
+        assert_eq!(dotenv_quote("a\nb\t$c`d"), "\"a\\nb\\t\\$c\\`d\"");
     }
 }

--- a/src/commands/export.rs
+++ b/src/commands/export.rs
@@ -211,6 +211,8 @@ fn dotenv_quote(value: &str) -> String {
         return value.to_string();
     }
 
+    // Dotenv parsers treat `$` and backticks literally; use `--format shell`
+    // for sourceable shell output.
     let mut quoted = String::with_capacity(value.len() + 2);
     quoted.push('"');
     for c in value.chars() {

--- a/src/commands/export.rs
+++ b/src/commands/export.rs
@@ -159,12 +159,7 @@ impl ExportCommand {
     fn export_as_env(&self, data: &ExportData) -> Result<String> {
         let mut output = String::new();
 
-        if let Some(metadata) = &data.metadata {
-            output.push_str(&format!("# Exported from profile: {}\n", metadata.profile));
-            output.push_str(&format!("# Exported at: {}\n", metadata.exported_at));
-            output.push_str(&format!("# Total secrets: {}\n", metadata.total_secrets));
-            output.push('\n');
-        }
+        append_metadata_header(&mut output, data.metadata.as_ref());
 
         for (key, value) in &data.secrets {
             output.push_str(&format!("{}={}\n", key, dotenv_quote(value)));
@@ -176,12 +171,7 @@ impl ExportCommand {
     fn export_as_shell(&self, data: &ExportData) -> Result<String> {
         let mut output = String::new();
 
-        if let Some(metadata) = &data.metadata {
-            output.push_str(&format!("# Exported from profile: {}\n", metadata.profile));
-            output.push_str(&format!("# Exported at: {}\n", metadata.exported_at));
-            output.push_str(&format!("# Total secrets: {}\n", metadata.total_secrets));
-            output.push('\n');
-        }
+        append_metadata_header(&mut output, data.metadata.as_ref());
 
         for (key, value) in &data.secrets {
             output.push_str(&format!("export {}={}\n", key, shell::posix_quote(value)));
@@ -203,6 +193,15 @@ impl ExportCommand {
     }
 }
 
+fn append_metadata_header(output: &mut String, metadata: Option<&ExportMetadata>) {
+    if let Some(metadata) = metadata {
+        output.push_str(&format!("# Exported from profile: {}\n", metadata.profile));
+        output.push_str(&format!("# Exported at: {}\n", metadata.exported_at));
+        output.push_str(&format!("# Total secrets: {}\n", metadata.total_secrets));
+        output.push('\n');
+    }
+}
+
 fn dotenv_quote(value: &str) -> String {
     if !value.is_empty()
         && value
@@ -218,8 +217,6 @@ fn dotenv_quote(value: &str) -> String {
         match c {
             '\\' => quoted.push_str("\\\\"),
             '"' => quoted.push_str("\\\""),
-            '$' => quoted.push_str("\\$"),
-            '`' => quoted.push_str("\\`"),
             '\n' => quoted.push_str("\\n"),
             '\r' => quoted.push_str("\\r"),
             '\t' => quoted.push_str("\\t"),
@@ -247,6 +244,6 @@ mod tests {
     fn dotenv_quote_escapes_special_values() {
         assert_eq!(dotenv_quote("value with spaces"), "\"value with spaces\"");
         assert_eq!(dotenv_quote("it's \"fine\""), "\"it's \\\"fine\\\"\"");
-        assert_eq!(dotenv_quote("a\nb\t$c`d"), "\"a\\nb\\t\\$c\\`d\"");
+        assert_eq!(dotenv_quote("a\nb\t$c`d"), "\"a\\nb\\t$c`d\"");
     }
 }

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -317,10 +317,13 @@ impl ImportCommand {
             let key = key.trim();
             let value = value.trim();
 
-            let value = if value.starts_with('"') && value.ends_with('"') {
-                unescape_double_quoted_env_value(&value[1..value.len() - 1])
-            } else if value.starts_with('\'') && value.ends_with('\'') {
-                value[1..value.len() - 1].to_string()
+            let value = if let Some(inner) =
+                value.strip_prefix('"').and_then(|v| v.strip_suffix('"'))
+            {
+                unescape_double_quoted_env_value(inner)
+            } else if let Some(inner) = value.strip_prefix('\'').and_then(|v| v.strip_suffix('\''))
+            {
+                inner.to_string()
             } else {
                 value.to_string()
             };

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -317,10 +317,9 @@ impl ImportCommand {
             let key = key.trim();
             let value = value.trim();
 
-            // Handle quoted values
-            let value = if (value.starts_with('"') && value.ends_with('"'))
-                || (value.starts_with('\'') && value.ends_with('\''))
-            {
+            let value = if value.starts_with('"') && value.ends_with('"') {
+                unescape_double_quoted_env_value(&value[1..value.len() - 1])
+            } else if value.starts_with('\'') && value.ends_with('\'') {
                 value[1..value.len() - 1].to_string()
             } else {
                 value.to_string()
@@ -463,5 +462,53 @@ impl ImportCommand {
         }
 
         Ok(secrets)
+    }
+}
+
+fn unescape_double_quoted_env_value(value: &str) -> String {
+    let mut unescaped = String::with_capacity(value.len());
+    let mut chars = value.chars();
+
+    while let Some(c) = chars.next() {
+        if c != '\\' {
+            unescaped.push(c);
+            continue;
+        }
+
+        match chars.next() {
+            Some('\\') => unescaped.push('\\'),
+            Some('"') => unescaped.push('"'),
+            Some('n') => unescaped.push('\n'),
+            Some('r') => unescaped.push('\r'),
+            Some('t') => unescaped.push('\t'),
+            Some(other) => {
+                unescaped.push('\\');
+                unescaped.push(other);
+            }
+            None => unescaped.push('\\'),
+        }
+    }
+
+    unescaped
+}
+
+#[cfg(test)]
+mod tests {
+    use super::unescape_double_quoted_env_value;
+
+    #[test]
+    fn unescape_double_quoted_env_value_handles_export_escapes() {
+        assert_eq!(
+            unescape_double_quoted_env_value(r#"line1\nline2\t\"quoted\"\\path"#),
+            "line1\nline2\t\"quoted\"\\path"
+        );
+    }
+
+    #[test]
+    fn unescape_double_quoted_env_value_preserves_unknown_escapes() {
+        assert_eq!(
+            unescape_double_quoted_env_value(r#"secret\$value\`tick"#),
+            r#"secret\$value\`tick"#
+        );
     }
 }

--- a/test/config-ordering.bats
+++ b/test/config-ordering.bats
@@ -115,7 +115,7 @@ teardown() {
 	assert_success
 
 	# Extract just the variable names in the order they appear
-	keys=$(echo "$output" | grep "^export" | sed 's/export \([^=]*\)=.*/\1/' | tr '\n' ' ')
+	keys=$(echo "$output" | grep "^[A-Z]" | sed 's/\([^=]*\)=.*/\1/' | tr '\n' ' ')
 
 	expected_order="ONE TWO THREE "
 	assert_equal "$keys" "$expected_order"

--- a/test/config-ordering.bats
+++ b/test/config-ordering.bats
@@ -115,7 +115,7 @@ teardown() {
 	assert_success
 
 	# Extract just the variable names in the order they appear
-	keys=$(echo "$output" | grep "^[A-Z]" | sed 's/\([^=]*\)=.*/\1/' | tr '\n' ' ')
+	keys=$(echo "$output" | grep "^[A-Z_]" | sed 's/\([^=]*\)=.*/\1/' | tr '\n' ' ')
 
 	expected_order="ONE TWO THREE "
 	assert_equal "$keys" "$expected_order"

--- a/test/file_secrets.bats
+++ b/test/file_secrets.bats
@@ -396,19 +396,44 @@ EOF
 	run "$FNOX_BIN" export --format env
 	assert_success
 
-	# Output should contain export statements
-	assert_output --partial "export FILE_SECRET="
-	assert_output --partial "export NORMAL_SECRET="
+	# Output should contain dotenv assignments
+	assert_output --partial "FILE_SECRET="
+	assert_output --partial "NORMAL_SECRET="
 
 	# FILE_SECRET should be a file path (contains fnox-export)
-	assert_output --regexp "export FILE_SECRET='.*/fnox-export-FILE_SECRET-.*'"
+	assert_output --regexp "FILE_SECRET=.*/fnox-export-FILE_SECRET-.*"
 
 	# NORMAL_SECRET should be the actual value
-	assert_output --partial "export NORMAL_SECRET='normal-value'"
+	assert_output --partial "NORMAL_SECRET=normal-value"
 
 	# Extract the file path and verify it exists
 	local file_path
-	file_path=$(echo "$output" | grep "export FILE_SECRET=" | sed "s/export FILE_SECRET='//" | sed "s/'//g")
+	file_path=$(echo "$output" | grep "^FILE_SECRET=" | sed "s/FILE_SECRET=//")
+	test -f "$file_path"
+	[ "$(cat "$file_path")" = "file-secret-value" ]
+}
+
+@test "export shell format emits sourceable export statements" {
+	# Create config with file-based secrets
+	cat >fnox.toml <<EOF
+root = true
+
+[providers.plain]
+type = "plain"
+
+[secrets]
+FILE_SECRET = { provider = "plain", value = "file-secret-value", as_file = true }
+NORMAL_SECRET = { provider = "plain", value = "normal-value" }
+EOF
+
+	run "$FNOX_BIN" export --format shell
+	assert_success
+	assert_output --partial "export FILE_SECRET="
+	assert_output --partial "export NORMAL_SECRET=normal-value"
+	assert_output --regexp "export FILE_SECRET=.*/fnox-export-FILE_SECRET-.*"
+
+	local file_path
+	file_path=$(echo "$output" | grep "export FILE_SECRET=" | sed -E "s/^export FILE_SECRET=//; s/^'(.*)'\$/\\1/" | head -1)
 	test -f "$file_path"
 	[ "$(cat "$file_path")" = "file-secret-value" ]
 }
@@ -463,12 +488,12 @@ EOF
 
 	# Verify export file exists and contains file paths
 	test -f "$export_file"
-	grep -q "export FILE_SECRET=" "$export_file"
-	grep -q "export NORMAL_SECRET='normal-value'" "$export_file"
+	grep -q "FILE_SECRET=" "$export_file"
+	grep -q "NORMAL_SECRET=normal-value" "$export_file"
 
 	# Extract file path from export file
 	local file_path
-	file_path=$(grep "export FILE_SECRET=" "$export_file" | sed "s/export FILE_SECRET='//" | sed "s/'//g")
+	file_path=$(grep "^FILE_SECRET=" "$export_file" | sed "s/FILE_SECRET=//")
 	test -f "$file_path"
 	[ "$(cat "$file_path")" = "file-value" ]
 }

--- a/test/file_secrets.bats
+++ b/test/file_secrets.bats
@@ -438,6 +438,24 @@ EOF
 	[ "$(cat "$file_path")" = "file-secret-value" ]
 }
 
+@test "export env format preserves dotenv literal dollar and backtick values" {
+	cat >fnox.toml <<'EOF'
+root = true
+
+[providers.plain]
+type = "plain"
+
+[secrets]
+SPECIAL_SECRET = { provider = "plain", value = "secret$value`tick`" }
+QUOTED_SECRET = { provider = "plain", value = "quoted \"value\" with \\ backslash" }
+EOF
+
+	run "$FNOX_BIN" export --format env
+	assert_success
+	assert_output --partial 'SPECIAL_SECRET="secret$value`tick`"'
+	assert_output --partial 'QUOTED_SECRET="quoted \"value\" with \\ backslash"'
+}
+
 @test "export to JSON with file-based secrets" {
 	# Create config with file-based secret
 	cat >fnox.toml <<EOF

--- a/test/import.bats
+++ b/test/import.bats
@@ -79,9 +79,11 @@ EOF
 	setup_age_provider
 
 	# Create a .env file with quoted values
-	cat >.env <<EOF
+	cat >.env <<'EOF'
 SINGLE_QUOTED='value with spaces'
 DOUBLE_QUOTED="another value with spaces"
+DOUBLE_QUOTED_ESCAPES="quoted \"value\" with \\ backslash and \n newline"
+DOLLAR_AND_BACKTICK="secret$value`tick`"
 UNQUOTED=no_spaces
 EOF
 
@@ -92,6 +94,12 @@ EOF
 
 	assert_fnox_success get DOUBLE_QUOTED --age-key-file key.txt
 	assert_output "another value with spaces"
+
+	assert_fnox_success get DOUBLE_QUOTED_ESCAPES --age-key-file key.txt
+	assert_output $'quoted "value" with \\ backslash and \n newline'
+
+	assert_fnox_success get DOLLAR_AND_BACKTICK --age-key-file key.txt
+	assert_output 'secret$value`tick`'
 
 	assert_fnox_success get UNQUOTED --age-key-file key.txt
 	assert_output "no_spaces"

--- a/test/toplevel_secrets.bats
+++ b/test/toplevel_secrets.bats
@@ -220,8 +220,13 @@ EOF
 	# Export from dev profile should include both
 	run "$FNOX_BIN" export --profile dev --format env
 	assert_success
-	assert_output --partial "export SHARED_VAR='shared-value'"
-	assert_output --partial "export DEV_VAR='dev-value'"
+	assert_output --partial "SHARED_VAR=shared-value"
+	assert_output --partial "DEV_VAR=dev-value"
+
+	run "$FNOX_BIN" export --profile dev --format shell
+	assert_success
+	assert_output --partial "export SHARED_VAR=shared-value"
+	assert_output --partial "export DEV_VAR=dev-value"
 }
 
 @test "top-level secrets work with exec command" {


### PR DESCRIPTION
## Summary

- change `fnox export --format env` to emit dotenv-style `KEY=value` output
- add `fnox export --format shell` for sourceable `export KEY=value` output
- update generated CLI docs, guide docs, and export-related Bats assertions

## Why

The export command documented `env` as `.env`/`KEY=value`, but emitted shell export statements instead. This made generated dotenv files incompatible with consumers that expect bare assignments.

## Validation

- `mise run render:usage`
- `cargo fmt --check`
- `mise run test:cargo`
- `mise x bats@1.13.0 age jq -- bats --jobs 16 test/file_secrets.bats test/toplevel_secrets.bats test/config-ordering.bats`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changing default `--format env` output is a breaking behavior shift for anyone piping exports into shells expecting `export` lines; secret serialization and import parsing also affect migration workflows.
> 
> **Overview**
> **`fnox export --format env`** now writes **dotenv-style `KEY=value` lines** (with metadata comments unchanged), including quoting/escaping for values that need it, instead of shell `export` statements. That aligns default export output with `.env` consumers.
> 
> A new **`--format shell`** option emits **sourceable `export KEY=…` lines** using POSIX shell quoting (the previous env-style behavior). CLI usage specs, generated docs, and the import/export guide document the new choice.
> 
> **`fnox import`** improves parsing of **double-quoted** `.env` values by unescaping `\n`, `\t`, quotes, and backslashes so round-trips with the updated env export behave correctly.
> 
> Bats tests were updated for the new formats and expanded for shell export, dotenv literals (`$`, backticks), and import escape handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6e2b02938689bc622418475657eac404e1f83d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `shell` as a supported `fnox export --format` option, generating POSIX-style `export KEY=VALUE` statements.

* **Documentation**
  * Updated CLI references and the import/export guide with `--format shell`, including example file redirection usage.

* **Bug Fixes**
  * Improved `--format env` serialization for dotenv-style output (including safer quoting/escaping for complex values).
  * Enhanced `fnox import` parsing of double-quoted values to properly unescape common escape sequences.

* **Tests**
  * Updated export/import test coverage and assertions to match the new env/shell formatting and quote/escape handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->