### PR TITLE
fix(ci): install qualified vault formula

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     steps:
-      - run: brew install parallel vault
+      - run: brew install parallel hashicorp/tap/vault
         if: ${{ matrix.os == 'macos-latest' }}
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:


### PR DESCRIPTION
## Summary
- install Vault as `hashicorp/tap/vault` on macOS CI so Homebrew treats the HashiCorp formula as explicitly selected under tap trust
- leave trust scoped to the formula instead of trusting the whole tap

## Validation
- `git diff --check`
- `mise exec actionlint -- actionlint .github/workflows/ci.yml`

_This pull request was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only Homebrew install change with no application or security logic impact.
> 
> **Overview**
> Updates the **macOS `ci-bats`** Homebrew step so Vault is installed as **`hashicorp/tap/vault`** instead of the unqualified **`vault`** name, while **`parallel`** is unchanged.
> 
> This makes Homebrew treat Vault as an explicitly chosen HashiCorp tap formula under current tap-trust rules, without trusting the whole tap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95c3140bc285c9670963eaa47944676cea034628. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->