### PR TITLE
chore: release v1.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,48 @@
 # Changelog
 
+## [1.30.0](https://github.com/jdx/fnox/compare/v1.29.0..v1.30.0) - 2026-07-09
+
+### 🚀 Features
+
+- **(config)** add exec-only env mode and top-level env default by [@jdx](https://github.com/jdx) in [#604](https://github.com/jdx/fnox/pull/604)
+- **(proton-pass)** support agent and PAT auth by [@TyceHerrman](https://github.com/TyceHerrman) in [#598](https://github.com/jdx/fnox/pull/598)
+
+### 🐛 Bug Fixes
+
+- **(daemon)** respect default provider daemon cache setting by [@TyceHerrman](https://github.com/TyceHerrman) in [#599](https://github.com/jdx/fnox/pull/599)
+- **(export)** omit metadata header by default by [@jdx](https://github.com/jdx) in [#603](https://github.com/jdx/fnox/pull/603)
+- **(release-plz)** install claude cli from lockfile by [@jdx](https://github.com/jdx) in [#592](https://github.com/jdx/fnox/pull/592)
+
+### 📚 Documentation
+
+- redesign logo with fox-in-keyhole mark matching site theme by [@jdx](https://github.com/jdx) in [#595](https://github.com/jdx/fnox/pull/595)
+
+### 🔍 Other Changes
+
+- **(release)** skip ai reviews for release prs by [@jdx](https://github.com/jdx) in [#606](https://github.com/jdx/fnox/pull/606)
+- Update sponsor references for jdx.dev by [@jdx](https://github.com/jdx) in [#585](https://github.com/jdx/fnox/pull/585)
+- use release backends for cargo tools by [@jdx](https://github.com/jdx) in [#593](https://github.com/jdx/fnox/pull/593)
+- schedule releases for Monday morning by [@jdx](https://github.com/jdx) in [#597](https://github.com/jdx/fnox/pull/597)
+- gate autorelease on fix and feat commits by [@jdx](https://github.com/jdx) in [#600](https://github.com/jdx/fnox/pull/600)
+
+### 📦️ Dependency Updates
+
+- update rust crate anyhow to v1.0.103 by [@renovate[bot]](https://github.com/renovate[bot]) in [#586](https://github.com/jdx/fnox/pull/586)
+- update zizmorcore/zizmor-action action to v0.5.7 by [@renovate[bot]](https://github.com/renovate[bot]) in [#587](https://github.com/jdx/fnox/pull/587)
+- update rust crate tera to v2 by [@renovate[bot]](https://github.com/renovate[bot]) in [#588](https://github.com/jdx/fnox/pull/588)
+- lock file maintenance by [@renovate[bot]](https://github.com/renovate[bot]) in [#591](https://github.com/jdx/fnox/pull/591)
+
 ## [1.29.0](https://github.com/jdx/fnox/compare/v1.28.0..v1.29.0) - 2026-07-01
 
 ### 🚀 Features
 
 - **(age)** support age plugin recipients and identities by [@nightvisi0n](https://github.com/nightvisi0n) in [#569](https://github.com/jdx/fnox/pull/569)
+- nix flake packaging by [@o-az](https://github.com/o-az) in [#583](https://github.com/jdx/fnox/pull/583)
 
 ### 🐛 Bug Fixes
 
 - **(config)** fall back to defaults for inactive providers by [@jdx](https://github.com/jdx) in [#572](https://github.com/jdx/fnox/pull/572)
+- **(config)** resolve relative provider paths from config file by [@jdx](https://github.com/jdx) in [#582](https://github.com/jdx/fnox/pull/582)
 - **(daemon)** clear all profile caches by [@jdx](https://github.com/jdx) in [#581](https://github.com/jdx/fnox/pull/581)
 
 ### 🚜 Refactor
@@ -27,6 +61,7 @@
 
 ### New Contributors
 
+- @o-az made their first contribution in [#583](https://github.com/jdx/fnox/pull/583)
 - @nightvisi0n made their first contribution in [#569](https://github.com/jdx/fnox/pull/569)
 
 ## [1.28.0](https://github.com/jdx/fnox/compare/v1.27.1..v1.28.0) - 2026-06-24

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2401,7 +2401,7 @@ dependencies = [
 
 [[package]]
 name = "fnox"
-version = "1.29.0"
+version = "1.30.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -2449,7 +2449,7 @@ dependencies = [
 
 [[package]]
 name = "fnox-core"
-version = "1.29.0"
+version = "1.30.0"
 dependencies = [
  "aes-gcm 0.11.0",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "crates/fnox-core"]
 resolver = "3"
 
 [workspace.package]
-version = "1.29.0"
+version = "1.30.0"
 edition = "2024"
 authors = ["@jdx"]
 license = "MIT"
@@ -114,7 +114,7 @@ name = "fnox"
 path = "src/main.rs"
 
 [dependencies]
-fnox-core = { path = "crates/fnox-core", version = "1.29.0" }
+fnox-core = { path = "crates/fnox-core", version = "1.30.0" }
 
 # Direct dependencies of the CLI binary (commands, MCP server, TUI, hook-env,
 # shell integration). Provider/config/secret-resolver crates are pulled in

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -1747,7 +1747,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.29.0",
+  "version": "1.30.0",
   "usage": "Usage: fnox [OPTIONS] <COMMAND>",
   "complete": {
     "key": {

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -4,7 +4,7 @@
 
 **Usage**: `fnox [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.29.0
+**Version**: 1.30.0
 
 - **Usage**: `fnox [FLAGS] <SUBCOMMAND>`
 

--- a/fnox.usage.kdl
+++ b/fnox.usage.kdl
@@ -1,7 +1,7 @@
 min_usage_version "1.3"
 name fnox
 bin fnox
-version "1.29.0"
+version "1.30.0"
 about "A flexible secret management tool by @jdx"
 usage "Usage: fnox [OPTIONS] <COMMAND>"
 flag "-c --config" help="Path to the configuration file (default: fnox.toml, searches parent directories)" global=#true default=fnox.toml {


### PR DESCRIPTION
### 🚀 Features

- **(config)** add exec-only env mode and top-level env default by [@jdx](https://github.com/jdx) in [#604](https://github.com/jdx/fnox/pull/604)
- **(proton-pass)** support agent and PAT auth by [@TyceHerrman](https://github.com/TyceHerrman) in [#598](https://github.com/jdx/fnox/pull/598)

### 🐛 Bug Fixes

- **(daemon)** respect default provider daemon cache setting by [@TyceHerrman](https://github.com/TyceHerrman) in [#599](https://github.com/jdx/fnox/pull/599)
- **(export)** omit metadata header by default by [@jdx](https://github.com/jdx) in [#603](https://github.com/jdx/fnox/pull/603)
- **(release-plz)** install claude cli from lockfile by [@jdx](https://github.com/jdx) in [#592](https://github.com/jdx/fnox/pull/592)

### 📚 Documentation

- redesign logo with fox-in-keyhole mark matching site theme by [@jdx](https://github.com/jdx) in [#595](https://github.com/jdx/fnox/pull/595)

### 🔍 Other Changes

- **(release)** skip ai reviews for release prs by [@jdx](https://github.com/jdx) in [#606](https://github.com/jdx/fnox/pull/606)
- Update sponsor references for jdx.dev by [@jdx](https://github.com/jdx) in [#585](https://github.com/jdx/fnox/pull/585)
- use release backends for cargo tools by [@jdx](https://github.com/jdx) in [#593](https://github.com/jdx/fnox/pull/593)
- schedule releases for Monday morning by [@jdx](https://github.com/jdx) in [#597](https://github.com/jdx/fnox/pull/597)
- gate autorelease on fix and feat commits by [@jdx](https://github.com/jdx) in [#600](https://github.com/jdx/fnox/pull/600)

### 📦️ Dependency Updates

- update rust crate anyhow to v1.0.103 by [@renovate[bot]](https://github.com/renovate[bot]) in [#586](https://github.com/jdx/fnox/pull/586)
- update zizmorcore/zizmor-action action to v0.5.7 by [@renovate[bot]](https://github.com/renovate[bot]) in [#587](https://github.com/jdx/fnox/pull/587)
- update rust crate tera to v2 by [@renovate[bot]](https://github.com/renovate[bot]) in [#588](https://github.com/jdx/fnox/pull/588)
- lock file maintenance by [@renovate[bot]](https://github.com/renovate[bot]) in [#591](https://github.com/jdx/fnox/pull/591)