### PR TITLE
chore: release v1.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## [1.29.0](https://github.com/jdx/fnox/compare/v1.28.0..v1.29.0) - 2026-07-01
+
+### 🚀 Features
+
+- **(age)** support age plugin recipients and identities by [@nightvisi0n](https://github.com/nightvisi0n) in [#569](https://github.com/jdx/fnox/pull/569)
+
+### 🐛 Bug Fixes
+
+- **(config)** fall back to defaults for inactive providers by [@jdx](https://github.com/jdx) in [#572](https://github.com/jdx/fnox/pull/572)
+- **(daemon)** clear all profile caches by [@jdx](https://github.com/jdx) in [#581](https://github.com/jdx/fnox/pull/581)
+
+### 🚜 Refactor
+
+- **(gcp-sm)** implement get_secrets_batch to improve performance by [@nils-degroot](https://github.com/nils-degroot) in [#580](https://github.com/jdx/fnox/pull/580)
+
+### 🔍 Other Changes
+
+- Enable Entire for Codex by [@jdx](https://github.com/jdx) in [#573](https://github.com/jdx/fnox/pull/573)
+
+### 📦️ Dependency Updates
+
+- update rust-lang/crates-io-auth-action action to v1.0.5 by [@renovate[bot]](https://github.com/renovate[bot]) in [#574](https://github.com/jdx/fnox/pull/574)
+- update jdx/mise-action action to v4.2.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#575](https://github.com/jdx/fnox/pull/575)
+- update actions/checkout action to v7 by [@renovate[bot]](https://github.com/renovate[bot]) in [#576](https://github.com/jdx/fnox/pull/576)
+
+### New Contributors
+
+- @nightvisi0n made their first contribution in [#569](https://github.com/jdx/fnox/pull/569)
+
 ## [1.28.0](https://github.com/jdx/fnox/compare/v1.27.1..v1.28.0) - 2026-06-24
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2400,7 +2400,7 @@ dependencies = [
 
 [[package]]
 name = "fnox"
-version = "1.28.0"
+version = "1.29.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -2448,7 +2448,7 @@ dependencies = [
 
 [[package]]
 name = "fnox-core"
-version = "1.28.0"
+version = "1.29.0"
 dependencies = [
  "aes-gcm 0.11.0-rc.4",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "crates/fnox-core"]
 resolver = "3"
 
 [workspace.package]
-version = "1.28.0"
+version = "1.29.0"
 edition = "2024"
 authors = ["@jdx"]
 license = "MIT"
@@ -114,7 +114,7 @@ name = "fnox"
 path = "src/main.rs"
 
 [dependencies]
-fnox-core = { path = "crates/fnox-core", version = "1.28.0" }
+fnox-core = { path = "crates/fnox-core", version = "1.29.0" }
 
 # Direct dependencies of the CLI binary (commands, MCP server, TUI, hook-env,
 # shell integration). Provider/config/secret-resolver crates are pulled in

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -1727,7 +1727,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.28.0",
+  "version": "1.29.0",
   "usage": "Usage: fnox [OPTIONS] <COMMAND>",
   "complete": {
     "key": {

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -4,7 +4,7 @@
 
 **Usage**: `fnox [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.28.0
+**Version**: 1.29.0
 
 - **Usage**: `fnox [FLAGS] <SUBCOMMAND>`
 

--- a/fnox.usage.kdl
+++ b/fnox.usage.kdl
@@ -1,7 +1,7 @@
 min_usage_version "1.3"
 name fnox
 bin fnox
-version "1.28.0"
+version "1.29.0"
 about "A flexible secret management tool by @jdx"
 usage "Usage: fnox [OPTIONS] <COMMAND>"
 flag "-c --config" help="Path to the configuration file (default: fnox.toml, searches parent directories)" global=#true default=fnox.toml {


### PR DESCRIPTION
### 🚀 Features

- **(age)** support age plugin recipients and identities by [@nightvisi0n](https://github.com/nightvisi0n) in [#569](https://github.com/jdx/fnox/pull/569)

### 🐛 Bug Fixes

- **(config)** fall back to defaults for inactive providers by [@jdx](https://github.com/jdx) in [#572](https://github.com/jdx/fnox/pull/572)
- **(daemon)** clear all profile caches by [@jdx](https://github.com/jdx) in [#581](https://github.com/jdx/fnox/pull/581)

### 🚜 Refactor

- **(gcp-sm)** implement get_secrets_batch to improve performance by [@nils-degroot](https://github.com/nils-degroot) in [#580](https://github.com/jdx/fnox/pull/580)

### 🔍 Other Changes

- Enable Entire for Codex by [@jdx](https://github.com/jdx) in [#573](https://github.com/jdx/fnox/pull/573)

### 📦️ Dependency Updates

- update rust-lang/crates-io-auth-action action to v1.0.5 by [@renovate[bot]](https://github.com/renovate[bot]) in [#574](https://github.com/jdx/fnox/pull/574)
- update jdx/mise-action action to v4.2.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#575](https://github.com/jdx/fnox/pull/575)
- update actions/checkout action to v7 by [@renovate[bot]](https://github.com/renovate[bot]) in [#576](https://github.com/jdx/fnox/pull/576)

### New Contributors

- @nightvisi0n made their first contribution in [#569](https://github.com/jdx/fnox/pull/569)