### PR TITLE
feat: nix flake packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ mise.local.toml
 node_modules/
 docs/.vitepress/dist
 docs/.vitepress/cache
+
+# Nix
+result

--- a/flake.lock
+++ b/flake.lock
@@ -15,6 +15,24 @@
         "type": "github"
       }
     },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1782723713,
@@ -34,7 +52,23 @@
     "root": {
       "inputs": {
         "crane": "crane",
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1781825982,
+        "narHash": "sha256-SlXKwIRIhrOSAcTjCB3ftPLzJWZStQIPS7J1FlZPnKk=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "469fd08d0bcf6926321fa973c6777fbc87785dd7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,87 @@
+{
+  description = "Fort Knox for your secrets.";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+    crane.url = "github:ipetkov/crane";
+  };
+
+  outputs =
+    {
+      self,
+      crane,
+      nixpkgs,
+    }:
+    let
+      systems = [
+        "aarch64-darwin"
+        "aarch64-linux"
+        "x86_64-linux"
+      ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+    in
+    {
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          craneLib = crane.mkLib pkgs;
+          src = pkgs.lib.cleanSourceWith {
+            src = craneLib.path ./.;
+            filter =
+              path: type:
+              (craneLib.filterCargoSources path type) || (pkgs.lib.hasInfix "/src/assets/" (toString path));
+          };
+          commonArgs = {
+            inherit src;
+            strictDeps = true;
+            nativeBuildInputs = with pkgs; [
+              perl
+              pkg-config
+            ];
+            buildInputs =
+              with pkgs;
+              [
+              ]
+              ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
+                dbus
+                udev
+              ];
+
+          };
+          cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+          fnox =
+            let
+              cargoToml = craneLib.crateNameFromCargoToml { inherit src; };
+            in
+            craneLib.buildPackage (
+              commonArgs
+              // {
+                inherit cargoArtifacts;
+                doCheck = false;
+                meta = {
+                  description = "A flexible secret management tool by @jdx";
+                  homepage = "https://github.com/jdx/fnox";
+                  changelog = "https://github.com/jdx/fnox/releases/tag/v${cargoToml.version}";
+                  license = pkgs.lib.licenses.mit;
+                  mainProgram = "fnox";
+                  platforms = systems;
+                };
+              }
+            );
+        in
+        {
+          default = fnox;
+          fnox = fnox;
+        }
+      );
+
+      apps = forAllSystems (system: {
+        default = {
+          type = "app";
+          program = "${self.packages.${system}.default}/bin/fnox";
+        };
+      });
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -3,85 +3,82 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-
     crane.url = "github:ipetkov/crane";
+    flake-utils.url = "github:numtide/flake-utils";
   };
 
   outputs =
     {
-      self,
       crane,
       nixpkgs,
+      flake-utils,
+      ...
     }:
-    let
-      systems = [
-        "aarch64-darwin"
-        "aarch64-linux"
-        "x86_64-linux"
-      ];
-      forAllSystems = nixpkgs.lib.genAttrs systems;
-    in
-    {
-      packages = forAllSystems (
-        system:
-        let
-          pkgs = nixpkgs.legacyPackages.${system};
-          craneLib = crane.mkLib pkgs;
-          src = pkgs.lib.cleanSourceWith {
-            src = craneLib.path ./.;
-            filter =
-              path: type:
-              (craneLib.filterCargoSources path type) || (pkgs.lib.hasInfix "/src/assets/" (toString path));
-          };
-          commonArgs = {
-            inherit src;
-            strictDeps = true;
-            nativeBuildInputs = with pkgs; [
-              perl
-              pkg-config
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        craneLib = crane.mkLib pkgs;
+        src = pkgs.lib.cleanSourceWith {
+          src = craneLib.path ./.;
+          filter =
+            path: type:
+            (craneLib.filterCargoSources path type) || (pkgs.lib.hasInfix "/src/assets/" (toString path));
+        };
+        commonArgs = {
+          inherit src;
+          strictDeps = true;
+          nativeBuildInputs = with pkgs; [
+            perl
+            pkg-config
+          ];
+          buildInputs =
+            with pkgs;
+            [ ]
+            ++ lib.optionals stdenv.isLinux [
+              dbus
+              udev
             ];
-            buildInputs =
-              with pkgs;
-              [
-              ]
-              ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
-                dbus
-                udev
-              ];
-
-          };
-          cargoArtifacts = craneLib.buildDepsOnly commonArgs;
-          fnox =
-            let
-              cargoToml = craneLib.crateNameFromCargoToml { inherit src; };
-            in
-            craneLib.buildPackage (
-              commonArgs
-              // {
-                inherit cargoArtifacts;
-                doCheck = false;
-                meta = {
-                  description = "A flexible secret management tool by @jdx";
-                  homepage = "https://github.com/jdx/fnox";
-                  changelog = "https://github.com/jdx/fnox/releases/tag/v${cargoToml.version}";
-                  license = pkgs.lib.licenses.mit;
-                  mainProgram = "fnox";
-                  platforms = systems;
-                };
-              }
-            );
-        in
-        {
+        };
+        cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+        fnox =
+          let
+            cargoToml = craneLib.crateNameFromCargoToml { inherit src; };
+          in
+          craneLib.buildPackage (
+            commonArgs
+            // {
+              inherit cargoArtifacts;
+              doCheck = false;
+              meta = {
+                mainProgram = "fnox";
+                description = "A flexible secret management tool by @jdx";
+                homepage = "https://github.com/jdx/fnox";
+                changelog = "https://github.com/jdx/fnox/releases/tag/v${cargoToml.version}";
+                license = pkgs.lib.licenses.mit;
+                platforms = flake-utils.lib.defaultSystems;
+              };
+            }
+          );
+      in
+      {
+        packages = {
           default = fnox;
           fnox = fnox;
-        }
-      );
-
-      apps = forAllSystems (system: {
-        default = {
-          type = "app";
-          program = "${self.packages.${system}.default}/bin/fnox";
         };
-      });
-    };
+
+        apps.default = {
+          type = "app";
+          program = "${fnox}/bin/fnox";
+        };
+
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [
+            cargo
+            clippy
+            rustfmt
+          ];
+        };
+      }
+    );
 }


### PR DESCRIPTION
Adds Nix flake support for fnox.

User guide:

Add to your Nix flakes setup:
- In `flake.nix`:
	```nix
	inputs.fnox.url = "github:jdx/fnox";
	```
- Then consume
	```nix
	inputs.fnox.packages.${system}.default
	```

Run without installing using `nix` CLI:
```sh
nix run github:jdx/fnox
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added packaged build support for the project, making it easier to run the app and use it in Nix-based workflows.
  * Exposed the app as a runnable command and provided a development shell with common Rust tooling.
* **Chores**
  * Updated ignore rules to prevent generated build output from being tracked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->