### PR TITLE
feat(config): add exec-only env mode and top-level env default

### DIFF
--- a/crates/fnox-core/src/config.rs
+++ b/crates/fnox-core/src/config.rs
@@ -126,6 +126,13 @@ pub struct Config {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub if_missing: Option<IfMissing>,
 
+    /// Default env injection mode for all secrets in this config.
+    /// Set `env = "exec"` to keep every secret out of the interactive shell
+    /// (secrets are still injected into `fnox exec` subprocesses) unless a
+    /// secret explicitly opts back in with `env = true`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub env: Option<EnvMode>,
+
     /// Whether to prompt for authentication when provider auth fails (default: true in TTY)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub prompt_auth: Option<bool>,
@@ -187,10 +194,14 @@ pub struct SecretConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     value: Option<SpannedValue<String>>,
 
-    /// Whether to inject this secret into env vars (default: true)
-    /// When false, the secret is only accessible via `fnox get`
-    #[serde(default = "default_true", skip_serializing_if = "is_true")]
-    pub env: bool,
+    /// Where to inject this secret as an environment variable:
+    /// - `true` — shell integration and `fnox exec` (default)
+    /// - `"exec"` — only `fnox exec` subprocesses, never the interactive shell
+    /// - `false` — never injected; only accessible via `fnox get`
+    ///
+    /// When unset, inherits the top-level `env` default (which itself defaults to `true`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub env: Option<EnvMode>,
 
     /// Write secret to a temporary file and set env var to the file path instead of the secret value
     #[serde(default, skip_serializing_if = "is_false")]
@@ -386,6 +397,102 @@ pub enum IfMissing {
     Error,
     Warn,
     Ignore,
+}
+
+/// Controls where a secret's value is injected as an environment variable.
+///
+/// Serialized in TOML as `true` (Shell), `"exec"` (Exec), or `false` (Never).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum EnvMode {
+    /// Injected by shell integration (hook-env) and `fnox exec` (TOML: `true`)
+    #[default]
+    Shell,
+    /// Only injected into `fnox exec` subprocesses, never the interactive shell (TOML: `"exec"`)
+    Exec,
+    /// Never injected as an env var; only accessible via `fnox get` (TOML: `false`)
+    Never,
+}
+
+impl EnvMode {
+    /// Whether shell integration (hook-env / export) should inject this secret
+    pub fn in_shell(self) -> bool {
+        matches!(self, Self::Shell)
+    }
+
+    /// Whether `fnox exec` subprocesses should receive this secret
+    pub fn in_exec(self) -> bool {
+        matches!(self, Self::Shell | Self::Exec)
+    }
+
+    /// TOML representation for config-file editing
+    pub fn to_toml_value(self) -> toml_edit::Value {
+        match self {
+            Self::Shell => toml_edit::Value::from(true),
+            Self::Exec => toml_edit::Value::from("exec"),
+            Self::Never => toml_edit::Value::from(false),
+        }
+    }
+}
+
+impl Serialize for EnvMode {
+    fn serialize<S: serde::Serializer>(
+        &self,
+        serializer: S,
+    ) -> std::result::Result<S::Ok, S::Error> {
+        match self {
+            Self::Shell => serializer.serialize_bool(true),
+            Self::Exec => serializer.serialize_str("exec"),
+            Self::Never => serializer.serialize_bool(false),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for EnvMode {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        deserializer: D,
+    ) -> std::result::Result<Self, D::Error> {
+        struct EnvModeVisitor;
+
+        impl serde::de::Visitor<'_> for EnvModeVisitor {
+            type Value = EnvMode;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str("true, false, or \"exec\"")
+            }
+
+            fn visit_bool<E: serde::de::Error>(self, v: bool) -> std::result::Result<EnvMode, E> {
+                Ok(if v { EnvMode::Shell } else { EnvMode::Never })
+            }
+
+            fn visit_str<E: serde::de::Error>(self, v: &str) -> std::result::Result<EnvMode, E> {
+                match v {
+                    "exec" => Ok(EnvMode::Exec),
+                    other => Err(E::invalid_value(
+                        serde::de::Unexpected::Str(other),
+                        &"true, false, or \"exec\"",
+                    )),
+                }
+            }
+        }
+
+        deserializer.deserialize_any(EnvModeVisitor)
+    }
+}
+
+impl JsonSchema for EnvMode {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        "EnvMode".into()
+    }
+
+    fn json_schema(_generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        schemars::json_schema!({
+            "description": "Where to inject the secret as an env var: true = shell + fnox exec (default), \"exec\" = fnox exec subprocesses only, false = never (fnox get only)",
+            "anyOf": [
+                { "type": "boolean" },
+                { "type": "string", "enum": ["exec"] }
+            ]
+        })
+    }
 }
 
 impl Config {
@@ -611,6 +718,11 @@ impl Config {
         // Merge if_missing (overlay takes precedence)
         if overlay.if_missing.is_some() {
             merged.if_missing = overlay.if_missing;
+        }
+
+        // Merge env default (overlay takes precedence)
+        if overlay.env.is_some() {
+            merged.env = overlay.env;
         }
 
         // Merge prompt_auth (overlay takes precedence)
@@ -1031,6 +1143,7 @@ impl Config {
             profiles: IndexMap::new(),
             age_key_file: None,
             if_missing: None,
+            env: None,
             prompt_auth: None,
             mcp: None,
             daemon: None,
@@ -1086,25 +1199,36 @@ impl Config {
     /// Note: If a profile doesn't exist in [profiles], it's treated as "default".
     /// This allows fnox.$FNOX_PROFILE.toml files to work without requiring a [profiles] section.
     pub fn get_secrets(&self, profile: &str) -> Result<IndexMap<String, SecretConfig>> {
-        if profile == "default" {
-            return Ok(self.secrets.clone());
-        }
-
-        let mut secrets = if Settings::get().no_defaults {
-            // Profile-only mode: do not merge top-level secrets.
-            IndexMap::new()
-        } else {
-            // Start with top-level secrets as base
+        let mut secrets = if profile == "default" {
             self.secrets.clone()
+        } else {
+            let mut secrets = if Settings::get().no_defaults {
+                // Profile-only mode: do not merge top-level secrets.
+                IndexMap::new()
+            } else {
+                // Start with top-level secrets as base
+                self.secrets.clone()
+            };
+
+            // Get profile-specific secrets and merge/override (if profile exists)
+            if let Some(profile_config) = self.profiles.get(profile) {
+                // Profile-specific secrets override top-level ones
+                secrets.extend(profile_config.secrets.clone());
+            }
+            // If profile doesn't exist in [profiles], that's OK - just use top-level secrets
+            // This allows fnox.$FNOX_PROFILE.toml to work without requiring [profiles.xxx]
+            secrets
         };
 
-        // Get profile-specific secrets and merge/override (if profile exists)
-        if let Some(profile_config) = self.profiles.get(profile) {
-            // Profile-specific secrets override top-level ones
-            secrets.extend(profile_config.secrets.clone());
+        // Secrets that don't set `env` themselves inherit the top-level default
+        if self.env.is_some() {
+            for secret in secrets.values_mut() {
+                if secret.env.is_none() {
+                    secret.env = self.env;
+                }
+            }
         }
-        // If profile doesn't exist in [profiles], that's OK - just use top-level secrets
-        // This allows fnox.$FNOX_PROFILE.toml to work without requiring [profiles.xxx]
+
         Ok(secrets)
     }
 
@@ -1525,7 +1649,7 @@ impl SecretConfig {
             default: None,
             provider: None,
             value: None,
-            env: true,
+            env: None,
             as_file: false,
             json_path: None,
             line: None,
@@ -1534,6 +1658,16 @@ impl SecretConfig {
             source_is_profile: false,
             daemon_cache: None,
         }
+    }
+
+    /// Effective env injection mode for this secret.
+    ///
+    /// Note: [`Config::get_secrets`] stamps the top-level `env` default into
+    /// secrets that don't set it, so on maps obtained from `get_secrets` this
+    /// is the fully-resolved mode. On a raw `SecretConfig` an unset `env`
+    /// falls back to [`EnvMode::Shell`].
+    pub fn env_mode(&self) -> EnvMode {
+        self.env.unwrap_or_default()
     }
 
     /// Return a copy that will resolve to the original provider value,
@@ -1577,8 +1711,8 @@ impl SecretConfig {
             };
             inline.insert("if_missing", toml_edit::Value::from(if_missing_str));
         }
-        if !self.env {
-            inline.insert("env", toml_edit::Value::from(false));
+        if let Some(env) = self.env {
+            inline.insert("env", env.to_toml_value());
         }
         if self.as_file {
             inline.insert("as_file", toml_edit::Value::from(true));
@@ -1640,7 +1774,7 @@ impl SecretConfig {
                 })
             }),
         );
-        set_or_remove(table, "env", (!self.env).then(|| Value::from(false)));
+        set_or_remove(table, "env", self.env.map(EnvMode::to_toml_value));
         set_or_remove(table, "as_file", self.as_file.then(|| Value::from(true)));
         set_or_remove(
             table,
@@ -1758,14 +1892,6 @@ impl Default for ProfileConfig {
 
 fn is_false(value: &bool) -> bool {
     !value
-}
-
-fn is_true(value: &bool) -> bool {
-    *value
-}
-
-fn default_true() -> bool {
-    true
 }
 
 #[cfg(test)]
@@ -2182,13 +2308,95 @@ USERNAME = { provider = "pass", value = "master", line = 2 }
     }
 
     #[test]
+    fn test_env_mode_parsing() {
+        let toml_input = r#"
+[secrets]
+SHELL_DEFAULT = { provider = "plain", value = "a" }
+SHELL_EXPLICIT = { provider = "plain", value = "b", env = true }
+EXEC_ONLY = { provider = "plain", value = "c", env = "exec" }
+HIDDEN = { provider = "plain", value = "d", env = false }
+"#;
+        let parsed: Config = toml_edit::de::from_str(toml_input).unwrap();
+        assert_eq!(parsed.secrets["SHELL_DEFAULT"].env, None);
+        assert_eq!(parsed.secrets["SHELL_EXPLICIT"].env, Some(EnvMode::Shell));
+        assert_eq!(parsed.secrets["EXEC_ONLY"].env, Some(EnvMode::Exec));
+        assert_eq!(parsed.secrets["HIDDEN"].env, Some(EnvMode::Never));
+
+        assert!(parsed.secrets["SHELL_DEFAULT"].env_mode().in_shell());
+        assert!(parsed.secrets["EXEC_ONLY"].env_mode().in_exec());
+        assert!(!parsed.secrets["EXEC_ONLY"].env_mode().in_shell());
+        assert!(!parsed.secrets["HIDDEN"].env_mode().in_exec());
+    }
+
+    #[test]
+    fn test_env_mode_rejects_unknown_string() {
+        let toml_input = r#"
+[secrets]
+BAD = { provider = "plain", value = "a", env = "sometimes" }
+"#;
+        assert!(toml_edit::de::from_str::<Config>(toml_input).is_err());
+    }
+
+    #[test]
+    fn test_env_mode_top_level_default_inheritance() {
+        let toml_input = r#"
+env = "exec"
+
+[secrets]
+INHERITED = { provider = "plain", value = "a" }
+OPTED_IN = { provider = "plain", value = "b", env = true }
+HIDDEN = { provider = "plain", value = "c", env = false }
+
+[profiles.dev.secrets]
+DEV_INHERITED = { provider = "plain", value = "d" }
+"#;
+        let parsed: Config = toml_edit::de::from_str(toml_input).unwrap();
+        assert_eq!(parsed.env, Some(EnvMode::Exec));
+
+        let secrets = parsed.get_secrets("default").unwrap();
+        assert_eq!(secrets["INHERITED"].env_mode(), EnvMode::Exec);
+        assert_eq!(secrets["OPTED_IN"].env_mode(), EnvMode::Shell);
+        assert_eq!(secrets["HIDDEN"].env_mode(), EnvMode::Never);
+
+        // Only assert on the profile-level secret here: merging top-level
+        // secrets into profiles depends on the global no_defaults setting,
+        // which other tests mutate concurrently.
+        let dev_secrets = parsed.get_secrets("dev").unwrap();
+        assert_eq!(dev_secrets["DEV_INHERITED"].env_mode(), EnvMode::Exec);
+    }
+
+    #[test]
+    fn test_env_mode_serialization_roundtrip() {
+        let mut secret = SecretConfig::new();
+        secret.set_provider(Some("plain".to_string()));
+        secret.set_value(Some("v".to_string()));
+
+        secret.env = Some(EnvMode::Exec);
+        assert!(
+            secret
+                .to_inline_table()
+                .to_string()
+                .contains("env = \"exec\"")
+        );
+
+        secret.env = Some(EnvMode::Never);
+        assert!(secret.to_inline_table().to_string().contains("env = false"));
+
+        secret.env = Some(EnvMode::Shell);
+        assert!(secret.to_inline_table().to_string().contains("env = true"));
+
+        secret.env = None;
+        assert!(!secret.to_inline_table().to_string().contains("env"));
+    }
+
+    #[test]
     fn test_for_raw_resolve_preserves_non_post_processing_fields() {
         let mut secret = SecretConfig::new();
         secret.set_provider(Some("plain".to_string()));
         secret.set_value(Some("my-secret".to_string()));
         secret.description = Some("A test secret".to_string());
         secret.if_missing = Some(IfMissing::Warn);
-        secret.env = false;
+        secret.env = Some(EnvMode::Never);
         secret.as_file = true;
         secret.source_path = Some(PathBuf::from("/tmp/fnox.toml"));
         secret.source_is_profile = true;
@@ -2205,7 +2413,7 @@ USERNAME = { provider = "pass", value = "master", line = 2 }
         assert_eq!(raw.value(), Some("my-secret"));
         assert_eq!(raw.description.as_deref(), Some("A test secret"));
         assert_eq!(raw.if_missing, Some(IfMissing::Warn));
-        assert!(!raw.env);
+        assert_eq!(raw.env, Some(EnvMode::Never));
         assert!(raw.as_file);
         assert_eq!(
             raw.source_path.as_deref(),

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -325,22 +325,22 @@
             }
           },
           {
-            "name": "header",
-            "usage": "--header",
-            "help": "Include metadata comments in env and shell output",
-            "help_first_line": "Include metadata comments in env and shell output",
-            "short": [],
-            "long": ["header"],
-            "hide": false,
-            "global": false
-          },
-          {
             "name": "all",
             "usage": "--all",
             "help": "Include secrets with env = false or env = \"exec\" (excluded by default)",
             "help_first_line": "Include secrets with env = false or env = \"exec\" (excluded by default)",
             "short": [],
             "long": ["all"],
+            "hide": false,
+            "global": false
+          },
+          {
+            "name": "header",
+            "usage": "--header",
+            "help": "Include metadata comments in env and shell output",
+            "help_first_line": "Include metadata comments in env and shell output",
+            "short": [],
+            "long": ["header"],
             "hide": false,
             "global": false
           }

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -333,6 +333,16 @@
             "long": ["header"],
             "hide": false,
             "global": false
+          },
+          {
+            "name": "all",
+            "usage": "--all",
+            "help": "Include secrets with env = false or env = \"exec\" (excluded by default)",
+            "help_first_line": "Include secrets with env = false or env = \"exec\" (excluded by default)",
+            "short": [],
+            "long": ["all"],
+            "hide": false,
+            "global": false
           }
         ],
         "mounts": [],

--- a/docs/cli/export.md
+++ b/docs/cli/export.md
@@ -34,3 +34,7 @@ Output file (default: stdout)
 ### `--header`
 
 Include metadata comments in env and shell output
+
+### `--all`
+
+Include secrets with env = false or env = "exec" (excluded by default)

--- a/docs/cli/export.md
+++ b/docs/cli/export.md
@@ -31,10 +31,10 @@ Show what would be exported without writing to file
 
 Output file (default: stdout)
 
-### `--header`
-
-Include metadata comments in env and shell output
-
 ### `--all`
 
 Include secrets with env = false or env = "exec" (excluded by default)
+
+### `--header`
+
+Include metadata comments in env and shell output

--- a/docs/guide/mcp.md
+++ b/docs/guide/mcp.md
@@ -87,7 +87,7 @@ Executes a command with all secrets injected as environment variables. The agent
 ## How It Works
 
 1. The MCP server starts in non-interactive mode (no stdin prompts)
-2. On the **first tool call**, all `env = true` profile secrets are resolved in a single batch — this amortizes the cost of yubikey taps or SSO prompts. Secrets configured with `env = false` are resolved on-demand when individually requested via `get_secret`.
+2. On the **first tool call**, all env-injectable profile secrets (`env = true` or `env = "exec"`) are resolved in a single batch — this amortizes the cost of yubikey taps or SSO prompts. Secrets configured with `env = false` are resolved on-demand when individually requested via `get_secret`.
 3. Resolved secrets are cached in process memory for the session
 4. Subsequent tool calls use the cache
 5. When the agent disconnects (EOF), the process exits and all secrets are cleared from memory
@@ -101,3 +101,4 @@ Executes a command with all secrets injected as environment variables. The agent
 - With `tools = ["exec"]` and redaction enabled (default), agents cannot retrieve raw secret values through either `get_secret` or subprocess output
 - Use `mcp.secrets` to limit which secrets the agent can access — unlisted secrets are never resolved or injected
 - Disabled tools are not advertised in `tools/list` — agents only see tools they can actually call
+- The MCP allowlist only controls the MCP channel — secrets injected into your shell by shell integration are still visible to any agent running there. Set the top-level `env = "exec"` default (see the [configuration reference](/reference/configuration#env)) to keep secrets out of the interactive shell entirely; they remain available through `fnox exec` and the MCP tools

--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -29,6 +29,17 @@
         }
       ]
     },
+    "env": {
+      "description": "Default env injection mode for all secrets in this config.\nSet `env = \"exec\"` to keep every secret out of the interactive shell\n(secrets are still injected into `fnox exec` subprocesses) unless a\nsecret explicitly opts back in with `env = true`.",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/EnvMode"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "if_missing": {
       "description": "Default if_missing behavior for all secrets in this config",
       "anyOf": [
@@ -170,6 +181,18 @@
         }
       },
       "additionalProperties": false
+    },
+    "EnvMode": {
+      "description": "Where to inject the secret as an env var: true = shell + fnox exec (default), \"exec\" = fnox exec subprocesses only, false = never (fnox get only)",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "string",
+          "enum": ["exec"]
+        }
+      ]
     },
     "IfMissing": {
       "type": "string",
@@ -1190,8 +1213,15 @@
           "type": ["string", "null"]
         },
         "env": {
-          "description": "Whether to inject this secret into env vars (default: true)\nWhen false, the secret is only accessible via `fnox get`",
-          "type": "boolean"
+          "description": "Where to inject this secret as an environment variable:\n- `true` — shell integration and `fnox exec` (default)\n- `\"exec\"` — only `fnox exec` subprocesses, never the interactive shell\n- `false` — never injected; only accessible via `fnox get`\n\nWhen unset, inherits the top-level `env` default (which itself defaults to `true`).",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EnvMode"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "if_missing": {
           "description": "What to do if the secret is missing (error, warn, or ignore)",

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -95,6 +95,32 @@ if_missing = "error"  # or "warn", "ignore"
 
 **Priority:** Lowest (overridden by secret-level, env vars, CLI flags).
 
+### `env`
+
+Default injection mode for all secrets in the config. Secrets that don't set their own `env` inherit this value.
+
+```toml
+env = "exec"  # or true, false
+```
+
+**Values:**
+
+- `true` - Inject into the shell (via shell integration / `fnox export`) and `fnox exec` subprocesses (default)
+- `"exec"` - Only inject into `fnox exec` subprocesses; never the interactive shell
+- `false` - Never inject; secrets are only accessible via `fnox get`
+
+Setting `env = "exec"` at the top level keeps every secret out of the interactive shell by default — useful when AI coding agents or other tools run in your shell and would otherwise inherit all injected secrets. Applications still receive secrets when launched through `fnox exec -- <command>`, and individual secrets can opt back in with `env = true`:
+
+```toml
+env = "exec"  # nothing enters the interactive shell...
+
+[secrets]
+DATABASE_URL = { provider = "age", value = "..." }              # exec-only (inherited)
+HOMEBREW_GITHUB_API_TOKEN = { provider = "age", value = "...", env = true }  # ...except this
+```
+
+Note that this limits _ambient_ exposure: processes in your shell no longer see secret values in their environment. Anyone who can run commands in your shell can still invoke `fnox get` or `fnox exec` themselves — for a hard boundary, combine this with the [MCP server allowlist](/guide/mcp) and OS-level sandboxing.
+
 ### `imports`
 
 List of config files to import.
@@ -338,6 +364,54 @@ ANALYTICS_KEY = { provider = "aws", value = "analytics-key", if_missing = "ignor
 **Values:** `"error"`, `"warn"`, `"ignore"`
 
 **Priority:** Overrides top-level `if_missing`, but overridden by env vars and CLI flags.
+
+#### `env`
+
+Where the secret is injected as an environment variable.
+
+```toml
+[secrets]
+GITHUB_TOKEN = { provider = "age", value = "..." }                    # true (default): shell + fnox exec
+DATABASE_URL = { provider = "age", value = "...", env = "exec" }      # only fnox exec subprocesses
+SIGNING_KEY  = { provider = "age", value = "...", env = false }       # never injected; fnox get only
+```
+
+**Values:**
+
+- `true` - Injected by shell integration and `fnox exec` (default)
+- `"exec"` - Only injected into `fnox exec` subprocesses, never the interactive shell
+- `false` - Never injected as an env var; retrieve explicitly with `fnox get`
+
+**Priority:** Overrides the top-level `env` default.
+
+`fnox export` follows shell semantics: `env = "exec"` and `env = false` secrets are excluded unless `--all` is passed.
+
+#### `as_file`
+
+Write the secret to an ephemeral temp file and set the env var to the file path instead of the value.
+
+```toml
+[secrets]
+GOOGLE_APPLICATION_CREDENTIALS = { provider = "op", value = "GCP Service Account/key file", as_file = true }
+```
+
+#### `json_path`
+
+Extract a field from a JSON secret value (dot notation for nesting).
+
+```toml
+[secrets]
+DB_PASSWORD = { provider = "aws", value = "db-credentials", json_path = "credentials.password" }
+```
+
+#### `line`
+
+Extract the Nth line (1-indexed) from a multi-line secret value. Useful for providers that pack several related values into one entry. Mutually exclusive with `json_path`.
+
+```toml
+[secrets]
+USERNAME = { provider = "pass", value = "master", line = 2 }
+```
 
 #### `description`
 

--- a/fnox.usage.kdl
+++ b/fnox.usage.kdl
@@ -64,6 +64,7 @@ cmd export help="Export secrets in various formats" {
         arg <OUTPUT>
     }
     flag --header help="Include metadata comments in env and shell output"
+    flag --all help="Include secrets with env = false or env = \"exec\" (excluded by default)"
 }
 cmd get help="Get a secret value" {
     flag --base64-decode help="Base64 decode the secret"

--- a/fnox.usage.kdl
+++ b/fnox.usage.kdl
@@ -63,8 +63,8 @@ cmd export help="Export secrets in various formats" {
     flag "-o --output" help="Output file (default: stdout)" {
         arg <OUTPUT>
     }
-    flag --header help="Include metadata comments in env and shell output"
     flag --all help="Include secrets with env = false or env = \"exec\" (excluded by default)"
+    flag --header help="Include metadata comments in env and shell output"
 }
 cmd get help="Get a secret value" {
     flag --base64-decode help="Base64 decode the secret"

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -89,6 +89,21 @@ impl DoctorCommand {
             println!("  FNOX_PROFILE: (not set)");
         }
 
+        // A top-level env = "exec" / env = false posture is meant to keep
+        // secrets out of the interactive shell — but an exported FNOX_AGE_KEY
+        // is itself a shell-visible master credential that undermines it.
+        if let Some(env_default) = config.env
+            && !env_default.in_shell()
+            && env::FNOX_AGE_KEY.is_some()
+        {
+            println!(
+                "  ⚠ FNOX_AGE_KEY is exported in this shell while the top-level `env` \
+                 default keeps secrets out of it."
+            );
+            println!("    Anything running in this shell can decrypt your secrets with that key.");
+            println!("    Consider `age_key_file` or an OS keychain instead.");
+        }
+
         // Test providers
         if !providers.is_empty() {
             println!();

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -131,8 +131,10 @@ impl ExecCommand {
             }
             // Strip env=false secrets from child environment regardless of whether
             // resolution succeeded — a stale inherited env var must not leak through.
+            // env="exec" secrets ARE injected here: exec subprocesses are their
+            // intended destination.
             if let Some(secret_config) = profile_secrets.get(&key)
-                && !secret_config.env
+                && !secret_config.env_mode().in_exec()
             {
                 cmd.env_remove(&key);
                 continue;

--- a/src/commands/export.rs
+++ b/src/commands/export.rs
@@ -45,6 +45,10 @@ pub struct ExportCommand {
     /// Include metadata comments in env and shell output
     #[arg(long)]
     header: bool,
+
+    /// Include secrets with env = false or env = "exec" (excluded by default)
+    #[arg(long)]
+    all: bool,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -65,7 +69,14 @@ impl ExportCommand {
         let profile = Config::get_profile(cli.profile.as_deref());
         tracing::debug!("Exporting secrets from profile '{}'", profile);
 
-        let profile_secrets = config.get_secrets(&profile)?;
+        let mut profile_secrets = config.get_secrets(&profile)?;
+
+        // Export is a shell-injection surface (the mise plugin evaluates it),
+        // so exclude secrets not meant for the shell unless --all is passed.
+        // Filtering before resolution avoids auth prompts for hidden secrets.
+        if !self.all {
+            profile_secrets.retain(|_, sc| sc.env_mode().in_shell());
+        }
 
         // Resolve secrets using batch resolution for better performance
         let resolved_secrets = crate::daemon::resolve_batch(

--- a/src/commands/export.rs
+++ b/src/commands/export.rs
@@ -42,13 +42,13 @@ pub struct ExportCommand {
     #[arg(short = 'o', long)]
     output: Option<PathBuf>,
 
-    /// Include metadata comments in env and shell output
-    #[arg(long)]
-    header: bool,
-
     /// Include secrets with env = false or env = "exec" (excluded by default)
     #[arg(long)]
     all: bool,
+
+    /// Include metadata comments in env and shell output
+    #[arg(long)]
+    header: bool,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/src/commands/hook_env.rs
+++ b/src/commands/hook_env.rs
@@ -248,10 +248,11 @@ async fn load_secrets_from_config(cli: &Cli) -> Result<LoadedSecrets> {
     let mut temp_files = HashMap::new();
 
     for (key, value_opt) in resolved {
-        // Skip secrets with env = false regardless of resolution result —
-        // they must never appear in shell integration output.
+        // Skip secrets unless their env mode allows shell injection —
+        // env=false and env="exec" secrets must never appear in shell
+        // integration output.
         if let Some(secret_config) = profile_secrets.get(&key)
-            && !secret_config.env
+            && !secret_config.env_mode().in_shell()
         {
             continue;
         }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -113,7 +113,14 @@ struct ResolveBatchRequest {
     non_interactive: bool,
     purpose: String,
     keys: Vec<String>,
-    include_env_false: bool,
+    /// When true, resolve secrets of every env mode. When false, the resolve
+    /// layer keeps only shell-injectable secrets (`env = true`), dropping
+    /// `env = "exec"` and `env = false`; callers that pre-filter pass true.
+    ///
+    /// The wire key stays `include_env_false` for cross-version daemon
+    /// compatibility (a stale daemon must still deserialize new requests).
+    #[serde(rename = "include_env_false")]
+    include_all_modes: bool,
     env: Vec<(String, String)>,
 }
 
@@ -193,7 +200,7 @@ pub async fn resolve_batch(
     profile: &str,
     secrets: &IndexMap<String, SecretConfig>,
     purpose: Purpose,
-    include_env_false: bool,
+    include_all_modes: bool,
 ) -> Result<IndexMap<String, Option<String>>> {
     resolve_batch_with_context(
         &ResolveContext::from_cli(cli),
@@ -201,7 +208,7 @@ pub async fn resolve_batch(
         profile,
         secrets,
         purpose,
-        include_env_false,
+        include_all_modes,
     )
     .await
 }
@@ -212,10 +219,10 @@ pub async fn resolve_batch_with_context(
     profile: &str,
     secrets: &IndexMap<String, SecretConfig>,
     purpose: Purpose,
-    include_env_false: bool,
+    include_all_modes: bool,
 ) -> Result<IndexMap<String, Option<String>>> {
     if !should_use_daemon(ctx, config) {
-        let secrets = if include_env_false {
+        let secrets = if include_all_modes {
             secrets.clone()
         } else {
             secrets
@@ -239,7 +246,7 @@ pub async fn resolve_batch_with_context(
         non_interactive: ctx.non_interactive,
         purpose: purpose.as_str().to_string(),
         keys,
-        include_env_false,
+        include_all_modes,
         env: std::env::vars().collect(),
     });
 
@@ -781,7 +788,7 @@ async fn process_request(
             let secrets: IndexMap<String, SecretConfig> = all_secrets
                 .into_iter()
                 .filter(|(key, sc)| {
-                    requested.contains(key) && (req.include_env_false || sc.env_mode().in_shell())
+                    requested.contains(key) && (req.include_all_modes || sc.env_mode().in_shell())
                 })
                 .collect();
             let values = resolve_with_cache(&config, &req.profile, secrets, &req, state).await?;
@@ -814,7 +821,7 @@ async fn process_request(
                 non_interactive: req.non_interactive,
                 purpose: req.purpose,
                 keys: vec![req.key.clone()],
-                include_env_false: true,
+                include_all_modes: true,
                 env: req.env,
             };
             let values = resolve_with_cache(
@@ -1344,6 +1351,24 @@ mod tests {
         assert_eq!(parse_duration("1d2h3m4s").unwrap().as_secs(), 93784);
     }
 
+    // The `include_all_modes` field serializes as `include_env_false` on the
+    // wire so a stale daemon from an older fnox version can still deserialize
+    // requests from a newer client (and vice versa) across an upgrade. Guard
+    // that key name against accidental churn.
+    #[test]
+    fn resolve_batch_request_wire_key_is_stable() {
+        let req = test_batch_request();
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(
+            json.contains("\"include_env_false\":true"),
+            "wire key changed, breaking cross-version daemon IPC: {json}"
+        );
+        assert!(!json.contains("include_all_modes"));
+
+        let decoded: ResolveBatchRequest = serde_json::from_str(&json).unwrap();
+        assert!(decoded.include_all_modes);
+    }
+
     #[test]
     fn parse_duration_rejects_zero_and_overflow() {
         assert!(parse_duration("0s").is_err());
@@ -1427,7 +1452,7 @@ mod tests {
             non_interactive: true,
             purpose: Purpose::Get.as_str().to_string(),
             keys: vec!["API_KEY".to_string()],
-            include_env_false: true,
+            include_all_modes: true,
             env: Vec::new(),
         }
     }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -220,7 +220,7 @@ pub async fn resolve_batch_with_context(
         } else {
             secrets
                 .iter()
-                .filter(|(_, secret)| secret.env)
+                .filter(|(_, secret)| secret.env_mode().in_shell())
                 .map(|(key, secret)| (key.clone(), secret.clone()))
                 .collect()
         };
@@ -780,7 +780,9 @@ async fn process_request(
             let requested = req.keys.iter().cloned().collect::<HashSet<_>>();
             let secrets: IndexMap<String, SecretConfig> = all_secrets
                 .into_iter()
-                .filter(|(key, sc)| requested.contains(key) && (req.include_env_false || sc.env))
+                .filter(|(key, sc)| {
+                    requested.contains(key) && (req.include_env_false || sc.env_mode().in_shell())
+                })
                 .collect();
             let values = resolve_with_cache(&config, &req.profile, secrets, &req, state).await?;
             Ok(Response::Resolved { values })

--- a/src/mcp_server.rs
+++ b/src/mcp_server.rs
@@ -84,11 +84,13 @@ impl FnoxMcpServer {
         }
     }
 
-    /// Ensure env=true secrets are resolved and cached. First call resolves
-    /// the batch (amortizes yubikey/SSO cost); subsequent calls are no-ops.
+    /// Ensure env-injectable secrets are resolved and cached. First call
+    /// resolves the batch (amortizes yubikey/SSO cost); subsequent calls are
+    /// no-ops.
     ///
     /// env=false secrets are NOT resolved here — they are more sensitive and
     /// resolved on-demand by `get_secret` to avoid unnecessary auth prompts.
+    /// env="exec" secrets ARE resolved: the exec tool needs them in cache.
     async fn ensure_resolved(&self) -> Result<(), McpError> {
         let config = self.config.clone();
         let profile = self.profile.clone();
@@ -98,20 +100,23 @@ impl FnoxMcpServer {
 
         self.resolved
             .get_or_try_init(|| async {
-                // Only batch-resolve env=true secrets; env=false are deferred
+                // Only batch-resolve env-injectable secrets; env=false are deferred
                 let env_secrets: IndexMap<String, SecretConfig> = profile_secrets
                     .iter()
-                    .filter(|(_, sc)| sc.env)
+                    .filter(|(_, sc)| sc.env_mode().in_exec())
                     .map(|(k, v)| (k.clone(), v.clone()))
                     .collect();
 
+                // include_env_false=true: the map above is already filtered,
+                // and env="exec" secrets would otherwise be dropped by the
+                // shell-only filter in resolve_batch.
                 let resolved = crate::daemon::resolve_batch_with_context(
                     &daemon_context,
                     &config,
                     &profile,
                     &env_secrets,
                     Purpose::Mcp,
-                    false,
+                    true,
                 )
                 .await
                 .map_err(|e| {
@@ -251,7 +256,7 @@ impl FnoxMcpServer {
         // Not in cache — check if it's a configured secret
         if let Some(secret_config) = self.profile_secrets.get(&params.name) {
             // env=false secrets are deferred; try on-demand resolution
-            if !secret_config.env {
+            if !secret_config.env_mode().in_exec() {
                 return match self.resolve_single(&params.name).await? {
                     Some(value) => Ok(CallToolResult::success(vec![Content::text(value)])),
                     None => Err(McpError::invalid_request(
@@ -301,8 +306,10 @@ impl FnoxMcpServer {
 
         self.ensure_resolved().await?;
 
-        // Snapshot env vars from cache, filtering out env=false and absent secrets.
-        // This releases the read lock before the potentially long subprocess.
+        // Snapshot env vars from cache, filtering out env=false and absent
+        // secrets (env="exec" is injected: exec subprocesses are its intended
+        // destination). This releases the read lock before the potentially
+        // long subprocess.
         let env_vars: Vec<(String, String)> = {
             let cache = self.cache.read().await;
             cache
@@ -310,7 +317,7 @@ impl FnoxMcpServer {
                 .filter(|(key, _)| {
                     self.profile_secrets
                         .get(key.as_str())
-                        .is_some_and(|sc| sc.env)
+                        .is_some_and(|sc| sc.env_mode().in_exec())
                 })
                 .filter_map(|(k, v)| v.as_ref().map(|val| (k.clone(), val.clone())))
                 .collect()
@@ -348,7 +355,7 @@ impl FnoxMcpServer {
         // Strip env=false secrets that resolve_secrets_batch may have set
         // as process env vars (side effect of dependency resolution).
         for (key, secret_config) in self.profile_secrets.iter() {
-            if !secret_config.env {
+            if !secret_config.env_mode().in_exec() {
                 cmd.env_remove(key);
             }
         }

--- a/src/mcp_server.rs
+++ b/src/mcp_server.rs
@@ -107,7 +107,7 @@ impl FnoxMcpServer {
                     .map(|(k, v)| (k.clone(), v.clone()))
                     .collect();
 
-                // include_env_false=true: the map above is already filtered,
+                // include_all_modes=true: the map above is already filtered,
                 // and env="exec" secrets would otherwise be dropped by the
                 // shell-only filter in resolve_batch.
                 let resolved = crate::daemon::resolve_batch_with_context(
@@ -203,9 +203,9 @@ impl FnoxMcpServer {
 
     /// Retrieve a single secret by name.
     ///
-    /// env=true secrets are resolved eagerly in the first batch. env=false
-    /// secrets are resolved on-demand here (may trigger auth) and cached for
-    /// subsequent calls.
+    /// env=true and env="exec" secrets are resolved eagerly in the first
+    /// batch. env=false secrets are resolved on-demand here (may trigger auth)
+    /// and cached for subsequent calls.
     #[tool(description = "Get a secret value by name from the fnox configuration")]
     async fn get_secret(
         &self,
@@ -232,10 +232,11 @@ impl FnoxMcpServer {
             ));
         }
 
-        // Ensure env=true secrets are batch-resolved
+        // Ensure env-injectable secrets (env=true / env="exec") are batch-resolved
         self.ensure_resolved().await?;
 
-        // Check cache (covers env=true secrets and previously resolved env=false).
+        // Check cache (covers env=true/env="exec" secrets and previously
+        // resolved env=false).
         // Some(Some(v)) = present, Some(None) = known absent, None = not yet resolved.
         {
             let cache = self.cache.read().await;
@@ -268,8 +269,8 @@ impl FnoxMcpServer {
                     )),
                 };
             }
-            // env=true but not in cache — should not happen after ensure_resolved,
-            // but handle gracefully
+            // env=true or env="exec" but not in cache — should not happen
+            // after ensure_resolved, but handle gracefully
             Err(McpError::invalid_request(
                 format!(
                     "Secret '{}' has no value (it may be optional and absent)",

--- a/test/env_mode.bats
+++ b/test/env_mode.bats
@@ -1,0 +1,106 @@
+#!/usr/bin/env bats
+#
+# Tests for the three-state `env` mode (true / "exec" / false) and the
+# top-level `env` default, which keeps secrets out of the interactive shell
+# (e.g. away from AI coding agents) while still injecting them into
+# `fnox exec` subprocesses.
+#
+
+setup() {
+	load 'test_helper/common_setup'
+	_common_setup
+
+	# root = true stops config recursion into parent directories (the test
+	# temp dir lives inside the fnox repo, which has its own fnox.toml)
+	cat >fnox.toml <<'EOF'
+root = true
+env = "exec"
+
+[providers.plain]
+type = "plain"
+
+[secrets]
+SHELL_OK = { provider = "plain", value = "shell-value", env = true }
+EXEC_ONLY = { provider = "plain", value = "exec-value" }
+HIDDEN = { provider = "plain", value = "hidden-value", env = false }
+EOF
+}
+
+teardown() {
+	_common_teardown
+}
+
+@test "hook-env only injects env=true secrets under top-level env=exec" {
+	run "$FNOX_BIN" hook-env -s bash
+	assert_success
+	assert_output --partial "shell-value"
+	refute_output --partial "exec-value"
+	refute_output --partial "hidden-value"
+}
+
+@test "exec injects inherited exec-mode secrets but not env=false" {
+	run "$FNOX_BIN" exec -- sh -c 'echo "${SHELL_OK}:${EXEC_ONLY}:${HIDDEN:-unset}"'
+	assert_success
+	assert_output "shell-value:exec-value:unset"
+}
+
+@test "export excludes exec-only and hidden secrets by default" {
+	run "$FNOX_BIN" export
+	assert_success
+	assert_output --partial "SHELL_OK=shell-value"
+	refute_output --partial "exec-value"
+	refute_output --partial "hidden-value"
+}
+
+@test "export --all includes every secret" {
+	run "$FNOX_BIN" export --all
+	assert_success
+	assert_output --partial "SHELL_OK=shell-value"
+	assert_output --partial "EXEC_ONLY=exec-value"
+	assert_output --partial "HIDDEN=hidden-value"
+}
+
+@test "get retrieves secrets regardless of env mode" {
+	run "$FNOX_BIN" get EXEC_ONLY
+	assert_success
+	assert_output "exec-value"
+
+	run "$FNOX_BIN" get HIDDEN
+	assert_success
+	assert_output "hidden-value"
+}
+
+@test "per-secret env=exec works without a top-level default" {
+	cat >fnox.toml <<'EOF'
+root = true
+
+[providers.plain]
+type = "plain"
+
+[secrets]
+NORMAL = { provider = "plain", value = "normal-value" }
+EXEC_ONLY = { provider = "plain", value = "exec-value", env = "exec" }
+EOF
+
+	run "$FNOX_BIN" hook-env -s bash
+	assert_success
+	assert_output --partial "normal-value"
+	refute_output --partial "exec-value"
+
+	run "$FNOX_BIN" exec -- sh -c 'echo "${NORMAL}:${EXEC_ONLY}"'
+	assert_success
+	assert_output "normal-value:exec-value"
+}
+
+@test "local override can flip the top-level env default" {
+	# fnox.local.toml loads after fnox.toml, so its top-level env wins
+	cat >fnox.local.toml <<'EOF'
+env = true
+EOF
+
+	run "$FNOX_BIN" hook-env -s bash
+	assert_success
+	assert_output --partial "shell-value"
+	assert_output --partial "exec-value"
+	refute_output --partial "hidden-value"
+}


### PR DESCRIPTION
## Summary

Implements the "paranoid mode" requested in #578 (and discussed in #350): keep secrets out of the interactive shell — where AI coding agents and any other process inherit them — while still injecting them into `fnox exec` subprocesses.

The per-secret `env` field gains a third state, and a new top-level `env` sets the default for all secrets:

| `env` | shell integration / `fnox export` | `fnox exec` | `fnox get` |
|---|---|---|---|
| `true` (default) | ✅ | ✅ | ✅ |
| `"exec"` (new) | ❌ | ✅ | ✅ |
| `false` | ❌ | ❌ | ✅ |

One line flips a project to default-deny:

```toml
env = "exec"   # nothing enters the interactive shell

[secrets]
DATABASE_URL = { provider = "age", value = "..." }               # exec-only (inherited)
PS1_TOKEN    = { provider = "age", value = "...", env = true }   # explicit opt-back-in
```

Per-secret `env` overrides the top-level default, and the top-level default rides the normal config merge order, so `fnox.local.toml` can tighten or loosen it per machine. Existing configs parse with identical semantics (`true`/`false` unchanged).

## Also in this PR

- **Fixes an `env = false` leak through `fnox export`**: export resolved with `include_env_false=true` and never filtered on `env`, so `env = false` secrets were included in its output — and the [mise-env-fnox](https://github.com/jdx/mise-env-fnox) plugin evaluates `fnox export --format json`, injecting them into the shell despite the documented "only accessible via `fnox get`" behavior. Export now follows shell semantics; `--all` restores the full dump for explicit use.
- **MCP**: `env = "exec"` secrets are batch-resolved and injected by the MCP `exec` tool (fnox-mediated subprocess injection is their intended destination); `env = false` stays deferred/on-demand as before.
- **`fnox doctor`** warns when the top-level env default keeps secrets out of the shell but `FNOX_AGE_KEY` is itself exported — an ambient master key would undermine the whole posture.
- **Docs**: the `env`, `as_file`, `json_path`, and `line` secret fields were undocumented in the configuration reference (raised by @stempler in #350); all are now documented, plus the new top-level `env` section and a note in the MCP guide. JSON schema and CLI docs regenerated.

## What this does and doesn't protect against

This eliminates *ambient* exposure: agents and other processes in your shell no longer see secret values in their inherited environment. It is not a hard boundary — anything that can run commands in your shell can still invoke `fnox get`/`fnox exec` itself. The docs say so explicitly and point at the MCP allowlist + sandboxing for the stronger property.

## Testing

- New unit tests: `EnvMode` parsing (`true`/`false`/`"exec"`/rejects unknown strings), top-level inheritance + per-secret override, TOML serialization roundtrip
- New `test/env_mode.bats` (7 tests): hook-env exclusion, exec injection, export filtering, `export --all`, `fnox get` access, per-secret `"exec"` without top-level default, `fnox.local.toml` override
- Full cargo suite (212 core + 26 bin) and regression bats (hook_env*, exec/export if_missing, plain, toplevel_secrets, daemon, shell-integration, etc.) pass

Closes #578

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes secret injection semantics across shell integration, export, exec, daemon IPC, and MCP—security-sensitive behavior with backward-compatible TOML but new default-deny posture when `env = "exec"` is set globally.
> 
> **Overview**
> Adds a three-way **`env`** injection model (`true` / `"exec"` / `false`) plus an optional **top-level `env` default** so projects can keep secrets out of the interactive shell while still feeding **`fnox exec`** (and per-secret `env = true` opt-in).
> 
> **`hook-env`**, **`fnox export`**, the daemon batch resolver, and **MCP** now gate on `EnvMode` (`in_shell` vs `in_exec`) instead of a boolean. **`fnox export`** drops `env = "exec"` and `env = false` by default (fixes leakage via shell-oriented export paths); **`--all`** exports everything again. **MCP** batch-resolves injectable secrets including `"exec"` mode for the exec tool.
> 
> **`fnox doctor`** warns when a shell-hiding top-level `env` conflicts with **`FNOX_AGE_KEY`** in the environment. Docs/schema/CLI usage are updated; bats cover hook-env, exec, export, and inheritance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fafa785b86e2757ce54811c3a3fc70e8baa44be1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->