### PR TITLE
chore: release v1.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,35 @@
 # Changelog
 
-## [1.27.1](https://github.com/jdx/fnox/compare/v1.27.0..v1.27.1) - 2026-06-17
+## [1.28.0](https://github.com/jdx/fnox/compare/v1.27.1..v1.28.0) - 2026-06-24
+
+### 🚀 Features
+
+- **(exec)** add non-interactive auth mode by [@jdx](https://github.com/jdx) in [#565](https://github.com/jdx/fnox/pull/565)
 
 ### 🐛 Bug Fixes
 
+- **(ci)** install qualified vault formula by [@jdx](https://github.com/jdx) in [#567](https://github.com/jdx/fnox/pull/567)
+
+### 🧪 Testing
+
+- **(lease)** harden github app mock startup by [@jdx](https://github.com/jdx) in [#566](https://github.com/jdx/fnox/pull/566)
+
+### 📦️ Dependency Updates
+
+- update jdx/pr-closer action to v1.1.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#557](https://github.com/jdx/fnox/pull/557)
+- update rust crate openssl-sys to v0.9.117 by [@renovate[bot]](https://github.com/renovate[bot]) in [#559](https://github.com/jdx/fnox/pull/559)
+- update rust crate aws-sdk-secretsmanager to v1.108.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#562](https://github.com/jdx/fnox/pull/562)
+- update rust crate aws-sdk-kms to v1.111.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#561](https://github.com/jdx/fnox/pull/561)
+- update rust crate aws-sdk-ssm to v1.113.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#563](https://github.com/jdx/fnox/pull/563)
+- update rust crate aws-sdk-sts to v1.107.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#564](https://github.com/jdx/fnox/pull/564)
+- update rust crate xx to v2.6.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#560](https://github.com/jdx/fnox/pull/560)
+- lock file maintenance lockfile maintenance by [@renovate[bot]](https://github.com/renovate[bot]) in [#547](https://github.com/jdx/fnox/pull/547)
+
+## [1.27.1](https://github.com/jdx/fnox/compare/v1.27.0..v1.27.1) - 2026-06-18
+
+### 🐛 Bug Fixes
+
+- **(daemon)** gate unix socket code by [@jdx](https://github.com/jdx) in [#555](https://github.com/jdx/fnox/pull/555)
 - **(export)** emit dotenv format for env exports by [@jdx](https://github.com/jdx) in [#554](https://github.com/jdx/fnox/pull/554)
 
 ### 📚 Documentation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2381,7 +2381,7 @@ dependencies = [
 
 [[package]]
 name = "fnox"
-version = "1.27.1"
+version = "1.28.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -2429,7 +2429,7 @@ dependencies = [
 
 [[package]]
 name = "fnox-core"
-version = "1.27.1"
+version = "1.28.0"
 dependencies = [
  "aes-gcm 0.11.0-rc.4",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "crates/fnox-core"]
 resolver = "3"
 
 [workspace.package]
-version = "1.27.1"
+version = "1.28.0"
 edition = "2024"
 authors = ["@jdx"]
 license = "MIT"
@@ -114,7 +114,7 @@ name = "fnox"
 path = "src/main.rs"
 
 [dependencies]
-fnox-core = { path = "crates/fnox-core", version = "1.27.1" }
+fnox-core = { path = "crates/fnox-core", version = "1.28.0" }
 
 # Direct dependencies of the CLI binary (commands, MCP server, TUI, hook-env,
 # shell integration). Provider/config/secret-resolver crates are pulled in

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -1727,7 +1727,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.27.1",
+  "version": "1.28.0",
   "usage": "Usage: fnox [OPTIONS] <COMMAND>",
   "complete": {
     "key": {

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -4,7 +4,7 @@
 
 **Usage**: `fnox [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.27.1
+**Version**: 1.28.0
 
 - **Usage**: `fnox [FLAGS] <SUBCOMMAND>`
 

--- a/fnox.usage.kdl
+++ b/fnox.usage.kdl
@@ -1,7 +1,7 @@
 min_usage_version "1.3"
 name fnox
 bin fnox
-version "1.27.1"
+version "1.28.0"
 about "A flexible secret management tool by @jdx"
 usage "Usage: fnox [OPTIONS] <COMMAND>"
 flag "-c --config" help="Path to the configuration file (default: fnox.toml, searches parent directories)" global=#true default=fnox.toml {


### PR DESCRIPTION
### 🚀 Features

- **(exec)** add non-interactive auth mode by [@jdx](https://github.com/jdx) in [#565](https://github.com/jdx/fnox/pull/565)

### 🐛 Bug Fixes

- **(ci)** install qualified vault formula by [@jdx](https://github.com/jdx) in [#567](https://github.com/jdx/fnox/pull/567)

### 🧪 Testing

- **(lease)** harden github app mock startup by [@jdx](https://github.com/jdx) in [#566](https://github.com/jdx/fnox/pull/566)

### 📦️ Dependency Updates

- update jdx/pr-closer action to v1.1.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#557](https://github.com/jdx/fnox/pull/557)
- update rust crate openssl-sys to v0.9.117 by [@renovate[bot]](https://github.com/renovate[bot]) in [#559](https://github.com/jdx/fnox/pull/559)
- update rust crate aws-sdk-secretsmanager to v1.108.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#562](https://github.com/jdx/fnox/pull/562)
- update rust crate aws-sdk-kms to v1.111.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#561](https://github.com/jdx/fnox/pull/561)
- update rust crate aws-sdk-ssm to v1.113.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#563](https://github.com/jdx/fnox/pull/563)
- update rust crate aws-sdk-sts to v1.107.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#564](https://github.com/jdx/fnox/pull/564)
- update rust crate xx to v2.6.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#560](https://github.com/jdx/fnox/pull/560)
- lock file maintenance lockfile maintenance by [@renovate[bot]](https://github.com/renovate[bot]) in [#547](https://github.com/jdx/fnox/pull/547)