### PR TITLE
fix(config): resolve relative provider paths from config file

### DIFF
--- a/crates/fnox-core/src/config.rs
+++ b/crates/fnox-core/src/config.rs
@@ -576,14 +576,8 @@ impl Config {
 
     /// Load an imported config file
     fn load_import(import_path: &str, base_dir: &Path) -> Result<Self> {
-        let path = PathBuf::from(import_path);
-
-        // Handle relative paths - they're relative to the base config's directory
-        let absolute_path = if path.is_absolute() {
-            path
-        } else {
-            base_dir.join(path)
-        };
+        let absolute_path =
+            crate::config_path::resolve_relative_to_dir(import_path, Some(base_dir));
 
         if !absolute_path.exists() {
             return Err(FnoxError::Config(format!(

--- a/crates/fnox-core/src/config_path.rs
+++ b/crates/fnox-core/src/config_path.rs
@@ -1,0 +1,94 @@
+use std::path::{Path, PathBuf};
+
+/// Expands `~` in a config path using the current user's home directory.
+pub fn expand_tilde(path: &str) -> PathBuf {
+    PathBuf::from(shellexpand::tilde(path).to_string())
+}
+
+/// Resolve a path declared in config against the directory containing that config file.
+///
+/// Absolute paths are returned unchanged. Paths starting with `~` are expanded
+/// before relative resolution, so they also become absolute. When no source
+/// file is available, relative paths are preserved.
+pub fn resolve_relative_to_file(path: &str, source_file: Option<&Path>) -> PathBuf {
+    let expanded = expand_tilde(path);
+    if expanded.is_absolute() {
+        return expanded;
+    }
+
+    source_file
+        .and_then(Path::parent)
+        .map(|parent| parent.join(&expanded))
+        .unwrap_or(expanded)
+}
+
+/// Resolve a path declared in config against an already-known config directory.
+pub fn resolve_relative_to_dir(path: &str, source_dir: Option<&Path>) -> PathBuf {
+    let expanded = expand_tilde(path);
+    if expanded.is_absolute() {
+        return expanded;
+    }
+
+    source_dir
+        .map(|dir| dir.join(&expanded))
+        .unwrap_or(expanded)
+}
+
+/// Resolve a string path and return a string, preserving the original string if
+/// the resolved path cannot be represented as UTF-8.
+pub fn resolve_string_relative_to_file(path: String, source_file: Option<&Path>) -> String {
+    resolve_relative_to_file(&path, source_file)
+        .into_os_string()
+        .into_string()
+        .unwrap_or(path)
+}
+
+pub fn resolve_optional_string_relative_to_file(
+    path: Option<String>,
+    source_file: Option<&Path>,
+) -> Option<String> {
+    path.map(|path| resolve_string_relative_to_file(path, source_file))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_relative_path_against_source_file_parent() {
+        assert_eq!(
+            resolve_relative_to_file(
+                "./secrets/vault.kdbx",
+                Some(Path::new("/home/user/project/fnox.toml")),
+            ),
+            PathBuf::from("/home/user/project/./secrets/vault.kdbx"),
+        );
+    }
+
+    #[test]
+    fn resolves_relative_path_against_source_dir() {
+        assert_eq!(
+            resolve_relative_to_dir("./shared.toml", Some(Path::new("/home/user/project"))),
+            PathBuf::from("/home/user/project/./shared.toml"),
+        );
+    }
+
+    #[test]
+    fn leaves_absolute_path_unchanged() {
+        assert_eq!(
+            resolve_relative_to_file(
+                "/var/lib/password-store",
+                Some(Path::new("/home/user/project/fnox.toml")),
+            ),
+            PathBuf::from("/var/lib/password-store"),
+        );
+    }
+
+    #[test]
+    fn preserves_relative_path_without_source() {
+        assert_eq!(
+            resolve_relative_to_file("./password-store", None),
+            PathBuf::from("./password-store"),
+        );
+    }
+}

--- a/crates/fnox-core/src/lib.rs
+++ b/crates/fnox-core/src/lib.rs
@@ -10,6 +10,7 @@
 
 pub mod auth_prompt;
 pub mod config;
+pub mod config_path;
 pub(crate) mod credential_command;
 pub mod env;
 pub mod error;

--- a/crates/fnox-core/src/providers/age.rs
+++ b/crates/fnox-core/src/providers/age.rs
@@ -28,7 +28,7 @@ impl AgeEncryptionProvider {
     ) -> Result<Self> {
         Ok(Self {
             recipients,
-            key_file: key_file.map(|k| PathBuf::from(shellexpand::tilde(&k).to_string())),
+            key_file: key_file.map(|k| crate::config_path::resolve_relative_to_file(&k, None)),
             identity,
             config: None,
             profile: "default".to_string(),
@@ -48,7 +48,7 @@ impl AgeEncryptionProvider {
     ) -> Result<Self> {
         Ok(Self {
             recipients,
-            key_file: key_file.map(|k| PathBuf::from(shellexpand::tilde(&k).to_string())),
+            key_file: key_file.map(|k| crate::config_path::resolve_relative_to_file(&k, None)),
             identity,
             config: Some(config),
             profile,

--- a/crates/fnox-core/src/providers/keepass.rs
+++ b/crates/fnox-core/src/providers/keepass.rs
@@ -22,8 +22,8 @@ impl KeePassProvider {
         password: Option<String>,
     ) -> Result<Self> {
         Ok(Self {
-            database_path: PathBuf::from(shellexpand::tilde(&database).to_string()),
-            keyfile_path: keyfile.map(|k| PathBuf::from(shellexpand::tilde(&k).to_string())),
+            database_path: crate::config_path::resolve_relative_to_file(&database, None),
+            keyfile_path: keyfile.map(|k| crate::config_path::resolve_relative_to_file(&k, None)),
             password,
         })
     }

--- a/crates/fnox-core/src/providers/mod.rs
+++ b/crates/fnox-core/src/providers/mod.rs
@@ -1,6 +1,7 @@
 use crate::error::Result;
 use async_trait::async_trait;
 use std::collections::HashMap;
+use std::path::PathBuf;
 
 // Provider implementation modules
 pub mod age;
@@ -318,9 +319,13 @@ pub(crate) fn get_provider_from_resolved_with_context_and_identity_cycle_guard(
         identity,
     } = resolved
     {
+        let provider_source = provider_source_path(config, profile, provider_name);
         return Ok(Box::new(age::AgeEncryptionProvider::new_with_config(
             recipients.clone(),
-            key_file.clone(),
+            crate::config_path::resolve_optional_string_relative_to_file(
+                key_file.clone(),
+                provider_source.as_deref(),
+            ),
             identity.clone(),
             std::sync::Arc::new(config.clone()),
             profile.to_string(),
@@ -328,5 +333,149 @@ pub(crate) fn get_provider_from_resolved_with_context_and_identity_cycle_guard(
             identity_cycle_guard,
         )?));
     }
+    if let ResolvedProviderConfig::KeePass {
+        database,
+        keyfile,
+        password,
+    } = resolved
+    {
+        let provider_source = provider_source_path(config, profile, provider_name);
+        let resolved = ResolvedProviderConfig::KeePass {
+            database: crate::config_path::resolve_string_relative_to_file(
+                database.clone(),
+                provider_source.as_deref(),
+            ),
+            keyfile: crate::config_path::resolve_optional_string_relative_to_file(
+                keyfile.clone(),
+                provider_source.as_deref(),
+            ),
+            password: password.clone(),
+        };
+        return get_provider_from_resolved(provider_name, &resolved);
+    }
+    if let ResolvedProviderConfig::PasswordStore {
+        prefix,
+        store_dir,
+        gpg_opts,
+    } = resolved
+    {
+        let provider_source = provider_source_path(config, profile, provider_name);
+        let resolved = ResolvedProviderConfig::PasswordStore {
+            prefix: prefix.clone(),
+            store_dir: crate::config_path::resolve_optional_string_relative_to_file(
+                store_dir.clone(),
+                provider_source.as_deref(),
+            ),
+            gpg_opts: gpg_opts.clone(),
+        };
+        return get_provider_from_resolved(provider_name, &resolved);
+    }
+    if let ResolvedProviderConfig::Foks {
+        prefix,
+        team,
+        home,
+        host,
+        bot_token,
+    } = resolved
+    {
+        let provider_source = provider_source_path(config, profile, provider_name);
+        let resolved = ResolvedProviderConfig::Foks {
+            prefix: prefix.clone(),
+            team: team.clone(),
+            home: crate::config_path::resolve_optional_string_relative_to_file(
+                home.clone(),
+                provider_source.as_deref(),
+            ),
+            host: host.clone(),
+            bot_token: bot_token.clone(),
+        };
+        return get_provider_from_resolved(provider_name, &resolved);
+    }
     get_provider_from_resolved(provider_name, resolved)
+}
+
+fn provider_source_path(
+    config: &crate::config::Config,
+    profile: &str,
+    provider_name: &str,
+) -> Option<PathBuf> {
+    if profile != "default"
+        && let Some(profile_config) = config.profiles.get(profile)
+        && profile_config.providers.contains_key(provider_name)
+    {
+        return profile_config.provider_sources.get(provider_name).cloned();
+    }
+
+    config.provider_sources.get(provider_name).cloned()
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{Config, ProfileConfig, ProviderConfig};
+
+    #[test]
+    fn provider_source_path_prefers_profile_provider_source() {
+        let mut config = Config::new();
+        config.provider_sources.insert(
+            "pass".to_string(),
+            PathBuf::from("/home/user/project/fnox.toml"),
+        );
+
+        let mut profile = ProfileConfig::new();
+        profile.providers.insert(
+            "pass".to_string(),
+            ProviderConfig::Plain {
+                auth_command: None,
+                daemon_cache: None,
+            },
+        );
+        profile.provider_sources.insert(
+            "pass".to_string(),
+            PathBuf::from("/home/user/project/fnox.prod.toml"),
+        );
+        config.profiles.insert("prod".to_string(), profile);
+
+        assert_eq!(
+            provider_source_path(&config, "prod", "pass"),
+            Some(PathBuf::from("/home/user/project/fnox.prod.toml")),
+        );
+    }
+
+    #[test]
+    fn provider_source_path_does_not_fall_back_for_profile_provider_override() {
+        let mut config = Config::new();
+        config.provider_sources.insert(
+            "pass".to_string(),
+            PathBuf::from("/home/user/project/fnox.toml"),
+        );
+
+        let mut profile = ProfileConfig::new();
+        profile.providers.insert(
+            "pass".to_string(),
+            ProviderConfig::Plain {
+                auth_command: None,
+                daemon_cache: None,
+            },
+        );
+        config.profiles.insert("prod".to_string(), profile);
+
+        assert_eq!(provider_source_path(&config, "prod", "pass"), None);
+    }
+
+    #[test]
+    fn provider_source_path_falls_back_to_top_level_provider_source() {
+        let mut config = Config::new();
+        config.provider_sources.insert(
+            "pass".to_string(),
+            PathBuf::from("/home/user/project/fnox.toml"),
+        );
+        config
+            .profiles
+            .insert("prod".to_string(), ProfileConfig::new());
+
+        assert_eq!(
+            provider_source_path(&config, "prod", "pass"),
+            Some(PathBuf::from("/home/user/project/fnox.toml")),
+        );
+    }
 }

--- a/docs/providers/age.md
+++ b/docs/providers/age.md
@@ -87,6 +87,15 @@ Or with SSH key:
 age = { type = "age", recipients = ["ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGQs8..."] }
 ```
 
+Or with an explicit identity file:
+
+```toml
+[providers]
+age = { type = "age", recipients = ["age1..."], key_file = "./age.txt" }
+```
+
+Relative `key_file` paths are resolved from the config file that declares the provider. Paths beginning with `~` expand to your home directory, and absolute paths are used unchanged.
+
 Or store the age identity in another provider, such as the OS keychain:
 
 ```toml

--- a/docs/providers/foks.md
+++ b/docs/providers/foks.md
@@ -100,7 +100,7 @@ foks = { type = "foks", prefix = "/fnox/" }
 
 - `prefix` — Path prefix prepended to every key (must be absolute, e.g. `/fnox/` or `/apps/myapp/`). FOKS rejects relative paths; if you forget the leading `/`, the provider adds it for you.
 - `team` — A FOKS team name. When set, fnox passes `--team <name>` to every `foks kv` invocation, so secrets read and write to that team's namespace instead of your personal one.
-- `home` — A custom FOKS home directory, passed through as `--home`. Falls back to `FNOX_FOKS_HOME` / `FOKS_HOME` if not set.
+- `home` — A custom FOKS home directory, passed through as `--home`. Relative paths are resolved from the config file that declares the provider. Falls back to `FNOX_FOKS_HOME` / `FOKS_HOME` if not set.
 - `host` — The FOKS server hostname (e.g. `foks.app` or your self-hosted server). Required for non-interactive bot-token auth (see [CI/CD](#cicd)). Falls back to `FNOX_FOKS_HOST` / `FOKS_HOST`.
 - `bot_token` — A FOKS bot token for non-interactive auth (CI). Almost always you want to leave this unset and supply it via the `FOKS_BOT_TOKEN` env var instead, so it isn't checked into your config. Also accepts `FNOX_FOKS_BOT_TOKEN`.
 

--- a/docs/providers/keepass.md
+++ b/docs/providers/keepass.md
@@ -33,12 +33,12 @@ keepass = { type = "keepass", database = "~/secrets.kdbx", keyfile = "~/keyfile.
 
 ### Database Path
 
-The `database` field specifies the path to your `.kdbx` file. Shell expansion is supported:
+The `database` field specifies the path to your `.kdbx` file. Relative paths are resolved from the config file that declares the provider, and `~` expands to your home directory:
 
 ```toml
 [providers]
 keepass = { database = "~/secrets.kdbx" }           # Home directory
-keepass = { database = "./secrets/vault.kdbx" }     # Relative path
+keepass = { database = "./secrets/vault.kdbx" }     # Relative to this config file
 keepass = { database = "/opt/secrets/shared.kdbx" } # Absolute path
 ```
 
@@ -50,6 +50,8 @@ For additional security, use a keyfile alongside the password:
 [providers]
 keepass = { database = "~/secrets.kdbx", keyfile = "~/keyfile.key" }
 ```
+
+Relative `keyfile` paths follow the same config-relative rule as `database`.
 
 ## Authentication
 

--- a/docs/providers/password-store.md
+++ b/docs/providers/password-store.md
@@ -139,8 +139,10 @@ pass = { type = "password-store", prefix = "fnox/" }
 [providers.pass]
 type = "password-store"
 prefix = "fnox/"  # Optional: prepend to all secret paths (default: none)
-store_dir = "/custom/path"  # Optional: custom store location (default: ~/.password-store)
+store_dir = "./password-store"  # Optional: custom store location (default: ~/.password-store)
 ```
+
+Relative `store_dir` paths are resolved from the config file that declares the provider. Paths beginning with `~` expand to your home directory, and absolute paths are used unchanged.
 
 ## How It Works
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -109,6 +109,21 @@ import = ["./shared/base.toml", "./envs/dev.toml"]
 - Imported files merged into current config
 - Later imports override earlier ones
 
+### Path Values
+
+Paths declared in config files are resolved relative to the config file that declares them. This applies to imports and provider filesystem paths such as `age.key_file`, `keepass.database`, `keepass.keyfile`, `password-store.store_dir`, and `foks.home`.
+
+```toml
+# project/fnox.toml
+import = ["./shared/secrets.toml"] # project/shared/secrets.toml
+
+[providers.keepass]
+type = "keepass"
+database = "./secrets.kdbx" # project/secrets.kdbx
+```
+
+Paths beginning with `~` expand to your home directory. Absolute paths are used unchanged. CLI path arguments remain relative to the current working directory, and environment variable paths keep their existing environment-specific behavior.
+
 ### `daemon`
 
 Enable memory-only daemon caching for supported read commands.

--- a/src/commands/config_files.rs
+++ b/src/commands/config_files.rs
@@ -56,11 +56,8 @@ impl ConfigFilesCommand {
                 {
                     // Print imported config files
                     for import_path in &partial.import {
-                        let import = if Path::new(import_path).is_absolute() {
-                            PathBuf::from(import_path)
-                        } else {
-                            dir.join(import_path)
-                        };
+                        let import =
+                            crate::config_path::resolve_relative_to_dir(import_path, Some(dir));
                         if import.exists() && printed.insert(import.clone()) {
                             println!("{}", import.display());
                         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 // consumers and for our own modules.
 
 pub use fnox_core::{
-    auth_prompt, config, env, error, http, lease, lease_backends, library, providers,
+    auth_prompt, config, config_path, env, error, http, lease, lease_backends, library, providers,
     secret_resolver, settings, source_registry, spanned, suggest, temp_file_secrets,
 };
 

--- a/test/age.bats
+++ b/test/age.bats
@@ -87,6 +87,40 @@ EOF
 	assert_output "secret-value"
 }
 
+@test "decrypts using relative key_file from declaring config" {
+	# Skip if age not installed
+	if ! command -v age-keygen >/dev/null 2>&1; then
+		skip "age-keygen not installed"
+	fi
+
+	mkdir -p project/services/worker
+
+	local keygen_output
+	keygen_output=$(age-keygen -o project/age.txt 2>&1)
+	local public_key
+	public_key=$(echo "$keygen_output" | grep "^Public key:" | cut -d' ' -f3)
+
+	cat >project/fnox.toml <<EOF
+[providers.age]
+type = "age"
+recipients = ["$public_key"]
+key_file = "./age.txt"
+EOF
+
+	cat >project/services/worker/fnox.toml <<EOF
+[secrets]
+API_KEY = { provider = "age", value = "test" }
+EOF
+
+	cd project/services/worker
+	run "$FNOX_BIN" set API_KEY "relative-age-value" --provider age
+	assert_success
+
+	run "$FNOX_BIN" get API_KEY
+	assert_success
+	assert_output "relative-age-value"
+}
+
 @test "decrypts multiple provider-backed identity secrets in exec" {
 	# Skip if age not installed
 	if ! command -v age-keygen >/dev/null 2>&1; then

--- a/test/keepass.bats
+++ b/test/keepass.bats
@@ -83,6 +83,32 @@ track_entry_name() {
 	assert_output "test-value-123"
 }
 
+@test "keepass provider resolves relative database from declaring config" {
+	mkdir -p project/services/worker project/secrets
+	local project_dir="$PWD/project"
+
+	cat >project/fnox.toml <<EOF
+[providers.keepass]
+type = "keepass"
+database = "./secrets/test.kdbx"
+EOF
+
+	cat >project/services/worker/fnox.toml <<EOF
+[secrets]
+API_KEY = { provider = "keepass", value = "api-key" }
+EOF
+
+	cd project/services/worker
+	run "$FNOX_BIN" set API_KEY "relative-keepass-value" --provider keepass
+	assert_success
+
+	[ -f "$project_dir/secrets/test.kdbx" ]
+
+	run "$FNOX_BIN" get API_KEY
+	assert_success
+	assert_output "relative-keepass-value"
+}
+
 @test "fnox set and get with username field" {
 	create_keepass_config
 

--- a/test/password_store.bats
+++ b/test/password_store.bats
@@ -146,6 +146,29 @@ track_secret_path() {
 	assert_output "test-value-123"
 }
 
+@test "password-store provider resolves relative store_dir from declaring config" {
+	mkdir -p project/services/worker project/password-store
+
+	PASSWORD_STORE_DIR="$PWD/project/password-store" pass init "$GPG_KEY_ID" >/dev/null 2>&1
+	printf '%s\n' "relative-store-value" | PASSWORD_STORE_DIR="$PWD/project/password-store" pass insert -m -f api-key >/dev/null 2>&1
+
+	cat >project/fnox.toml <<EOF
+[providers.pass]
+type = "password-store"
+store_dir = "./password-store"
+EOF
+
+	cat >project/services/worker/fnox.toml <<EOF
+[secrets]
+API_KEY = { provider = "pass", value = "api-key" }
+EOF
+
+	cd project/services/worker
+	run "$FNOX_BIN" get API_KEY
+	assert_success
+	assert_output "relative-store-value"
+}
+
 @test "fnox set and get with prefix" {
 	create_pass_config "work/"
 


### PR DESCRIPTION
## Summary
- Add shared config path helpers for `~` expansion and config-file-relative path resolution.
- Use the shared path policy for imports, `fnox config-files`, and provider filesystem fields: `age.key_file`, `keepass.database`, `keepass.keyfile`, `password-store.store_dir`, and `foks.home`.
- Add regression coverage for inherited parent configs using relative Age, KeePass, and password-store paths.
- Document the unified path DX in the configuration reference and affected provider docs.

## Path behavior
- Paths declared in config files resolve relative to the config file that declares them.
- `~` expands to the current user's home directory.
- Absolute paths are used unchanged.
- CLI path arguments remain relative to the current working directory.
- Environment variable paths keep their existing environment-specific behavior.

## Tests
- `cargo test -p fnox-core config_path::`
- `cargo test -p fnox-core providers::tests::`
- `cargo test -p fnox-core`
- `mise run build`
- `mise run lint`
- `test/bats/bin/bats test/keepass.bats`
- `test/bats/bin/bats test/age.bats` (age-keygen unavailable locally, so age-tool-dependent cases skipped)
- `test/bats/bin/bats test/password_store.bats` (pass unavailable locally, so password-store cases skipped)

Note: `mise run test:bats -- test/password_store.bats` was attempted earlier, but the local wrapper could not start because GNU `parallel` is not installed.

_This PR description was generated by Codex._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved path handling for imported configs and provider settings, including support for relative paths and `~` expansion.
  * Added clearer configuration guidance for provider file and directory paths.

* **Bug Fixes**
  * Fixed path resolution so provider files and imported configs are now interpreted relative to the config file that declares them.
  * Ensured nested runs still find the correct provider resources.

* **Tests**
  * Added integration coverage for age, KeePass, and password-store path resolution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how relative paths are interpreted at runtime for imports and several providers; wrong resolution could break existing setups that relied on CWD-relative paths, though docs clarify the new contract and tests cover nested inheritance.
> 
> **Overview**
> Introduces a shared **`config_path`** module for `~` expansion and resolving paths relative to the config file (or its directory). **Imports**, **`fnox config-files`**, and provider filesystem fields now use this policy instead of ad hoc logic.
> 
> When providers are instantiated, **Age** (`key_file`), **KeePass** (`database`, `keyfile`), **password-store** (`store_dir`), and **FOKS** (`home`) resolve relative paths against the **declaring config file** via tracked `provider_sources`, including profile overrides (profile-specific source when the provider is defined in that profile; no silent fallback to top-level when the profile overrides the provider without a stored source).
> 
> Docs describe the unified path rules; **bats** tests cover nested configs where a child `fnox.toml` inherits a parent provider with relative paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a3bedad366fdae89bd70cafc723000a4c0ed59b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->