### PR TITLE
Update sponsor references for jdx.dev

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,7 +142,7 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           INPUTS_VERSION: ${{ inputs.version }}
-      - name: Append en.dev sponsor blurb
+      - name: Append jdx.dev sponsor blurb
         env:
           GH_TOKEN: ${{ secrets.FNOX_GH_TOKEN }}
           INPUTS_VERSION: ${{ inputs.version }}
@@ -166,8 +166,8 @@ jobs:
 
           ## 💚 Sponsor fnox
 
-          fnox is maintained by [@jdx](https://github.com/jdx) under [**en.dev**](https://en.dev) — a small independent studio building developer tooling like [mise](https://mise.jdx.dev/), [aube](https://aube.en.dev/), hk, and more. Keeping fnox secure, maintained, and free is funded by sponsors.
+          fnox is maintained by [@jdx](https://github.com/jdx), an open source developer for [**entire.io**](https://entire.io), the title sponsor of the [jdx.dev](https://jdx.dev) open source tools including [mise](https://mise.jdx.dev/), [aube](https://aube.jdx.dev/), hk, and more. Keeping fnox secure, maintained, and free is funded by sponsors.
 
-          If fnox is handling secrets or config for you or your team, please consider [sponsoring at en.dev](https://en.dev). Sponsorships are what let fnox stay independent and the project keep moving.
+          If fnox is handling secrets or config for you or your team, please consider [sponsoring at jdx.dev](https://jdx.dev/sponsors.html). Sponsorships are what let fnox stay independent and the project keep moving.
           EOF
           gh release edit "$TAG_NAME" --notes-file /tmp/release-notes.md

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Manage secrets with encryption or cloud providers—or both! fnox gives you a un
 
 ## Sponsors
 
-fnox is sponsored by [entire.io](https://entire.io), [37signals](https://37signals.com), [CodeRabbit](https://coderabbit.link/mise), and [Supabase](https://supabase.com).
+fnox is sponsored by [entire.io](https://entire.io), [37signals](https://37signals.com), and [CodeRabbit](https://coderabbit.link/mise).
 
 [View all sponsors](https://jdx.dev/sponsors.html).
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Manage secrets with encryption or cloud providers—or both! fnox gives you a un
 
 ## Sponsors
 
-fnox is sponsored by [37signals](https://37signals.com).
+fnox is sponsored by [entire.io](https://entire.io), [37signals](https://37signals.com), [CodeRabbit](https://coderabbit.link/mise), and [Supabase](https://supabase.com).
 
-[View all sponsors](https://en.dev/sponsors.html).
+[View all sponsors](https://jdx.dev/sponsors.html).
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Manage secrets with encryption or cloud providers—or both! fnox gives you a un
 
 ## Sponsors
 
-fnox is sponsored by [entire.io](https://entire.io), [37signals](https://37signals.com), and [CodeRabbit](https://coderabbit.link/mise).
+fnox is sponsored by [entire.io](https://entire.io) and [37signals](https://37signals.com).
 
 [View all sponsors](https://jdx.dev/sponsors.html).
 

--- a/communique.toml
+++ b/communique.toml
@@ -1,7 +1,7 @@
 context = "fnox is a secrets management CLI that encrypts and manages secrets in config files, supporting multiple providers (1Password, AWS, Azure, GCP, Bitwarden, etc.)."
 
 system_extra = """
-Do NOT include a "Sponsor fnox" / "Sponsor" / "Sponsorship" / "Support" section, donation links, or any en.dev / GitHub Sponsors blurb in the release body. The release workflow appends a canonical sponsor section after generation; including one here produces a duplicate. Style references from prior releases that contain a sponsor section are showing you the appended block — ignore that block when matching tone and structure.
+Do NOT include a "Sponsor fnox" / "Sponsor" / "Sponsorship" / "Support" section, donation links, or any jdx.dev / GitHub Sponsors blurb in the release body. The release workflow appends a canonical sponsor section after generation; including one here produces a duplicate. Style references from prior releases that contain a sponsor section are showing you the appended block — ignore that block when matching tone and structure.
 """
 
 [defaults]

--- a/docs/.vitepress/theme/EndevFooter.vue
+++ b/docs/.vitepress/theme/EndevFooter.vue
@@ -4,15 +4,15 @@
     <span aria-hidden="true">·</span>
     <span>Copyright © {{ year }}</span>
     <span aria-hidden="true">·</span>
-    <a class="EndevFooterLink" href="https://en.dev">
+    <a class="EndevFooterLink" href="https://jdx.dev">
       <img
         alt=""
         class="EndevFooterLogo"
         height="28"
-        src="https://github.com/endevco.png?size=96"
+        src="https://github.com/jdx.png?size=96"
         width="28"
       />
-      <span>en.dev</span>
+      <span>jdx.dev</span>
     </a>
   </footer>
 </template>

--- a/docs/.vitepress/theme/EndevSponsors.vue
+++ b/docs/.vitepress/theme/EndevSponsors.vue
@@ -36,7 +36,7 @@ import { onMounted, ref } from "vue";
 
 const sponsors = ref([]);
 const error = ref(false);
-const footerTiers = new Set(["anchor", "premier", "partner"]);
+const footerTiers = new Set(["title", "premier", "partner"]);
 const sponsorFeedTimeoutMs = 5000;
 
 const sponsorItems = (items) => (Array.isArray(items) ? items : []);

--- a/docs/.vitepress/theme/EndevSponsors.vue
+++ b/docs/.vitepress/theme/EndevSponsors.vue
@@ -24,7 +24,7 @@
           />
         </a>
       </div>
-      <a class="EndevSponsorsCta" href="https://en.dev/sponsors.html">
+      <a class="EndevSponsorsCta" href="https://jdx.dev/sponsors.html">
         View all sponsors
       </a>
     </div>
@@ -76,7 +76,7 @@ onMounted(async () => {
   );
 
   try {
-    const res = await fetch("https://en.dev/sponsors.json", {
+    const res = await fetch("https://jdx.dev/sponsors.json", {
       headers: { Accept: "application/json" },
       signal: controller.signal,
     });

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -1429,7 +1429,7 @@
         "flags": [],
         "mounts": [],
         "hide": false,
-        "help": "Show the companies sponsoring fnox and the en.dev project family",
+        "help": "Show the companies sponsoring fnox and the jdx.dev open source tools",
         "name": "sponsors",
         "aliases": [],
         "hidden_aliases": [],

--- a/docs/cli/sponsors.md
+++ b/docs/cli/sponsors.md
@@ -4,4 +4,4 @@
 
 - **Usage**: `fnox sponsors`
 
-Show the companies sponsoring fnox and the en.dev project family
+Show the companies sponsoring fnox and the jdx.dev open source tools

--- a/fnox.usage.kdl
+++ b/fnox.usage.kdl
@@ -226,7 +226,7 @@ If omitted: reads from stdin when piped (`echo "x" | fnox set KEY`), or prompts 
 Passing secrets as arguments exposes them in shell history and `ps` output. For sensitive values, prefer stdin or the interactive prompt.
 """# required=#false
 }
-cmd sponsors help="Show the companies sponsoring fnox and the en.dev project family"
+cmd sponsors help="Show the companies sponsoring fnox and the jdx.dev open source tools"
 cmd sync help="Sync secrets from remote providers to a local encryption provider" {
     flag "-f --force" help="Skip confirmation prompt"
     flag "-g --global" help="Write to global config (~/.config/fnox/config.toml)"

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -162,7 +162,7 @@ pub enum Commands {
     /// Set a secret value
     Set(set::SetCommand),
 
-    /// Show the companies sponsoring fnox and the en.dev project family
+    /// Show the companies sponsoring fnox and the jdx.dev open source tools
     Sponsors(sponsors::SponsorsCommand),
 
     /// Sync secrets from remote providers to a local encryption provider

--- a/src/commands/sponsors.rs
+++ b/src/commands/sponsors.rs
@@ -7,7 +7,7 @@ pub struct SponsorsCommand {}
 impl SponsorsCommand {
     pub async fn run(&self, _cli: &Cli) -> Result<()> {
         println!(
-            "fnox and the en.dev project family are sponsored by:\n\n  37signals - https://37signals.com\n\nView all sponsors: https://en.dev/sponsors.html"
+            "fnox and the jdx.dev open source tools are sponsored by:\n\n  entire.io - https://entire.io\n  37signals - https://37signals.com\n  CodeRabbit - https://coderabbit.link/mise\n  Supabase - https://supabase.com\n\nView all sponsors: https://jdx.dev/sponsors.html"
         );
         Ok(())
     }

--- a/src/commands/sponsors.rs
+++ b/src/commands/sponsors.rs
@@ -7,7 +7,7 @@ pub struct SponsorsCommand {}
 impl SponsorsCommand {
     pub async fn run(&self, _cli: &Cli) -> Result<()> {
         println!(
-            "fnox and the jdx.dev open source tools are sponsored by:\n\n  entire.io - https://entire.io\n  37signals - https://37signals.com\n  CodeRabbit - https://coderabbit.link/mise\n  Supabase - https://supabase.com\n\nView all sponsors: https://jdx.dev/sponsors.html"
+            "fnox and the jdx.dev open source tools are sponsored by:\n\n  entire.io - https://entire.io\n  37signals - https://37signals.com\n  CodeRabbit - https://coderabbit.link/mise\n\nView all sponsors: https://jdx.dev/sponsors.html"
         );
         Ok(())
     }

--- a/src/commands/sponsors.rs
+++ b/src/commands/sponsors.rs
@@ -7,7 +7,7 @@ pub struct SponsorsCommand {}
 impl SponsorsCommand {
     pub async fn run(&self, _cli: &Cli) -> Result<()> {
         println!(
-            "fnox and the jdx.dev open source tools are sponsored by:\n\n  entire.io - https://entire.io\n  37signals - https://37signals.com\n  CodeRabbit - https://coderabbit.link/mise\n\nView all sponsors: https://jdx.dev/sponsors.html"
+            "fnox and the jdx.dev open source tools are sponsored by:\n\n  entire.io - https://entire.io\n  37signals - https://37signals.com\n\nView all sponsors: https://jdx.dev/sponsors.html"
         );
         Ok(())
     }


### PR DESCRIPTION
## Summary
- list Entire first in the README and sponsors command
- point sponsor feed/page links at jdx.dev
- update docs sponsor/footer copy, release blurb, and generated CLI docs

## Tests
- git diff --check
- npm run docs:build
- cargo run -q -p fnox -- sponsors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy, URLs, and sponsor-display wiring only; no changes to secret handling, auth, or core CLI behavior.
> 
> **Overview**
> Repoints **fnox** sponsor messaging from **en.dev** to **jdx.dev** across README, GitHub release notes, docs site, and CLI output.
> 
> **entire.io** is added as a named sponsor (listed first in the README and `fnox sponsors`), with copy framing it as title sponsor of the jdx.dev open source tools. Sponsor links and the docs sponsor JSON feed now use `jdx.dev`; the docs footer uses the jdx GitHub avatar. The release workflow’s appended “Sponsor fnox” block and **communique** instructions are updated to match.
> 
> Docs sponsors UI filters footer tiers using **`title`** instead of **`anchor`**, aligned with the new feed. `fnox sponsors` help text and generated CLI docs describe “jdx.dev open source tools” instead of the “en.dev project family.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fda6e2b5e0bdc887af3dda5f30994d32e5a517f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->