### PR TITLE
test(lease): harden github app mock startup

### DIFF
--- a/test/lease_github_app.bats
+++ b/test/lease_github_app.bats
@@ -61,17 +61,33 @@ with open("$TEST_TEMP_DIR/mock_port", "w") as f:
 server.serve_forever()
 PYEOF
 
-	python3 "$TEST_TEMP_DIR/mock_github.py" &
+	local mock_log="$TEST_TEMP_DIR/mock_github.log"
+	python3 "$TEST_TEMP_DIR/mock_github.py" >"$mock_log" 2>&1 &
 	MOCK_PID=$!
 	# Wait for the port file to appear
-	for _ in $(seq 1 30); do
-		if [[ -f "$TEST_TEMP_DIR/mock_port" ]]; then
-			break
+	for _ in $(seq 1 100); do
+		if [[ -s "$TEST_TEMP_DIR/mock_port" ]]; then
+			MOCK_PORT=$(cat "$TEST_TEMP_DIR/mock_port")
+			export MOCK_PORT
+			return 0
+		fi
+		local mock_state
+		mock_state=$(ps -p "$MOCK_PID" -o stat= 2>/dev/null || true)
+		if [[ -z "$mock_state" || $mock_state == *Z* ]]; then
+			wait "$MOCK_PID" 2>/dev/null || true
+			echo "mock GitHub API exited before writing port" >&2
+			if [[ -s "$mock_log" ]]; then
+				cat "$mock_log" >&2
+			fi
+			return 1
 		fi
 		sleep 0.1
 	done
-	MOCK_PORT=$(cat "$TEST_TEMP_DIR/mock_port")
-	export MOCK_PORT
+	echo "timed out waiting for mock GitHub API to write port" >&2
+	if [[ -s "$mock_log" ]]; then
+		cat "$mock_log" >&2
+	fi
+	return 1
 }
 
 @test "github-app: creates installation token with private key file" {


### PR DESCRIPTION
## Summary
- capture mock GitHub API stderr when startup fails
- wait for a non-empty mock port file and detect early mock process exit
- extend the startup wait window for slower macOS CI runners

## Tests
- `mise run build`
- `test/bats/bin/bats test/lease_github_app.bats`

_This PR was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only helper changes with no production or security impact; slightly longer worst-case wait on mock startup failure.
> 
> **Overview**
> Hardens **`start_mock_github_api`** in `lease_github_app.bats` so GitHub App lease tests fail clearly when the mock HTTP server does not come up.
> 
> The mock process stdout/stderr is redirected to **`mock_github.log`**, and that log is printed on failure. Startup now waits for a **non-empty** port file (up to **100** × 0.1s vs 30), returns **0** as soon as the port is ready, and **fails fast** if the mock PID is gone or zombie instead of hanging until timeout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83b12e34dd22f9a26dabe74d1cfc78e8827a9dfc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->