### PR TITLE
feat(age): support age plugin recipients and identities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,22 +102,28 @@ dependencies = [
  "cbc 0.1.2",
  "chacha20poly1305",
  "cipher 0.4.4",
+ "console 0.15.11",
  "cookie-factory",
  "ctr 0.9.2",
  "curve25519-dalek",
  "hmac 0.12.1",
  "i18n-embed",
  "i18n-embed-fl",
+ "is-terminal",
  "lazy_static",
  "nom 7.1.3",
  "num-traits",
  "pin-project",
+ "pinentry",
  "rand 0.8.6",
+ "rpassword",
  "rsa",
  "rust-embed",
  "scrypt",
  "sha2 0.10.9",
  "subtle",
+ "which 4.4.2",
+ "wsl",
  "x25519-dalek",
  "zeroize",
 ]
@@ -137,6 +143,7 @@ dependencies = [
  "rand 0.8.6",
  "secrecy",
  "sha2 0.10.9",
+ "tempfile",
 ]
 
 [[package]]
@@ -393,7 +400,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -1568,6 +1575,18 @@ dependencies = [
 
 [[package]]
 name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "console"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
@@ -1707,7 +1726,7 @@ dependencies = [
  "futures-core",
  "mio",
  "parking_lot",
- "rustix",
+ "rustix 1.1.4",
  "signal-hook 0.3.18",
  "signal-hook-mio",
  "winapi",
@@ -1939,7 +1958,7 @@ version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e42d12bfa3506597636b814d58b3f540f6ee71aefd795da37892c45759cdbad"
 dependencies = [
- "console",
+ "console 0.16.3",
  "fuzzy-matcher",
  "itertools",
  "signal-hook 0.4.4",
@@ -2393,7 +2412,7 @@ dependencies = [
  "ci_info",
  "clap",
  "clap-sort",
- "console",
+ "console 0.16.3",
  "crossterm",
  "data-encoding",
  "demand",
@@ -2424,7 +2443,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "usage-lib",
- "which",
+ "which 8.0.4",
 ]
 
 [[package]]
@@ -2491,7 +2510,7 @@ dependencies = [
  "toml_edit",
  "tracing",
  "urlencoding",
- "which",
+ "which 8.0.4",
  "windows-native-keyring-store",
  "xx",
 ]
@@ -2698,7 +2717,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
- "rustix",
+ "rustix 1.1.4",
  "windows-link 0.2.1",
 ]
 
@@ -3153,6 +3172,12 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -3775,6 +3800,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi 0.5.2",
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "is_ci"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4032,6 +4068,12 @@ checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
  "bitflags 2.13.0",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -4902,6 +4944,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pinentry"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a108bb5e4e654a3d20c834e5676b4b20f7cd2cc73b22f849d93e028b259340ec"
+dependencies = [
+ "log",
+ "nom 7.1.3",
+ "percent-encoding",
+ "secrecy",
+ "wait-timeout",
+ "which 4.4.2",
+ "zeroize",
+]
+
+[[package]]
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5602,6 +5659,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "323c417e1d9665a65b263ec744ba09030cfb277e9daa0b018a4ab62e57bc8189"
 
 [[package]]
+name = "rpassword"
+version = "7.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da316a15f47e3d053de9cb2c439650bd8fa4aaeb9365f2e5f27f492ff73c196"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5619,6 +5687,16 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5705,6 +5783,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.13.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -5712,7 +5803,7 @@ dependencies = [
  "bitflags 2.13.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -6509,7 +6600,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.3",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -6552,7 +6643,7 @@ checksum = "9048a889effe34a5cddee0af7f53285198b16dca3be510858d38dfdb3e62a04e"
 dependencies = [
  "bitflags 2.13.0",
  "parking_lot",
- "rustix",
+ "rustix 1.1.4",
  "signal-hook 0.3.18",
  "windows-sys 0.61.2",
 ]
@@ -6563,7 +6654,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -7434,6 +7525,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7662,6 +7762,18 @@ dependencies = [
 
 [[package]]
 name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
+]
+
+[[package]]
+name = "which"
 version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248"
@@ -7869,6 +7981,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
@@ -8054,13 +8175,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "wsl"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dab7ac864710bdea6594becbea5b5050333cf34fefb0dc319567eb347950d4"
+
+[[package]]
 name = "x11rb"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
 dependencies = [
  "gethostname",
- "rustix",
+ "rustix 1.1.4",
  "x11rb-protocol",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.91.1"
 
 [workspace.dependencies]
 aes-gcm = "0.11.0-rc.3"
-age = { version = "0.11", features = ["ssh"] }
+age = { version = "0.11", features = ["ssh", "plugin", "cli-common"] }
 aho-corasick = "1.1.4"
 anyhow = "1"
 arboard = "3"

--- a/crates/fnox-core/src/providers/age.rs
+++ b/crates/fnox-core/src/providers/age.rs
@@ -149,8 +149,9 @@ impl crate::providers::Provider for AgeEncryptionProvider {
             return Err(FnoxError::AgeNotConfigured);
         }
 
-        // Parse recipients - try both SSH and native age formats
+        // Parse recipients - try SSH, native age, then plugin formats
         let mut parsed_recipients: Vec<Box<dyn age::Recipient + Send + Sync>> = Vec::new();
+        let mut plugin_recipients: Vec<age::plugin::Recipient> = Vec::new();
 
         for recipient in &self.recipients {
             // Try parsing as SSH recipient first
@@ -159,11 +160,15 @@ impl crate::providers::Provider for AgeEncryptionProvider {
                 continue;
             }
 
-            // Fall back to native age recipient
-            match recipient.parse::<age::x25519::Recipient>() {
-                Ok(age_recipient) => {
-                    parsed_recipients.push(Box::new(age_recipient));
-                }
+            // Try native age recipient
+            if let Ok(age_recipient) = recipient.parse::<age::x25519::Recipient>() {
+                parsed_recipients.push(Box::new(age_recipient));
+                continue;
+            }
+
+            // Fall back to plugin recipient, e.g. age-plugin-yubikey: age1yubikey1...
+            match recipient.parse::<age::plugin::Recipient>() {
+                Ok(plugin_recipient) => plugin_recipients.push(plugin_recipient),
                 Err(e) => {
                     return Err(FnoxError::AgeEncryptionFailed {
                         details: format!("Failed to parse recipient '{}': {}", recipient, e),
@@ -172,17 +177,45 @@ impl crate::providers::Provider for AgeEncryptionProvider {
             }
         }
 
+        // Build one plugin driver per distinct plugin name. RecipientPluginV1
+        // filters the recipient list by plugin name internally, so we pass the
+        // full list and spawn the matching `age-plugin-*` binary from $PATH.
+        let plugin_names: std::collections::BTreeSet<String> = plugin_recipients
+            .iter()
+            .map(|r| r.plugin().to_string())
+            .collect();
+        for plugin_name in plugin_names {
+            let plugin = age::plugin::RecipientPluginV1::new(
+                &plugin_name,
+                &plugin_recipients,
+                &[],
+                age::cli_common::UiCallbacks,
+            )
+            .map_err(|e| FnoxError::AgeEncryptionFailed {
+                details: format!(
+                    "Failed to initialize age plugin 'age-plugin-{}' \
+                     (is it installed and on your PATH?): {}",
+                    plugin_name, e
+                ),
+            })?;
+            parsed_recipients.push(Box::new(plugin));
+        }
+
         if parsed_recipients.is_empty() {
             return Err(FnoxError::AgeNotConfigured);
         }
 
-        // Create encryptor with parsed recipients
+        // Create encryptor with parsed recipients. With plugin recipients this
+        // talks to the plugin binary eagerly, so it can fail for reasons beyond
+        // an empty recipient list (which we already ruled out above).
         let encryptor = age::Encryptor::with_recipients(
             parsed_recipients
                 .iter()
                 .map(|r| r.as_ref() as &dyn age::Recipient),
         )
-        .expect("we provided at least one recipient");
+        .map_err(|e| FnoxError::AgeEncryptionFailed {
+            details: format!("Failed to initialize age encryptor: {}", e),
+        })?;
 
         // Encrypt the plaintext
         let mut encrypted = vec![];
@@ -287,12 +320,16 @@ impl crate::providers::Provider for AgeEncryptionProvider {
                     vec![Box::new(ssh_identity) as Box<dyn age::Identity>]
                 }
                 Err(_) => {
-                    // Not an SSH identity, try age identity file
+                    // Not an SSH identity, try age identity file. Setting
+                    // callbacks lets `into_identities` construct plugin
+                    // identities (e.g. AGE-PLUGIN-YUBIKEY-1...) by driving the
+                    // matching `age-plugin-*` binary for PIN/touch prompts.
                     cursor.set_position(0);
                     age::IdentityFile::from_buffer(cursor)
                         .map_err(|e| FnoxError::AgeIdentityParseFailed {
                             details: e.to_string(),
                         })?
+                        .with_callbacks(age::cli_common::UiCallbacks)
                         .into_identities()
                         .map_err(|e| FnoxError::AgeIdentityParseFailed {
                             details: e.to_string(),
@@ -323,5 +360,38 @@ impl crate::providers::Provider for AgeEncryptionProvider {
         String::from_utf8(decrypted).map_err(|e| FnoxError::AgeDecryptionFailed {
             details: format!("Failed to decode UTF-8: {}", e),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::providers::Provider;
+
+    /// Regression test for the "incorrect HRP" failure on age plugin recipients
+    /// (e.g. age-plugin-yubikey). A plugin recipient must now be recognized and
+    /// dispatched to the plugin driver instead of being rejected by the native
+    /// x25519 parser. This holds whether or not the plugin binary is installed:
+    /// if it is, wrapping may succeed; if it isn't, the error is about the
+    /// missing plugin binary -- never about an "incorrect HRP" / parse failure.
+    #[tokio::test]
+    async fn plugin_recipient_is_not_rejected_as_invalid_hrp() {
+        let recipient =
+            "age1yubikeyisahci6eesuwaaxoh6quoy9lae2koshah1chit0ceekiel0ohh1bab1eyai3".to_string();
+        let provider =
+            AgeEncryptionProvider::new(vec![recipient], None, OptionProviderSecretRef::none())
+                .expect("provider construction should succeed");
+
+        if let Err(err) = provider.encrypt("plaintext").await {
+            let message = err.to_string();
+            assert!(
+                !message.contains("incorrect HRP"),
+                "plugin recipient should not be rejected by the native parser: {message}"
+            );
+            assert!(
+                !message.contains("Failed to parse recipient"),
+                "plugin recipient should parse successfully: {message}"
+            );
+        }
     }
 }

--- a/crates/fnox-core/src/providers/age.rs
+++ b/crates/fnox-core/src/providers/age.rs
@@ -201,9 +201,13 @@ impl crate::providers::Provider for AgeEncryptionProvider {
             parsed_recipients.push(Box::new(plugin));
         }
 
-        if parsed_recipients.is_empty() {
-            return Err(FnoxError::AgeNotConfigured);
-        }
+        // Every recipient is parsed into `parsed_recipients` (directly or via a
+        // plugin driver) or returns early on failure, and the empty-input case
+        // is rejected at the top of the function, so this is always non-empty.
+        debug_assert!(
+            !parsed_recipients.is_empty(),
+            "non-empty recipients must yield at least one parsed recipient"
+        );
 
         // Create encryptor with parsed recipients. With plugin recipients this
         // talks to the plugin binary eagerly, so it can fail for reasons beyond

--- a/crates/fnox-core/src/providers/age.rs
+++ b/crates/fnox-core/src/providers/age.rs
@@ -377,7 +377,7 @@ mod tests {
     #[tokio::test]
     async fn plugin_recipient_is_not_rejected_as_invalid_hrp() {
         let recipient =
-            "age1yubikeyisahci6eesuwaaxoh6quoy9lae2koshah1chit0ceekiel0ohh1bab1eyai3".to_string();
+            "age1yubikey1qwla8v7cu3mx6mp79asgrh5ad2h52flwln7c66ydcyy50lg5uh0gxh4kmaz".to_string();
         let provider =
             AgeEncryptionProvider::new(vec![recipient], None, OptionProviderSecretRef::none())
                 .expect("provider construction should succeed");

--- a/docs/guide/sync.md
+++ b/docs/guide/sync.md
@@ -117,7 +117,7 @@ recipients = ["age1yubikey1q..."]  # YubiKey recipient
 fnox sync --provider age --config fnox.local.toml
 ```
 
-Secrets are encrypted to your YubiKey's age identity. Decryption requires the YubiKey to be plugged in, adding hardware-based security to your local cache.
+Secrets are encrypted to your YubiKey's age identity. Decryption requires the YubiKey to be plugged in, adding hardware-based security to your local cache. See [Age Plugin Support](/providers/age#plugin-support) for details and other plugins (TPM, FIDO2, …).
 
 ## Refreshing the Cache
 

--- a/docs/providers/age.md
+++ b/docs/providers/age.md
@@ -195,7 +195,7 @@ in its prefix (`age1yubikey1...`, `age1tpm1...`, …):
 ```toml
 [providers.age]
 type = "age"
-recipients = ["age1yubikeyisahci6eesuwaaxoh6quoy9lae2koshah1chit0ceekiel0ohh1bab1eyai3"]
+recipients = ["age1yubikey1qwla8v7cu3mx6mp79asgrh5ad2h52flwln7c66ydcyy50lg5uh0gxh4kmaz"]
 ```
 
 Please refer to the respective plugin docs for detailed setup instructions.

--- a/docs/providers/age.md
+++ b/docs/providers/age.md
@@ -185,6 +185,21 @@ cat ~/.ssh/id_ed25519.pub
 cat ~/.ssh/id_rsa.pub
 ```
 
+## Plugin Support
+
+Age plugins extend age with hardware-backed and alternative keys. fnox supports any [age plugin](https://github.com/FiloSottile/awesome-age#plugins), for example [age-plugin-yubikey](https://github.com/str4d/age-plugin-yubikey) (YubiKey / PIV) or [age-plugin-se](https://github.com/remko/age-plugin-se) (Apple's Secure Enclave).
+
+A plugin recipient looks like a native age recipient but carries the plugin name
+in its prefix (`age1yubikey1...`, `age1tpm1...`, …):
+
+```toml
+[providers.age]
+type = "age"
+recipients = ["age1yubikeyisahci6eesuwaaxoh6quoy9lae2koshah1chit0ceekiel0ohh1bab1eyai3"]
+```
+
+Please refer to the respective plugin docs for detailed setup instructions.
+
 ## Team Workflow
 
 ### 1. Collect Public Keys


### PR DESCRIPTION
## Summary

Adds [age plugin](https://github.com/FiloSottile/awesome-age#plugins) support to the `age` provider, so recipients/identities from plugins like [`age-plugin-yubikey`](https://github.com/str4d/age-plugin-yubikey) (YubiKey/PIV), [`age-plugin-se`](https://github.com/remko/age-plugin-se) (Apple Secure Enclave), `age-plugin-tpm`, etc. work for both encryption and decryption.

Previously a plugin recipient such as `age1yubikey1…` failed at config time with `Failed to parse recipient … incorrect HRP`, because the provider only tried native X25519 and SSH recipients.

## Changes

- **Enable plugin support** — `age` crate features `["ssh"]` → `["ssh", "plugin", "cli-common"]`. `cli-common` provides `age::cli_common::UiCallbacks`, which drives the plugins'  PIN/touch prompts.
- **Encryption** — parse plugin recipients (`age::plugin::Recipient`) alongside X25519/SSH and build one `RecipientPluginV1` per plugin, spawning the matching `age-plugin-*` binary.
- **Decryption** — attach `UiCallbacks` to the identity file (`IdentityFile::with_callbacks(…)`) so `AGE-PLUGIN-*` identities are honored.
- **Tests** — add a regression test asserting a plugin recipient is no longer rejected with "incorrect HRP".
- **Docs** — document plugin support in the age provider guide and sync guide.

related: https://github.com/jdx/fnox/discussions/500

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for age plugin recipients and identities, enabling encryption/decryption via installed age plugins.
  * Introduced improved plugin configuration guidance and examples.

* **Bug Fixes**
  * Improved handling of non-SSH recipients so plugin-style recipients are no longer treated as invalid.
  * Enhanced error reporting when plugin drivers fail to initialize.

* **Documentation**
  * Expanded age provider docs with a “Plugin Support” section and configuration example.
  * Clarified YubiKey encryption/decryption behavior and plugin-related notes.

* **Tests**
  * Added a regression test to prevent plugin recipients from being rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->