### PR TITLE
feat(exec): add non-interactive auth mode

### DIFF
--- a/crates/fnox-core/src/config.rs
+++ b/crates/fnox-core/src/config.rs
@@ -1064,8 +1064,8 @@ impl Config {
             .or(self.prompt_auth)
             .unwrap_or(true);
 
-        // Only prompt if enabled AND we're in a TTY
-        enabled && atty::is(atty::Stream::Stdin)
+        // Only prompt if enabled, not explicitly non-interactive, and we're in a TTY
+        enabled && !env::is_non_interactive() && atty::is(atty::Stream::Stdin)
     }
 
     /// Get secrets for the default profile (mutable)

--- a/crates/fnox-core/src/lease_backends/github_oauth.rs
+++ b/crates/fnox-core/src/lease_backends/github_oauth.rs
@@ -341,6 +341,10 @@ impl GitHubOauthBackend {
             }
         }
 
+        if crate::env::is_non_interactive() {
+            return Err(interactive_auth_required());
+        }
+
         let device = self.create_device_code().await?;
         self.print_device_instructions(&device);
         let response = self.poll_access_token(&device).await?;
@@ -397,6 +401,15 @@ fn auth_failed(details: String) -> FnoxError {
         provider: PROVIDER.to_string(),
         details,
         hint: "Run the command again and approve the device authorization prompt".to_string(),
+        url: URL.to_string(),
+    }
+}
+
+fn interactive_auth_required() -> FnoxError {
+    FnoxError::ProviderAuthFailed {
+        provider: PROVIDER.to_string(),
+        details: "interactive auth required for GitHub OAuth device authorization".to_string(),
+        hint: "Run 'fnox lease create <lease-name>' from an interactive terminal to authorize GitHub, then retry in non-interactive mode".to_string(),
         url: URL.to_string(),
     }
 }

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -1705,6 +1705,16 @@
         "long": ["no-defaults"],
         "hide": false,
         "global": true
+      },
+      {
+        "name": "non-interactive",
+        "usage": "--non-interactive",
+        "help": "Disable prompts and browser-based auth flows; use cached/non-interactive auth only",
+        "help_first_line": "Disable prompts and browser-based auth flows; use cached/non-interactive auth only",
+        "short": [],
+        "long": ["non-interactive"],
+        "hide": false,
+        "global": true
       }
     ],
     "mounts": [],

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -1709,8 +1709,8 @@
       {
         "name": "non-interactive",
         "usage": "--non-interactive",
-        "help": "Disable prompts and browser-based auth flows; use cached/non-interactive auth only",
-        "help_first_line": "Disable prompts and browser-based auth flows; use cached/non-interactive auth only",
+        "help": "Disable prompts and browser-based auth flows; use cached/non-interactive auth only (env: FNOX_NON_INTERACTIVE)",
+        "help_first_line": "Disable prompts and browser-based auth flows; use cached/non-interactive auth only (env: FNOX_NON_INTERACTIVE)",
         "short": [],
         "long": ["non-interactive"],
         "hide": false,

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -40,6 +40,10 @@ Disable daemon-backed resolution for this invocation
 
 Do not merge top-level secrets into the selected profile
 
+### `--non-interactive`
+
+Disable prompts and browser-based auth flows; use cached/non-interactive auth only
+
 ## Subcommands
 
 - [`fnox activate [--no-hook-env] [SHELL]`](/cli/activate.md)

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -42,7 +42,7 @@ Do not merge top-level secrets into the selected profile
 
 ### `--non-interactive`
 
-Disable prompts and browser-based auth flows; use cached/non-interactive auth only
+Disable prompts and browser-based auth flows; use cached/non-interactive auth only (env: FNOX_NON_INTERACTIVE)
 
 ## Subcommands
 

--- a/fnox.usage.kdl
+++ b/fnox.usage.kdl
@@ -20,7 +20,7 @@ flag --if-missing help="What to do if a secret is missing (error, warn, ignore)"
 flag --no-color help="Disable colored output" global=#true
 flag --no-daemon help="Disable daemon-backed resolution for this invocation" global=#true
 flag --no-defaults help="Do not merge top-level secrets into the selected profile" global=#true
-flag --non-interactive help="Disable prompts and browser-based auth flows; use cached/non-interactive auth only" global=#true
+flag --non-interactive help="Disable prompts and browser-based auth flows; use cached/non-interactive auth only (env: FNOX_NON_INTERACTIVE)" global=#true
 cmd activate help="Output shell activation code to enable automatic secret loading" {
     flag --no-hook-env help="Don't automatically invoke hook-env (for testing)"
     arg "[SHELL]" help="Shell to generate activation code for (bash, zsh, fish, nu, pwsh)" required=#false

--- a/fnox.usage.kdl
+++ b/fnox.usage.kdl
@@ -20,6 +20,7 @@ flag --if-missing help="What to do if a secret is missing (error, warn, ignore)"
 flag --no-color help="Disable colored output" global=#true
 flag --no-daemon help="Disable daemon-backed resolution for this invocation" global=#true
 flag --no-defaults help="Do not merge top-level secrets into the selected profile" global=#true
+flag --non-interactive help="Disable prompts and browser-based auth flows; use cached/non-interactive auth only" global=#true
 cmd activate help="Output shell activation code to enable automatic secret loading" {
     flag --no-hook-env help="Don't automatically invoke hook-env (for testing)"
     arg "[SHELL]" help="Shell to generate activation code for (bash, zsh, fish, nu, pwsh)" required=#false

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -74,7 +74,7 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub no_defaults: bool,
 
-    /// Disable prompts and browser-based auth flows; use cached/non-interactive auth only
+    /// Disable prompts and browser-based auth flows; use cached/non-interactive auth only (env: FNOX_NON_INTERACTIVE)
     #[arg(long, global = true, env = "FNOX_NON_INTERACTIVE")]
     pub non_interactive: bool,
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -74,6 +74,10 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub no_defaults: bool,
 
+    /// Disable prompts and browser-based auth flows; use cached/non-interactive auth only
+    #[arg(long, global = true, env = "FNOX_NON_INTERACTIVE")]
+    pub non_interactive: bool,
+
     #[command(subcommand)]
     pub command: Commands,
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -28,6 +28,7 @@ pub struct ResolveContext {
     pub age_key_file: Option<PathBuf>,
     pub if_missing: Option<String>,
     pub no_defaults: bool,
+    pub non_interactive: bool,
     pub no_daemon: bool,
 }
 
@@ -56,6 +57,7 @@ impl ResolveContext {
                 || settings
                     .as_ref()
                     .is_some_and(|settings| settings.no_defaults),
+            non_interactive: cli.non_interactive,
             no_daemon: cli.no_daemon,
         }
     }
@@ -108,6 +110,7 @@ struct ResolveBatchRequest {
     age_key_file: Option<PathBuf>,
     if_missing: Option<String>,
     no_defaults: bool,
+    non_interactive: bool,
     purpose: String,
     keys: Vec<String>,
     include_env_false: bool,
@@ -122,6 +125,7 @@ struct ResolveOneRequest {
     age_key_file: Option<PathBuf>,
     if_missing: Option<String>,
     no_defaults: bool,
+    non_interactive: bool,
     purpose: String,
     key: String,
     env: Vec<(String, String)>,
@@ -232,6 +236,7 @@ pub async fn resolve_batch_with_context(
         age_key_file: ctx.age_key_file.clone(),
         if_missing: ctx.if_missing.clone(),
         no_defaults: ctx.no_defaults,
+        non_interactive: ctx.non_interactive,
         purpose: purpose.as_str().to_string(),
         keys,
         include_env_false,
@@ -286,6 +291,7 @@ pub async fn resolve_one_with_context(
         age_key_file: ctx.age_key_file.clone(),
         if_missing: ctx.if_missing.clone(),
         no_defaults: ctx.no_defaults,
+        non_interactive: ctx.non_interactive,
         purpose: purpose.as_str().to_string(),
         key: key.to_string(),
         env: std::env::vars().collect(),
@@ -361,6 +367,9 @@ async fn start_background_for_context(
         .arg(Config::get_profile(ctx.profile.as_deref()));
     if ctx.no_defaults {
         cmd.arg("--no-defaults");
+    }
+    if ctx.non_interactive {
+        cmd.arg("--non-interactive");
     }
     if let Some(if_missing) = &ctx.if_missing {
         cmd.arg("--if-missing").arg(if_missing);
@@ -710,6 +719,7 @@ async fn process_request(
                 Some(req.profile.clone()),
                 req.if_missing.clone(),
                 req.no_defaults,
+                req.non_interactive,
             );
             let config = Config::load_smart(&req.config)?;
             let all_secrets = config.get_secrets(&req.profile)?;
@@ -730,6 +740,7 @@ async fn process_request(
                 Some(req.profile.clone()),
                 req.if_missing.clone(),
                 req.no_defaults,
+                req.non_interactive,
             );
             let config = Config::load_smart(&req.config)?;
             let Some(secret_config) = config.get_secret(&req.profile, &req.key).cloned() else {
@@ -744,6 +755,7 @@ async fn process_request(
                 age_key_file: req.age_key_file,
                 if_missing: req.if_missing,
                 no_defaults: req.no_defaults,
+                non_interactive: req.non_interactive,
                 purpose: req.purpose,
                 keys: vec![req.key.clone()],
                 include_env_false: true,
@@ -767,6 +779,7 @@ fn apply_request_settings(
     profile: Option<String>,
     if_missing: Option<String>,
     no_defaults: bool,
+    non_interactive: bool,
 ) {
     crate::settings::Settings::set_cli_snapshot(crate::settings::CliSnapshot {
         age_key_file,
@@ -774,6 +787,7 @@ fn apply_request_settings(
         if_missing,
         no_defaults,
     });
+    crate::env::set_non_interactive(non_interactive);
 }
 
 async fn resolve_with_cache(

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,7 @@ async fn main() -> miette::Result<()> {
         if_missing: cli.if_missing.clone(),
         no_defaults: cli.no_defaults,
     });
+    fnox::env::set_non_interactive(cli.non_interactive);
 
     // Handle --no-color flag
     if cli.no_color {

--- a/test/lease_github_oauth.bats
+++ b/test/lease_github_oauth.bats
@@ -109,6 +109,8 @@ PYEOF
 	start_mock_github_oauth
 
 	cat >"$FNOX_CONFIG_FILE" <<EOF
+root = true
+
 [leases.github]
 type = "github-oauth"
 client_id = "Iv1.mockclientid"
@@ -128,6 +130,8 @@ EOF
 	start_mock_github_oauth
 
 	cat >"$FNOX_CONFIG_FILE" <<EOF
+root = true
+
 [leases.github]
 type = "github-oauth"
 client_id = "Iv1.mockclientid"
@@ -143,10 +147,62 @@ EOF
 	assert_line "ghu_mock_user_token_abc123"
 }
 
+@test "github-oauth: non-interactive exec fails before device flow without cached token" {
+	start_mock_github_oauth
+
+	cat >"$FNOX_CONFIG_FILE" <<EOF
+root = true
+
+[leases.github]
+type = "github-oauth"
+client_id = "Iv1.mockclientid"
+scope = "repo"
+keyring_cache = false
+open_browser = false
+auth_base = "http://127.0.0.1:$MOCK_PORT/login/oauth"
+api_base = "http://127.0.0.1:$MOCK_PORT/api"
+EOF
+
+	run fnox --non-interactive exec -- printenv GITHUB_TOKEN
+	assert_failure
+	assert_output --partial "interactive auth required for GitHub"
+	refute_output --partial "ABCD-1234"
+}
+
+@test "github-oauth: non-interactive exec reuses cached lease" {
+	start_mock_github_oauth
+
+	cat >"$FNOX_CONFIG_FILE" <<EOF
+root = true
+
+[leases.github]
+type = "github-oauth"
+client_id = "Iv1.mockclientid"
+scope = "repo"
+keyring_cache = false
+open_browser = false
+auth_base = "http://127.0.0.1:$MOCK_PORT/login/oauth"
+api_base = "http://127.0.0.1:$MOCK_PORT/api"
+EOF
+
+	run fnox lease create github
+	assert_success
+
+	kill "$MOCK_PID" 2>/dev/null || true
+	wait "$MOCK_PID" 2>/dev/null || true
+	unset MOCK_PID
+
+	run fnox --non-interactive exec -- printenv GITHUB_TOKEN
+	assert_success
+	assert_line "ghu_mock_user_token_abc123"
+}
+
 @test "github-oauth: custom env_var" {
 	start_mock_github_oauth
 
 	cat >"$FNOX_CONFIG_FILE" <<EOF
+root = true
+
 [leases.github]
 type = "github-oauth"
 client_id = "Iv1.mockclientid"


### PR DESCRIPTION
## Summary
- add global `--non-interactive` / `FNOX_NON_INTERACTIVE` mode
- propagate non-interactive mode through daemon secret-resolution requests
- make `github-oauth` reuse cached/refreshable tokens but fail before starting device flow when interactive auth would be required
- refresh generated CLI usage docs

Refs #482.

## Tests
- `/Users/jdx/.cargo/bin/cargo build`
- `/Users/jdx/.cargo/bin/cargo test --workspace`
- `test/bats/bin/bats test/lease_github_oauth.bats`
- `PATH=/Users/jdx/.cargo/bin:$PATH mise run lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authentication and daemon request shape for secret resolution; misconfiguration in CI could fail jobs that previously hung on prompts, but behavior is intentional and tested for GitHub OAuth.
> 
> **Overview**
> Adds a global **`--non-interactive`** flag (and **`FNOX_NON_INTERACTIVE`**) so CI and scripted runs can forbid prompts and browser/device auth while still using cached credentials.
> 
> The flag is applied at startup and on each **daemon** resolve request (including when auto-starting `daemon serve`), so `fnox exec` and daemon-backed resolution behave consistently. **`should_prompt_auth`** no longer prompts when non-interactive is set.
> 
> **GitHub OAuth** leases still use cached or refreshable tokens; if interactive device flow would be required, the backend fails fast with a clear error instead of printing a user code. Generated CLI usage docs and **bats** coverage cover the non-interactive exec paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a5eaeb9ed52b2bfd5d1df92a101d867ed1dbb70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->