### PR TITLE
ci: gate autorelease on fix and feat commits

### DIFF
--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -15,18 +15,21 @@ jobs:
   merge:
     if: github.repository == 'jdx/fnox'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Merge release into main
         run: |
           set -euo pipefail
 
-          latest_tag=$(git tag --list 'v[0-9]*' --sort=-v:refname | head -1 || true)
+          latest_tag=$(git describe --tags --match 'v[0-9]*' --abbrev=0 || true)
           if [ -n "$latest_tag" ]; then
             range="${latest_tag}..HEAD"
-            tag_time=$(git log -1 --format=%ct "$latest_tag")
+            tag_time=$(git for-each-ref --format='%(creatordate:unix)' "refs/tags/$latest_tag")
             now=$(date +%s)
             min_age=$((7 * 24 * 60 * 60))
             age=$((now - tag_time))

--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -17,9 +17,23 @@ jobs:
     if: github.repository == 'jdx/fnox'
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
       - name: Merge release into main
         run: |
           set -euo pipefail
+
+          latest_tag=$(git tag --list 'v[0-9]*' --sort=-v:refname | head -1 || true)
+          if [ -n "$latest_tag" ]; then
+            range="${latest_tag}..HEAD"
+          else
+            range="HEAD"
+          fi
+          if ! git log --format=%s "$range" | grep -Eq '^(fix|feat)(\([^)]+\))?!?: '; then
+            echo "No pending fix/feat commits since the latest release; not auto-merging release PRs"
+            exit 0
+          fi
 
           PR_NUMBER=$(gh pr list -R jdx/fnox --base main --head release --state open --limit 100 --json number,headRefName,headRepositoryOwner \
             --jq '[.[] | select(.headRefName == "release") | select(.headRepositoryOwner.login == "jdx")][0].number // empty')

--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -2,8 +2,7 @@ name: auto-merge-release
 
 on:
   schedule:
-    # 10:00 UTC = 4am CST (winter) / 5am CDT (summer)
-    - cron: "0 10 * * 1"
+    - cron: "0 10 * * *"
   workflow_dispatch:
 
 permissions: {}
@@ -27,6 +26,14 @@ jobs:
           latest_tag=$(git tag --list 'v[0-9]*' --sort=-v:refname | head -1 || true)
           if [ -n "$latest_tag" ]; then
             range="${latest_tag}..HEAD"
+            tag_time=$(git log -1 --format=%ct "$latest_tag")
+            now=$(date +%s)
+            min_age=$((7 * 24 * 60 * 60))
+            age=$((now - tag_time))
+            if [ "$age" -lt "$min_age" ]; then
+              echo "Latest release ${latest_tag} is less than 7 days old; not auto-merging release PRs"
+              exit 0
+            fi
           else
             range="HEAD"
           fi
@@ -49,7 +56,7 @@ jobs:
             exit 0
           fi
 
-          echo "PR #$PR_NUMBER is ready for the Monday morning release window"
+          echo "PR #$PR_NUMBER is ready for the daily release window"
           gh pr merge "$PR_NUMBER" -R jdx/fnox --squash --auto
         env:
           GH_TOKEN: ${{ secrets.FNOX_GH_TOKEN }}

--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -21,28 +21,37 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          fetch-tags: true
           persist-credentials: false
       - name: Merge release into main
         run: |
           set -euo pipefail
 
-          latest_tag=$(git describe --tags --match 'v[0-9]*' --abbrev=0 || true)
-          if [ -n "$latest_tag" ]; then
-            range="${latest_tag}..HEAD"
-            tag_time=$(git for-each-ref --format='%(creatordate:unix)' "refs/tags/$latest_tag")
-            now=$(date +%s)
-            min_age=$((7 * 24 * 60 * 60))
-            age=$((now - tag_time))
-            if [ "$age" -lt "$min_age" ]; then
-              echo "Latest release ${latest_tag} is less than 7 days old; not auto-merging release PRs"
-              exit 0
+          if [ "${GITHUB_EVENT_NAME:-}" != "workflow_dispatch" ]; then
+            latest_tag=$(git describe --tags --match 'v[0-9]*' --abbrev=0 || true)
+            if [ -n "$latest_tag" ]; then
+              range="${latest_tag}..HEAD"
+              tag_time=$(git for-each-ref --format='%(creatordate:unix)' "refs/tags/$latest_tag")
+              now=$(date +%s)
+              min_age=$((7 * 24 * 60 * 60))
+              age=$((now - tag_time))
+              if [ "$age" -lt "$min_age" ]; then
+                echo "Latest release ${latest_tag} is less than 7 days old; not auto-merging release PRs"
+                exit 0
+              fi
+            else
+              echo "No v[0-9]* release tag found; allowing bootstrap release"
+              range=""
+            fi
+            if [ -n "$range" ]; then
+              commit_subjects=$(git log --format=%s "$range")
+              if ! grep -Eq '^(fix|feat)(\([^)]+\))?!?: ' <<<"$commit_subjects"; then
+                echo "No pending fix/feat commits since the latest release; not auto-merging release PRs"
+                exit 0
+              fi
             fi
           else
-            range="HEAD"
-          fi
-          if ! git log --format=%s "$range" | grep -Eq '^(fix|feat)(\([^)]+\))?!?: '; then
-            echo "No pending fix/feat commits since the latest release; not auto-merging release PRs"
-            exit 0
+            echo "Manual dispatch; skipping release cadence guards"
           fi
 
           PR_NUMBER=$(gh pr list -R jdx/fnox --base main --head release --state open --limit 100 --json number,headRefName,headRepositoryOwner \

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -11,8 +11,6 @@ on:
     branches:
       - main
       - release-plz
-  schedule:
-    - cron: "0 0 * * *"
 
 concurrency:
   group: release-plz
@@ -21,47 +19,7 @@ env:
   DRY_RUN: 0
 
 jobs:
-  pending-release:
-    runs-on: ubuntu-latest
-    outputs:
-      has_release_commits: ${{ steps.commits.outputs.has_release_commits }}
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          fetch-depth: 0
-      - name: Check release age and fix/feat commits
-        id: commits
-        run: |
-          set -euo pipefail
-
-          latest_tag=$(git tag --list 'v[0-9]*' --sort=-v:refname | head -1 || true)
-          if [ -n "$latest_tag" ]; then
-            range="${latest_tag}..HEAD"
-            echo "Checking pending commits since ${latest_tag}"
-            tag_time=$(git log -1 --format=%ct "$latest_tag")
-            now=$(date +%s)
-            min_age=$((7 * 24 * 60 * 60))
-            age=$((now - tag_time))
-            if [ "$age" -lt "$min_age" ]; then
-              echo "Latest release ${latest_tag} is less than 7 days old; skipping autorelease."
-              echo "has_release_commits=false" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-          else
-            range="HEAD"
-            echo "No v* release tag found; checking all commits"
-          fi
-
-          if git log --format=%s "$range" | grep -Eq '^(fix|feat)(\([^)]+\))?!?: '; then
-            echo "has_release_commits=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "No pending fix/feat commits; skipping autorelease."
-            echo "has_release_commits=false" >> "$GITHUB_OUTPUT"
-          fi
-
   release-plz:
-    needs: pending-release
-    if: needs.pending-release.outputs.has_release_commits == 'true'
     runs-on: ubuntu-latest
     steps:
       # release-plz pushes tags and the release branch via `git push`, which needs the scoped

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -19,7 +19,38 @@ env:
   DRY_RUN: 0
 
 jobs:
+  pending-release:
+    runs-on: ubuntu-latest
+    outputs:
+      has_release_commits: ${{ steps.commits.outputs.has_release_commits }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+      - name: Check for fix/feat commits since the latest release
+        id: commits
+        run: |
+          set -euo pipefail
+
+          latest_tag=$(git tag --list 'v[0-9]*' --sort=-v:refname | head -1 || true)
+          if [ -n "$latest_tag" ]; then
+            range="${latest_tag}..HEAD"
+            echo "Checking pending commits since ${latest_tag}"
+          else
+            range="HEAD"
+            echo "No v* release tag found; checking all commits"
+          fi
+
+          if git log --format=%s "$range" | grep -Eq '^(fix|feat)(\([^)]+\))?!?: '; then
+            echo "has_release_commits=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No pending fix/feat commits; skipping autorelease."
+            echo "has_release_commits=false" >> "$GITHUB_OUTPUT"
+          fi
+
   release-plz:
+    needs: pending-release
+    if: needs.pending-release.outputs.has_release_commits == 'true'
     runs-on: ubuntu-latest
     steps:
       # release-plz pushes tags and the release branch via `git push`, which needs the scoped

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -11,6 +11,8 @@ on:
     branches:
       - main
       - release-plz
+  schedule:
+    - cron: "0 0 * * *"
 
 concurrency:
   group: release-plz
@@ -27,7 +29,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-      - name: Check for fix/feat commits since the latest release
+      - name: Check release age and fix/feat commits
         id: commits
         run: |
           set -euo pipefail
@@ -36,6 +38,15 @@ jobs:
           if [ -n "$latest_tag" ]; then
             range="${latest_tag}..HEAD"
             echo "Checking pending commits since ${latest_tag}"
+            tag_time=$(git log -1 --format=%ct "$latest_tag")
+            now=$(date +%s)
+            min_age=$((7 * 24 * 60 * 60))
+            age=$((now - tag_time))
+            if [ "$age" -lt "$min_age" ]; then
+              echo "Latest release ${latest_tag} is less than 7 days old; skipping autorelease."
+              echo "has_release_commits=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
           else
             range="HEAD"
             echo "No v* release tag found; checking all commits"


### PR DESCRIPTION
## What changed

- Adds a preflight check to the release-plz workflow that looks for pending `fix` or `feat` conventional commits since the latest `v[0-9]*` release tag.
- Skips the automatic release-plz job when no release-worthy commits are pending.
- Adds the same guard before the scheduled release PR auto-merge.

## Why

This keeps automatic releases from running for maintenance-only commit ranges, while still allowing real fix/feature changes to publish automatically.

## Validation

- `actionlint .github/workflows/release-plz.yml .github/workflows/auto-merge-release.yml`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only changes to release automation guards and schedule; no application runtime or security-sensitive product code.
> 
> **Overview**
> The **auto-merge-release** workflow now runs **daily** (10:00 UTC) instead of only on Mondays, and checks out the repo with full history and tags before merging.
> 
> On **scheduled** runs (not manual `workflow_dispatch`), it **exits early** unless the latest `v[0-9]*` tag is **at least 7 days old** and there is at least one **`fix:` or `feat:`** conventional commit since that tag (with bootstrap allowed when no release tag exists). Manual dispatch skips these guards.
> 
> The merge job gets explicit **`contents: read`** permission and a pinned **checkout** action; the ready-to-merge log text refers to a **daily** release window.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd184e365cae0a427e32622373229deea1e3e025. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->