### PR TITLE
fix(config): fall back to defaults for inactive providers

### DIFF
--- a/crates/fnox-core/src/secret_resolver.rs
+++ b/crates/fnox-core/src/secret_resolver.rs
@@ -450,12 +450,6 @@ fn resolve_default_fallbacks(
         }
 
         if !progressed {
-            let key = next_pending.first().ok_or_else(|| {
-                FnoxError::Config("Unable to resolve default fallback values".to_string())
-            })?;
-            let secret_config = &secrets[key];
-            let context = default_context(resolved_so_far, results);
-            resolve_default_value(key, secret_config, &context)?;
             return Err(FnoxError::Config(format!(
                 "Interpolation dependency cycle among fallback defaults: {}",
                 next_pending.join(", ")
@@ -481,12 +475,6 @@ pub async fn resolve_secret(
     key: &str,
     secret_config: &SecretConfig,
 ) -> Result<Option<String>> {
-    if let Some(value) =
-        resolve_interpolated_default_value(config, profile, key, secret_config).await?
-    {
-        return Ok(Some(value));
-    }
-
     resolve_secret_raw(config, profile, key, secret_config).await
 }
 
@@ -1204,15 +1192,26 @@ async fn try_batch_with_auth_retry(
                 )?
             {
                 // Auth prompt successful, retry the batch operation.
-                let retry_results = try_get_secrets_batch(ctx, provider_secrets).await?;
-                process_batch_results(
-                    ctx.secrets,
-                    ctx.config,
-                    retry_results,
-                    ctx.resolved_so_far,
-                    results,
-                )?;
-                return Ok(std::mem::take(results));
+                return match try_get_secrets_batch(ctx, provider_secrets).await {
+                    Ok(retry_results) => {
+                        process_batch_results(
+                            ctx.secrets,
+                            ctx.config,
+                            retry_results,
+                            ctx.resolved_so_far,
+                            results,
+                        )?;
+                        Ok(std::mem::take(results))
+                    }
+                    Err(retry_error) => handle_batch_error(
+                        ctx.secrets,
+                        ctx.config,
+                        provider_secrets,
+                        &retry_error,
+                        ctx.resolved_so_far,
+                        results,
+                    ),
+                };
             }
             // No auth error, or user declined auth prompt. Process original results.
             process_batch_results(
@@ -1239,7 +1238,14 @@ async fn try_batch_with_auth_retry(
                         )?;
                         Ok(std::mem::take(results))
                     }
-                    Err(retry_error) => Err(retry_error),
+                    Err(retry_error) => handle_batch_error(
+                        ctx.secrets,
+                        ctx.config,
+                        provider_secrets,
+                        &retry_error,
+                        ctx.resolved_so_far,
+                        results,
+                    ),
                 }
             } else {
                 // No auth prompt or user declined - apply if_missing handling per secret
@@ -1713,6 +1719,29 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn test_resolve_secret_provider_value_wins_over_interpolated_default() {
+        let mut config = Config::new();
+        config.providers.insert(
+            "plain".to_string(),
+            ProviderConfig::Plain {
+                auth_command: None,
+                daemon_cache: None,
+            },
+        );
+
+        let mut secret = plain_provider_secret("provider-value");
+        secret.default = Some("${MISSING_REF}".to_string());
+        config.secrets.insert("API_KEY".to_string(), secret);
+
+        let secret_config = config.secrets.get("API_KEY").unwrap();
+        let resolved = resolve_secret(&config, "default", "API_KEY", secret_config)
+            .await
+            .unwrap();
+
+        assert_eq!(resolved, Some("provider-value".to_string()));
+    }
+
     #[test]
     fn test_batch_default_fallback_can_use_same_batch_success() {
         let config = Config::new();
@@ -1744,6 +1773,35 @@ mod tests {
         assert_eq!(
             results.get("DATABASE_URL").and_then(|value| value.as_ref()),
             Some(&"postgres://localhost/fnox".to_string())
+        );
+    }
+
+    #[test]
+    fn test_batch_default_fallback_reports_cycle() {
+        let config = Config::new();
+        let mut secrets = IndexMap::new();
+        secrets.insert("A".to_string(), default_secret("${B}"));
+        secrets.insert("B".to_string(), default_secret("${A}"));
+
+        let mut batch_results = HashMap::new();
+        batch_results.insert("A".to_string(), Err(provider_secret_not_found("A")));
+        batch_results.insert("B".to_string(), Err(provider_secret_not_found("B")));
+
+        let resolved_so_far = HashMap::new();
+        let mut results = HashMap::new();
+        let err = process_batch_results(
+            &secrets,
+            &config,
+            batch_results,
+            &resolved_so_far,
+            &mut results,
+        )
+        .unwrap_err();
+        let msg = format!("{err}");
+
+        assert!(
+            msg.contains("Interpolation dependency cycle among fallback defaults"),
+            "unexpected error: {msg}"
         );
     }
 

--- a/crates/fnox-core/src/secret_resolver.rs
+++ b/crates/fnox-core/src/secret_resolver.rs
@@ -377,6 +377,97 @@ pub fn handle_provider_error(
     }
 }
 
+fn log_provider_default_fallback(key: &str, error: &FnoxError) {
+    if matches!(
+        error,
+        FnoxError::ProviderNotConfigured { .. } | FnoxError::ProviderNotConfiguredWithSource { .. }
+    ) {
+        tracing::debug!(
+            "Falling back to default value for secret '{}' after provider resolution failed: {}",
+            key,
+            error
+        );
+    } else {
+        tracing::warn!(
+            "Falling back to default value for secret '{}' after provider resolution failed: {}",
+            key,
+            error
+        );
+    }
+}
+
+fn default_context(
+    resolved_so_far: &HashMap<String, Option<String>>,
+    results: &HashMap<String, Option<String>>,
+) -> HashMap<String, Option<String>> {
+    let mut context = resolved_so_far.clone();
+    context.extend(
+        results
+            .iter()
+            .map(|(key, value)| (key.clone(), value.clone())),
+    );
+    context
+}
+
+fn resolve_default_fallbacks(
+    keys: &[String],
+    secrets: &IndexMap<String, SecretConfig>,
+    resolved_so_far: &HashMap<String, Option<String>>,
+    results: &mut HashMap<String, Option<String>>,
+) -> Result<HashSet<String>> {
+    let mut context = default_context(resolved_so_far, results);
+    let mut pending: Vec<String> = keys
+        .iter()
+        .filter(|key| secrets[*key].default.is_some())
+        .cloned()
+        .collect();
+    let pending_set: HashSet<String> = pending.iter().cloned().collect();
+    let mut resolved = HashSet::new();
+
+    while !pending.is_empty() {
+        let mut progressed = false;
+        let mut next_pending = Vec::new();
+
+        for key in pending {
+            let secret_config = &secrets[&key];
+            let missing_pending_ref = secret_config.default.as_deref().is_some_and(|default| {
+                extract_default_references(default).iter().any(|reference| {
+                    pending_set.contains(reference) && !context.contains_key(reference)
+                })
+            });
+
+            if missing_pending_ref {
+                next_pending.push(key);
+                continue;
+            }
+
+            if let Some(default) = resolve_default_value(&key, secret_config, &context)? {
+                results.insert(key.clone(), Some(default.clone()));
+                context.insert(key.clone(), Some(default));
+                resolved.insert(key);
+                progressed = true;
+            }
+        }
+
+        if !progressed {
+            let key = next_pending.first().ok_or_else(|| {
+                FnoxError::Config("Unable to resolve default fallback values".to_string())
+            })?;
+            let secret_config = &secrets[key];
+            let context = default_context(resolved_so_far, results);
+            resolve_default_value(key, secret_config, &context)?;
+            return Err(FnoxError::Config(format!(
+                "Interpolation dependency cycle among fallback defaults: {}",
+                next_pending.join(", ")
+            )));
+        }
+
+        pending = next_pending;
+    }
+
+    Ok(resolved)
+}
+
 /// Resolves a secret value using the correct priority order:
 /// 1. Provider (if specified)
 /// 2. Default value (if specified)
@@ -390,23 +481,41 @@ pub async fn resolve_secret(
     key: &str,
     secret_config: &SecretConfig,
 ) -> Result<Option<String>> {
-    if let Some(default) = &secret_config.default
-        && has_default_interpolation(default)
+    if let Some(value) =
+        resolve_interpolated_default_value(config, profile, key, secret_config).await?
     {
-        let secrets = config.get_secrets(profile)?;
-        if secrets.contains_key(key) {
-            let subset = collect_interpolation_closure(config, profile, key, &secrets)?;
-            let mut resolved = resolve_secrets_batch(config, profile, &subset).await?;
-            if let Some(Some(value)) = resolved.shift_remove(key) {
-                return Ok(Some(value));
-            }
-            let resolved_context: HashMap<String, Option<String>> = resolved.into_iter().collect();
-            let default = render_default_template(key, default, &resolved_context)?;
-            return Ok(Some(apply_post_processing(default, secret_config)?));
-        }
+        return Ok(Some(value));
     }
 
     resolve_secret_raw(config, profile, key, secret_config).await
+}
+
+async fn resolve_interpolated_default_value(
+    config: &Config,
+    profile: &str,
+    key: &str,
+    secret_config: &SecretConfig,
+) -> Result<Option<String>> {
+    let Some(default) = &secret_config.default else {
+        return Ok(None);
+    };
+    if !has_default_interpolation(default) {
+        return Ok(None);
+    }
+
+    let secrets = config.get_secrets(profile)?;
+    if !secrets.contains_key(key) {
+        return Ok(None);
+    }
+
+    let subset = collect_interpolation_closure(config, profile, key, &secrets)?;
+    let mut resolved = resolve_secrets_batch(config, profile, &subset).await?;
+    if let Some(Some(value)) = resolved.shift_remove(key) {
+        return Ok(Some(value));
+    }
+    let resolved_context: HashMap<String, Option<String>> = resolved.into_iter().collect();
+    let default = render_default_template(key, default, &resolved_context)?;
+    Ok(Some(apply_post_processing(default, secret_config)?))
 }
 
 async fn resolve_secret_raw(
@@ -419,11 +528,7 @@ async fn resolve_secret_raw(
     let provider_value = match try_resolve_from_provider(config, profile, secret_config).await {
         Ok(value) => value,
         Err(error) if secret_config.default.is_some() => {
-            tracing::debug!(
-                "Falling back to default value for secret '{}' after provider resolution failed: {}",
-                key,
-                error
-            );
+            log_provider_default_fallback(key, &error);
             None
         }
         Err(error) => return Err(error),
@@ -435,6 +540,16 @@ async fn resolve_secret_raw(
     }
 
     // Priority 2: Default value
+    if secret_config
+        .default
+        .as_deref()
+        .is_some_and(has_default_interpolation)
+        && let Some(value) =
+            resolve_interpolated_default_value(config, profile, key, secret_config).await?
+    {
+        return Ok(Some(value));
+    }
+
     if let Some(value) = resolve_default_value(key, secret_config, &HashMap::new())? {
         return Ok(Some(value));
     }
@@ -972,13 +1087,27 @@ async fn resolve_provider_batch(
             let suggestion = format_suggestions(&similar);
 
             // Provider not configured, handle errors for all secrets
+            let fallback_keys: Vec<String> = provider_secrets
+                .iter()
+                .map(|(key, _)| key.clone())
+                .collect();
+            let fallback_resolved =
+                resolve_default_fallbacks(&fallback_keys, secrets, resolved_so_far, &mut results)?;
             for (key, _) in &provider_secrets {
-                let secret_config = &secrets[key];
-                if let Some(default) = resolve_default_value(key, secret_config, resolved_so_far)? {
-                    results.insert(key.clone(), Some(default));
+                if fallback_resolved.contains(key) {
+                    log_provider_default_fallback(
+                        key,
+                        &FnoxError::ProviderNotConfigured {
+                            provider: provider_name.to_string(),
+                            profile: profile.to_string(),
+                            config_path: None,
+                            suggestion: suggestion.clone(),
+                        },
+                    );
                     continue;
                 }
 
+                let secret_config = &secrets[key];
                 let if_missing = resolve_if_missing_behavior(secret_config, config);
                 let error = FnoxError::ProviderNotConfigured {
                     provider: provider_name.to_string(),
@@ -1000,13 +1129,25 @@ async fn resolve_provider_batch(
     // Handle per-secret if_missing policy (like ProviderNotConfigured above)
     // so other providers at the same resolution level are not affected.
     if crate::env::is_non_interactive() && provider_config.requires_interactive_auth() {
+        let fallback_keys: Vec<String> = provider_secrets
+            .iter()
+            .map(|(key, _)| key.clone())
+            .collect();
+        let fallback_resolved =
+            resolve_default_fallbacks(&fallback_keys, secrets, resolved_so_far, &mut results)?;
         for (key, _) in &provider_secrets {
-            let secret_config = &secrets[key];
-            if let Some(default) = resolve_default_value(key, secret_config, resolved_so_far)? {
-                results.insert(key.clone(), Some(default));
+            if fallback_resolved.contains(key) {
+                log_provider_default_fallback(
+                    key,
+                    &FnoxError::Provider(format!(
+                        "Provider '{}' requires interactive authentication and cannot be used in non-interactive mode. Use 'fnox exec' instead.",
+                        provider_name
+                    )),
+                );
                 continue;
             }
 
+            let secret_config = &secrets[key];
             let if_missing = resolve_if_missing_behavior(secret_config, config);
             let error = FnoxError::Provider(format!(
                 "Provider '{}' requires interactive authentication and cannot be used in non-interactive mode. Use 'fnox exec' instead.",
@@ -1020,83 +1161,80 @@ async fn resolve_provider_batch(
         return Ok(results);
     }
 
-    // Try to get secrets with auth retry on failure
-    try_batch_with_auth_retry(
+    let ctx = ProviderBatchContext {
         config,
         profile,
         secrets,
         provider_name,
         provider_config,
-        &provider_secrets,
         resolved_so_far,
-        &mut results,
-    )
-    .await
+    };
+
+    // Try to get secrets with auth retry on failure
+    try_batch_with_auth_retry(&ctx, &provider_secrets, &mut results).await
+}
+
+struct ProviderBatchContext<'a> {
+    config: &'a Config,
+    profile: &'a str,
+    secrets: &'a IndexMap<String, SecretConfig>,
+    provider_name: &'a str,
+    provider_config: &'a ProviderConfig,
+    resolved_so_far: &'a HashMap<String, Option<String>>,
 }
 
 /// Attempts to resolve secrets in batch with optional auth retry.
 /// If the initial attempt fails and we're in a TTY with auth prompting enabled,
 /// prompts the user to run the auth command and retries once.
 async fn try_batch_with_auth_retry(
-    config: &Config,
-    profile: &str,
-    secrets: &IndexMap<String, SecretConfig>,
-    provider_name: &str,
-    provider_config: &ProviderConfig,
+    ctx: &ProviderBatchContext<'_>,
     provider_secrets: &[(String, String)],
-    resolved_so_far: &HashMap<String, Option<String>>,
     results: &mut HashMap<String, Option<String>>,
 ) -> Result<HashMap<String, Option<String>>> {
     // Initial batch secret retrieval attempt before any authentication retry logic
-    match try_get_secrets_batch(
-        config,
-        profile,
-        provider_name,
-        provider_config,
-        provider_secrets,
-    )
-    .await
-    {
+    match try_get_secrets_batch(ctx, provider_secrets).await {
         Ok(batch_results) => {
             let auth_error = extract_auth_error_from_batch(&batch_results);
             if let Some(ref auth_err) = auth_error
-                && prompt_and_run_auth(config, provider_config, provider_name, auth_err)?
+                && prompt_and_run_auth(
+                    ctx.config,
+                    ctx.provider_config,
+                    ctx.provider_name,
+                    auth_err,
+                )?
             {
                 // Auth prompt successful, retry the batch operation.
-                let retry_results = try_get_secrets_batch(
-                    config,
-                    profile,
-                    provider_name,
-                    provider_config,
-                    provider_secrets,
-                )
-                .await?;
-                process_batch_results(secrets, config, retry_results, resolved_so_far, results)?;
+                let retry_results = try_get_secrets_batch(ctx, provider_secrets).await?;
+                process_batch_results(
+                    ctx.secrets,
+                    ctx.config,
+                    retry_results,
+                    ctx.resolved_so_far,
+                    results,
+                )?;
                 return Ok(std::mem::take(results));
             }
             // No auth error, or user declined auth prompt. Process original results.
-            process_batch_results(secrets, config, batch_results, resolved_so_far, results)?;
+            process_batch_results(
+                ctx.secrets,
+                ctx.config,
+                batch_results,
+                ctx.resolved_so_far,
+                results,
+            )?;
             Ok(std::mem::take(results))
         }
         Err(error) => {
             // Try auth prompt and retry
-            if prompt_and_run_auth(config, provider_config, provider_name, &error)? {
+            if prompt_and_run_auth(ctx.config, ctx.provider_config, ctx.provider_name, &error)? {
                 // Auth command ran successfully, retry
-                match try_get_secrets_batch(
-                    config,
-                    profile,
-                    provider_name,
-                    provider_config,
-                    provider_secrets,
-                )
-                .await
-                {
+                match try_get_secrets_batch(ctx, provider_secrets).await {
                     Ok(batch_results) => {
                         process_batch_results(
-                            secrets,
-                            config,
+                            ctx.secrets,
+                            ctx.config,
                             batch_results,
-                            resolved_so_far,
+                            ctx.resolved_so_far,
                             results,
                         )?;
                         Ok(std::mem::take(results))
@@ -1106,11 +1244,11 @@ async fn try_batch_with_auth_retry(
             } else {
                 // No auth prompt or user declined - apply if_missing handling per secret
                 handle_batch_error(
-                    secrets,
-                    config,
+                    ctx.secrets,
+                    ctx.config,
                     provider_secrets,
                     &error,
-                    resolved_so_far,
+                    ctx.resolved_so_far,
                     results,
                 )
             }
@@ -1127,13 +1265,19 @@ fn handle_batch_error(
     resolved_so_far: &HashMap<String, Option<String>>,
     results: &mut HashMap<String, Option<String>>,
 ) -> Result<HashMap<String, Option<String>>> {
+    let fallback_keys: Vec<String> = provider_secrets
+        .iter()
+        .map(|(key, _)| key.clone())
+        .collect();
+    let fallback_resolved =
+        resolve_default_fallbacks(&fallback_keys, secrets, resolved_so_far, results)?;
     for (key, _) in provider_secrets {
-        let secret_config = &secrets[key];
-        if let Some(default) = resolve_default_value(key, secret_config, resolved_so_far)? {
-            results.insert(key.clone(), Some(default));
+        if fallback_resolved.contains(key) {
+            log_provider_default_fallback(key, error);
             continue;
         }
 
+        let secret_config = &secrets[key];
         let if_missing = resolve_if_missing_behavior(secret_config, config);
         let provider_error = FnoxError::Provider(error.to_string());
         if let Some(err) = handle_provider_error(key, provider_error, if_missing, true) {
@@ -1169,13 +1313,16 @@ fn extract_auth_error_from_batch(
 /// Helper to get multiple secrets in batch from a provider without auth retry logic.
 /// Creates the provider instance and calls `get_secrets_batch` on it.
 async fn try_get_secrets_batch(
-    config: &Config,
-    profile: &str,
-    provider_name: &str,
-    provider_config: &ProviderConfig,
+    ctx: &ProviderBatchContext<'_>,
     provider_secrets: &[(String, String)],
 ) -> Result<HashMap<String, Result<String>>> {
-    let provider = get_provider_resolved(config, profile, provider_name, provider_config).await?;
+    let provider = get_provider_resolved(
+        ctx.config,
+        ctx.profile,
+        ctx.provider_name,
+        ctx.provider_config,
+    )
+    .await?;
     Ok(provider.get_secrets_batch(provider_secrets).await)
 }
 
@@ -1187,6 +1334,8 @@ fn process_batch_results(
     resolved_so_far: &HashMap<String, Option<String>>,
     results: &mut HashMap<String, Option<String>>,
 ) -> Result<()> {
+    let mut failed = Vec::new();
+
     for (key, result) in batch_results {
         let secret_config = &secrets[&key];
         match result {
@@ -1204,21 +1353,30 @@ fn process_batch_results(
                 }
             }
             Err(e) => {
-                if let Some(default) = resolve_default_value(&key, secret_config, resolved_so_far)?
-                {
-                    results.insert(key, Some(default));
-                    continue;
-                }
-
-                let if_missing = resolve_if_missing_behavior(secret_config, config);
-                if let Some(error) = handle_provider_error(&key, e, if_missing, true) {
-                    // Fail fast if if_missing is error
-                    return Err(error);
-                }
-                results.insert(key, None);
+                failed.push((key, e));
             }
         }
     }
+
+    let fallback_keys: Vec<String> = failed.iter().map(|(key, _)| key.clone()).collect();
+    let fallback_resolved =
+        resolve_default_fallbacks(&fallback_keys, secrets, resolved_so_far, results)?;
+
+    for (key, e) in failed {
+        if fallback_resolved.contains(&key) {
+            log_provider_default_fallback(&key, &e);
+            continue;
+        }
+
+        let secret_config = &secrets[&key];
+        let if_missing = resolve_if_missing_behavior(secret_config, config);
+        if let Some(error) = handle_provider_error(&key, e, if_missing, true) {
+            // Fail fast if if_missing is error
+            return Err(error);
+        }
+        results.insert(key, None);
+    }
+
     Ok(())
 }
 
@@ -1258,6 +1416,15 @@ mod tests {
         secret.set_provider(Some("plain".to_string()));
         secret.set_value(Some(value.to_string()));
         secret
+    }
+
+    fn provider_secret_not_found(secret: &str) -> FnoxError {
+        FnoxError::ProviderSecretNotFound {
+            provider: "plain".to_string(),
+            secret: secret.to_string(),
+            hint: String::new(),
+            url: "https://fnox.jdx.dev/providers".to_string(),
+        }
     }
 
     #[test]
@@ -1543,6 +1710,40 @@ mod tests {
         assert_eq!(
             resolved.get("API_KEY").and_then(|value| value.as_ref()),
             Some(&"provider-value".to_string())
+        );
+    }
+
+    #[test]
+    fn test_batch_default_fallback_can_use_same_batch_success() {
+        let config = Config::new();
+        let mut secrets = IndexMap::new();
+        secrets.insert("HOSTNAME".to_string(), SecretConfig::new());
+        secrets.insert(
+            "DATABASE_URL".to_string(),
+            default_secret("postgres://${HOSTNAME}/fnox"),
+        );
+
+        let mut batch_results = HashMap::new();
+        batch_results.insert("HOSTNAME".to_string(), Ok("localhost".to_string()));
+        batch_results.insert(
+            "DATABASE_URL".to_string(),
+            Err(provider_secret_not_found("DATABASE_URL")),
+        );
+
+        let resolved_so_far = HashMap::new();
+        let mut results = HashMap::new();
+        process_batch_results(
+            &secrets,
+            &config,
+            batch_results,
+            &resolved_so_far,
+            &mut results,
+        )
+        .unwrap();
+
+        assert_eq!(
+            results.get("DATABASE_URL").and_then(|value| value.as_ref()),
+            Some(&"postgres://localhost/fnox".to_string())
         );
     }
 

--- a/crates/fnox-core/src/secret_resolver.rs
+++ b/crates/fnox-core/src/secret_resolver.rs
@@ -421,22 +421,30 @@ fn resolve_default_fallbacks(
         .filter(|key| secrets[*key].default.is_some())
         .cloned()
         .collect();
-    let pending_set: HashSet<String> = pending.iter().cloned().collect();
     let mut resolved = HashSet::new();
 
     while !pending.is_empty() {
+        let pending_set: HashSet<String> = pending.iter().cloned().collect();
         let mut progressed = false;
         let mut next_pending = Vec::new();
 
         for key in pending {
             let secret_config = &secrets[&key];
-            let missing_pending_ref = secret_config.default.as_deref().is_some_and(|default| {
-                extract_default_references(default).iter().any(|reference| {
-                    pending_set.contains(reference) && !context.contains_key(reference)
-                })
+            let refs = secret_config
+                .default
+                .as_deref()
+                .map(extract_default_references)
+                .unwrap_or_default();
+            let unresolved_external_ref = refs.iter().any(|reference| {
+                !context.contains_key(reference) && !pending_set.contains(reference)
             });
+            if unresolved_external_ref {
+                continue;
+            }
 
-            if missing_pending_ref {
+            if refs.iter().any(|reference| {
+                pending_set.contains(reference) && !context.contains_key(reference)
+            }) {
                 next_pending.push(key);
                 continue;
             }
@@ -449,7 +457,7 @@ fn resolve_default_fallbacks(
             }
         }
 
-        if !progressed {
+        if !progressed && !next_pending.is_empty() {
             return Err(FnoxError::Config(format!(
                 "Interpolation dependency cycle among fallback defaults: {}",
                 next_pending.join(", ")
@@ -731,6 +739,7 @@ pub async fn resolve_secrets_batch(
     let all_keys: Vec<String> = secrets.keys().cloned().collect();
     let secret_keys: HashSet<&str> = all_keys.iter().map(|k| k.as_str()).collect();
     let mut default_deps: HashMap<String, Vec<String>> = HashMap::new();
+    let mut hard_default_deps: HashMap<String, Vec<String>> = HashMap::new();
 
     for (key, secret_config) in secrets {
         // If a sync cache exists, use the sync provider/value
@@ -760,30 +769,34 @@ pub async fn resolve_secrets_batch(
         let provider_is_unconfigured = secret_provider
             .get(key)
             .is_some_and(|(provider_name, _)| !providers.contains_key(provider_name));
-        if !no_provider_set.contains(key.as_str()) && !provider_is_unconfigured {
-            continue;
-        }
+        let hard_default = no_provider_set.contains(key.as_str()) || provider_is_unconfigured;
 
         let Some(default) = &secret_config.default else {
             continue;
         };
 
         let refs = extract_default_references(default);
-        if refs.iter().any(|reference| reference == key) {
+        if hard_default && refs.iter().any(|reference| reference == key) {
             return Err(FnoxError::Config(format!(
                 "Secret '{}' has an interpolation cycle in default value",
                 key
             )));
         }
 
-        for reference in &refs {
-            if !secret_keys.contains(reference.as_str()) {
-                return Err(default_reference_error(key, reference));
+        let mut deps = Vec::new();
+        for reference in refs {
+            if secret_keys.contains(reference.as_str()) {
+                deps.push(reference);
+            } else if hard_default {
+                return Err(default_reference_error(key, &reference));
             }
         }
 
-        if !refs.is_empty() {
-            default_deps.insert(key.clone(), refs);
+        if !deps.is_empty() {
+            default_deps.insert(key.clone(), deps.clone());
+            if hard_default {
+                hard_default_deps.insert(key.clone(), deps);
+            }
         }
     }
 
@@ -846,7 +859,7 @@ pub async fn resolve_secrets_batch(
     if !cycle.is_empty() {
         let cycle_keys: HashSet<&str> = cycle.iter().map(|key| key.as_str()).collect();
         let has_default_cycle = cycle.iter().any(|key| {
-            default_deps.get(key).is_some_and(|refs| {
+            hard_default_deps.get(key).is_some_and(|refs| {
                 refs.iter()
                     .any(|reference| cycle_keys.contains(reference.as_str()))
             })
@@ -1777,6 +1790,42 @@ mod tests {
     }
 
     #[test]
+    fn test_batch_default_fallback_skips_unresolved_reference() {
+        let config = Config::new();
+        let mut secrets = IndexMap::new();
+        let mut host = SecretConfig::new();
+        host.if_missing = Some(IfMissing::Ignore);
+        let mut database_url = default_secret("postgres://${DB_HOST}/fnox");
+        database_url.if_missing = Some(IfMissing::Ignore);
+        secrets.insert("DB_HOST".to_string(), host);
+        secrets.insert("DATABASE_URL".to_string(), database_url);
+
+        let mut batch_results = HashMap::new();
+        batch_results.insert(
+            "DB_HOST".to_string(),
+            Err(provider_secret_not_found("DB_HOST")),
+        );
+        batch_results.insert(
+            "DATABASE_URL".to_string(),
+            Err(provider_secret_not_found("DATABASE_URL")),
+        );
+
+        let resolved_so_far = HashMap::new();
+        let mut results = HashMap::new();
+        process_batch_results(
+            &secrets,
+            &config,
+            batch_results,
+            &resolved_so_far,
+            &mut results,
+        )
+        .unwrap();
+
+        assert_eq!(results.get("DB_HOST"), Some(&None));
+        assert_eq!(results.get("DATABASE_URL"), Some(&None));
+    }
+
+    #[test]
     fn test_batch_default_fallback_reports_cycle() {
         let config = Config::new();
         let mut secrets = IndexMap::new();
@@ -1802,6 +1851,40 @@ mod tests {
         assert!(
             msg.contains("Interpolation dependency cycle among fallback defaults"),
             "unexpected error: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_configured_provider_default_reference_orders_fallback_dependency() {
+        let mut config = Config::new();
+        config.providers.insert(
+            "plain".to_string(),
+            ProviderConfig::Plain {
+                auth_command: None,
+                daemon_cache: None,
+            },
+        );
+
+        let mut database_url = plain_provider_secret("provider-value");
+        database_url.default = Some("postgres://${DB_HOST}/fnox".to_string());
+
+        let mut secrets = IndexMap::new();
+        secrets.insert("DATABASE_URL".to_string(), database_url);
+        secrets.insert("DB_HOST".to_string(), default_secret("localhost"));
+
+        let resolved = resolve_secrets_batch(&config, "default", &secrets)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            resolved
+                .get("DATABASE_URL")
+                .and_then(|value| value.as_ref()),
+            Some(&"provider-value".to_string())
+        );
+        assert_eq!(
+            resolved.get("DB_HOST").and_then(|value| value.as_ref()),
+            Some(&"localhost".to_string())
         );
     }
 

--- a/crates/fnox-core/src/secret_resolver.rs
+++ b/crates/fnox-core/src/secret_resolver.rs
@@ -415,22 +415,37 @@ async fn resolve_secret_raw(
     key: &str,
     secret_config: &SecretConfig,
 ) -> Result<Option<String>> {
-    // Try to get a value from any source (provider, default, or env var)
-    let value_to_process =
-        // Priority 1: Provider (if specified and has a value)
-        if let Some(value) = try_resolve_from_provider(config, profile, secret_config).await? {
-            Some(value)
-        // Priority 2: Default value
-        } else if let Some(default) = &secret_config.default {
-            tracing::debug!("Using default value for secret '{}'", key);
-            Some(default.clone())
-        // Priority 3: Environment variable
-        } else if let Ok(env_value) = env::var(key) {
-            tracing::debug!("Found secret '{}' in current environment", key);
-            Some(env_value)
-        } else {
+    // Priority 1: Provider (if specified and has a value)
+    let provider_value = match try_resolve_from_provider(config, profile, secret_config).await {
+        Ok(value) => value,
+        Err(error) if secret_config.default.is_some() => {
+            tracing::debug!(
+                "Falling back to default value for secret '{}' after provider resolution failed: {}",
+                key,
+                error
+            );
             None
-        };
+        }
+        Err(error) => return Err(error),
+    };
+
+    if let Some(value) = provider_value {
+        let processed = apply_post_processing(value, secret_config)?;
+        return Ok(Some(processed));
+    }
+
+    // Priority 2: Default value
+    if let Some(value) = resolve_default_value(key, secret_config, &HashMap::new())? {
+        return Ok(Some(value));
+    }
+
+    // Priority 3: Environment variable
+    let value_to_process = if let Ok(env_value) = env::var(key) {
+        tracing::debug!("Found secret '{}' in current environment", key);
+        Some(env_value)
+    } else {
+        None
+    };
 
     // Apply post-processing to whatever value we found (e.g., JSON path extraction)
     if let Some(value) = value_to_process {
@@ -572,6 +587,24 @@ fn handle_missing_secret(
     }
 }
 
+fn resolve_default_value(
+    key: &str,
+    secret_config: &SecretConfig,
+    resolved_so_far: &HashMap<String, Option<String>>,
+) -> Result<Option<String>> {
+    let Some(default) = &secret_config.default else {
+        return Ok(None);
+    };
+
+    tracing::debug!("Using default value for secret '{}'", key);
+    let value = if has_default_interpolation(default) {
+        render_default_template(key, default, resolved_so_far)?
+    } else {
+        default.clone()
+    };
+    Ok(Some(apply_post_processing(value, secret_config)?))
+}
+
 /// Resolves multiple secrets efficiently using batch operations when possible.
 ///
 /// Secrets are resolved in dependency order using Kahn's algorithm. If a provider
@@ -619,8 +652,15 @@ pub async fn resolve_secrets_batch(
         }
     }
 
-    for key in &no_provider {
-        let secret_config = &secrets[key];
+    let no_provider_set: HashSet<&str> = no_provider.iter().map(|s| s.as_str()).collect();
+    for (key, secret_config) in secrets {
+        let provider_is_unconfigured = secret_provider
+            .get(key)
+            .is_some_and(|(provider_name, _)| !providers.contains_key(provider_name));
+        if !no_provider_set.contains(key.as_str()) && !provider_is_unconfigured {
+            continue;
+        }
+
         let Some(default) = &secret_config.default else {
             continue;
         };
@@ -672,7 +712,6 @@ pub async fn resolve_secrets_batch(
         }
     }
 
-    let no_provider_set: HashSet<&str> = no_provider.iter().map(|s| s.as_str()).collect();
     let (levels, cycle) = compute_resolution_levels(&all_keys, &deps_for_secret, &no_provider_set);
 
     // Resolve each level in order
@@ -852,7 +891,15 @@ async fn resolve_level(
     // Resolve provider-backed secrets in parallel by provider
     let provider_results: Vec<_> = stream::iter(by_provider)
         .map(|(provider_name, provider_secrets)| async move {
-            resolve_provider_batch(config, profile, secrets, &provider_name, provider_secrets).await
+            resolve_provider_batch(
+                config,
+                profile,
+                secrets,
+                &provider_name,
+                provider_secrets,
+                resolved_so_far,
+            )
+            .await
         })
         .buffer_unordered(10)
         .collect()
@@ -890,14 +937,8 @@ async fn resolve_no_provider_secret(
     secret_config: &SecretConfig,
     resolved_so_far: &HashMap<String, Option<String>>,
 ) -> Result<Option<String>> {
-    if let Some(default) = &secret_config.default {
-        tracing::debug!("Using default value for secret '{}'", key);
-        let value = if has_default_interpolation(default) {
-            render_default_template(key, default, resolved_so_far)?
-        } else {
-            default.clone()
-        };
-        return Ok(Some(apply_post_processing(value, secret_config)?));
+    if let Some(value) = resolve_default_value(key, secret_config, resolved_so_far)? {
+        return Ok(Some(value));
     }
 
     resolve_secret_raw(config, profile, key, secret_config).await
@@ -910,6 +951,7 @@ async fn resolve_provider_batch(
     secrets: &IndexMap<String, SecretConfig>,
     provider_name: &str,
     provider_secrets: Vec<(String, String)>,
+    resolved_so_far: &HashMap<String, Option<String>>,
 ) -> Result<HashMap<String, Option<String>>> {
     let mut results = HashMap::new();
 
@@ -932,6 +974,11 @@ async fn resolve_provider_batch(
             // Provider not configured, handle errors for all secrets
             for (key, _) in &provider_secrets {
                 let secret_config = &secrets[key];
+                if let Some(default) = resolve_default_value(key, secret_config, resolved_so_far)? {
+                    results.insert(key.clone(), Some(default));
+                    continue;
+                }
+
                 let if_missing = resolve_if_missing_behavior(secret_config, config);
                 let error = FnoxError::ProviderNotConfigured {
                     provider: provider_name.to_string(),
@@ -955,6 +1002,11 @@ async fn resolve_provider_batch(
     if crate::env::is_non_interactive() && provider_config.requires_interactive_auth() {
         for (key, _) in &provider_secrets {
             let secret_config = &secrets[key];
+            if let Some(default) = resolve_default_value(key, secret_config, resolved_so_far)? {
+                results.insert(key.clone(), Some(default));
+                continue;
+            }
+
             let if_missing = resolve_if_missing_behavior(secret_config, config);
             let error = FnoxError::Provider(format!(
                 "Provider '{}' requires interactive authentication and cannot be used in non-interactive mode. Use 'fnox exec' instead.",
@@ -976,6 +1028,7 @@ async fn resolve_provider_batch(
         provider_name,
         provider_config,
         &provider_secrets,
+        resolved_so_far,
         &mut results,
     )
     .await
@@ -991,6 +1044,7 @@ async fn try_batch_with_auth_retry(
     provider_name: &str,
     provider_config: &ProviderConfig,
     provider_secrets: &[(String, String)],
+    resolved_so_far: &HashMap<String, Option<String>>,
     results: &mut HashMap<String, Option<String>>,
 ) -> Result<HashMap<String, Option<String>>> {
     // Initial batch secret retrieval attempt before any authentication retry logic
@@ -1017,11 +1071,11 @@ async fn try_batch_with_auth_retry(
                     provider_secrets,
                 )
                 .await?;
-                process_batch_results(secrets, config, retry_results, results)?;
+                process_batch_results(secrets, config, retry_results, resolved_so_far, results)?;
                 return Ok(std::mem::take(results));
             }
             // No auth error, or user declined auth prompt. Process original results.
-            process_batch_results(secrets, config, batch_results, results)?;
+            process_batch_results(secrets, config, batch_results, resolved_so_far, results)?;
             Ok(std::mem::take(results))
         }
         Err(error) => {
@@ -1038,14 +1092,27 @@ async fn try_batch_with_auth_retry(
                 .await
                 {
                     Ok(batch_results) => {
-                        process_batch_results(secrets, config, batch_results, results)?;
+                        process_batch_results(
+                            secrets,
+                            config,
+                            batch_results,
+                            resolved_so_far,
+                            results,
+                        )?;
                         Ok(std::mem::take(results))
                     }
                     Err(retry_error) => Err(retry_error),
                 }
             } else {
                 // No auth prompt or user declined - apply if_missing handling per secret
-                handle_batch_error(secrets, config, provider_secrets, &error, results)
+                handle_batch_error(
+                    secrets,
+                    config,
+                    provider_secrets,
+                    &error,
+                    resolved_so_far,
+                    results,
+                )
             }
         }
     }
@@ -1057,10 +1124,16 @@ fn handle_batch_error(
     config: &Config,
     provider_secrets: &[(String, String)],
     error: &FnoxError,
+    resolved_so_far: &HashMap<String, Option<String>>,
     results: &mut HashMap<String, Option<String>>,
 ) -> Result<HashMap<String, Option<String>>> {
     for (key, _) in provider_secrets {
         let secret_config = &secrets[key];
+        if let Some(default) = resolve_default_value(key, secret_config, resolved_so_far)? {
+            results.insert(key.clone(), Some(default));
+            continue;
+        }
+
         let if_missing = resolve_if_missing_behavior(secret_config, config);
         let provider_error = FnoxError::Provider(error.to_string());
         if let Some(err) = handle_provider_error(key, provider_error, if_missing, true) {
@@ -1111,6 +1184,7 @@ fn process_batch_results(
     secrets: &IndexMap<String, SecretConfig>,
     config: &Config,
     batch_results: HashMap<String, Result<String>>,
+    resolved_so_far: &HashMap<String, Option<String>>,
     results: &mut HashMap<String, Option<String>>,
 ) -> Result<()> {
     for (key, result) in batch_results {
@@ -1130,6 +1204,12 @@ fn process_batch_results(
                 }
             }
             Err(e) => {
+                if let Some(default) = resolve_default_value(&key, secret_config, resolved_so_far)?
+                {
+                    results.insert(key, Some(default));
+                    continue;
+                }
+
                 let if_missing = resolve_if_missing_behavior(secret_config, config);
                 if let Some(error) = handle_provider_error(&key, e, if_missing, true) {
                     // Fail fast if if_missing is error

--- a/test/aws_sts.bats
+++ b/test/aws_sts.bats
@@ -56,7 +56,9 @@ setup() {
 }
 
 teardown() {
-	_common_teardown
+	if declare -F _common_teardown >/dev/null; then
+		_common_teardown
+	fi
 }
 
 # Helper: create fnox config with STS lease backend

--- a/test/lease_github_app.bats
+++ b/test/lease_github_app.bats
@@ -5,6 +5,8 @@
 # These tests verify the GitHub App installation token lease backend.
 # They use a mock HTTP server to avoid requiring real GitHub credentials.
 
+export BATS_NO_PARALLELIZE_WITHIN_FILE=true
+
 setup() {
 	load 'test_helper/common_setup'
 	_common_setup
@@ -15,6 +17,7 @@ teardown() {
 	if [[ -n ${MOCK_PID:-} ]]; then
 		kill "$MOCK_PID" 2>/dev/null || true
 		wait "$MOCK_PID" 2>/dev/null || true
+		unset MOCK_PID
 	fi
 	_common_teardown
 }
@@ -31,7 +34,7 @@ start_mock_github_api() {
 	local expires_at="${2:-2099-01-01T00:00:00Z}"
 
 	cat >"$TEST_TEMP_DIR/mock_github.py" <<PYEOF
-import http.server, json, sys, socket
+import http.server, json, os, sys, socket
 
 class Handler(http.server.BaseHTTPRequestHandler):
     def do_POST(self):
@@ -58,14 +61,16 @@ port = server.server_address[1]
 # Write the assigned port so the test can read it
 with open("$TEST_TEMP_DIR/mock_port", "w") as f:
     f.write(str(port))
+    f.flush()
+    os.fsync(f.fileno())
 server.serve_forever()
 PYEOF
 
 	local mock_log="$TEST_TEMP_DIR/mock_github.log"
-	python3 "$TEST_TEMP_DIR/mock_github.py" >"$mock_log" 2>&1 &
+	python3 -u "$TEST_TEMP_DIR/mock_github.py" >"$mock_log" 2>&1 &
 	MOCK_PID=$!
 	# Wait for the port file to appear
-	for _ in $(seq 1 100); do
+	for _ in $(seq 1 300); do
 		if [[ -s "$TEST_TEMP_DIR/mock_port" ]]; then
 			MOCK_PORT=$(cat "$TEST_TEMP_DIR/mock_port")
 			export MOCK_PORT
@@ -87,6 +92,9 @@ PYEOF
 	if [[ -s "$mock_log" ]]; then
 		cat "$mock_log" >&2
 	fi
+	kill "$MOCK_PID" 2>/dev/null || true
+	wait "$MOCK_PID" 2>/dev/null || true
+	unset MOCK_PID
 	return 1
 }
 

--- a/test/lease_github_oauth.bats
+++ b/test/lease_github_oauth.bats
@@ -5,6 +5,8 @@
 # These tests verify the GitHub OAuth device-flow lease backend against a mock
 # HTTP server, so no real GitHub credentials or browser interaction are needed.
 
+export BATS_NO_PARALLELIZE_WITHIN_FILE=true
+
 setup() {
 	load 'test_helper/common_setup'
 	_common_setup
@@ -14,6 +16,7 @@ teardown() {
 	if [[ -n ${MOCK_PID:-} ]]; then
 		kill "$MOCK_PID" 2>/dev/null || true
 		wait "$MOCK_PID" 2>/dev/null || true
+		unset MOCK_PID
 	fi
 	_common_teardown
 }
@@ -23,7 +26,7 @@ start_mock_github_oauth() {
 	local expires_in="${2:-28800}"
 
 	cat >"$TEST_TEMP_DIR/mock_github_oauth.py" <<PYEOF
-import http.server, json, urllib.parse
+import http.server, json, os, urllib.parse
 
 class Handler(http.server.BaseHTTPRequestHandler):
     def do_POST(self):
@@ -90,19 +93,41 @@ class Handler(http.server.BaseHTTPRequestHandler):
 server = http.server.HTTPServer(("127.0.0.1", 0), Handler)
 with open("$TEST_TEMP_DIR/mock_port", "w") as f:
     f.write(str(server.server_address[1]))
+    f.flush()
+    os.fsync(f.fileno())
 server.serve_forever()
 PYEOF
 
-	python3 "$TEST_TEMP_DIR/mock_github_oauth.py" &
+	local mock_log="$TEST_TEMP_DIR/mock_github_oauth.log"
+	python3 -u "$TEST_TEMP_DIR/mock_github_oauth.py" >"$mock_log" 2>&1 &
 	MOCK_PID=$!
-	for _ in $(seq 1 30); do
-		if [[ -f "$TEST_TEMP_DIR/mock_port" ]]; then
-			break
+	for _ in $(seq 1 300); do
+		if [[ -s "$TEST_TEMP_DIR/mock_port" ]]; then
+			MOCK_PORT=$(cat "$TEST_TEMP_DIR/mock_port")
+			export MOCK_PORT
+			return 0
+		fi
+		local mock_state
+		mock_state=$(ps -p "$MOCK_PID" -o stat= 2>/dev/null || true)
+		if [[ -z "$mock_state" || $mock_state == *Z* ]]; then
+			wait "$MOCK_PID" 2>/dev/null || true
+			echo "mock GitHub OAuth server exited before writing port" >&2
+			if [[ -s "$mock_log" ]]; then
+				cat "$mock_log" >&2
+			fi
+			unset MOCK_PID
+			return 1
 		fi
 		sleep 0.1
 	done
-	MOCK_PORT=$(cat "$TEST_TEMP_DIR/mock_port")
-	export MOCK_PORT
+	echo "timed out waiting for mock GitHub OAuth server to write port" >&2
+	if [[ -s "$mock_log" ]]; then
+		cat "$mock_log" >&2
+	fi
+	kill "$MOCK_PID" 2>/dev/null || true
+	wait "$MOCK_PID" 2>/dev/null || true
+	unset MOCK_PID
+	return 1
 }
 
 @test "github-oauth: creates user access token via device flow" {

--- a/test/secret_resolution_priority.bats
+++ b/test/secret_resolution_priority.bats
@@ -230,6 +230,27 @@ EOF
 	assert_output "from-default"
 }
 
+@test "default profile falls back to defaults when provider only exists in named profiles" {
+	cat >fnox.toml <<'EOF'
+root = true
+
+[secrets]
+DB_HOST = { provider = "ps", value = "DB_HOST", default = "127.0.0.1" }
+DB_PORT = { provider = "ps", value = "DB_PORT", default = "5432" }
+
+[profiles.test.providers.ps]
+type = "plain"
+EOF
+
+	run "$FNOX_BIN" get DB_HOST
+	assert_success
+	assert_output "127.0.0.1"
+
+	run "$FNOX_BIN" exec -- sh -c 'printf "%s:%s" "$DB_HOST" "$DB_PORT"'
+	assert_success
+	assert_output "127.0.0.1:5432"
+}
+
 @test "provider value used as provider input, not direct output" {
 	# This tests that the 'value' field is used as input to the provider
 	# not returned directly


### PR DESCRIPTION
## Summary
- fall back to a secret's `default` when provider resolution fails, including when an explicit provider is not configured for the active profile
- reuse the same default rendering path for single and batch resolution
- add regression coverage for `get` and `exec` when providers only exist under named profiles

## Tests
- `cargo test -p fnox-core secret_resolver`
- `mise run build`
- `PATH="$PWD/target/debug:$PWD/test/bats/bin:$PATH" bats test/secret_resolution_priority.bats`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core secret resolution for get, exec, and batch paths; behavior changes when providers fail but defaults exist, though successful provider values still take priority.
> 
> **Overview**
> Secrets with a **`default`** now use it when provider resolution fails (missing provider for the active profile, batch fetch errors, non-interactive auth, etc.) instead of stopping at the provider error. Single-secret and batch paths share **`resolve_default_value`** / **`resolve_default_fallbacks`**, including interpolated defaults that can reuse values resolved in the same batch.
> 
> Batch provider handling passes **`resolved_so_far`** so fallback defaults can depend on sibling secrets; cycles among fallback defaults are rejected explicitly. Provider wins over defaults when it succeeds; logging distinguishes expected “provider not configured” fallbacks from other failures.
> 
> Adds regression coverage for **`get`** / **`exec`** when providers exist only under named profiles, plus unit tests for batch fallback behavior. BATS lease tests get mock-server startup hardening and optional teardown guards (test infra only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10b0bfa3154eff4b19f448ca8b6fcefc774c53b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Secrets now resolve interpolated default values (e.g., `${...}`) more consistently when provider-based resolution isn’t available.
  * Default handling is extended across multi-step and batch secret resolution so earlier resolved values can be reused in later defaults.
  * Provider batch flows can opportunistically fill missing secrets using resolvable defaults before falling back.

* **Bug Fixes**
  * Improved handling of provider-related failures so defaults are used instead of aborting resolution.
  * Fixed fallback behavior when the provider is only defined under a named profile (non-default).

* **Tests**
  * Added coverage for default fallback behavior in named-profile provider scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->