### PR TITLE
fix(export): omit metadata header by default

### DIFF
--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -323,6 +323,16 @@
               "double_dash": "Optional",
               "hide": false
             }
+          },
+          {
+            "name": "header",
+            "usage": "--header",
+            "help": "Include metadata comments in env and shell output",
+            "help_first_line": "Include metadata comments in env and shell output",
+            "short": [],
+            "long": ["header"],
+            "hide": false,
+            "global": false
           }
         ],
         "mounts": [],

--- a/docs/cli/export.md
+++ b/docs/cli/export.md
@@ -30,3 +30,7 @@ Show what would be exported without writing to file
 ### `-o --output <OUTPUT>`
 
 Output file (default: stdout)
+
+### `--header`
+
+Include metadata comments in env and shell output

--- a/docs/guide/import-export.md
+++ b/docs/guide/import-export.md
@@ -134,6 +134,9 @@ fnox export --format yaml
 
 # Export as TOML
 fnox export --format toml
+
+# Include metadata comments in env/shell output
+fnox export --header
 ```
 
 ### Save to File

--- a/fnox.usage.kdl
+++ b/fnox.usage.kdl
@@ -63,6 +63,7 @@ cmd export help="Export secrets in various formats" {
     flag "-o --output" help="Output file (default: stdout)" {
         arg <OUTPUT>
     }
+    flag --header help="Include metadata comments in env and shell output"
 }
 cmd get help="Get a secret value" {
     flag --base64-decode help="Base64 decode the secret"

--- a/src/commands/export.rs
+++ b/src/commands/export.rs
@@ -41,6 +41,10 @@ pub struct ExportCommand {
     /// Output file (default: stdout)
     #[arg(short = 'o', long)]
     output: Option<PathBuf>,
+
+    /// Include metadata comments in env and shell output
+    #[arg(long)]
+    header: bool,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -159,7 +163,9 @@ impl ExportCommand {
     fn export_as_env(&self, data: &ExportData) -> Result<String> {
         let mut output = String::new();
 
-        append_metadata_header(&mut output, data.metadata.as_ref());
+        if self.header {
+            append_metadata_header(&mut output, data.metadata.as_ref());
+        }
 
         for (key, value) in &data.secrets {
             output.push_str(&format!("{}={}\n", key, dotenv_quote(value)));
@@ -171,7 +177,9 @@ impl ExportCommand {
     fn export_as_shell(&self, data: &ExportData) -> Result<String> {
         let mut output = String::new();
 
-        append_metadata_header(&mut output, data.metadata.as_ref());
+        if self.header {
+            append_metadata_header(&mut output, data.metadata.as_ref());
+        }
 
         for (key, value) in &data.secrets {
             output.push_str(&format!("export {}={}\n", key, shell::posix_quote(value)));

--- a/test/export_if_missing.bats
+++ b/test/export_if_missing.bats
@@ -44,10 +44,10 @@ TOML
 	# Set invalid age key to trigger error
 	export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
 
-	run "$FNOX_BIN" export
+	run bash -c '"$1" export 2>/dev/null' _ "$FNOX_BIN"
 	assert_success
-	# Should output env format even though secret failed to resolve
-	assert_output --partial "# Exported from profile: default"
+	# Should output clean env format even though secret failed to resolve
+	assert_output ""
 }
 
 @test "fnox export with default if_missing (warn) continues on missing secret" {
@@ -66,10 +66,10 @@ TOML
 	# Set invalid age key to trigger error
 	export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
 
-	run "$FNOX_BIN" export
+	run bash -c '"$1" export 2>/dev/null' _ "$FNOX_BIN"
 	assert_success
-	# Should output env format even though secret failed to resolve
-	assert_output --partial "# Exported from profile: default"
+	# Should output clean env format even though secret failed to resolve
+	assert_output ""
 }
 
 @test "fnox export with if_missing=ignore silently continues on missing secret" {
@@ -89,8 +89,8 @@ TOML
 	# Set invalid age key to trigger error
 	export FNOX_AGE_KEY="/tmp/nonexistent-age-key.txt"
 
-	run "$FNOX_BIN" export
+	run bash -c '"$1" export 2>/dev/null' _ "$FNOX_BIN"
 	assert_success
-	# Should output env format even though secret failed to resolve
-	assert_output --partial "# Exported from profile: default"
+	# Should output clean env format even though secret failed to resolve
+	assert_output ""
 }

--- a/test/file_secrets.bats
+++ b/test/file_secrets.bats
@@ -399,6 +399,7 @@ EOF
 	# Output should contain dotenv assignments
 	assert_output --partial "FILE_SECRET="
 	assert_output --partial "NORMAL_SECRET="
+	refute_output --partial "# Exported from profile:"
 
 	# FILE_SECRET should be a file path (contains fnox-export)
 	assert_output --regexp "FILE_SECRET=.*/fnox-export-FILE_SECRET-.*"
@@ -431,6 +432,7 @@ EOF
 	assert_output --partial "export FILE_SECRET="
 	assert_output --partial "export NORMAL_SECRET=normal-value"
 	assert_output --regexp "export FILE_SECRET=.*/fnox-export-FILE_SECRET-.*"
+	refute_output --partial "# Exported from profile:"
 
 	local file_path
 	file_path=$(echo "$output" | grep "export FILE_SECRET=" | sed -E "s/^export FILE_SECRET=//; s/^'(.*)'\$/\\1/" | head -1)
@@ -454,6 +456,42 @@ EOF
 	assert_success
 	assert_output --partial 'SPECIAL_SECRET="secret$value`tick`"'
 	assert_output --partial 'QUOTED_SECRET="quoted \"value\" with \\ backslash"'
+}
+
+@test "export env format can include metadata header" {
+	cat >fnox.toml <<EOF
+root = true
+
+[providers.plain]
+type = "plain"
+
+[secrets]
+NORMAL_SECRET = { provider = "plain", value = "normal-value" }
+EOF
+
+	run "$FNOX_BIN" export --format env --header
+	assert_success
+	assert_line --index 0 "# Exported from profile: default"
+	assert_output --partial "# Total secrets: 1"
+	assert_output --partial "NORMAL_SECRET=normal-value"
+}
+
+@test "export shell format can include metadata header" {
+	cat >fnox.toml <<EOF
+root = true
+
+[providers.plain]
+type = "plain"
+
+[secrets]
+NORMAL_SECRET = { provider = "plain", value = "normal-value" }
+EOF
+
+	run "$FNOX_BIN" export --format shell --header
+	assert_success
+	assert_line --index 0 "# Exported from profile: default"
+	assert_output --partial "# Total secrets: 1"
+	assert_output --partial "export NORMAL_SECRET=normal-value"
 }
 
 @test "export to JSON with file-based secrets" {
@@ -508,6 +546,7 @@ EOF
 	test -f "$export_file"
 	grep -q "FILE_SECRET=" "$export_file"
 	grep -q "NORMAL_SECRET=normal-value" "$export_file"
+	refute grep -q "^# Exported from profile:" "$export_file"
 
 	# Extract file path from export file
 	local file_path


### PR DESCRIPTION
## Summary
- make env and shell export metadata comments opt-in with `--header`
- keep default env/shell export output to data lines only
- update generated CLI docs, guide docs, and Bats coverage

Follow-up to discussion #602.

## Tests
- `cargo fmt`
- `mise run render:usage`
- `test/bats/bin/bats test/file_secrets.bats test/export_if_missing.bats`
- `mise run test:cargo`
- `mise run lint`

_This PR description was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI output shape change for default env/shell export (pipelines expecting comment headers may need `--header`); no change to secret resolution or structured formats.
> 
> **Overview**
> **Default `fnox export` env and shell output is now assignment lines only**—profile/timestamp/secret-count comment blocks are no longer emitted unless you pass **`--header`**.
> 
> The export command gains a **`header`** flag wired through usage spec, generated CLI JSON/docs, and the import/export guide. **`export_as_env`** and **`export_as_shell`** only call **`append_metadata_header`** when that flag is set; JSON/YAML/TOML behavior is unchanged.
> 
> Bats tests assert default exports lack `# Exported from profile:` (including **`--output`** files and **`if_missing`** warn/ignore cases with stderr discarded), and add coverage for **`--header`** on env and shell formats.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3e9660d16924f7edef605f30995fa8dfa04eb4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `--header` option to export commands to include metadata comments in `env` and shell output.
  * Updated the export guide with examples showing how to use the new option.

* **Bug Fixes**
  * Exported `env` and shell output now only includes metadata headers when explicitly requested.
  * Adjusted export behavior for missing secrets so warning/ignore cases no longer produce partial output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->