### PR TITLE
feat(proton-pass): support agent and PAT auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Your `fnox.toml` config file either contains encrypted secrets or references to 
 - [**1password**](https://fnox.jdx.dev/providers/1password) - 1Password CLI
 - [**bitwarden**](https://fnox.jdx.dev/providers/bitwarden) - Bitwarden/Vaultwarden
 - [**infisical**](https://fnox.jdx.dev/providers/infisical) - Infisical secrets management
+- [**proton-pass**](https://fnox.jdx.dev/providers/proton-pass) - Proton Pass CLI
 
 ### 💻 Local Storage
 

--- a/crates/fnox-core/providers/proton-pass.toml
+++ b/crates/fnox-core/providers/proton-pass.toml
@@ -5,15 +5,23 @@ rust_variant = "ProtonPass"
 category = "PasswordManager"
 description = "Requires Proton Pass CLI and authenticated session"
 default_name = "protonpass"
-auth_command = "pass-cli login --interactive"
+auth_command = "pass-cli login"
 setup_instructions = """
 Requires: Proton Pass CLI (pass-cli) and authenticated session.
-Login: pass-cli login --interactive (username/password login)
-Or: pass-cli login (opens browser for authentication)
-Set: export PROTON_PASS_PASSWORD=<password> for non-interactive login"""
+Default/web login: pass-cli login
+Interactive username/password login: pass-cli login --interactive
+PAT login: PROTON_PASS_PERSONAL_ACCESS_TOKEN=<token> pass-cli login
+PAT login flag: pass-cli login --personal-access-token <token>
+Agent reason: fnox can pass PROTON_PASS_AGENT_REASON when configured"""
 
 [fields.vault]
 type = "optional"
 placeholder = ""
 label = "Default vault name (optional):"
 wizard = true
+
+[fields.agent_reason]
+type = "optional"
+placeholder = "fnox secret retrieval"
+label = "Agent audit reason (optional):"
+wizard = false

--- a/crates/fnox-core/src/providers/proton_pass.rs
+++ b/crates/fnox-core/src/providers/proton_pass.rs
@@ -53,24 +53,16 @@ impl ProtonPassProvider {
         let reason = reason.trim().to_string();
 
         if reason.is_empty() {
-            return Err(FnoxError::ProviderInvalidResponse {
-                provider: "Proton Pass".to_string(),
-                details: "agent_reason cannot be empty".to_string(),
-                hint: "Remove providers.<name>.agent_reason, or set it to a non-empty reason for audited agent access".to_string(),
-                url: "https://fnox.jdx.dev/providers/proton-pass".to_string(),
-            });
+            return Err(FnoxError::Config(
+                "Proton Pass provider agent_reason cannot be empty".to_string(),
+            ));
         }
 
         if reason.chars().count() > MAX_AGENT_REASON_CHARS {
-            return Err(FnoxError::ProviderInvalidResponse {
-                provider: "Proton Pass".to_string(),
-                details: format!(
-                    "agent_reason must be at most {} characters",
-                    MAX_AGENT_REASON_CHARS
-                ),
-                hint: "Shorten providers.<name>.agent_reason to match the Proton Pass CLI agent reason limit".to_string(),
-                url: "https://fnox.jdx.dev/providers/proton-pass".to_string(),
-            });
+            return Err(FnoxError::Config(format!(
+                "Proton Pass provider agent_reason must be at most {} characters",
+                MAX_AGENT_REASON_CHARS
+            )));
         }
 
         Ok(reason)
@@ -286,7 +278,7 @@ impl ProtonPassProvider {
         if !env_vars
             .iter()
             .any(|(name, _)| *name == "PROTON_PASS_AGENT_REASON")
-            && let Some(reason) = self.agent_reason.as_ref().filter(|value| !value.is_empty())
+            && let Some(reason) = self.agent_reason.as_ref()
         {
             env_vars.push(("PROTON_PASS_AGENT_REASON", reason.clone()));
         }
@@ -569,8 +561,7 @@ mod tests {
 
             assert!(matches!(
                 err,
-                FnoxError::ProviderInvalidResponse { details, .. }
-                    if details.contains("cannot be empty")
+                FnoxError::Config(message) if message.contains("cannot be empty")
             ));
         });
     }
@@ -585,8 +576,7 @@ mod tests {
 
             assert!(matches!(
                 err,
-                FnoxError::ProviderInvalidResponse { details, .. }
-                    if details.contains("at most 300 characters")
+                FnoxError::Config(message) if message.contains("at most 300 characters")
             ));
         });
     }

--- a/crates/fnox-core/src/providers/proton_pass.rs
+++ b/crates/fnox-core/src/providers/proton_pass.rs
@@ -3,6 +3,8 @@ use crate::error::{FnoxError, Result};
 use async_trait::async_trait;
 use tokio::process::Command;
 
+const MAX_AGENT_REASON_CHARS: usize = 300;
+
 pub fn env_dependencies() -> &'static [&'static str] {
     &[
         "PROTON_PASS_PASSWORD",
@@ -39,10 +41,39 @@ pub struct ProtonPassProvider {
 
 impl ProtonPassProvider {
     pub fn new(vault: Option<String>, agent_reason: Option<String>) -> Result<Self> {
+        let agent_reason = agent_reason.map(Self::validate_agent_reason).transpose()?;
+
         Ok(Self {
             vault,
             agent_reason,
         })
+    }
+
+    fn validate_agent_reason(reason: String) -> Result<String> {
+        let reason = reason.trim().to_string();
+
+        if reason.is_empty() {
+            return Err(FnoxError::ProviderInvalidResponse {
+                provider: "Proton Pass".to_string(),
+                details: "agent_reason cannot be empty".to_string(),
+                hint: "Remove providers.<name>.agent_reason, or set it to a non-empty reason for audited agent access".to_string(),
+                url: "https://fnox.jdx.dev/providers/proton-pass".to_string(),
+            });
+        }
+
+        if reason.chars().count() > MAX_AGENT_REASON_CHARS {
+            return Err(FnoxError::ProviderInvalidResponse {
+                provider: "Proton Pass".to_string(),
+                details: format!(
+                    "agent_reason must be at most {} characters",
+                    MAX_AGENT_REASON_CHARS
+                ),
+                hint: "Shorten providers.<name>.agent_reason to match the Proton Pass CLI agent reason limit".to_string(),
+                url: "https://fnox.jdx.dev/providers/proton-pass".to_string(),
+            });
+        }
+
+        Ok(reason)
     }
 
     /// Convert a value to a pass:// reference
@@ -514,15 +545,49 @@ mod tests {
     }
 
     #[test]
-    fn test_pass_cli_env_vars_ignores_empty_provider_agent_reason() {
+    fn test_pass_cli_env_vars_trims_provider_agent_reason() {
         with_clean_proton_pass_env(|| {
-            let provider = ProtonPassProvider::new(None, Some(String::new())).unwrap();
+            let provider =
+                ProtonPassProvider::new(None, Some("  fnox secret retrieval  ".to_string()))
+                    .unwrap();
             let env_vars = provider.pass_cli_env_vars();
 
             assert_eq!(
                 mapped_env_value(&env_vars, "PROTON_PASS_AGENT_REASON"),
-                None
+                Some("fnox secret retrieval")
             );
+        });
+    }
+
+    #[test]
+    fn test_provider_agent_reason_rejects_blank_provider_config() {
+        with_clean_proton_pass_env(|| {
+            let err = match ProtonPassProvider::new(None, Some(" \t\n".to_string())) {
+                Ok(_) => panic!("expected blank agent reason to fail"),
+                Err(err) => err,
+            };
+
+            assert!(matches!(
+                err,
+                FnoxError::ProviderInvalidResponse { details, .. }
+                    if details.contains("cannot be empty")
+            ));
+        });
+    }
+
+    #[test]
+    fn test_provider_agent_reason_rejects_overlong_provider_config() {
+        with_clean_proton_pass_env(|| {
+            let err = match ProtonPassProvider::new(None, Some("x".repeat(301))) {
+                Ok(_) => panic!("expected overlong agent reason to fail"),
+                Err(err) => err,
+            };
+
+            assert!(matches!(
+                err,
+                FnoxError::ProviderInvalidResponse { details, .. }
+                    if details.contains("at most 300 characters")
+            ));
         });
     }
 

--- a/crates/fnox-core/src/providers/proton_pass.rs
+++ b/crates/fnox-core/src/providers/proton_pass.rs
@@ -1,7 +1,6 @@
 use crate::env;
 use crate::error::{FnoxError, Result};
 use async_trait::async_trait;
-use std::sync::LazyLock;
 use tokio::process::Command;
 
 pub fn env_dependencies() -> &'static [&'static str] {
@@ -18,16 +17,32 @@ pub fn env_dependencies() -> &'static [&'static str] {
         "FNOX_PROTON_PASS_TOTP_FILE",
         "PROTON_PASS_EXTRA_PASSWORD_FILE",
         "FNOX_PROTON_PASS_EXTRA_PASSWORD_FILE",
+        "PROTON_PASS_PERSONAL_ACCESS_TOKEN",
+        "FNOX_PROTON_PASS_PERSONAL_ACCESS_TOKEN",
+        "PROTON_PASS_AGENT_REASON",
+        "FNOX_PROTON_PASS_AGENT_REASON",
+        "PROTON_PASS_SESSION_DIR",
+        "FNOX_PROTON_PASS_SESSION_DIR",
+        "PROTON_PASS_KEY_PROVIDER",
+        "FNOX_PROTON_PASS_KEY_PROVIDER",
+        "PROTON_PASS_ENCRYPTION_KEY",
+        "FNOX_PROTON_PASS_ENCRYPTION_KEY",
+        "PROTON_PASS_LINUX_KEYRING",
+        "FNOX_PROTON_PASS_LINUX_KEYRING",
     ]
 }
 
 pub struct ProtonPassProvider {
     vault: Option<String>,
+    agent_reason: Option<String>,
 }
 
 impl ProtonPassProvider {
-    pub fn new(vault: Option<String>) -> Result<Self> {
-        Ok(Self { vault })
+    pub fn new(vault: Option<String>, agent_reason: Option<String>) -> Result<Self> {
+        Ok(Self {
+            vault,
+            agent_reason,
+        })
     }
 
     /// Convert a value to a pass:// reference
@@ -123,22 +138,8 @@ impl ProtonPassProvider {
         let mut cmd = Command::new("pass-cli");
         cmd.args(args);
 
-        // Pass through Proton Pass environment variables for non-interactive auth
-        let env_vars_to_pass = [
-            ("PROTON_PASS_PASSWORD", &*PROTON_PASS_PASSWORD),
-            ("PROTON_PASS_PASSWORD_FILE", &*PROTON_PASS_PASSWORD_FILE),
-            ("PROTON_PASS_TOTP", &*PROTON_PASS_TOTP),
-            ("PROTON_PASS_TOTP_FILE", &*PROTON_PASS_TOTP_FILE),
-            ("PROTON_PASS_EXTRA_PASSWORD", &*PROTON_PASS_EXTRA_PASSWORD),
-            (
-                "PROTON_PASS_EXTRA_PASSWORD_FILE",
-                &*PROTON_PASS_EXTRA_PASSWORD_FILE,
-            ),
-        ];
-        for (name, value) in env_vars_to_pass {
-            if let Some(v) = value {
-                cmd.env(name, v);
-            }
+        for (name, value) in self.pass_cli_env_vars() {
+            cmd.env(name, value);
         }
 
         let output = cmd.output().await.map_err(|e| {
@@ -166,17 +167,39 @@ impl ProtonPassProvider {
             let stderr = String::from_utf8_lossy(&output.stderr);
             let stderr_lower = stderr.to_lowercase();
 
-            // Check for authentication-related errors (using CLI-specific patterns)
-            if stderr_lower.contains("not logged in")
-                || stderr_lower.contains("session expired")
-                || stderr_lower.contains("login required")
-                || stderr_lower.contains("could not get local key from keyring")
-                || stderr_lower.contains("failed to get encryption key")
+            if stderr_lower.contains("proton_pass_agent_reason")
+                || stderr_lower.contains("agent reason")
+                || stderr_lower.contains("reason must be provided")
             {
                 return Err(FnoxError::ProviderAuthFailed {
                     provider: "Proton Pass".to_string(),
                     details: stderr.trim().to_string(),
-                    hint: "Run 'pass-cli login --interactive' to authenticate".to_string(),
+                    hint: "Set PROTON_PASS_AGENT_REASON, FNOX_PROTON_PASS_AGENT_REASON, or providers.<name>.agent_reason for audited agent access".to_string(),
+                    url: "https://fnox.jdx.dev/providers/proton-pass".to_string(),
+                });
+            }
+
+            if stderr_lower.contains("could not get local key from keyring")
+                || stderr_lower.contains("failed to get encryption key")
+                || stderr_lower.contains("key provider")
+            {
+                return Err(FnoxError::ProviderAuthFailed {
+                    provider: "Proton Pass".to_string(),
+                    details: stderr.trim().to_string(),
+                    hint: "Check Proton Pass session/key storage: PROTON_PASS_SESSION_DIR, PROTON_PASS_KEY_PROVIDER=fs|env|keyring, and PROTON_PASS_ENCRYPTION_KEY".to_string(),
+                    url: "https://fnox.jdx.dev/providers/proton-pass".to_string(),
+                });
+            }
+
+            // Check for authentication-related errors (using CLI-specific patterns)
+            if stderr_lower.contains("not logged in")
+                || stderr_lower.contains("session expired")
+                || stderr_lower.contains("login required")
+            {
+                return Err(FnoxError::ProviderAuthFailed {
+                    provider: "Proton Pass".to_string(),
+                    details: stderr.trim().to_string(),
+                    hint: "Run 'pass-cli login', or set PROTON_PASS_PERSONAL_ACCESS_TOKEN and run 'pass-cli login' for PAT/agent access".to_string(),
                     url: "https://fnox.jdx.dev/providers/proton-pass".to_string(),
                 });
             }
@@ -218,6 +241,26 @@ impl ProtonPassProvider {
             })?;
 
         Ok(stdout.trim().to_string())
+    }
+
+    fn pass_cli_env_vars(&self) -> Vec<(&'static str, String)> {
+        let mut env_vars = Vec::new();
+
+        for (target, fnox_name, native_name) in PROTON_PASS_ENV_MAPPINGS {
+            if let Some(value) = env_value(fnox_name, native_name) {
+                env_vars.push((*target, value));
+            }
+        }
+
+        if !env_vars
+            .iter()
+            .any(|(name, _)| *name == "PROTON_PASS_AGENT_REASON")
+            && let Some(reason) = self.agent_reason.as_ref().filter(|value| !value.is_empty())
+        {
+            env_vars.push(("PROTON_PASS_AGENT_REASON", reason.clone()));
+        }
+
+        env_vars
     }
 }
 
@@ -286,52 +329,206 @@ impl crate::providers::Provider for ProtonPassProvider {
     }
 }
 
-// Environment variables for Proton Pass authentication
-// Pattern: FNOX_* prefix takes priority, fallback to native
+// Environment variables for Proton Pass authentication.
+// Pattern: FNOX_* prefix takes priority, fallback to native pass-cli variables.
+const PROTON_PASS_ENV_MAPPINGS: &[(&str, &str, &str)] = &[
+    (
+        "PROTON_PASS_PASSWORD",
+        "FNOX_PROTON_PASS_PASSWORD",
+        "PROTON_PASS_PASSWORD",
+    ),
+    (
+        "PROTON_PASS_PASSWORD_FILE",
+        "FNOX_PROTON_PASS_PASSWORD_FILE",
+        "PROTON_PASS_PASSWORD_FILE",
+    ),
+    (
+        "PROTON_PASS_TOTP",
+        "FNOX_PROTON_PASS_TOTP",
+        "PROTON_PASS_TOTP",
+    ),
+    (
+        "PROTON_PASS_TOTP_FILE",
+        "FNOX_PROTON_PASS_TOTP_FILE",
+        "PROTON_PASS_TOTP_FILE",
+    ),
+    (
+        "PROTON_PASS_EXTRA_PASSWORD",
+        "FNOX_PROTON_PASS_EXTRA_PASSWORD",
+        "PROTON_PASS_EXTRA_PASSWORD",
+    ),
+    (
+        "PROTON_PASS_EXTRA_PASSWORD_FILE",
+        "FNOX_PROTON_PASS_EXTRA_PASSWORD_FILE",
+        "PROTON_PASS_EXTRA_PASSWORD_FILE",
+    ),
+    (
+        "PROTON_PASS_PERSONAL_ACCESS_TOKEN",
+        "FNOX_PROTON_PASS_PERSONAL_ACCESS_TOKEN",
+        "PROTON_PASS_PERSONAL_ACCESS_TOKEN",
+    ),
+    (
+        "PROTON_PASS_AGENT_REASON",
+        "FNOX_PROTON_PASS_AGENT_REASON",
+        "PROTON_PASS_AGENT_REASON",
+    ),
+    (
+        "PROTON_PASS_SESSION_DIR",
+        "FNOX_PROTON_PASS_SESSION_DIR",
+        "PROTON_PASS_SESSION_DIR",
+    ),
+    (
+        "PROTON_PASS_KEY_PROVIDER",
+        "FNOX_PROTON_PASS_KEY_PROVIDER",
+        "PROTON_PASS_KEY_PROVIDER",
+    ),
+    (
+        "PROTON_PASS_ENCRYPTION_KEY",
+        "FNOX_PROTON_PASS_ENCRYPTION_KEY",
+        "PROTON_PASS_ENCRYPTION_KEY",
+    ),
+    (
+        "PROTON_PASS_LINUX_KEYRING",
+        "FNOX_PROTON_PASS_LINUX_KEYRING",
+        "PROTON_PASS_LINUX_KEYRING",
+    ),
+];
 
-static PROTON_PASS_PASSWORD: LazyLock<Option<String>> = LazyLock::new(|| {
-    env::var("FNOX_PROTON_PASS_PASSWORD")
-        .or_else(|_| env::var("PROTON_PASS_PASSWORD"))
+fn env_value(fnox_name: &str, native_name: &str) -> Option<String> {
+    env::var(fnox_name)
+        .or_else(|_| env::var(native_name))
         .ok()
-});
-
-static PROTON_PASS_PASSWORD_FILE: LazyLock<Option<String>> = LazyLock::new(|| {
-    env::var("FNOX_PROTON_PASS_PASSWORD_FILE")
-        .or_else(|_| env::var("PROTON_PASS_PASSWORD_FILE"))
-        .ok()
-});
-
-static PROTON_PASS_TOTP: LazyLock<Option<String>> = LazyLock::new(|| {
-    env::var("FNOX_PROTON_PASS_TOTP")
-        .or_else(|_| env::var("PROTON_PASS_TOTP"))
-        .ok()
-});
-
-static PROTON_PASS_TOTP_FILE: LazyLock<Option<String>> = LazyLock::new(|| {
-    env::var("FNOX_PROTON_PASS_TOTP_FILE")
-        .or_else(|_| env::var("PROTON_PASS_TOTP_FILE"))
-        .ok()
-});
-
-static PROTON_PASS_EXTRA_PASSWORD: LazyLock<Option<String>> = LazyLock::new(|| {
-    env::var("FNOX_PROTON_PASS_EXTRA_PASSWORD")
-        .or_else(|_| env::var("PROTON_PASS_EXTRA_PASSWORD"))
-        .ok()
-});
-
-static PROTON_PASS_EXTRA_PASSWORD_FILE: LazyLock<Option<String>> = LazyLock::new(|| {
-    env::var("FNOX_PROTON_PASS_EXTRA_PASSWORD_FILE")
-        .or_else(|_| env::var("PROTON_PASS_EXTRA_PASSWORD_FILE"))
-        .ok()
-});
+        .filter(|value| !value.is_empty())
+}
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    static PROTON_PASS_ENV_TEST_LOCK: std::sync::LazyLock<std::sync::Mutex<()>> =
+        std::sync::LazyLock::new(|| std::sync::Mutex::new(()));
+
+    const PROTON_PASS_TEST_ENV_NAMES: &[&str] = &[
+        "FNOX_PROTON_PASS_PERSONAL_ACCESS_TOKEN",
+        "PROTON_PASS_PERSONAL_ACCESS_TOKEN",
+        "FNOX_PROTON_PASS_AGENT_REASON",
+        "PROTON_PASS_AGENT_REASON",
+    ];
+
+    fn with_clean_proton_pass_env<T>(test: impl FnOnce() -> T) -> T {
+        let _lock = PROTON_PASS_ENV_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        clear_proton_pass_test_env();
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(test));
+
+        clear_proton_pass_test_env();
+
+        match result {
+            Ok(value) => value,
+            Err(payload) => std::panic::resume_unwind(payload),
+        }
+    }
+
+    fn clear_proton_pass_test_env() {
+        for name in PROTON_PASS_TEST_ENV_NAMES {
+            env::remove_var(name);
+        }
+    }
+
+    fn mapped_env_value<'a>(env_vars: &'a [(&'static str, String)], name: &str) -> Option<&'a str> {
+        env_vars
+            .iter()
+            .find_map(|(env_name, value)| (*env_name == name).then_some(value.as_str()))
+    }
+
+    #[test]
+    fn test_provider_metadata_uses_token_aware_login_command() {
+        let metadata = include_str!("../../providers/proton-pass.toml");
+
+        assert!(metadata.contains("auth_command = \"pass-cli login\""));
+        assert!(!metadata.contains("auth_command = \"pass-cli login --interactive\""));
+    }
+
+    #[test]
+    fn test_env_value_prefers_fnox_alias_over_native_env() {
+        with_clean_proton_pass_env(|| {
+            env::set_var("FNOX_PROTON_PASS_PERSONAL_ACCESS_TOKEN", "fnox-token");
+            env::set_var("PROTON_PASS_PERSONAL_ACCESS_TOKEN", "native-token");
+
+            assert_eq!(
+                env_value(
+                    "FNOX_PROTON_PASS_PERSONAL_ACCESS_TOKEN",
+                    "PROTON_PASS_PERSONAL_ACCESS_TOKEN",
+                )
+                .as_deref(),
+                Some("fnox-token")
+            );
+        });
+    }
+
+    #[test]
+    fn test_pass_cli_env_vars_maps_fnox_pat_to_native_env() {
+        with_clean_proton_pass_env(|| {
+            env::set_var("FNOX_PROTON_PASS_PERSONAL_ACCESS_TOKEN", "pst_test::key");
+
+            let provider = ProtonPassProvider::new(None, None).unwrap();
+            let env_vars = provider.pass_cli_env_vars();
+
+            assert_eq!(
+                mapped_env_value(&env_vars, "PROTON_PASS_PERSONAL_ACCESS_TOKEN"),
+                Some("pst_test::key")
+            );
+        });
+    }
+
+    #[test]
+    fn test_pass_cli_env_vars_uses_provider_agent_reason_when_env_absent() {
+        with_clean_proton_pass_env(|| {
+            let provider =
+                ProtonPassProvider::new(None, Some("fnox secret retrieval".to_string())).unwrap();
+            let env_vars = provider.pass_cli_env_vars();
+
+            assert_eq!(
+                mapped_env_value(&env_vars, "PROTON_PASS_AGENT_REASON"),
+                Some("fnox secret retrieval")
+            );
+        });
+    }
+
+    #[test]
+    fn test_pass_cli_env_vars_prefers_env_agent_reason_over_provider_config() {
+        with_clean_proton_pass_env(|| {
+            env::set_var("FNOX_PROTON_PASS_AGENT_REASON", "env reason");
+
+            let provider =
+                ProtonPassProvider::new(None, Some("provider reason".to_string())).unwrap();
+            let env_vars = provider.pass_cli_env_vars();
+
+            assert_eq!(
+                mapped_env_value(&env_vars, "PROTON_PASS_AGENT_REASON"),
+                Some("env reason")
+            );
+        });
+    }
+
+    #[test]
+    fn test_pass_cli_env_vars_ignores_empty_provider_agent_reason() {
+        with_clean_proton_pass_env(|| {
+            let provider = ProtonPassProvider::new(None, Some(String::new())).unwrap();
+            let env_vars = provider.pass_cli_env_vars();
+
+            assert_eq!(
+                mapped_env_value(&env_vars, "PROTON_PASS_AGENT_REASON"),
+                None
+            );
+        });
+    }
+
     #[test]
     fn test_value_to_reference_passthrough() {
-        let provider = ProtonPassProvider::new(Some("vault".to_string())).unwrap();
+        let provider = ProtonPassProvider::new(Some("vault".to_string()), None).unwrap();
         let result = provider
             .value_to_reference("pass://MyVault/item/password")
             .unwrap();
@@ -340,28 +537,28 @@ mod tests {
 
     #[test]
     fn test_value_to_reference_single_part_with_vault() {
-        let provider = ProtonPassProvider::new(Some("TestVault".to_string())).unwrap();
+        let provider = ProtonPassProvider::new(Some("TestVault".to_string()), None).unwrap();
         let result = provider.value_to_reference("my-item").unwrap();
         assert_eq!(result, "pass://TestVault/my-item/password");
     }
 
     #[test]
     fn test_value_to_reference_single_part_without_vault() {
-        let provider = ProtonPassProvider::new(None).unwrap();
+        let provider = ProtonPassProvider::new(None, None).unwrap();
         let result = provider.value_to_reference("my-item");
         assert!(result.is_err());
     }
 
     #[test]
     fn test_value_to_reference_two_parts_with_vault() {
-        let provider = ProtonPassProvider::new(Some("TestVault".to_string())).unwrap();
+        let provider = ProtonPassProvider::new(Some("TestVault".to_string()), None).unwrap();
         let result = provider.value_to_reference("my-item/username").unwrap();
         assert_eq!(result, "pass://TestVault/my-item/username");
     }
 
     #[test]
     fn test_value_to_reference_three_parts() {
-        let provider = ProtonPassProvider::new(None).unwrap();
+        let provider = ProtonPassProvider::new(None, None).unwrap();
         let result = provider
             .value_to_reference("OtherVault/item/field")
             .unwrap();
@@ -370,42 +567,42 @@ mod tests {
 
     #[test]
     fn test_value_to_reference_too_many_parts() {
-        let provider = ProtonPassProvider::new(Some("vault".to_string())).unwrap();
+        let provider = ProtonPassProvider::new(Some("vault".to_string()), None).unwrap();
         let result = provider.value_to_reference("a/b/c/d");
         assert!(result.is_err());
     }
 
     #[test]
     fn test_value_to_reference_empty() {
-        let provider = ProtonPassProvider::new(Some("vault".to_string())).unwrap();
+        let provider = ProtonPassProvider::new(Some("vault".to_string()), None).unwrap();
         let result = provider.value_to_reference("");
         assert!(result.is_err());
     }
 
     #[test]
     fn test_value_to_reference_whitespace_only() {
-        let provider = ProtonPassProvider::new(Some("vault".to_string())).unwrap();
+        let provider = ProtonPassProvider::new(Some("vault".to_string()), None).unwrap();
         let result = provider.value_to_reference("   ");
         assert!(result.is_err());
     }
 
     #[test]
     fn test_value_to_reference_invalid_pass_uri_too_few_parts() {
-        let provider = ProtonPassProvider::new(None).unwrap();
+        let provider = ProtonPassProvider::new(None, None).unwrap();
         let result = provider.value_to_reference("pass://vault");
         assert!(result.is_err());
     }
 
     #[test]
     fn test_value_to_reference_invalid_pass_uri_empty_parts() {
-        let provider = ProtonPassProvider::new(None).unwrap();
+        let provider = ProtonPassProvider::new(None, None).unwrap();
         let result = provider.value_to_reference("pass://vault//field");
         assert!(result.is_err());
     }
 
     #[test]
     fn test_value_to_reference_invalid_pass_uri_vault_item_only() {
-        let provider = ProtonPassProvider::new(None).unwrap();
+        let provider = ProtonPassProvider::new(None, None).unwrap();
         let result = provider.value_to_reference("pass://vault/item");
         assert!(result.is_err());
     }

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -141,6 +141,7 @@ export default defineConfig({
               { text: "1Password", link: "/providers/1password" },
               { text: "Bitwarden", link: "/providers/bitwarden" },
               { text: "Infisical", link: "/providers/infisical" },
+              { text: "Proton Pass", link: "/providers/proton-pass" },
             ],
           },
           {

--- a/docs/providers/overview.md
+++ b/docs/providers/overview.md
@@ -34,11 +34,12 @@ Store secrets remotely in cloud providers. Your `fnox.toml` contains only refere
 
 Integrate with password managers and secret services you already use.
 
-| Provider                          | Description               | Best For                              |
-| --------------------------------- | ------------------------- | ------------------------------------- |
-| [1Password](/providers/1password) | 1Password CLI integration | Teams already using 1Password         |
-| [Bitwarden](/providers/bitwarden) | Bitwarden/Vaultwarden     | Open source preference, self-hosting  |
-| [Infisical](/providers/infisical) | Infisical secrets         | Modern secret management, open source |
+| Provider                              | Description                 | Best For                                |
+| ------------------------------------- | --------------------------- | --------------------------------------- |
+| [1Password](/providers/1password)     | 1Password CLI integration   | Teams already using 1Password           |
+| [Bitwarden](/providers/bitwarden)     | Bitwarden/Vaultwarden       | Open source preference, self-hosting    |
+| [Infisical](/providers/infisical)     | Infisical secrets           | Modern secret management, open source   |
+| [Proton Pass](/providers/proton-pass) | Proton Pass CLI integration | Teams using Proton Pass or agent tokens |
 
 ### 💻 Local Storage
 

--- a/docs/providers/proton-pass.md
+++ b/docs/providers/proton-pass.md
@@ -1,0 +1,119 @@
+# Proton Pass
+
+Integrate with Proton Pass through the Proton Pass CLI (`pass-cli`) to retrieve secrets from vault items.
+
+## Quick Start
+
+```bash
+# 1. Install Proton Pass CLI
+# See https://proton.me/pass/download
+
+# 2. Log in once with the default browser-based flow
+pass-cli login
+
+# 3. Configure fnox
+cat >> fnox.toml << 'EOF'
+[providers.protonpass]
+type = "proton-pass"
+vault = "Personal"
+
+[secrets]
+DATABASE_PASSWORD = { provider = "protonpass", value = "Database/password" }
+EOF
+
+# 4. Retrieve the secret
+fnox get DATABASE_PASSWORD
+```
+
+## Configuration
+
+```toml
+[providers.protonpass]
+type = "proton-pass"
+vault = "Personal" # Optional default vault for item-only references
+agent_reason = "fnox secret retrieval" # Optional reason for audited agent access
+```
+
+`agent_reason` is used only when neither `FNOX_PROTON_PASS_AGENT_REASON` nor `PROTON_PASS_AGENT_REASON` is set.
+
+## References
+
+Supported secret references:
+
+```toml
+[secrets]
+FROM_DEFAULT_VAULT = { provider = "protonpass", value = "Database" }
+FIELD_FROM_DEFAULT_VAULT = { provider = "protonpass", value = "Database/username" }
+FIELD_FROM_NAMED_VAULT = { provider = "protonpass", value = "Work/Database/password" }
+FULL_URI = { provider = "protonpass", value = "pass://Work/Database/password" }
+BY_ITEM_ID = { provider = "protonpass", value = "id:ITEM_ID/password" }
+```
+
+Item-only references default to the `password` field and require `vault`.
+
+Use full `pass://vault/item/field` references when vault or item names contain `/`.
+
+## Personal Access Tokens
+
+For CI or headless use, create a Proton Pass personal access token, then log in with `pass-cli`.
+The official CLI supports either an environment variable or a login flag:
+
+```bash
+export PROTON_PASS_PERSONAL_ACCESS_TOKEN="pst_token::key"
+pass-cli login
+```
+
+```bash
+pass-cli login --personal-access-token "pst_token::key"
+```
+
+Run `pass-cli info` after login to verify the session. `fnox` also accepts `FNOX_PROTON_PASS_PERSONAL_ACCESS_TOKEN` and passes it to `pass-cli` as `PROTON_PASS_PERSONAL_ACCESS_TOKEN`.
+
+## Agent Tokens
+
+Some `pass-cli` builds and token policies may ask for an agent reason when reading items. `fnox` can pass that value through with either environment or provider config:
+
+```bash
+export FNOX_PROTON_PASS_AGENT_REASON="fnox secret retrieval"
+fnox get DATABASE_PASSWORD
+```
+
+```toml
+[providers.protonpass]
+type = "proton-pass"
+vault = "Personal"
+agent_reason = "fnox secret retrieval"
+```
+
+Environment values take priority over provider config. This is compatibility pass-through; the current official `pass-cli` PAT documentation does not list `PROTON_PASS_AGENT_REASON` as a general login requirement.
+
+## Session and Key Storage
+
+`fnox` passes through these Proton Pass CLI environment variables, with `FNOX_` aliases available for project-local setup:
+
+| fnox env alias                           | pass-cli env                        |
+| ---------------------------------------- | ----------------------------------- |
+| `FNOX_PROTON_PASS_PERSONAL_ACCESS_TOKEN` | `PROTON_PASS_PERSONAL_ACCESS_TOKEN` |
+| `FNOX_PROTON_PASS_AGENT_REASON`          | `PROTON_PASS_AGENT_REASON`          |
+| `FNOX_PROTON_PASS_SESSION_DIR`           | `PROTON_PASS_SESSION_DIR`           |
+| `FNOX_PROTON_PASS_KEY_PROVIDER`          | `PROTON_PASS_KEY_PROVIDER`          |
+| `FNOX_PROTON_PASS_ENCRYPTION_KEY`        | `PROTON_PASS_ENCRYPTION_KEY`        |
+| `FNOX_PROTON_PASS_LINUX_KEYRING`         | `PROTON_PASS_LINUX_KEYRING`         |
+
+Existing `PROTON_PASS_*` login variables such as `PROTON_PASS_PASSWORD`, `PROTON_PASS_TOTP`, and extra-password variants are also supported.
+
+## Limits
+
+The Proton Pass provider is read-only in `fnox`.
+
+Supported:
+
+- `fnox get`
+- `fnox exec` and other commands that resolve configured secrets
+- `fnox provider test`
+
+Not supported:
+
+- `fnox set` to create or update Proton Pass items
+- Remote item listing/import
+- Item delete/archive/update flows

--- a/docs/providers/proton-pass.md
+++ b/docs/providers/proton-pass.md
@@ -71,7 +71,9 @@ Run `pass-cli info` after login to verify the session. `fnox` also accepts `FNOX
 
 ## Agent Tokens
 
-Some `pass-cli` builds and token policies may ask for an agent reason when reading items. `fnox` can pass that value through with either environment or provider config:
+Proton Pass agent tokens are personal access tokens with dedicated access logging. Current `pass-cli` releases require `PROTON_PASS_AGENT_REASON` for audited agent operations, including item reads performed by `fnox`.
+
+Set the reason with either environment or provider config:
 
 ```bash
 export FNOX_PROTON_PASS_AGENT_REASON="fnox secret retrieval"
@@ -85,7 +87,7 @@ vault = "Personal"
 agent_reason = "fnox secret retrieval"
 ```
 
-Environment values take priority over provider config. This is compatibility pass-through; the current official `pass-cli` PAT documentation does not list `PROTON_PASS_AGENT_REASON` as a general login requirement.
+Environment values take priority over provider config. Provider `agent_reason` values are trimmed, must be non-empty, and must be at most 300 characters to match the `pass-cli` agent reason limit.
 
 ## Session and Key Storage
 

--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -815,6 +815,9 @@
         {
           "type": "object",
           "properties": {
+            "agent_reason": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
             "auth_command": {
               "type": ["string", "null"]
             },

--- a/src/commands/provider/add.rs
+++ b/src/commands/provider/add.rs
@@ -261,6 +261,7 @@ impl AddCommand {
                     .map_or_else(OptionStringOrSecretRef::none, |vault| {
                         OptionStringOrSecretRef::literal(vault.clone())
                     }),
+                agent_reason: OptionStringOrSecretRef::none(),
                 auth_command: None,
                 daemon_cache: None,
             },

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -975,6 +975,18 @@ fn provider_env_key(key: &str) -> bool {
             | "INFISICAL_TOKEN"
             | "KEEPASS_PASSWORD"
             | "PASSWORDSTATE_API_KEY"
+            | "PROTON_PASS_PASSWORD"
+            | "PROTON_PASS_TOTP"
+            | "PROTON_PASS_EXTRA_PASSWORD"
+            | "PROTON_PASS_PASSWORD_FILE"
+            | "PROTON_PASS_TOTP_FILE"
+            | "PROTON_PASS_EXTRA_PASSWORD_FILE"
+            | "PROTON_PASS_PERSONAL_ACCESS_TOKEN"
+            | "PROTON_PASS_AGENT_REASON"
+            | "PROTON_PASS_SESSION_DIR"
+            | "PROTON_PASS_KEY_PROVIDER"
+            | "PROTON_PASS_ENCRYPTION_KEY"
+            | "PROTON_PASS_LINUX_KEYRING"
     )
 }
 
@@ -1278,7 +1290,8 @@ pub fn parse_duration(value: &str) -> Result<Duration> {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_duration;
+    use super::{config_fingerprint, parse_duration};
+    use fnox_core::config::Config;
 
     #[test]
     fn parse_duration_accepts_combined_values() {
@@ -1290,5 +1303,51 @@ mod tests {
     fn parse_duration_rejects_zero_and_overflow() {
         assert!(parse_duration("0s").is_err());
         assert!(parse_duration("18446744073709551615d").is_err());
+    }
+
+    #[test]
+    fn config_fingerprint_tracks_proton_pass_native_pat() {
+        let config = Config::default();
+        let first = config_fingerprint(
+            &config,
+            &[(
+                "PROTON_PASS_PERSONAL_ACCESS_TOKEN".to_string(),
+                "pst_first".to_string(),
+            )],
+        )
+        .unwrap();
+        let second = config_fingerprint(
+            &config,
+            &[(
+                "PROTON_PASS_PERSONAL_ACCESS_TOKEN".to_string(),
+                "pst_second".to_string(),
+            )],
+        )
+        .unwrap();
+
+        assert_ne!(first, second);
+    }
+
+    #[test]
+    fn config_fingerprint_tracks_proton_pass_session_env() {
+        let config = Config::default();
+        let first = config_fingerprint(
+            &config,
+            &[(
+                "PROTON_PASS_SESSION_DIR".to_string(),
+                "/tmp/proton-pass-first".to_string(),
+            )],
+        )
+        .unwrap();
+        let second = config_fingerprint(
+            &config,
+            &[(
+                "PROTON_PASS_SESSION_DIR".to_string(),
+                "/tmp/proton-pass-second".to_string(),
+            )],
+        )
+        .unwrap();
+
+        assert_ne!(first, second);
     }
 }

--- a/test/proton_pass.bats
+++ b/test/proton_pass.bats
@@ -6,9 +6,9 @@
 #
 # Prerequisites:
 #   1. Install Proton Pass CLI: Download from https://proton.me/pass/download
-#   2. Login to Proton Pass: pass-cli login --interactive
+#   2. Login to Proton Pass: pass-cli login
 #   3. Create test items in a vault
-#   4. Run tests: mise run test:bats -- test/proton-pass.bats
+#   4. Run tests: mise run test:bats -- test/proton_pass.bats
 #
 # Note: Tests will automatically skip if:
 #       - pass-cli is not installed
@@ -16,7 +16,9 @@
 #       - Test vault/items don't exist
 #
 # Environment Variables:
-#   FNOX_PROTON_PASS_PASSWORD or PROTON_PASS_PASSWORD - Account password for non-interactive auth
+#   FNOX_PROTON_PASS_PERSONAL_ACCESS_TOKEN or PROTON_PASS_PERSONAL_ACCESS_TOKEN - PAT for login
+#   FNOX_PROTON_PASS_AGENT_REASON or PROTON_PASS_AGENT_REASON - Reason for audited agent access
+#   FNOX_PROTON_PASS_PASSWORD or PROTON_PASS_PASSWORD - Account password for interactive auth
 #   FNOX_PROTON_PASS_TOTP or PROTON_PASS_TOTP - 2FA TOTP code if enabled
 #   PROTON_PASS_TEST_VAULT - Vault name to use for tests (default: "Personal")
 #   PROTON_PASS_TEST_ITEM - An existing item in your vault that tests will read from
@@ -37,7 +39,7 @@ setup() {
 	if [[ $BATS_TEST_DESCRIPTION != *"list"* ]] && [[ $BATS_TEST_DESCRIPTION != *"fails gracefully"* ]]; then
 		# Check if we can authenticate by running pass-cli test
 		if ! pass-cli test >/dev/null 2>&1; then
-			skip "Cannot authenticate with Proton Pass. Run 'pass-cli login --interactive' first."
+			skip "Cannot authenticate with Proton Pass. Run 'pass-cli login' first."
 		fi
 	fi
 


### PR DESCRIPTION
## Summary

- Add Proton Pass PAT/agent auth support, including native `PROTON_PASS_*` env mapping and token-aware login metadata.
- Add Proton Pass provider docs/schema/provider-add wiring and keep the Bats provider test under `test/proton_pass.bats`.
- Include native `PROTON_PASS_*` variables in the daemon config fingerprint so cached values invalidate when PAT/session/key env changes.

## Test Plan

- [x] `cargo test -p fnox-core proton_pass -- --test-threads=1`
- [x] `cargo test -p fnox daemon::tests -- --test-threads=1`
- [x] `cargo test -p fnox-core`
- [x] `cargo test -p fnox`
- [x] `git diff --check`

## Notes

- Closes https://github.com/jdx/fnox/discussions/516
- Resolver/default-interpolation changes are intentionally out of scope because upstream already merged that path.
- The `default_provider` + provider-level `daemon_cache = false` issue is a separate daemon follow-up, not part of this PAT branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Proton Pass provider support, including configuration for headless PAT access and optional agent audit reasons.
  * Updated provider templates and published schema to include the new `agent_reason` option.
  * Extended docs/navigation and README to include Proton Pass.

* **Bug Fixes**
  * Improved Proton Pass CLI auth handling and clearer guidance when authentication or required environment variables are missing/invalid.
  * Enhanced environment-variable passthrough and precedence for PAT and agent audit reason inputs.

* **Chores**
  * Improved config fingerprinting to reliably detect Proton Pass-related environment changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->