### PR TITLE
fix(daemon): respect default provider daemon cache setting

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1,5 +1,5 @@
 use crate::commands::Cli;
-use crate::config::{Config, SecretConfig};
+use crate::config::{Config, ProviderConfig, SecretConfig};
 use crate::error::{FnoxError, Result};
 use crate::secret_resolver::resolve_secrets_batch;
 use indexmap::IndexMap;
@@ -862,10 +862,7 @@ async fn resolve_with_cache(
         for (key, secret) in &secrets {
             let cacheable = req.purpose != Purpose::Check.as_str()
                 && secret.daemon_cache.unwrap_or(true)
-                && secret
-                    .provider()
-                    .and_then(|p| providers.get(p))
-                    .is_none_or(|p| p.daemon_cache_enabled());
+                && provider_daemon_cache_enabled(config, profile, &providers, secret)?;
             if cacheable {
                 let cache_key = cache_key(&fingerprint, profile, key, secret, req);
                 if let Some(value) = state.cache.get(&cache_key) {
@@ -896,6 +893,26 @@ async fn resolve_with_cache(
         }
     }
     Ok(ordered)
+}
+
+fn provider_daemon_cache_enabled(
+    config: &Config,
+    profile: &str,
+    providers: &IndexMap<String, ProviderConfig>,
+    secret: &SecretConfig,
+) -> Result<bool> {
+    let provider_name = if let Some(provider_name) = secret.provider() {
+        Some(provider_name.to_string())
+    } else if secret.value().is_some() {
+        config.get_default_provider(profile)?
+    } else {
+        None
+    };
+
+    Ok(provider_name
+        .as_deref()
+        .and_then(|provider_name| providers.get(provider_name))
+        .is_none_or(|provider| provider.daemon_cache_enabled()))
 }
 
 fn cache_key(
@@ -1290,8 +1307,14 @@ pub fn parse_duration(value: &str) -> Result<Duration> {
 
 #[cfg(test)]
 mod tests {
-    use super::{config_fingerprint, parse_duration};
-    use fnox_core::config::Config;
+    use super::{
+        CacheKey, DaemonState, Purpose, ResolveBatchRequest, cache_key, config_fingerprint,
+        parse_duration, resolve_with_cache,
+    };
+    use fnox_core::config::{Config, ProviderConfig, SecretConfig};
+    use indexmap::IndexMap;
+    use std::{path::PathBuf, sync::Arc};
+    use tokio::sync::Mutex;
 
     #[test]
     fn parse_duration_accepts_combined_values() {
@@ -1349,5 +1372,133 @@ mod tests {
         .unwrap();
 
         assert_ne!(first, second);
+    }
+
+    fn plain_provider_config(daemon_cache: Option<bool>) -> ProviderConfig {
+        ProviderConfig::Plain {
+            auth_command: None,
+            daemon_cache,
+        }
+    }
+
+    fn plain_secret(value: &str) -> SecretConfig {
+        let mut secret = SecretConfig::new();
+        secret.set_provider(Some("plain".to_string()));
+        secret.set_value(Some(value.to_string()));
+        secret
+    }
+
+    fn default_provider_secret(value: &str) -> SecretConfig {
+        let mut secret = SecretConfig::new();
+        secret.set_value(Some(value.to_string()));
+        secret
+    }
+
+    fn test_batch_request() -> ResolveBatchRequest {
+        ResolveBatchRequest {
+            cwd: PathBuf::from("."),
+            config: PathBuf::from("fnox.toml"),
+            profile: "default".to_string(),
+            age_key_file: None,
+            if_missing: None,
+            no_defaults: false,
+            non_interactive: true,
+            purpose: Purpose::Get.as_str().to_string(),
+            keys: vec!["API_KEY".to_string()],
+            include_env_false: true,
+            env: Vec::new(),
+        }
+    }
+
+    fn state_with_cached_secret(
+        config: &Config,
+        secret: &SecretConfig,
+        req: &ResolveBatchRequest,
+    ) -> Arc<Mutex<DaemonState>> {
+        let fingerprint = config_fingerprint(config, &req.env).unwrap();
+        let key = cache_key(&fingerprint, &req.profile, "API_KEY", secret, req);
+        let mut cache = std::collections::HashMap::<CacheKey, Option<String>>::new();
+        cache.insert(key, Some("cached".to_string()));
+        Arc::new(Mutex::new(DaemonState { cache }))
+    }
+
+    #[tokio::test]
+    async fn resolve_with_cache_skips_explicit_provider_when_provider_daemon_cache_disabled() {
+        let mut config = Config::new();
+        config
+            .providers
+            .insert("plain".to_string(), plain_provider_config(Some(false)));
+        let secret = plain_secret("fresh");
+        let req = test_batch_request();
+        let state = state_with_cached_secret(&config, &secret, &req);
+
+        let resolved = resolve_with_cache(
+            &config,
+            &req.profile,
+            IndexMap::from([("API_KEY".to_string(), secret)]),
+            &req,
+            state,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            resolved.get("API_KEY").and_then(|value| value.as_deref()),
+            Some("fresh")
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_with_cache_skips_default_provider_when_provider_daemon_cache_disabled() {
+        let mut config = Config::new();
+        config
+            .providers
+            .insert("plain".to_string(), plain_provider_config(Some(false)));
+        config.set_default_provider(Some("plain".to_string()));
+        let secret = default_provider_secret("fresh");
+        let req = test_batch_request();
+        let state = state_with_cached_secret(&config, &secret, &req);
+
+        let resolved = resolve_with_cache(
+            &config,
+            &req.profile,
+            IndexMap::from([("API_KEY".to_string(), secret)]),
+            &req,
+            state,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            resolved.get("API_KEY").and_then(|value| value.as_deref()),
+            Some("fresh")
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_with_cache_uses_cache_for_default_provider_when_daemon_cache_is_default() {
+        let mut config = Config::new();
+        config
+            .providers
+            .insert("plain".to_string(), plain_provider_config(None));
+        config.set_default_provider(Some("plain".to_string()));
+        let secret = default_provider_secret("fresh");
+        let req = test_batch_request();
+        let state = state_with_cached_secret(&config, &secret, &req);
+
+        let resolved = resolve_with_cache(
+            &config,
+            &req.profile,
+            IndexMap::from([("API_KEY".to_string(), secret)]),
+            &req,
+            state,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            resolved.get("API_KEY").and_then(|value| value.as_deref()),
+            Some("cached")
+        );
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -853,6 +853,7 @@ async fn resolve_with_cache(
 ) -> Result<IndexMap<String, Option<String>>> {
     let fingerprint = config_fingerprint(config, &req.env)?;
     let providers = config.get_providers(profile);
+    let default_provider = cache_policy_default_provider(config, profile, &providers);
     let mut results = IndexMap::new();
     let mut misses = IndexMap::new();
     let mut miss_keys = HashMap::new();
@@ -862,7 +863,7 @@ async fn resolve_with_cache(
         for (key, secret) in &secrets {
             let cacheable = req.purpose != Purpose::Check.as_str()
                 && secret.daemon_cache.unwrap_or(true)
-                && provider_daemon_cache_enabled(config, profile, &providers, secret)?;
+                && provider_daemon_cache_enabled(&providers, default_provider, secret);
             if cacheable {
                 let cache_key = cache_key(&fingerprint, profile, key, secret, req);
                 if let Some(value) = state.cache.get(&cache_key) {
@@ -895,24 +896,43 @@ async fn resolve_with_cache(
     Ok(ordered)
 }
 
-fn provider_daemon_cache_enabled(
-    config: &Config,
+fn cache_policy_default_provider<'a>(
+    config: &'a Config,
     profile: &str,
+    providers: &'a IndexMap<String, ProviderConfig>,
+) -> Option<&'a str> {
+    if profile != "default"
+        && let Some(profile_config) = config.profiles.get(profile)
+        && let Some(default_provider) = profile_config.default_provider()
+    {
+        return Some(default_provider);
+    }
+
+    config.default_provider().or_else(|| {
+        if providers.len() == 1 {
+            providers.keys().next().map(String::as_str)
+        } else {
+            None
+        }
+    })
+}
+
+fn provider_daemon_cache_enabled(
     providers: &IndexMap<String, ProviderConfig>,
+    default_provider: Option<&str>,
     secret: &SecretConfig,
-) -> Result<bool> {
+) -> bool {
     let provider_name = if let Some(provider_name) = secret.provider() {
-        Some(provider_name.to_string())
+        Some(provider_name)
     } else if secret.value().is_some() {
-        config.get_default_provider(profile)?
+        default_provider
     } else {
         None
     };
 
-    Ok(provider_name
-        .as_deref()
+    provider_name
         .and_then(|provider_name| providers.get(provider_name))
-        .is_none_or(|provider| provider.daemon_cache_enabled()))
+        .is_none_or(|provider| provider.daemon_cache_enabled())
 }
 
 fn cache_key(
@@ -1476,12 +1496,105 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn resolve_with_cache_skips_profile_default_provider_when_provider_daemon_cache_disabled()
+    {
+        let config: Config = toml_edit::de::from_str(
+            r#"
+root = true
+
+[providers.global]
+type = "plain"
+
+[profiles.prod]
+default_provider = "plain"
+
+[profiles.prod.providers.plain]
+type = "plain"
+daemon_cache = false
+"#,
+        )
+        .unwrap();
+        let secret = default_provider_secret("fresh");
+        let mut req = test_batch_request();
+        req.profile = "prod".to_string();
+        let state = state_with_cached_secret(&config, &secret, &req);
+
+        let resolved = resolve_with_cache(
+            &config,
+            &req.profile,
+            IndexMap::from([("API_KEY".to_string(), secret)]),
+            &req,
+            state,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            resolved.get("API_KEY").and_then(|value| value.as_deref()),
+            Some("fresh")
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_with_cache_skips_auto_selected_provider_when_provider_daemon_cache_disabled() {
+        let mut config = Config::new();
+        config
+            .providers
+            .insert("plain".to_string(), plain_provider_config(Some(false)));
+        let secret = default_provider_secret("fresh");
+        let req = test_batch_request();
+        let state = state_with_cached_secret(&config, &secret, &req);
+
+        let resolved = resolve_with_cache(
+            &config,
+            &req.profile,
+            IndexMap::from([("API_KEY".to_string(), secret)]),
+            &req,
+            state,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            resolved.get("API_KEY").and_then(|value| value.as_deref()),
+            Some("fresh")
+        );
+    }
+
+    #[tokio::test]
     async fn resolve_with_cache_uses_cache_for_default_provider_when_daemon_cache_is_default() {
         let mut config = Config::new();
         config
             .providers
             .insert("plain".to_string(), plain_provider_config(None));
         config.set_default_provider(Some("plain".to_string()));
+        let secret = default_provider_secret("fresh");
+        let req = test_batch_request();
+        let state = state_with_cached_secret(&config, &secret, &req);
+
+        let resolved = resolve_with_cache(
+            &config,
+            &req.profile,
+            IndexMap::from([("API_KEY".to_string(), secret)]),
+            &req,
+            state,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            resolved.get("API_KEY").and_then(|value| value.as_deref()),
+            Some("cached")
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_with_cache_uses_cache_when_default_provider_config_is_invalid() {
+        let mut config = Config::new();
+        config
+            .providers
+            .insert("plain".to_string(), plain_provider_config(None));
+        config.set_default_provider(Some("missing".to_string()));
         let secret = default_provider_secret("fresh");
         let req = test_batch_request();
         let state = state_with_cached_secret(&config, &secret, &req);


### PR DESCRIPTION
## Summary

- Respect provider-level `daemon_cache = false` when a secret resolves through `default_provider`.
- Add daemon cache regression tests for explicit providers, default providers with caching disabled, and default providers with normal cache behavior.

## Root Cause

`resolve_with_cache` only checked provider cache policy when a secret had an explicit `provider`. Secrets with a provider `value` but no explicit provider can still resolve through `default_provider`, so those cache decisions skipped the effective provider's `daemon_cache` setting.

## Relevant Discussions

- https://github.com/jdx/fnox/discussions/222 reports slow fnox + mise shell-env loading when provider-backed secrets are resolved repeatedly during shell integration. This PR does not solve the mise-side cache behavior from that thread, but it is relevant because daemon caching is the fnox-side boundary for repeated secret resolution in those workflows. Provider-level cache opt-outs need to be honored there.
- https://github.com/jdx/fnox/discussions/570 covers provider resolution/fallback behavior when config inheritance and active profiles mean the provider used by a secret is not always obvious from the secret alone. This PR touches the same boundary for cache policy: daemon caching must reason about the effective provider, including `default_provider`, not only `SecretConfig.provider()`.

## Test Plan

- [x] `rtk cargo test --manifest-path /private/tmp/codex-fnox-daemon-cache/Cargo.toml -p fnox daemon::tests -- --test-threads=1`
- [x] `rtk cargo test --manifest-path /private/tmp/codex-fnox-daemon-cache/Cargo.toml -p fnox-core`
- [x] `rtk cargo test --manifest-path /private/tmp/codex-fnox-daemon-cache/Cargo.toml -p fnox`
- [x] `rtk zsh -lc 'export MISE_TRUSTED_CONFIG_PATHS=/private/tmp/codex-fnox-daemon-cache; cd /private/tmp/codex-fnox-daemon-cache; hk check --all --check'`
- [x] `rtk git -C /private/tmp/codex-fnox-daemon-cache diff --check`

_This PR description was generated with Codex._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved secret caching behavior so it now respects provider-level cache settings more consistently.
  * Caching now works correctly when a secret uses a default provider, an auto-selected provider, or an invalid configured provider.
  * Expanded test coverage for more cache-policy scenarios to reduce regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->