### PR TITLE
fix(daemon): clear all profile caches

### DIFF
--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -129,7 +129,7 @@
             "flags": [],
             "mounts": [],
             "hide": false,
-            "help": "Clear the daemon's in-memory cache",
+            "help": "Clear all running daemon caches",
             "name": "clear",
             "aliases": [],
             "hidden_aliases": [],

--- a/docs/cli/daemon/clear.md
+++ b/docs/cli/daemon/clear.md
@@ -4,4 +4,4 @@
 
 - **Usage**: `fnox daemon clear`
 
-Clear the daemon's in-memory cache
+Clear all running daemon caches

--- a/docs/guide/daemon.md
+++ b/docs/guide/daemon.md
@@ -57,7 +57,7 @@ The daemon cache is memory-only. Secret values are not written to disk by the da
 
 Cached values are discarded when:
 
-- You run `fnox daemon clear`
+- You run `fnox daemon clear`, which clears all running profile-scoped daemon caches
 - You run `fnox daemon stop`
 - The daemon exits after its idle timeout
 - Config files, profile settings, provider references, post-processing options, or relevant `FNOX_*` and provider environment variables change

--- a/fnox.usage.kdl
+++ b/fnox.usage.kdl
@@ -36,7 +36,7 @@ cmd completion help="Generate shell completions" {
 }
 cmd config-files help="List all config files that would be loaded"
 cmd daemon subcommand_required=#true help="Manage the per-user daemon" {
-    cmd clear help="Clear the daemon's in-memory cache"
+    cmd clear help="Clear all running daemon caches"
     cmd serve hide=#true help="Run the daemon server in the foreground"
     cmd start help="Start the per-user daemon in the background"
     cmd status help="Show daemon status"

--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -12,7 +12,7 @@ pub struct DaemonCommand {
 
 #[derive(Debug, Subcommand)]
 enum DaemonSubcommand {
-    /// Clear the daemon's in-memory cache
+    /// Clear all running daemon caches
     Clear,
     /// Run the daemon server in the foreground
     #[command(hide = true)]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -326,14 +326,68 @@ async fn status_for_context(ctx: &ResolveContext) -> Result<Option<(u32, usize)>
 }
 
 pub async fn clear(cli: &Cli) -> Result<()> {
-    match call(socket_path(cli)?, Request::Clear).await {
-        Ok(Response::Ok) => Ok(()),
+    let paths = daemon_socket_paths()?;
+    if paths.is_empty() {
+        clear_socket(socket_path(cli)?, false).await?;
+        return Ok(());
+    }
+
+    let mut cleared = false;
+    for path in paths {
+        cleared |= clear_socket(path, true).await?;
+    }
+
+    if !cleared {
+        clear_socket(socket_path(cli)?, false).await?;
+    }
+    Ok(())
+}
+
+async fn clear_socket(path: PathBuf, ignore_missing: bool) -> Result<bool> {
+    match call(path, Request::Clear).await {
+        Ok(Response::Ok) => Ok(true),
         Ok(Response::Error { message }) => Err(FnoxError::Config(message)),
         Ok(_) => Err(FnoxError::Config(
             "Invalid daemon response for Clear".to_string(),
         )),
+        Err(e) if ignore_missing && e.is_socket_missing() => Ok(false),
         Err(e) => Err(e.into_fnox_error()),
     }
+}
+
+fn daemon_socket_paths() -> Result<Vec<PathBuf>> {
+    let dir = runtime_dir()?;
+    let entries = match std::fs::read_dir(&dir) {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => {
+            return Err(FnoxError::Config(format!(
+                "Failed to read daemon runtime dir {}: {e}",
+                dir.display()
+            )));
+        }
+    };
+
+    let suffix = format!("-{SOCKET_NAME}");
+    let expected_len = 16 + suffix.len();
+    let mut paths = Vec::new();
+    for entry in entries {
+        let entry = entry.map_err(|e| {
+            FnoxError::Config(format!(
+                "Failed to read daemon runtime dir {}: {e}",
+                dir.display()
+            ))
+        })?;
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+            continue;
+        };
+        if name.len() == expected_len && name.ends_with(&suffix) {
+            paths.push(path);
+        }
+    }
+    paths.sort();
+    Ok(paths)
 }
 
 pub async fn shutdown(cli: &Cli) -> Result<()> {

--- a/test/daemon.bats
+++ b/test/daemon.bats
@@ -9,6 +9,9 @@ setup() {
 
 teardown() {
 	"$FNOX_BIN" daemon stop >/dev/null 2>&1 || true
+	"$FNOX_BIN" --profile dev daemon stop >/dev/null 2>&1 || true
+	"$FNOX_BIN" --profile staging daemon stop >/dev/null 2>&1 || true
+	"$FNOX_BIN" --profile staging --no-defaults daemon stop >/dev/null 2>&1 || true
 	_common_teardown
 }
 
@@ -54,6 +57,54 @@ EOF
 	run "$FNOX_BIN" daemon status
 	assert_success
 	assert_output --partial "cached_entries: 0"
+}
+
+@test "daemon clear removes cached entries for all profiles" {
+	cat >fnox.toml <<'EOF'
+root = true
+
+[daemon]
+enabled = true
+
+[providers.plain]
+type = "plain"
+
+[secrets]
+FOO = { provider = "plain", value = "default" }
+
+[profiles.dev.secrets]
+FOO = { provider = "plain", value = "dev" }
+EOF
+
+	run "$FNOX_BIN" get FOO
+	assert_success
+	assert_output "default"
+
+	run "$FNOX_BIN" --profile dev get FOO
+	assert_success
+	assert_output "dev"
+
+	run "$FNOX_BIN" daemon status
+	assert_success
+	assert_output --partial "cached_entries: 1"
+
+	run "$FNOX_BIN" --profile dev daemon status
+	assert_success
+	assert_output --partial "cached_entries: 1"
+
+	run "$FNOX_BIN" daemon clear
+	assert_success
+
+	run "$FNOX_BIN" daemon status
+	assert_success
+	assert_output --partial "cached_entries: 0"
+
+	run "$FNOX_BIN" --profile dev daemon status
+	assert_success
+	assert_output --partial "cached_entries: 0"
+
+	run "$FNOX_BIN" --profile dev daemon stop
+	assert_success
 }
 
 @test "no-daemon bypass does not start daemon" {


### PR DESCRIPTION
## Summary
- make `fnox daemon clear` clear every running fnox daemon cache instead of only the current profile socket
- ignore stale daemon sockets discovered during the all-cache scan while preserving the old missing-daemon error when no live cache is cleared
- add regression coverage for default and non-default profile caches, and stop profile daemon variants during daemon test teardown
- update daemon help and docs wording

Addresses discussion #577.

## Tests
- `mise run build`
- `test/bats/bin/bats test/daemon.bats`
- `mise run test:cargo`
- `mise run lint`

Note: `mise run test:bats -- test/daemon.bats` reached bats but this local environment is missing GNU `parallel`, so I ran the daemon bats file directly without `--jobs`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized daemon admin behavior with a clear fallback path; main risk is mis-identifying runtime sockets, mitigated by strict filename matching and existing tests.
> 
> **Overview**
> **`fnox daemon clear`** now clears in-memory caches on **every** running profile-scoped daemon, not only the socket for the current CLI profile.
> 
> Implementation scans the user daemon runtime directory for sockets matching the profile hash naming pattern, sends `Clear` to each, and **ignores stale/missing sockets** during that sweep. If the directory is empty or no live daemon responds, behavior falls back to the current profile socket so you still get the same error when nothing is running.
> 
> CLI help, usage spec, and docs now say the command clears **all running daemon caches**. A bats regression covers default + `dev` profile caches, and teardown stops daemons for multiple profile variants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72e2d9b1e6e222f517263fb375e6074348187fae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->