### PR TITLE
fix(daemon): gate unix socket code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,6 +207,27 @@ jobs:
           max_attempts: 3
           command: mise run test:bats
 
+  windows-check:
+    runs-on: windows-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          submodules: recursive
+          persist-credentials: false
+      - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          cache: false
+      # save-if: only saves on main pushes, so PRs cannot poison the cache.
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 # zizmor: ignore[cache-poisoning]
+        with:
+          shared-key: check-windows
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Check Windows build
+        run: cargo check --workspace
+
   ci-other:
     needs: build
     permissions:
@@ -317,6 +338,7 @@ jobs:
       - ci-bats
       - ci-other
       - msrv
+      - windows-check
     runs-on: ubuntu-latest
     timeout-minutes: 1
     # Run on success or upstream failure but skip when the workflow is cancelled
@@ -327,6 +349,7 @@ jobs:
         if: |
           needs.ci-bats.result != 'success' ||
           needs.ci-other.result != 'success' ||
-          needs.msrv.result != 'success'
+          needs.msrv.result != 'success' ||
+          needs.windows-check.result != 'success'
         run: exit 1
       - run: echo "All CI jobs completed successfully"

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -5,13 +5,17 @@ use crate::secret_resolver::resolve_secrets_batch;
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
+#[cfg(unix)]
 use std::os::fd::AsRawFd;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::Duration;
+#[cfg(unix)]
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+#[cfg(unix)]
 use tokio::net::{UnixListener, UnixStream};
 use tokio::sync::Mutex;
+#[cfg(unix)]
 use tokio::task::JoinSet;
 
 const SOCKET_NAME: &str = "fnoxd.sock";
@@ -635,6 +639,7 @@ async fn call(_path: PathBuf, _request: Request) -> std::result::Result<Response
     )))
 }
 
+#[cfg(unix)]
 async fn handle_connection(
     stream: UnixStream,
     state: std::sync::Arc<Mutex<DaemonState>>,


### PR DESCRIPTION
## Summary

- Gate Unix-only daemon socket imports behind `#[cfg(unix)]`.
- Gate the Unix socket connection handler so Windows release builds do not compile Unix socket types.
- Add a `windows-check` CI job that runs `cargo check --workspace` on `windows-latest` and feeds into the final aggregate job.

## Root Cause

The release workflow failed on Windows because `src/daemon.rs` imported `std::os::fd::AsRawFd` and `tokio::net::{UnixListener, UnixStream}` at module scope. Those APIs are Unix-only even though the daemon runtime path is disabled on non-Unix platforms. CI did not have a lightweight Windows compile check, so this was only caught by the release workflow.

## Validation

- `cargo fmt --check`
- `mise run test:cargo`
- `mise run lint`
- `actionlint .github/workflows/ci.yml`
- `npx prettier --check .github/workflows/ci.yml`
- Attempted `cargo check --target x86_64-pc-windows-msvc` and `cargo check --target aarch64-pc-windows-msvc`; local checks were blocked by missing Windows C toolchain components (`ml64.exe` / Windows SDK / clang-cl support) after installing Rust targets.

_This pull request was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted `cfg` gating and a compile-only CI job; daemon behavior on supported Unix platforms is unchanged.
> 
> **Overview**
> Fixes **Windows workspace compile failures** by moving Unix-only daemon socket imports (`AsRawFd`, `UnixListener`/`UnixStream`, related tokio helpers) behind `#[cfg(unix)]`, and marking `handle_connection` as Unix-only so non-Unix builds never reference those types.
> 
> Adds a **`windows-check`** CI job on `windows-latest` that runs `cargo check --workspace`, and wires it into the **`final`** aggregate gate so Unix-only compile regressions are caught before release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69b54b21fe588b39cdc1c00664b7a79490465fb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Windows platform compatibility verification to the CI pipeline.
  * Improved cross-platform compilation support to prevent build failures on non-Unix systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->