### PR TITLE
feat(config): support composing multiple active profiles

### DIFF
--- a/crates/fnox-core/build/generate_providers.rs
+++ b/crates/fnox-core/build/generate_providers.rs
@@ -807,7 +807,7 @@ fn generate_provider_resolver(
         /// This is the generated match statement for resolving provider configs.
         pub async fn resolve_provider_config_match(
             config: &Config,
-            profile: &str,
+            profile: &[String],
             provider_name: &str,
             provider_config: &ProviderConfig,
             ctx: &mut super::super::resolver::ResolutionContext,

--- a/crates/fnox-core/build/generate_settings.rs
+++ b/crates/fnox-core/build/generate_settings.rs
@@ -115,6 +115,7 @@ fn generate_merge_types(_settings: &SettingsToml) -> Result<String, Box<dyn std:
             Path(PathBuf),
             OptionPath(Option<PathBuf>),
             Bool(bool),
+            VecString(Vec<String>),
         }
 
         pub type SourceMap = IndexMap<&'static str, SettingValue>;
@@ -210,6 +211,7 @@ fn parse_type(typ: &str) -> Result<TokenStream, Box<dyn std::error::Error>> {
         "option<string>" => quote! { Option<String> },
         "path" => quote! { PathBuf },
         "option<path>" => quote! { Option<PathBuf> },
+        "vec_string" => quote! { Vec<String> },
         "bool" => quote! { bool },
         _ => return Err(format!("Unsupported type: {}", typ).into()),
     })
@@ -253,6 +255,20 @@ fn parse_default(default: &str, typ: &str) -> Result<TokenStream, Box<dyn std::e
             "false" => quote! { false },
             _ => return Err(format!("Invalid bool default: {}", default).into()),
         },
+        "vec_string" => {
+            let trimmed = default.trim();
+            let inner = trimmed
+                .strip_prefix('[')
+                .and_then(|s| s.strip_suffix(']'))
+                .ok_or_else(|| format!("Invalid vec_string default: {default}"))?;
+            let arr: Vec<String> = inner
+                .split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(|s| s.trim_matches('"').to_string())
+                .collect();
+            quote! { vec![#(#arr.to_string()),*] }
+        }
         _ => return Err(format!("Unsupported type for default: {}", typ).into()),
     })
 }

--- a/crates/fnox-core/build/generate_settings.rs
+++ b/crates/fnox-core/build/generate_settings.rs
@@ -211,7 +211,7 @@ fn parse_type(typ: &str) -> Result<TokenStream, Box<dyn std::error::Error>> {
         "option<string>" => quote! { Option<String> },
         "path" => quote! { PathBuf },
         "option<path>" => quote! { Option<PathBuf> },
-        "vec_string" => quote! { Vec<String> },
+        "vec<string>" => quote! { Vec<String> },
         "bool" => quote! { bool },
         _ => return Err(format!("Unsupported type: {}", typ).into()),
     })
@@ -255,7 +255,7 @@ fn parse_default(default: &str, typ: &str) -> Result<TokenStream, Box<dyn std::e
             "false" => quote! { false },
             _ => return Err(format!("Invalid bool default: {}", default).into()),
         },
-        "vec_string" => {
+        "vec<string>" => {
             let trimmed = default.trim();
             let inner = trimmed
                 .strip_prefix('[')

--- a/crates/fnox-core/settings.toml
+++ b/crates/fnox-core/settings.toml
@@ -34,7 +34,7 @@ since = "0.1.0"
 [profile]
 type = "vec<string>"
 default = '["default"]'
-sources.cli = ["--profile", "-p"]
+sources.cli = ["--profile", "-P"]
 sources.env = ["FNOX_PROFILE"]
 docs = """
 Configuration profile to use for secrets retrieval.

--- a/crates/fnox-core/settings.toml
+++ b/crates/fnox-core/settings.toml
@@ -32,7 +32,7 @@ examples = [
 since = "0.1.0"
 
 [profile]
-type = "vec_string"
+type = "vec<string>"
 default = '["default"]'
 sources.cli = ["--profile", "-p"]
 sources.env = ["FNOX_PROFILE"]

--- a/crates/fnox-core/settings.toml
+++ b/crates/fnox-core/settings.toml
@@ -32,8 +32,8 @@ examples = [
 since = "0.1.0"
 
 [profile]
-type = "string"
-default = "\"default\""
+type = "vec_string"
+default = '["default"]'
 sources.cli = ["--profile", "-p"]
 sources.env = ["FNOX_PROFILE"]
 docs = """

--- a/crates/fnox-core/src/config.rs
+++ b/crates/fnox-core/src/config.rs
@@ -91,6 +91,22 @@ pub fn find_local_config(dir: &Path, profiles: &[String]) -> PathBuf {
     dir.join(DEFAULT_CONFIG_FILENAME)
 }
 
+/// Check whether a file is a profile-specific config file (e.g.
+/// `fnox.prod.toml` or `.fnox.prod.toml`). Such files use top-level
+/// `[secrets]` to represent the profile's secrets, rather than nesting
+/// under `[profiles.<name>.secrets]`.
+pub fn is_profile_file(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .is_some_and(|name| {
+            let name = name.strip_prefix('.').unwrap_or(name);
+            name.starts_with("fnox.")
+                && name.ends_with(".toml")
+                && name != "fnox.toml"
+                && name != "fnox.local.toml"
+        })
+}
+
 // Re-export ProviderConfig from providers module
 pub use crate::providers::ProviderConfig;
 
@@ -970,19 +986,7 @@ impl Config {
         // .fnox.<profile>.toml), the top-level [secrets] section already
         // represents that profile's secrets — no need to nest under
         // [profiles.<profile>].
-        let is_profile_file = target_file
-            .file_name()
-            .and_then(|n| n.to_str())
-            .is_some_and(|name| {
-                // Strip leading dot for dotfile variants (.fnox.prod.toml)
-                let name = name.strip_prefix('.').unwrap_or(name);
-                name.starts_with("fnox.")
-                    && name.ends_with(".toml")
-                    && name != "fnox.toml"
-                    && name != "fnox.local.toml"
-            });
-
-        let secrets_table = if profile == "default" || is_profile_file {
+        let secrets_table = if profile == "default" || is_profile_file(&target_file) {
             if doc.get("secrets").is_none() {
                 doc["secrets"] = Item::Table(toml_edit::Table::new());
             }
@@ -1053,7 +1057,7 @@ impl Config {
         })?;
 
         // Navigate to the secrets table
-        let removed = if profile == "default" {
+        let removed = if profile == "default" || is_profile_file(target_file) {
             doc.get_mut("secrets")
                 .and_then(|s| s.as_table_mut())
                 .map(|t| t.remove(secret_name).is_some())
@@ -1110,7 +1114,7 @@ impl Config {
         };
 
         // Get or create the secrets table
-        let secrets_table = if profile == "default" {
+        let secrets_table = if profile == "default" || is_profile_file(target_file) {
             if doc.get("secrets").is_none() {
                 doc["secrets"] = Item::Table(toml_edit::Table::new());
             }

--- a/crates/fnox-core/src/config.rs
+++ b/crates/fnox-core/src/config.rs
@@ -19,14 +19,14 @@ pub const DEFAULT_CONFIG_FILENAME: &str = "fnox.toml";
 
 /// Returns all config filenames in load order (first = lowest priority, last = highest priority).
 ///
-/// Order: main configs → profile configs → local configs
+/// Order: main configs → profile configs (in the order given) → local configs
 /// Within each group, non-dotfiles come first (lower priority); dotfiles follow (higher priority).
-pub fn all_config_filenames(profile: Option<&str>) -> Vec<String> {
+pub fn all_config_filenames(profiles: &[String]) -> Vec<String> {
     let mut files = vec![
         DEFAULT_CONFIG_FILENAME.to_string(),
         ".fnox.toml".to_string(),
     ];
-    if let Some(p) = profile.filter(|p| *p != "default") {
+    for p in profiles.iter().filter(|p| *p != "default") {
         files.push(format!("fnox.{p}.toml"));
         files.push(format!(".fnox.{p}.toml"));
     }
@@ -48,14 +48,17 @@ pub fn local_override_filename(path: &Path) -> Option<&'static str> {
 
 /// Find the most appropriate existing config file in `dir` for writing.
 ///
-/// When a non-default profile is active, prefers the profile-specific file
-/// (e.g. `fnox.staging.toml`) if it exists, so secrets stay scoped to that
-/// profile. Otherwise falls back to the lowest-priority existing file.
-/// If no config files exist yet, returns `fnox.toml`.
-pub fn find_local_config(dir: &Path, profile: Option<&str>) -> PathBuf {
-    // If a non-default profile is specified, prefer its config file first
-    if let Some(p) = profile.filter(|p| *p != "default") {
-        for name in [format!("fnox.{p}.toml"), format!(".fnox.{p}.toml")] {
+/// When non-default profiles are active, the last profile is the write target. Its
+/// profile-specific file (e.g. `fnox.staging.toml`) is preferred if it exists, so
+/// secrets stay scoped to that profile. Otherwise falls back to the lowest-priority
+/// existing file. If no config files exist yet, returns `fnox.toml`.
+pub fn find_local_config(dir: &Path, profiles: &[String]) -> PathBuf {
+    // The last profile is the write target.
+    let write_profile = Config::write_profile(profiles);
+
+    // If the write profile is non-default, prefer its config file first
+    if write_profile != "default" {
+        for name in [format!("fnox.{write_profile}.toml"), format!(".fnox.{write_profile}.toml")] {
             let path = dir.join(&name);
             if path.exists() {
                 return path;
@@ -64,9 +67,10 @@ pub fn find_local_config(dir: &Path, profile: Option<&str>) -> PathBuf {
     }
 
     // Fall back to lowest-priority existing base file.
-    // When a profile is active, exclude local files (fnox.local.toml, .fnox.local.toml)
-    // to avoid silently routing profile-scoped secrets into a gitignored local-override file.
-    let is_profiled = profile.is_some_and(|p| p != "default");
+    // When a non-default profile is active, exclude local files
+    // (fnox.local.toml, .fnox.local.toml) to avoid silently routing profile-scoped
+    // secrets into a gitignored local-override file.
+    let is_profiled = profiles.iter().any(|p| p != "default");
     for name in &["fnox.toml", ".fnox.toml"] {
         let path = dir.join(name);
         if path.exists() {
@@ -231,6 +235,10 @@ pub struct SecretConfig {
     /// When false, the secret was loaded from a root-level [secrets] section.
     #[serde(skip)]
     pub source_is_profile: bool,
+
+    /// The profile name this secret was loaded from, if any (not serialized).
+    #[serde(skip)]
+    pub source_profile: Option<String>,
 
     /// Whether this secret may be cached by the per-user daemon.
     /// Defaults to true; set false for secrets that should always resolve directly.
@@ -501,7 +509,7 @@ impl Config {
         let path_ref = path.as_ref();
 
         // If the path is one of the default config filenames, use recursive loading
-        let default_filenames = all_config_filenames(None);
+        let default_filenames = all_config_filenames(&[]);
         if default_filenames.iter().any(|f| path_ref == Path::new(f)) {
             Self::load_with_recursion(path_ref)
         } else {
@@ -586,9 +594,9 @@ impl Config {
     /// Recursively search for fnox.toml files and merge them
     /// Returns (config, found_any) where found_any indicates if any config file was found
     fn load_recursive(dir: &Path, found_any: bool) -> Result<(Self, bool)> {
-        // Get current profile from Settings (respects: CLI flag > Env var > Default)
-        let profile = crate::settings::Settings::get().profile.clone();
-        let filenames = all_config_filenames(Some(&profile));
+        // Get active profiles from Settings (respects: CLI flag > Env var > Default)
+        let profiles = Self::get_profiles(&[]);
+        let filenames = all_config_filenames(&profiles);
 
         // Load all existing config files in order (later files override earlier ones)
         let mut config = Self::new();
@@ -645,8 +653,8 @@ impl Config {
     /// Find the nearest directory to `start` that contains a config file.
     /// Walks upward from `start` and returns the first match.
     fn find_project_dir(start: &Path) -> Option<PathBuf> {
-        let profile = crate::settings::Settings::get().profile.clone();
-        let filenames = all_config_filenames(Some(&profile));
+        let profiles = Self::get_profiles(&[]);
+        let filenames = all_config_filenames(&profiles);
         let mut dir = Some(start);
         while let Some(d) = dir {
             for filename in &filenames {
@@ -1154,12 +1162,46 @@ impl Config {
         }
     }
 
-    /// Get the profile to use (from flag or env var, defaulting to "default")
-    pub fn get_profile(profile_flag: Option<&str>) -> String {
-        profile_flag
-            .map(String::from)
-            .or_else(|| (*env::FNOX_PROFILE).clone())
-            .unwrap_or_else(|| "default".to_string())
+    /// Resolve the ordered list of active profiles.
+    ///
+    /// Precedence: CLI flags > FNOX_PROFILE env > settings default. If all are
+    /// empty, returns `["default"]`. The `default` profile name represents the
+    /// top-level config; no `[profiles.default]` lookup is performed.
+    pub fn get_profiles(cli_profiles: &[String]) -> Vec<String> {
+        if !cli_profiles.is_empty() {
+            return Self::normalize_profiles(cli_profiles);
+        }
+        Self::normalize_profiles(&Settings::get().profile)
+    }
+
+    /// Normalize a profile list: split comma-separated entries, trim whitespace,
+    /// drop invalid names, and remove empty entries. Order is preserved.
+    pub fn normalize_profiles(input: &[String]) -> Vec<String> {
+        let profiles: Vec<String> = input
+            .iter()
+            .flat_map(|s| s.split(','))
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty() && env::is_valid_profile_name(s))
+            .collect();
+        if profiles.is_empty() {
+            vec!["default".to_string()]
+        } else {
+            profiles
+        }
+    }
+
+    /// Format a profile list for display.
+    pub fn display_profiles(profiles: &[String]) -> String {
+        if profiles.is_empty() {
+            "default".to_string()
+        } else {
+            profiles.join(",")
+        }
+    }
+
+    /// Return the profile that write operations should target.
+    pub fn write_profile(profiles: &[String]) -> &str {
+        profiles.last().map(String::as_str).unwrap_or("default")
     }
 
     /// Determine if we should prompt for authentication when provider auth fails.
@@ -1192,33 +1234,33 @@ impl Config {
             .secrets
     }
 
-    /// Get effective secrets (default or profile)
-    /// For non-default profiles, this merges top-level secrets with profile-specific secrets,
-    /// with profile secrets taking precedence.
+    /// Get effective secrets for the active profile stack.
     ///
-    /// Note: If a profile doesn't exist in [profiles], it's treated as "default".
-    /// This allows fnox.$FNOX_PROFILE.toml files to work without requiring a [profiles] section.
-    pub fn get_secrets(&self, profile: &str) -> Result<IndexMap<String, SecretConfig>> {
-        let mut secrets = if profile == "default" {
+    /// Top-level secrets form the base (unless `no_defaults` is set and at least one
+    /// non-default profile is active). Profile-specific secrets are overlaid in order,
+    /// with later profiles taking precedence.
+    pub fn get_secrets(&self, profiles: &[String]) -> Result<IndexMap<String, SecretConfig>> {
+        self.get_secrets_with_no_defaults(profiles, Settings::get().no_defaults)
+    }
+
+    /// Get effective secrets with an explicit no-defaults setting.
+    pub fn get_secrets_with_no_defaults(
+        &self,
+        profiles: &[String],
+        no_defaults: bool,
+    ) -> Result<IndexMap<String, SecretConfig>> {
+        let has_non_default = profiles.iter().any(|p| p != "default");
+        let mut secrets = if !has_non_default || !no_defaults {
             self.secrets.clone()
         } else {
-            let mut secrets = if Settings::get().no_defaults {
-                // Profile-only mode: do not merge top-level secrets.
-                IndexMap::new()
-            } else {
-                // Start with top-level secrets as base
-                self.secrets.clone()
-            };
+            IndexMap::new()
+        };
 
-            // Get profile-specific secrets and merge/override (if profile exists)
+        for profile in profiles.iter().filter(|p| *p != "default") {
             if let Some(profile_config) = self.profiles.get(profile) {
-                // Profile-specific secrets override top-level ones
                 secrets.extend(profile_config.secrets.clone());
             }
-            // If profile doesn't exist in [profiles], that's OK - just use top-level secrets
-            // This allows fnox.$FNOX_PROFILE.toml to work without requiring [profiles.xxx]
-            secrets
-        };
+        }
 
         // Secrets that don't set `env` themselves inherit the top-level default
         if self.env.is_some() {
@@ -1234,66 +1276,92 @@ impl Config {
 
     /// Look up a single secret by key without cloning the secrets map.
     ///
-    /// Mirrors the precedence used by [`Self::get_secrets`]: profile-specific
-    /// secrets take precedence, falling back to top-level secrets unless
-    /// `no_defaults` is set.
-    pub fn get_secret(&self, profile: &str, key: &str) -> Option<&SecretConfig> {
-        if profile != "default"
-            && let Some(profile_config) = self.profiles.get(profile)
-            && let Some(secret) = profile_config.secrets.get(key)
-        {
-            return Some(secret);
+    /// Mirrors the precedence used by [`Self::get_secrets`]: later profiles take
+    /// precedence, falling back to top-level secrets unless `no_defaults` is set
+    /// and at least one non-default profile is active.
+    pub fn get_secret(&self, profiles: &[String], key: &str) -> Option<&SecretConfig> {
+        self.get_secret_with_no_defaults(profiles, key, Settings::get().no_defaults)
+    }
+
+    /// Look up a single secret with an explicit no-defaults setting.
+    pub fn get_secret_with_no_defaults(
+        &self,
+        profiles: &[String],
+        key: &str,
+        no_defaults: bool,
+    ) -> Option<&SecretConfig> {
+        let has_non_default = profiles.iter().any(|p| p != "default");
+
+        for profile in profiles.iter().filter(|p| *p != "default").rev() {
+            if let Some(profile_config) = self.profiles.get(profile) {
+                if let Some(secret) = profile_config.secrets.get(key) {
+                    return Some(secret);
+                }
+            }
         }
 
-        if profile != "default" && Settings::get().no_defaults {
+        if has_non_default && no_defaults {
             return None;
         }
 
         self.secrets.get(key)
     }
 
-    /// Get effective secrets (default or profile, mutable)
-    pub fn get_secrets_mut(&mut self, profile: &str) -> &mut IndexMap<String, SecretConfig> {
-        if profile == "default" {
+    /// Get effective secrets (mutable) for the write target profile.
+    ///
+    /// The write target is the last active profile. If it is `default` (or the
+    /// list is empty), the top-level secrets map is returned.
+    pub fn get_secrets_mut(&mut self, profiles: &[String]) -> &mut IndexMap<String, SecretConfig> {
+        let write_profile = Self::write_profile(profiles);
+        if write_profile == "default" {
             self.get_default_secrets_mut()
         } else {
-            self.get_profile_secrets_mut(profile)
+            self.get_profile_secrets_mut(write_profile)
         }
     }
 
-    /// Get effective lease backends for a profile
+    /// Get effective lease backends for the active profile stack.
+    ///
+    /// Top-level leases form the base. Profile-specific leases are overlaid in
+    /// order, with later profiles taking precedence.
     pub fn get_leases(
         &self,
-        profile: &str,
+        profiles: &[String],
     ) -> IndexMap<String, crate::lease_backends::LeaseBackendConfig> {
         let mut leases = self.leases.clone();
 
-        if profile != "default"
-            && let Some(profile_config) = self.profiles.get(profile)
-        {
-            leases.extend(profile_config.leases.clone());
+        for profile in profiles.iter().filter(|p| *p != "default") {
+            if let Some(profile_config) = self.profiles.get(profile) {
+                leases.extend(profile_config.leases.clone());
+            }
         }
 
         leases
     }
 
-    /// Get effective providers for a profile
-    pub fn get_providers(&self, profile: &str) -> IndexMap<String, ProviderConfig> {
-        let mut providers = self.providers.clone(); // Start with global providers
+    /// Get effective providers for the active profile stack.
+    ///
+    /// Top-level providers form the base. Profile-specific providers are overlaid
+    /// in order, with later profiles taking precedence.
+    pub fn get_providers(&self, profiles: &[String]) -> IndexMap<String, ProviderConfig> {
+        let mut providers = self.providers.clone();
 
-        if profile != "default"
-            && let Some(profile_config) = self.profiles.get(profile)
-        {
-            providers.extend(profile_config.providers.clone());
+        for profile in profiles.iter().filter(|p| *p != "default") {
+            if let Some(profile_config) = self.profiles.get(profile) {
+                providers.extend(profile_config.providers.clone());
+            }
         }
 
         providers
     }
 
-    /// Get the default provider for a profile
-    /// Returns the configured default_provider, or auto-selects if there's only one provider
-    pub fn get_default_provider(&self, profile: &str) -> Result<Option<String>> {
-        let providers = self.get_providers(profile);
+    /// Get the default provider for the active profile stack.
+    ///
+    /// Returns the configured default_provider (last profile that sets one wins),
+    /// or auto-selects if there's only one provider. Top-level default_provider
+    /// is used when no profile overrides it.
+    pub fn get_default_provider(&self, profiles: &[String]) -> Result<Option<String>> {
+        let providers = self.get_providers(profiles);
 
         // If no providers configured and this is a root config, return None
         if providers.is_empty() && self.root {
@@ -1307,59 +1375,51 @@ impl Config {
             ));
         }
 
-        // Check for profile-specific default provider
-        if profile != "default"
-            && let Some(profile_config) = self.profiles.get(profile)
-            && let Some(default_provider_name) = profile_config.default_provider()
-        {
+        // Find the winning default_provider: last profile that sets one wins.
+        let mut winning_profile = None;
+        let mut default_provider_name: Option<&str> = None;
+        if let Some(name) = self.default_provider() {
+            winning_profile = Some("default");
+            default_provider_name = Some(name);
+        }
+        for profile in profiles.iter().filter(|p| *p != "default") {
+            if let Some(profile_config) = self.profiles.get(profile) {
+                if let Some(name) = profile_config.default_provider() {
+                    winning_profile = Some(profile.as_str());
+                    default_provider_name = Some(name);
+                }
+            }
+        }
+
+        if let Some(name) = default_provider_name {
             // Validate that the default provider exists
-            if !providers.contains_key(default_provider_name) {
-                // Try to get source info for better error reporting
-                if let Some(source_path) = &profile_config.default_provider_source
-                    && let (Some(src), Some(span)) = (
-                        source_registry::get_named_source(source_path),
-                        profile_config.default_provider_span(),
-                    )
-                {
-                    return Err(FnoxError::DefaultProviderNotFoundWithSource {
-                        provider: default_provider_name.to_string(),
-                        profile: profile.to_string(),
-                        src,
-                        span: span.into(),
-                    });
+            if !providers.contains_key(name) {
+                let profile = winning_profile.unwrap_or("default");
+                if let Some(source_path) = self.default_provider_source_for(profile) {
+                    let span = self.default_provider_span_for(profile);
+                    if let (Some(src), Some(span)) =
+                        (source_registry::get_named_source(&source_path), span)
+                    {
+                        return Err(FnoxError::DefaultProviderNotFoundWithSource {
+                            provider: name.to_string(),
+                            profile: profile.to_string(),
+                            src,
+                            span: span.into(),
+                        });
+                    }
+                }
+                if profile == "default" {
+                    return Err(FnoxError::Config(format!(
+                        "Default provider '{}' not found in configuration",
+                        name
+                    )));
                 }
                 return Err(FnoxError::Config(format!(
                     "Default provider '{}' not found in profile '{}'",
-                    default_provider_name, profile
+                    name, profile
                 )));
             }
-            return Ok(Some(default_provider_name.to_string()));
-        }
-
-        // Check for global default provider (for default profile or as fallback)
-        if let Some(default_provider_name) = self.default_provider() {
-            // Validate that the default provider exists
-            if !providers.contains_key(default_provider_name) {
-                // Try to get source info for better error reporting
-                if let Some(source_path) = &self.default_provider_source
-                    && let (Some(src), Some(span)) = (
-                        source_registry::get_named_source(source_path),
-                        self.default_provider_span(),
-                    )
-                {
-                    return Err(FnoxError::DefaultProviderNotFoundWithSource {
-                        provider: default_provider_name.to_string(),
-                        profile: profile.to_string(),
-                        src,
-                        span: span.into(),
-                    });
-                }
-                return Err(FnoxError::Config(format!(
-                    "Default provider '{}' not found in configuration",
-                    default_provider_name
-                )));
-            }
-            return Ok(Some(default_provider_name.to_string()));
+            return Ok(Some(name.to_string()));
         }
 
         // If there's exactly one provider, auto-select it
@@ -1376,11 +1436,35 @@ impl Config {
         Ok(None)
     }
 
+    /// Source path for the effective default_provider of a given profile name.
+    fn default_provider_source_for(&self, profile: &str) -> Option<PathBuf> {
+        if profile == "default" {
+            self.default_provider_source.clone()
+        } else {
+            self.profiles
+                .get(profile)
+                .and_then(|p| p.default_provider_source.clone())
+        }
+    }
+
+    /// Source span for the effective default_provider of a given profile name.
+    fn default_provider_span_for(&self, profile: &str) -> Option<Range<usize>> {
+        if profile == "default" {
+            self.default_provider_span()
+        } else {
+            self.profiles
+                .get(profile)
+                .and_then(|p| p.default_provider_span())
+        }
+    }
+
     /// Set source paths for all secrets and providers in this config
     fn set_source_paths(&mut self, path: &Path) {
         // Set source paths for default profile secrets
         for (key, secret) in self.secrets.iter_mut() {
             secret.source_path = Some(path.to_path_buf());
+            secret.source_is_profile = false;
+            secret.source_profile = None;
             self.secret_sources.insert(key.clone(), path.to_path_buf());
         }
 
@@ -1396,10 +1480,11 @@ impl Config {
         }
 
         // Set source paths for named profiles
-        for (_profile_name, profile) in self.profiles.iter_mut() {
+        for (profile_name, profile) in self.profiles.iter_mut() {
             for (key, secret) in profile.secrets.iter_mut() {
                 secret.source_path = Some(path.to_path_buf());
                 secret.source_is_profile = true;
+                secret.source_profile = Some(profile_name.clone());
                 profile
                     .secret_sources
                     .insert(key.clone(), path.to_path_buf());
@@ -1457,7 +1542,7 @@ impl Config {
     /// Returns true if the provider is "plain" type.
     fn is_plain_provider(&self, secret_provider: Option<&str>, profile: &str) -> bool {
         // Get providers for this profile first (needed for auto-selection)
-        let providers = self.get_providers(profile);
+        let providers = self.get_providers(&[profile.to_string()]);
 
         // Determine which provider name to use
         let provider_name = secret_provider
@@ -1555,7 +1640,7 @@ impl Config {
 
         // Validate each profile
         for (profile_name, profile_config) in &self.profiles {
-            let providers = self.get_providers(profile_name);
+            let providers = self.get_providers(&[profile_name.to_string()]);
 
             // Check for profile secrets with empty values (likely a mistake, but allowed for plain provider)
             for (key, secret) in &profile_config.secrets {
@@ -1656,6 +1741,7 @@ impl SecretConfig {
             sync: None,
             source_path: None,
             source_is_profile: false,
+            source_profile: None,
             daemon_cache: None,
         }
     }
@@ -2037,7 +2123,7 @@ mod tests {
         crate::settings::Settings::reset_for_tests();
         crate::settings::Settings::set_cli_snapshot(crate::settings::CliSnapshot {
             age_key_file: None,
-            profile: Some("prod".to_string()),
+            profile: vec!["prod".to_string()],
             if_missing: None,
             no_defaults: true,
         });
@@ -2053,7 +2139,7 @@ mod tests {
             .insert("PROD_ONLY".to_string(), SecretConfig::new());
         config.profiles.insert("prod".to_string(), prod_profile);
 
-        let secrets = config.get_secrets("prod").unwrap();
+        let secrets = config.get_secrets(&["prod".to_string()]).unwrap();
         assert!(secrets.contains_key("PROD_ONLY"));
         assert!(!secrets.contains_key("DEFAULT_ONLY"));
     }
@@ -2063,7 +2149,7 @@ mod tests {
         crate::settings::Settings::reset_for_tests();
         crate::settings::Settings::set_cli_snapshot(crate::settings::CliSnapshot {
             age_key_file: None,
-            profile: Some("prod".to_string()),
+            profile: vec!["prod".to_string()],
             if_missing: None,
             no_defaults: true,
         });
@@ -2073,14 +2159,14 @@ mod tests {
             .secrets
             .insert("DEFAULT_ONLY".to_string(), SecretConfig::new());
 
-        let secrets = config.get_secrets("prod").unwrap();
+        let secrets = config.get_secrets(&["prod".to_string()]).unwrap();
         assert!(secrets.is_empty());
     }
 
     #[test]
     fn test_find_local_config_no_files() {
         let dir = tempfile::tempdir().unwrap();
-        let result = super::find_local_config(dir.path(), None);
+        let result = super::find_local_config(dir.path(), &[]);
         assert_eq!(result, dir.path().join("fnox.toml"));
     }
 
@@ -2088,7 +2174,7 @@ mod tests {
     fn test_find_local_config_only_fnox_toml() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("fnox.toml"), "").unwrap();
-        let result = super::find_local_config(dir.path(), None);
+        let result = super::find_local_config(dir.path(), &[]);
         assert_eq!(result, dir.path().join("fnox.toml"));
     }
 
@@ -2096,7 +2182,7 @@ mod tests {
     fn test_find_local_config_only_local_toml() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("fnox.local.toml"), "").unwrap();
-        let result = super::find_local_config(dir.path(), None);
+        let result = super::find_local_config(dir.path(), &[]);
         assert_eq!(result, dir.path().join("fnox.local.toml"));
     }
 
@@ -2105,7 +2191,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("fnox.toml"), "").unwrap();
         std::fs::write(dir.path().join("fnox.local.toml"), "").unwrap();
-        let result = super::find_local_config(dir.path(), None);
+        let result = super::find_local_config(dir.path(), &[]);
         // Should pick fnox.toml (lowest priority)
         assert_eq!(result, dir.path().join("fnox.toml"));
     }
@@ -2114,7 +2200,7 @@ mod tests {
     fn test_find_local_config_only_dotfile() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join(".fnox.toml"), "").unwrap();
-        let result = super::find_local_config(dir.path(), None);
+        let result = super::find_local_config(dir.path(), &[]);
         assert_eq!(result, dir.path().join(".fnox.toml"));
     }
 
@@ -2122,7 +2208,7 @@ mod tests {
     fn test_find_local_config_profile() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("fnox.staging.toml"), "").unwrap();
-        let result = super::find_local_config(dir.path(), Some("staging"));
+        let result = super::find_local_config(dir.path(), &["staging".to_string()]);
         assert_eq!(result, dir.path().join("fnox.staging.toml"));
     }
 
@@ -2131,7 +2217,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("fnox.toml"), "").unwrap();
         std::fs::write(dir.path().join("fnox.staging.toml"), "").unwrap();
-        let result = super::find_local_config(dir.path(), Some("staging"));
+        let result = super::find_local_config(dir.path(), &["staging".to_string()]);
         // Profile-specific file is preferred when profile is active
         assert_eq!(result, dir.path().join("fnox.staging.toml"));
     }
@@ -2142,7 +2228,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("fnox.toml"), "").unwrap();
         std::fs::write(dir.path().join("fnox.local.toml"), "").unwrap();
-        let result = super::find_local_config(dir.path(), Some("default"));
+        let result = super::find_local_config(dir.path(), &["default".to_string()]);
         assert_eq!(result, dir.path().join("fnox.toml"));
     }
 
@@ -2151,7 +2237,7 @@ mod tests {
         // Profile specified but only base config exists — fall back to it
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("fnox.toml"), "").unwrap();
-        let result = super::find_local_config(dir.path(), Some("staging"));
+        let result = super::find_local_config(dir.path(), &["staging".to_string()]);
         assert_eq!(result, dir.path().join("fnox.toml"));
     }
 
@@ -2161,7 +2247,7 @@ mod tests {
         // should NOT write there — fall through to creating fnox.toml
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("fnox.local.toml"), "").unwrap();
-        let result = super::find_local_config(dir.path(), Some("staging"));
+        let result = super::find_local_config(dir.path(), &["staging".to_string()]);
         assert_eq!(result, dir.path().join("fnox.toml"));
     }
 
@@ -2170,8 +2256,67 @@ mod tests {
         // Without a profile, fnox.local.toml is a valid write target
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("fnox.local.toml"), "").unwrap();
-        let result = super::find_local_config(dir.path(), None);
+        let result = super::find_local_config(dir.path(), &[]);
         assert_eq!(result, dir.path().join("fnox.local.toml"));
+    }
+
+    #[test]
+    fn test_profile_stack_overlays_in_order() {
+        let config: Config = toml_edit::de::from_str(
+            r#"
+[providers.base]
+type = "plain"
+
+[secrets.SHARED]
+value = "base"
+
+[profiles.aws]
+default_provider = "aws_plain"
+
+[profiles.aws.providers.aws_plain]
+type = "plain"
+
+[profiles.aws.secrets.AWS_ONLY]
+value = "aws"
+
+[profiles.aws.secrets.SHARED]
+value = "aws"
+
+[profiles.prod]
+default_provider = "prod_plain"
+
+[profiles.prod.providers.prod_plain]
+type = "plain"
+
+[profiles.prod.secrets.PROD_ONLY]
+value = "prod"
+
+[profiles.prod.secrets.SHARED]
+value = "prod"
+"#,
+        )
+        .unwrap();
+
+        let profiles = vec!["aws".to_string(), "prod".to_string()];
+        let providers = config.get_providers(&profiles);
+        assert!(providers.contains_key("base"));
+        assert!(providers.contains_key("aws_plain"));
+        assert!(providers.contains_key("prod_plain"));
+        assert_eq!(
+            config.get_default_provider(&profiles).unwrap(),
+            Some("prod_plain".to_string())
+        );
+
+        let secrets = config.get_secrets(&profiles).unwrap();
+        assert_eq!(secrets.get("SHARED").and_then(SecretConfig::value), Some("prod"));
+        assert_eq!(
+            secrets.get("AWS_ONLY").and_then(SecretConfig::value),
+            Some("aws")
+        );
+        assert_eq!(
+            secrets.get("PROD_ONLY").and_then(SecretConfig::value),
+            Some("prod")
+        );
     }
 
     #[test]
@@ -2353,7 +2498,7 @@ DEV_INHERITED = { provider = "plain", value = "d" }
         let parsed: Config = toml_edit::de::from_str(toml_input).unwrap();
         assert_eq!(parsed.env, Some(EnvMode::Exec));
 
-        let secrets = parsed.get_secrets("default").unwrap();
+        let secrets = parsed.get_secrets(&["default".to_string()]).unwrap();
         assert_eq!(secrets["INHERITED"].env_mode(), EnvMode::Exec);
         assert_eq!(secrets["OPTED_IN"].env_mode(), EnvMode::Shell);
         assert_eq!(secrets["HIDDEN"].env_mode(), EnvMode::Never);
@@ -2361,7 +2506,7 @@ DEV_INHERITED = { provider = "plain", value = "d" }
         // Only assert on the profile-level secret here: merging top-level
         // secrets into profiles depends on the global no_defaults setting,
         // which other tests mutate concurrently.
-        let dev_secrets = parsed.get_secrets("dev").unwrap();
+        let dev_secrets = parsed.get_secrets(&["dev".to_string()]).unwrap();
         assert_eq!(dev_secrets["DEV_INHERITED"].env_mode(), EnvMode::Exec);
     }
 

--- a/crates/fnox-core/src/config.rs
+++ b/crates/fnox-core/src/config.rs
@@ -966,13 +966,16 @@ impl Config {
         };
 
         // Get or create the secrets table.
-        // When writing to a profile-specific file (fnox.<profile>.toml),
-        // the top-level [secrets] section already represents that profile's
-        // secrets — no need to nest under [profiles.<profile>].
+        // When writing to a profile-specific file (fnox.<profile>.toml or
+        // .fnox.<profile>.toml), the top-level [secrets] section already
+        // represents that profile's secrets — no need to nest under
+        // [profiles.<profile>].
         let is_profile_file = target_file
             .file_name()
             .and_then(|n| n.to_str())
             .is_some_and(|name| {
+                // Strip leading dot for dotfile variants (.fnox.prod.toml)
+                let name = name.strip_prefix('.').unwrap_or(name);
                 name.starts_with("fnox.")
                     && name.ends_with(".toml")
                     && name != "fnox.toml"

--- a/crates/fnox-core/src/config.rs
+++ b/crates/fnox-core/src/config.rs
@@ -965,8 +965,21 @@ impl Config {
             DocumentMut::new()
         };
 
-        // Get or create the secrets table
-        let secrets_table = if profile == "default" {
+        // Get or create the secrets table.
+        // When writing to a profile-specific file (fnox.<profile>.toml),
+        // the top-level [secrets] section already represents that profile's
+        // secrets — no need to nest under [profiles.<profile>].
+        let is_profile_file = target_file
+            .file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|name| {
+                name.starts_with("fnox.")
+                    && name.ends_with(".toml")
+                    && name != "fnox.toml"
+                    && name != "fnox.local.toml"
+            });
+
+        let secrets_table = if profile == "default" || is_profile_file {
             if doc.get("secrets").is_none() {
                 doc["secrets"] = Item::Table(toml_edit::Table::new());
             }
@@ -1199,6 +1212,31 @@ impl Config {
             "default".to_string()
         } else {
             profiles.join(",")
+        }
+    }
+
+    /// Resolve the write-target profile.
+    ///
+    /// - If `explicit` is set, use it (validated against profile name rules).
+    /// - If exactly one profile is active, use it.
+    /// - If multiple profiles are active without `--write-profile`, return an error.
+    pub fn resolve_write_profile(profiles: &[String], explicit: Option<&str>) -> Result<String> {
+        if let Some(name) = explicit {
+            if !env::is_valid_profile_name(name) {
+                return Err(FnoxError::Config(format!(
+                    "Invalid --write-profile name: '{name}'"
+                )));
+            }
+            return Ok(name.to_string());
+        }
+
+        match profiles.len() {
+            0 => Ok("default".to_string()),
+            1 => Ok(profiles[0].clone()),
+            _ => Err(FnoxError::Config(format!(
+                "Multiple profiles are active ({}). Specify --write-profile <NAME> to choose the write target.",
+                profiles.join(",")
+            ))),
         }
     }
 

--- a/crates/fnox-core/src/config.rs
+++ b/crates/fnox-core/src/config.rs
@@ -58,7 +58,10 @@ pub fn find_local_config(dir: &Path, profiles: &[String]) -> PathBuf {
 
     // If the write profile is non-default, prefer its config file first
     if write_profile != "default" {
-        for name in [format!("fnox.{write_profile}.toml"), format!(".fnox.{write_profile}.toml")] {
+        for name in [
+            format!("fnox.{write_profile}.toml"),
+            format!(".fnox.{write_profile}.toml"),
+        ] {
             let path = dir.join(&name);
             if path.exists() {
                 return path;
@@ -1293,10 +1296,10 @@ impl Config {
         let has_non_default = profiles.iter().any(|p| p != "default");
 
         for profile in profiles.iter().filter(|p| *p != "default").rev() {
-            if let Some(profile_config) = self.profiles.get(profile) {
-                if let Some(secret) = profile_config.secrets.get(key) {
-                    return Some(secret);
-                }
+            if let Some(profile_config) = self.profiles.get(profile)
+                && let Some(secret) = profile_config.secrets.get(key)
+            {
+                return Some(secret);
             }
         }
 
@@ -1383,11 +1386,11 @@ impl Config {
             default_provider_name = Some(name);
         }
         for profile in profiles.iter().filter(|p| *p != "default") {
-            if let Some(profile_config) = self.profiles.get(profile) {
-                if let Some(name) = profile_config.default_provider() {
-                    winning_profile = Some(profile.as_str());
-                    default_provider_name = Some(name);
-                }
+            if let Some(profile_config) = self.profiles.get(profile)
+                && let Some(name) = profile_config.default_provider()
+            {
+                winning_profile = Some(profile.as_str());
+                default_provider_name = Some(name);
             }
         }
 
@@ -2308,7 +2311,10 @@ value = "prod"
         );
 
         let secrets = config.get_secrets(&profiles).unwrap();
-        assert_eq!(secrets.get("SHARED").and_then(SecretConfig::value), Some("prod"));
+        assert_eq!(
+            secrets.get("SHARED").and_then(SecretConfig::value),
+            Some("prod")
+        );
         assert_eq!(
             secrets.get("AWS_ONLY").and_then(SecretConfig::value),
             Some("aws")

--- a/crates/fnox-core/src/env.rs
+++ b/crates/fnox-core/src/env.rs
@@ -68,15 +68,12 @@ pub static FNOX_STATE_DIR: LazyLock<PathBuf> = LazyLock::new(|| {
 });
 
 // Profile configuration
-pub static FNOX_PROFILE: LazyLock<Option<String>> = LazyLock::new(|| {
-    var("FNOX_PROFILE").ok().and_then(|profile| {
-        if is_valid_profile_name(&profile) {
-            Some(profile)
-        } else {
-            eprintln!("Warning: Invalid FNOX_PROFILE value '{}' ignored (contains path separators or invalid characters)", profile);
-            None
-        }
-    })
+pub static FNOX_PROFILE: LazyLock<Vec<String>> = LazyLock::new(|| {
+    var("FNOX_PROFILE")
+        .ok()
+        .map(|profiles| parse_profile_list(&profiles))
+        .filter(|profiles| !profiles.is_empty())
+        .unwrap_or_default()
 });
 
 // Age encryption key configuration
@@ -98,9 +95,18 @@ fn var_path(name: &str) -> Option<PathBuf> {
         .filter(|p| p.is_absolute())
 }
 
-/// Validates that a profile name is safe to use in file paths
-/// Rejects names containing path separators or other dangerous characters
-fn is_valid_profile_name(name: &str) -> bool {
+/// Parse a comma-separated profile list, skipping invalid/empty entries.
+pub fn parse_profile_list(profiles: &str) -> Vec<String> {
+    profiles
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .filter(|s| is_valid_profile_name(s))
+        .collect()
+}
+/// Validates that a profile name is safe to use in file paths.
+/// Rejects names containing path separators or other dangerous characters.
+pub fn is_valid_profile_name(name: &str) -> bool {
     // Profile names must be non-empty
     if name.is_empty() {
         return false;

--- a/crates/fnox-core/src/env.rs
+++ b/crates/fnox-core/src/env.rs
@@ -96,12 +96,25 @@ fn var_path(name: &str) -> Option<PathBuf> {
 }
 
 /// Parse a comma-separated profile list, skipping invalid/empty entries.
+/// Warns on stderr when an entry is rejected so misconfigured environments
+/// are not silently ignored.
 pub fn parse_profile_list(profiles: &str) -> Vec<String> {
     profiles
         .split(',')
         .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-        .filter(|s| is_valid_profile_name(s))
+        .filter(|s| {
+            if s.is_empty() {
+                return false;
+            }
+            if !is_valid_profile_name(s) {
+                eprintln!(
+                    "Warning: Invalid profile name '{}' in FNOX_PROFILE ignored (contains path separators or invalid characters)",
+                    s
+                );
+                return false;
+            }
+            true
+        })
         .collect()
 }
 /// Validates that a profile name is safe to use in file paths.

--- a/crates/fnox-core/src/env.rs
+++ b/crates/fnox-core/src/env.rs
@@ -136,6 +136,10 @@ pub fn is_valid_profile_name(name: &str) -> bool {
         match ch {
             // Path separators
             '/' | '\\' => return false,
+            // Comma — used as delimiter in multi-profile lists (FNOX_PROFILE=a,b)
+            // and in socket-path/cache-key joins. Allowing it would cause
+            // collisions: "a,b" as one name vs "a" + "b" as two names.
+            ',' => return false,
             // Null byte (could truncate paths)
             '\0' => return false,
             // Control characters
@@ -202,5 +206,11 @@ mod tests {
         assert!(!is_valid_profile_name("prod\0uction")); // null byte
         assert!(!is_valid_profile_name("prod\ntest")); // newline
         assert!(!is_valid_profile_name("prod\rtest")); // carriage return
+
+        // Comma — used as multi-profile delimiter, must be rejected
+        // to prevent cache-key/socket-path collisions.
+        assert!(!is_valid_profile_name("a,b"));
+        assert!(!is_valid_profile_name("prod,"));
+        assert!(!is_valid_profile_name(",prod"));
     }
 }

--- a/crates/fnox-core/src/lease.rs
+++ b/crates/fnox-core/src/lease.rs
@@ -334,7 +334,10 @@ pub enum EncryptionProviderResult {
 }
 
 /// Find an encryption provider if one is configured (default_provider with Encryption capability)
-pub async fn find_encryption_provider(config: &Config, profile: &[String]) -> EncryptionProviderResult {
+pub async fn find_encryption_provider(
+    config: &Config,
+    profile: &[String],
+) -> EncryptionProviderResult {
     let provider_name = match config.get_default_provider(profile) {
         Ok(Some(name)) => name,
         _ => return EncryptionProviderResult::NotConfigured,

--- a/crates/fnox-core/src/lease.rs
+++ b/crates/fnox-core/src/lease.rs
@@ -334,7 +334,7 @@ pub enum EncryptionProviderResult {
 }
 
 /// Find an encryption provider if one is configured (default_provider with Encryption capability)
-pub async fn find_encryption_provider(config: &Config, profile: &str) -> EncryptionProviderResult {
+pub async fn find_encryption_provider(config: &Config, profile: &[String]) -> EncryptionProviderResult {
     let provider_name = match config.get_default_provider(profile) {
         Ok(Some(name)) => name,
         _ => return EncryptionProviderResult::NotConfigured,
@@ -412,7 +412,7 @@ pub async fn create_and_record_lease(
     duration: std::time::Duration,
     config_hash: String,
     config: &Config,
-    profile: &str,
+    profile: &[String],
     ledger: &mut LeaseLedger,
     project_dir: &Path,
 ) -> Result<crate::lease_backends::Lease> {
@@ -496,7 +496,7 @@ pub async fn decrypt_credentials(
 /// plaintext if no encryption provider is configured.
 pub async fn cache_credentials(
     config: &Config,
-    profile: &str,
+    profile: &[String],
     credentials: &IndexMap<String, String>,
     lease_id: &str,
 ) -> (Option<IndexMap<String, String>>, Option<String>) {
@@ -569,7 +569,7 @@ pub fn find_cached_entry(
 pub async fn resolve_cached_entry(
     entry: CachedEntry,
     config: &Config,
-    profile: &str,
+    profile: &[String],
     backend_name: &str,
 ) -> Option<IndexMap<String, String>> {
     if let Some(ref enc_provider_name) = entry.encryption_provider {
@@ -596,7 +596,7 @@ pub async fn resolve_cached_entry(
 /// Returns `None` if the provider is unavailable or decryption fails.
 pub async fn try_decrypt_cached(
     config: &Config,
-    profile: &str,
+    profile: &[String],
     enc_provider_name: &str,
     cached_creds: &IndexMap<String, String>,
     lease_id: &str,
@@ -655,7 +655,7 @@ pub async fn resolve_lease(
     name: &str,
     lease_config: &crate::lease_backends::LeaseBackendConfig,
     config: &Config,
-    profile: &str,
+    profile: &[String],
     project_dir: &Path,
     prereq_missing: Option<&str>,
     label_prefix: &str,

--- a/crates/fnox-core/src/library.rs
+++ b/crates/fnox-core/src/library.rs
@@ -47,9 +47,14 @@ pub const CONFIG_FILENAME: &str = "fnox.toml";
 pub struct Fnox {
     config: Arc<Config>,
     profile: String,
+    profiles: Vec<String>,
 }
 
 impl Fnox {
+    fn env_profiles() -> Vec<String> {
+        Config::normalize_profiles(&crate::env::FNOX_PROFILE)
+    }
+
     /// Walk up from the current directory looking for `fnox.toml`
     /// AND merge in the parent / local-override / global config chain
     /// — same exact behavior as the binary when invoked without an
@@ -66,10 +71,12 @@ impl Fnox {
         // parent + local + global merging that load(absolute) would
         // bypass. Per AGENTS.md "Loading order".
         let config = Config::load_smart(CONFIG_FILENAME)?;
-        let profile = Config::get_profile(None);
+        let profiles = Self::env_profiles();
+        let profile = Config::display_profiles(&profiles);
         Ok(Self {
             config: Arc::new(config),
             profile,
+            profiles,
         })
     }
 
@@ -94,17 +101,25 @@ impl Fnox {
             path_ref.to_path_buf()
         };
         let config = Config::load(resolved)?;
-        let profile = Config::get_profile(None);
+        let profiles = Self::env_profiles();
+        let profile = Config::display_profiles(&profiles);
         Ok(Self {
             config: Arc::new(config),
             profile,
+            profiles,
         })
     }
 
     /// Use a specific profile instead of whatever
     /// [`Config::get_profile`] resolved. Builder-style.
-    pub fn with_profile(mut self, profile: impl Into<String>) -> Self {
-        self.profile = profile.into();
+    pub fn with_profile(self, profile: impl Into<String>) -> Self {
+        self.with_profiles([profile.into()])
+    }
+
+    /// Use a specific ordered profile stack.
+    pub fn with_profiles(mut self, profiles: impl IntoIterator<Item = String>) -> Self {
+        self.profiles = Config::normalize_profiles(&profiles.into_iter().collect::<Vec<_>>());
+        self.profile = Config::display_profiles(&self.profiles);
         self
     }
 
@@ -133,10 +148,13 @@ impl Fnox {
     pub async fn get(&self, key: &str) -> Result<Option<String>> {
         // get_secret returns Option<&SecretConfig> without cloning the
         // whole IndexMap — preferred over get_secrets(profile)?.get(key).
-        if let Some(secret_config) = self.config.get_secret(&self.profile, key) {
+        if let Some(secret_config) = self
+            .config
+            .get_secret_with_no_defaults(&self.profiles, key, false)
+        {
             return crate::secret_resolver::resolve_secret(
                 &self.config,
-                &self.profile,
+                &self.profiles,
                 key,
                 secret_config,
             )
@@ -163,7 +181,7 @@ impl Fnox {
     /// configs), not necessarily the set of secrets that currently
     /// have a resolvable value.
     pub fn list(&self) -> Result<Vec<String>> {
-        let secrets = self.config.get_secrets(&self.profile)?;
+        let secrets = self.config.get_secrets_with_no_defaults(&self.profiles, false)?;
         Ok(secrets.keys().cloned().collect())
     }
 }

--- a/crates/fnox-core/src/library.rs
+++ b/crates/fnox-core/src/library.rs
@@ -148,9 +148,9 @@ impl Fnox {
     pub async fn get(&self, key: &str) -> Result<Option<String>> {
         // get_secret returns Option<&SecretConfig> without cloning the
         // whole IndexMap — preferred over get_secrets(profile)?.get(key).
-        if let Some(secret_config) = self
-            .config
-            .get_secret_with_no_defaults(&self.profiles, key, false)
+        if let Some(secret_config) =
+            self.config
+                .get_secret_with_no_defaults(&self.profiles, key, false)
         {
             return crate::secret_resolver::resolve_secret(
                 &self.config,
@@ -181,7 +181,9 @@ impl Fnox {
     /// configs), not necessarily the set of secrets that currently
     /// have a resolvable value.
     pub fn list(&self) -> Result<Vec<String>> {
-        let secrets = self.config.get_secrets_with_no_defaults(&self.profiles, false)?;
+        let secrets = self
+            .config
+            .get_secrets_with_no_defaults(&self.profiles, false)?;
         Ok(secrets.keys().cloned().collect())
     }
 }

--- a/crates/fnox-core/src/library.rs
+++ b/crates/fnox-core/src/library.rs
@@ -48,11 +48,18 @@ pub struct Fnox {
     config: Arc<Config>,
     profile: String,
     profiles: Vec<String>,
+    no_defaults: bool,
 }
 
 impl Fnox {
     fn env_profiles() -> Vec<String> {
         Config::normalize_profiles(&crate::env::FNOX_PROFILE)
+    }
+
+    fn env_no_defaults() -> bool {
+        crate::settings::Settings::try_get()
+            .map(|s| s.no_defaults)
+            .unwrap_or(false)
     }
 
     /// Walk up from the current directory looking for `fnox.toml`
@@ -73,10 +80,12 @@ impl Fnox {
         let config = Config::load_smart(CONFIG_FILENAME)?;
         let profiles = Self::env_profiles();
         let profile = Config::display_profiles(&profiles);
+        let no_defaults = Self::env_no_defaults();
         Ok(Self {
             config: Arc::new(config),
             profile,
             profiles,
+            no_defaults,
         })
     }
 
@@ -103,10 +112,13 @@ impl Fnox {
         let config = Config::load(resolved)?;
         let profiles = Self::env_profiles();
         let profile = Config::display_profiles(&profiles);
+        // open() does not walk the config chain, so it should not read
+        // global Settings either — defaults to no_defaults = false.
         Ok(Self {
             config: Arc::new(config),
             profile,
             profiles,
+            no_defaults: false,
         })
     }
 
@@ -120,6 +132,13 @@ impl Fnox {
     pub fn with_profiles(mut self, profiles: impl IntoIterator<Item = String>) -> Self {
         self.profiles = Config::normalize_profiles(&profiles.into_iter().collect::<Vec<_>>());
         self.profile = Config::display_profiles(&self.profiles);
+        self
+    }
+
+    /// Override the no-defaults behavior. When true, top-level secrets
+    /// are not merged into non-default profiles.
+    pub fn with_no_defaults(mut self, no_defaults: bool) -> Self {
+        self.no_defaults = no_defaults;
         self
     }
 
@@ -150,7 +169,7 @@ impl Fnox {
         // whole IndexMap — preferred over get_secrets(profile)?.get(key).
         if let Some(secret_config) =
             self.config
-                .get_secret_with_no_defaults(&self.profiles, key, false)
+                .get_secret_with_no_defaults(&self.profiles, key, self.no_defaults)
         {
             return crate::secret_resolver::resolve_secret(
                 &self.config,
@@ -183,7 +202,7 @@ impl Fnox {
     pub fn list(&self) -> Result<Vec<String>> {
         let secrets = self
             .config
-            .get_secrets_with_no_defaults(&self.profiles, false)?;
+            .get_secrets_with_no_defaults(&self.profiles, self.no_defaults)?;
         Ok(secrets.keys().cloned().collect())
     }
 }

--- a/crates/fnox-core/src/providers/age.rs
+++ b/crates/fnox-core/src/providers/age.rs
@@ -15,7 +15,7 @@ pub struct AgeEncryptionProvider {
     key_file: Option<PathBuf>,
     identity: OptionProviderSecretRef,
     config: Option<Arc<crate::config::Config>>,
-    profile: String,
+    profile: Vec<String>,
     provider_name: String,
     identity_cycle_guard: Option<AgeIdentityCycleGuard>,
 }
@@ -31,7 +31,7 @@ impl AgeEncryptionProvider {
             key_file: key_file.map(|k| crate::config_path::resolve_relative_to_file(&k, None)),
             identity,
             config: None,
-            profile: "default".to_string(),
+            profile: vec!["default".to_string()],
             provider_name: "age".to_string(),
             identity_cycle_guard: None,
         })
@@ -42,7 +42,7 @@ impl AgeEncryptionProvider {
         key_file: Option<String>,
         identity: OptionProviderSecretRef,
         config: Arc<crate::config::Config>,
-        profile: String,
+        profile: Vec<String>,
         provider_name: String,
         identity_cycle_guard: Option<AgeIdentityCycleGuard>,
     ) -> Result<Self> {

--- a/crates/fnox-core/src/providers/mod.rs
+++ b/crates/fnox-core/src/providers/mod.rs
@@ -400,10 +400,10 @@ fn provider_source_path(
     provider_name: &str,
 ) -> Option<PathBuf> {
     for profile in profiles.iter().filter(|p| *p != "default").rev() {
-        if let Some(profile_config) = config.profiles.get(profile) {
-            if profile_config.providers.contains_key(provider_name) {
-                return profile_config.provider_sources.get(provider_name).cloned();
-            }
+        if let Some(profile_config) = config.profiles.get(profile)
+            && profile_config.providers.contains_key(provider_name)
+        {
+            return profile_config.provider_sources.get(provider_name).cloned();
         }
     }
 
@@ -460,7 +460,10 @@ mod tests {
         );
         config.profiles.insert("prod".to_string(), profile);
 
-        assert_eq!(provider_source_path(&config, &["prod".to_string()], "pass"), None);
+        assert_eq!(
+            provider_source_path(&config, &["prod".to_string()], "pass"),
+            None
+        );
     }
 
     #[test]

--- a/crates/fnox-core/src/providers/mod.rs
+++ b/crates/fnox-core/src/providers/mod.rs
@@ -283,7 +283,7 @@ impl ProviderConfig {
 /// `get_provider_from_resolved` directly with a resolved config.
 pub async fn get_provider_resolved(
     config: &crate::config::Config,
-    profile: &str,
+    profile: &[String],
     provider_name: &str,
     provider_config: &ProviderConfig,
 ) -> Result<Box<dyn Provider>> {
@@ -293,7 +293,7 @@ pub async fn get_provider_resolved(
 
 pub(crate) fn get_provider_from_resolved_with_context(
     config: &crate::config::Config,
-    profile: &str,
+    profile: &[String],
     provider_name: &str,
     resolved: &ResolvedProviderConfig,
 ) -> Result<Box<dyn Provider>> {
@@ -308,7 +308,7 @@ pub(crate) fn get_provider_from_resolved_with_context(
 
 pub(crate) fn get_provider_from_resolved_with_context_and_identity_cycle_guard(
     config: &crate::config::Config,
-    profile: &str,
+    profile: &[String],
     provider_name: &str,
     resolved: &ResolvedProviderConfig,
     identity_cycle_guard: Option<age::AgeIdentityCycleGuard>,
@@ -328,7 +328,7 @@ pub(crate) fn get_provider_from_resolved_with_context_and_identity_cycle_guard(
             ),
             identity.clone(),
             std::sync::Arc::new(config.clone()),
-            profile.to_string(),
+            profile.to_vec(),
             provider_name.to_string(),
             identity_cycle_guard,
         )?));
@@ -396,14 +396,15 @@ pub(crate) fn get_provider_from_resolved_with_context_and_identity_cycle_guard(
 
 fn provider_source_path(
     config: &crate::config::Config,
-    profile: &str,
+    profiles: &[String],
     provider_name: &str,
 ) -> Option<PathBuf> {
-    if profile != "default"
-        && let Some(profile_config) = config.profiles.get(profile)
-        && profile_config.providers.contains_key(provider_name)
-    {
-        return profile_config.provider_sources.get(provider_name).cloned();
+    for profile in profiles.iter().filter(|p| *p != "default").rev() {
+        if let Some(profile_config) = config.profiles.get(profile) {
+            if profile_config.providers.contains_key(provider_name) {
+                return profile_config.provider_sources.get(provider_name).cloned();
+            }
+        }
     }
 
     config.provider_sources.get(provider_name).cloned()
@@ -436,7 +437,7 @@ mod tests {
         config.profiles.insert("prod".to_string(), profile);
 
         assert_eq!(
-            provider_source_path(&config, "prod", "pass"),
+            provider_source_path(&config, &["prod".to_string()], "pass"),
             Some(PathBuf::from("/home/user/project/fnox.prod.toml")),
         );
     }
@@ -459,7 +460,7 @@ mod tests {
         );
         config.profiles.insert("prod".to_string(), profile);
 
-        assert_eq!(provider_source_path(&config, "prod", "pass"), None);
+        assert_eq!(provider_source_path(&config, &["prod".to_string()], "pass"), None);
     }
 
     #[test]
@@ -474,7 +475,7 @@ mod tests {
             .insert("prod".to_string(), ProfileConfig::new());
 
         assert_eq!(
-            provider_source_path(&config, "prod", "pass"),
+            provider_source_path(&config, &["prod".to_string()], "pass"),
             Some(PathBuf::from("/home/user/project/fnox.toml")),
         );
     }

--- a/crates/fnox-core/src/providers/resolver.rs
+++ b/crates/fnox-core/src/providers/resolver.rs
@@ -78,7 +78,7 @@ impl Default for ResolutionContext {
 /// A `ResolvedProviderConfig` with all secret references replaced with actual values.
 pub async fn resolve_provider_config(
     config: &Config,
-    profile: &str,
+    profile: &[String],
     provider_name: &str,
     provider_config: &ProviderConfig,
 ) -> Result<ResolvedProviderConfig> {
@@ -90,7 +90,7 @@ pub async fn resolve_provider_config(
 /// Internal function that carries the resolution context for cycle detection.
 pub fn resolve_provider_config_with_context<'a>(
     config: &'a Config,
-    profile: &'a str,
+    profile: &'a [String],
     provider_name: &'a str,
     provider_config: &'a ProviderConfig,
     ctx: &'a mut ResolutionContext,
@@ -128,7 +128,7 @@ pub fn resolve_provider_config_with_context<'a>(
 /// Resolve a required `StringOrSecretRef` field to its actual string value.
 pub fn resolve_required<'a>(
     config: &'a Config,
-    profile: &'a str,
+    profile: &'a [String],
     provider_name: &'a str,
     _field_name: &'a str,
     value: &'a StringOrSecretRef,
@@ -147,7 +147,7 @@ pub fn resolve_required<'a>(
 /// Resolve an optional `OptionStringOrSecretRef` field to its actual value.
 pub fn resolve_option<'a>(
     config: &'a Config,
-    profile: &'a str,
+    profile: &'a [String],
     provider_name: &'a str,
     value: &'a OptionStringOrSecretRef,
     ctx: &'a mut ResolutionContext,
@@ -168,7 +168,7 @@ pub fn resolve_option<'a>(
 /// Resolve an optional provider-backed secret reference to its actual value.
 pub fn resolve_provider_ref<'a>(
     config: &'a Config,
-    profile: &'a str,
+    profile: &'a [String],
     value: &'a OptionProviderSecretRef,
     ctx: &'a mut ResolutionContext,
 ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Option<String>>> + Send + 'a>> {
@@ -183,7 +183,7 @@ pub fn resolve_provider_ref<'a>(
 
 pub fn resolve_provider_ref_with_identity_cycle_guard<'a>(
     config: &'a Config,
-    profile: &'a str,
+    profile: &'a [String],
     value: &'a OptionProviderSecretRef,
     ctx: &'a mut ResolutionContext,
     identity_cycle_guard: super::age::AgeIdentityCycleGuard,
@@ -201,7 +201,7 @@ pub fn resolve_provider_ref_with_identity_cycle_guard<'a>(
 
             return Err(FnoxError::ProviderNotConfigured {
                 provider: provider_ref.provider.clone(),
-                profile: profile.to_string(),
+                profile: profile.join(","),
                 config_path: config.provider_sources.get(&provider_ref.provider).cloned(),
                 suggestion,
             });
@@ -241,7 +241,7 @@ pub fn resolve_provider_ref_with_identity_cycle_guard<'a>(
 /// config will also be resolved recursively.
 fn resolve_secret_ref<'a>(
     config: &'a Config,
-    profile: &'a str,
+    profile: &'a [String],
     provider_name: &'a str,
     secret_name: &'a str,
     ctx: &'a mut ResolutionContext,
@@ -294,7 +294,7 @@ fn resolve_secret_ref<'a>(
 
                     return Err(FnoxError::ProviderNotConfigured {
                         provider: secret_provider_name.to_string(),
-                        profile: profile.to_string(),
+                        profile: profile.join(","),
                         config_path: config.provider_sources.get(secret_provider_name).cloned(),
                         suggestion,
                     });

--- a/crates/fnox-core/src/secret_resolver.rs
+++ b/crates/fnox-core/src/secret_resolver.rs
@@ -177,7 +177,7 @@ fn default_reference_error(key: &str, reference: &str) -> FnoxError {
 
 fn default_can_be_used_in_batch(
     config: &Config,
-    profile: &str,
+    profile: &[String],
     secret_config: &SecretConfig,
 ) -> bool {
     if secret_config.sync.is_some() {
@@ -194,13 +194,13 @@ fn default_can_be_used_in_batch(
 
 fn collect_interpolation_closure(
     config: &Config,
-    profile: &str,
+    profile: &[String],
     key: &str,
     secrets: &IndexMap<String, SecretConfig>,
 ) -> Result<IndexMap<String, SecretConfig>> {
     struct ClosureCollector<'a> {
         config: &'a Config,
-        profile: &'a str,
+        profile: &'a [String],
         root_key: &'a str,
         secrets: &'a IndexMap<String, SecretConfig>,
         visiting: HashSet<String>,
@@ -262,7 +262,7 @@ fn collect_interpolation_closure(
 /// Creates a ProviderNotConfigured error, using source spans when available for better error display.
 fn create_provider_not_configured_error(
     provider_name: &str,
-    profile: &str,
+    profile: &[String],
     secret_config: &SecretConfig,
     config: &Config,
 ) -> FnoxError {
@@ -278,7 +278,7 @@ fn create_provider_not_configured_error(
     {
         return FnoxError::ProviderNotConfiguredWithSource {
             provider: provider_name.to_string(),
-            profile: profile.to_string(),
+            profile: profile.join(","),
             suggestion,
             src,
             span: SourceSpan::new(span.start.into(), span.end - span.start),
@@ -288,7 +288,7 @@ fn create_provider_not_configured_error(
     // Fall back to the basic error without source highlighting
     FnoxError::ProviderNotConfigured {
         provider: provider_name.to_string(),
-        profile: profile.to_string(),
+        profile: profile.join(","),
         config_path: secret_config.source_path.clone(),
         suggestion,
     }
@@ -479,7 +479,7 @@ fn resolve_default_fallbacks(
 /// Post-processing (e.g., JSON path extraction) is applied to all sources consistently.
 pub async fn resolve_secret(
     config: &Config,
-    profile: &str,
+    profile: &[String],
     key: &str,
     secret_config: &SecretConfig,
 ) -> Result<Option<String>> {
@@ -488,7 +488,7 @@ pub async fn resolve_secret(
 
 async fn resolve_interpolated_default_value(
     config: &Config,
-    profile: &str,
+    profile: &[String],
     key: &str,
     secret_config: &SecretConfig,
 ) -> Result<Option<String>> {
@@ -516,7 +516,7 @@ async fn resolve_interpolated_default_value(
 
 async fn resolve_secret_raw(
     config: &Config,
-    profile: &str,
+    profile: &[String],
     key: &str,
     secret_config: &SecretConfig,
 ) -> Result<Option<String>> {
@@ -570,7 +570,7 @@ async fn resolve_secret_raw(
 
 async fn try_resolve_from_provider(
     config: &Config,
-    profile: &str,
+    profile: &[String],
     secret_config: &SecretConfig,
 ) -> Result<Option<String>> {
     // If a sync cache exists, resolve from the sync provider/value instead
@@ -618,7 +618,7 @@ async fn try_resolve_from_provider(
 /// prompts the user to run the auth command and retries once.
 async fn try_resolve_with_auth_retry(
     config: &Config,
-    profile: &str,
+    profile: &[String],
     provider_name: &str,
     provider_config: &ProviderConfig,
     provider_value: &str,
@@ -659,7 +659,7 @@ async fn try_resolve_with_auth_retry(
 /// Creates the provider instance and calls `get_secret`.
 async fn try_get_secret(
     config: &Config,
-    profile: &str,
+    profile: &[String],
     provider_name: &str,
     provider_config: &ProviderConfig,
     provider_value: &str,
@@ -728,7 +728,7 @@ fn resolve_default_value(
 /// Returns an error immediately if any secret with `if_missing = "error"` fails to resolve.
 pub async fn resolve_secrets_batch(
     config: &Config,
-    profile: &str,
+    profile: &[String],
     secrets: &IndexMap<String, SecretConfig>,
 ) -> Result<IndexMap<String, Option<String>>> {
     // Classify each secret: provider-backed vs no-provider
@@ -978,7 +978,7 @@ fn compute_resolution_levels(
 /// Resolve a single level of secrets (all can be resolved in parallel).
 async fn resolve_level(
     config: &Config,
-    profile: &str,
+    profile: &[String],
     secrets: &IndexMap<String, SecretConfig>,
     secret_provider: &HashMap<String, (String, String)>,
     no_provider: &[String],
@@ -1048,7 +1048,7 @@ async fn resolve_level(
 
 async fn resolve_no_provider_secret(
     config: &Config,
-    profile: &str,
+    profile: &[String],
     key: &str,
     secret_config: &SecretConfig,
     resolved_so_far: &HashMap<String, Option<String>>,
@@ -1063,7 +1063,7 @@ async fn resolve_no_provider_secret(
 /// Resolve all secrets for a single provider using batch operations
 async fn resolve_provider_batch(
     config: &Config,
-    profile: &str,
+    profile: &[String],
     secrets: &IndexMap<String, SecretConfig>,
     provider_name: &str,
     provider_secrets: Vec<(String, String)>,
@@ -1100,7 +1100,7 @@ async fn resolve_provider_batch(
                         key,
                         &FnoxError::ProviderNotConfigured {
                             provider: provider_name.to_string(),
-                            profile: profile.to_string(),
+                            profile: profile.join(","),
                             config_path: None,
                             suggestion: suggestion.clone(),
                         },
@@ -1112,7 +1112,7 @@ async fn resolve_provider_batch(
                 let if_missing = resolve_if_missing_behavior(secret_config, config);
                 let error = FnoxError::ProviderNotConfigured {
                     provider: provider_name.to_string(),
-                    profile: profile.to_string(),
+                    profile: profile.join(","),
                     config_path: config.provider_sources.get(provider_name).cloned(),
                     suggestion: suggestion.clone(),
                 };
@@ -1177,7 +1177,7 @@ async fn resolve_provider_batch(
 
 struct ProviderBatchContext<'a> {
     config: &'a Config,
-    profile: &'a str,
+    profile: &'a [String],
     secrets: &'a IndexMap<String, SecretConfig>,
     provider_name: &'a str,
     provider_config: &'a ProviderConfig,
@@ -1430,6 +1430,10 @@ mod tests {
         secret
     }
 
+    fn profile(name: &str) -> Vec<String> {
+        vec![name.to_string()]
+    }
+
     fn plain_provider_secret(value: &str) -> SecretConfig {
         let mut secret = SecretConfig::new();
         secret.set_provider(Some("plain".to_string()));
@@ -1587,7 +1591,7 @@ mod tests {
         secrets.insert("POSTGRES_HOST".to_string(), default_secret("localhost"));
         secrets.insert("POSTGRES_PORT".to_string(), default_secret("5432"));
 
-        let resolved = resolve_secrets_batch(&config, "default", &secrets)
+        let resolved = resolve_secrets_batch(&config, &profile("default"), &secrets)
             .await
             .unwrap();
 
@@ -1625,7 +1629,7 @@ mod tests {
         secrets.extend(dev.secrets.clone());
         config.profiles.insert("dev".to_string(), dev);
 
-        let resolved = resolve_secrets_batch(&config, "dev", &secrets)
+        let resolved = resolve_secrets_batch(&config, &profile("dev"), &secrets)
             .await
             .unwrap();
 
@@ -1646,7 +1650,7 @@ mod tests {
             default_secret("postgres://${POSTGRES_USER}@localhost/fnox"),
         );
 
-        let err = resolve_secrets_batch(&config, "default", &secrets)
+        let err = resolve_secrets_batch(&config, &profile("default"), &secrets)
             .await
             .unwrap_err();
         let msg = format!("{err}");
@@ -1664,7 +1668,7 @@ mod tests {
         secrets.insert("A".to_string(), default_secret("${B}"));
         secrets.insert("B".to_string(), default_secret("${A}"));
 
-        let err = resolve_secrets_batch(&config, "default", &secrets)
+        let err = resolve_secrets_batch(&config, &profile("default"), &secrets)
             .await
             .unwrap_err();
         let msg = format!("{err}");
@@ -1693,7 +1697,7 @@ mod tests {
             default_secret("postgres://${POSTGRES_USER}@localhost/fnox"),
         );
 
-        let resolved = resolve_secrets_batch(&config, "default", &secrets)
+        let resolved = resolve_secrets_batch(&config, &profile("default"), &secrets)
             .await
             .unwrap();
 
@@ -1722,7 +1726,7 @@ mod tests {
         let mut secrets = IndexMap::new();
         secrets.insert("API_KEY".to_string(), secret);
 
-        let resolved = resolve_secrets_batch(&config, "default", &secrets)
+        let resolved = resolve_secrets_batch(&config, &profile("default"), &secrets)
             .await
             .unwrap();
 
@@ -1748,7 +1752,7 @@ mod tests {
         config.secrets.insert("API_KEY".to_string(), secret);
 
         let secret_config = config.secrets.get("API_KEY").unwrap();
-        let resolved = resolve_secret(&config, "default", "API_KEY", secret_config)
+        let resolved = resolve_secret(&config, &profile("default"), "API_KEY", secret_config)
             .await
             .unwrap();
 
@@ -1872,7 +1876,7 @@ mod tests {
         secrets.insert("DATABASE_URL".to_string(), database_url);
         secrets.insert("DB_HOST".to_string(), default_secret("localhost"));
 
-        let resolved = resolve_secrets_batch(&config, "default", &secrets)
+        let resolved = resolve_secrets_batch(&config, &profile("default"), &secrets)
             .await
             .unwrap();
 
@@ -1894,7 +1898,7 @@ mod tests {
         let mut secrets = IndexMap::new();
         secrets.insert("DATABASE_URL".to_string(), default_secret("${}"));
 
-        let err = resolve_secrets_batch(&config, "default", &secrets)
+        let err = resolve_secrets_batch(&config, &profile("default"), &secrets)
             .await
             .unwrap_err();
         let msg = format!("{err}");
@@ -1917,7 +1921,7 @@ mod tests {
             default_secret("postgres://${FNOX_TEST_MISSING_OPTIONAL_REF}@localhost/fnox"),
         );
 
-        let resolved = resolve_secrets_batch(&config, "default", &secrets)
+        let resolved = resolve_secrets_batch(&config, &profile("default"), &secrets)
             .await
             .unwrap();
 
@@ -1941,7 +1945,7 @@ mod tests {
             .insert("POSTGRES_USER".to_string(), default_secret("app"));
 
         let secret_config = config.secrets.get("DATABASE_URL").unwrap();
-        let resolved = resolve_secret(&config, "default", "DATABASE_URL", secret_config)
+        let resolved = resolve_secret(&config, &profile("default"), "DATABASE_URL", secret_config)
             .await
             .unwrap();
 
@@ -1965,7 +1969,7 @@ mod tests {
             .insert("HOSTNAME".to_string(), default_secret("localhost"));
 
         let secret_config = config.secrets.get("DATABASE_URL").unwrap();
-        let resolved = resolve_secret(&config, "default", "DATABASE_URL", secret_config)
+        let resolved = resolve_secret(&config, &profile("default"), "DATABASE_URL", secret_config)
             .await
             .unwrap();
 
@@ -1988,7 +1992,7 @@ mod tests {
             .insert("DATABASE_URL".to_string(), database_url);
 
         let secret_config = config.secrets.get("DATABASE_URL").unwrap();
-        let resolved = resolve_secret(&config, "default", "DATABASE_URL", secret_config)
+        let resolved = resolve_secret(&config, &profile("default"), "DATABASE_URL", secret_config)
             .await
             .unwrap();
 
@@ -2011,7 +2015,7 @@ mod tests {
         );
 
         let secret_config = config.secrets.get("DATABASE_URL").unwrap();
-        let resolved = resolve_secret(&config, "default", "DATABASE_URL", secret_config)
+        let resolved = resolve_secret(&config, &profile("default"), "DATABASE_URL", secret_config)
             .await
             .unwrap();
 

--- a/crates/fnox-core/src/settings.rs
+++ b/crates/fnox-core/src/settings.rs
@@ -135,7 +135,7 @@ impl Settings {
                                 matches!(val.to_lowercase().as_str(), "true" | "1" | "yes" | "on");
                             map.insert(setting_name, SettingValue::Bool(bool_val));
                         }
-                        "vec_string" => {
+                        "vec<string>" => {
                             map.insert(
                                 setting_name,
                                 SettingValue::VecString(crate::env::parse_profile_list(&val)),

--- a/crates/fnox-core/src/settings.rs
+++ b/crates/fnox-core/src/settings.rs
@@ -42,7 +42,7 @@ static INITIALIZED: LazyLock<Mutex<bool>> = LazyLock::new(|| Mutex::new(false));
 #[derive(Debug, Clone, Default)]
 pub struct CliSnapshot {
     pub age_key_file: Option<std::path::PathBuf>,
-    pub profile: Option<String>,
+    pub profile: Vec<String>,
     pub if_missing: Option<String>,
     pub no_defaults: bool,
 }
@@ -135,6 +135,12 @@ impl Settings {
                                 matches!(val.to_lowercase().as_str(), "true" | "1" | "yes" | "on");
                             map.insert(setting_name, SettingValue::Bool(bool_val));
                         }
+                        "vec_string" => {
+                            map.insert(
+                                setting_name,
+                                SettingValue::VecString(crate::env::parse_profile_list(&val)),
+                            );
+                        }
                         _ => {
                             // Ignore unknown types
                         }
@@ -156,8 +162,8 @@ impl Settings {
                 map.insert("age_key_file", SettingValue::OptionPath(Some(age_key_file)));
             }
 
-            if let Some(profile) = snapshot.profile {
-                map.insert("profile", SettingValue::String(profile));
+            if !snapshot.profile.is_empty() {
+                map.insert("profile", SettingValue::VecString(snapshot.profile.clone()));
             }
 
             if let Some(if_missing) = snapshot.if_missing {
@@ -192,6 +198,7 @@ impl Settings {
                     serde_json::json!(opt.as_ref().map(|p| p.display().to_string()))
                 }
                 SettingValue::Bool(b) => serde_json::json!(b),
+                SettingValue::VecString(v) => serde_json::json!(v),
             };
 
             if let Some(obj) = val.as_object_mut() {
@@ -232,7 +239,7 @@ mod tests {
     #[test]
     fn test_default_settings() {
         let settings = GeneratedSettings::default();
-        assert_eq!(settings.profile, "default");
+        assert_eq!(settings.profile, vec!["default".to_string()]);
         assert_eq!(settings.age_key_file, None);
         assert!(!settings.no_defaults);
     }
@@ -241,7 +248,7 @@ mod tests {
     fn test_settings_merge_precedence() {
         let defaults = GeneratedSettings {
             age_key_file: None,
-            profile: "default".to_string(),
+            profile: vec!["default".to_string()],
             no_defaults: false,
             shell_integration_output: "normal".to_string(),
             if_missing: None,
@@ -274,7 +281,7 @@ mod tests {
     fn test_settings_merge_partial() {
         let defaults = GeneratedSettings {
             age_key_file: None,
-            profile: "default".to_string(),
+            profile: vec!["default".to_string()],
             no_defaults: false,
             shell_integration_output: "normal".to_string(),
             if_missing: None,
@@ -298,7 +305,7 @@ mod tests {
             Some(std::path::PathBuf::from("/env/key.txt"))
         );
         // Default profile should remain
-        assert_eq!(merged.profile, "default");
+        assert_eq!(merged.profile, vec!["default".to_string()]);
     }
 
     #[test]

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -1728,6 +1728,23 @@
         "global": true
       },
       {
+        "name": "write-profile",
+        "usage": "--write-profile <WRITE_PROFILE>",
+        "help": "Target profile for write commands (set, remove, import, sync, provider add/remove). Required when multiple profiles are active; defaults to the single active profile otherwise",
+        "help_first_line": "Target profile for write commands (set, remove, import, sync, provider add/remove). Required when multiple profiles are active; defaults to the single active profile otherwise",
+        "short": [],
+        "long": ["write-profile"],
+        "hide": false,
+        "global": true,
+        "arg": {
+          "name": "WRITE_PROFILE",
+          "usage": "<WRITE_PROFILE>",
+          "required": true,
+          "double_dash": "Optional",
+          "hide": false
+        }
+      },
+      {
         "name": "non-interactive",
         "usage": "--non-interactive",
         "help": "Disable prompts and browser-based auth flows; use cached/non-interactive auth only (env: FNOX_NON_INTERACTIVE)",

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -1728,6 +1728,16 @@
         "global": true
       },
       {
+        "name": "non-interactive",
+        "usage": "--non-interactive",
+        "help": "Disable prompts and browser-based auth flows; use cached/non-interactive auth only (env: FNOX_NON_INTERACTIVE)",
+        "help_first_line": "Disable prompts and browser-based auth flows; use cached/non-interactive auth only (env: FNOX_NON_INTERACTIVE)",
+        "short": [],
+        "long": ["non-interactive"],
+        "hide": false,
+        "global": true
+      },
+      {
         "name": "write-profile",
         "usage": "--write-profile <WRITE_PROFILE>",
         "help": "Target profile for write commands (set, remove, import, sync, provider add/remove). Required when multiple profiles are active; defaults to the single active profile otherwise",
@@ -1743,16 +1753,6 @@
           "double_dash": "Optional",
           "hide": false
         }
-      },
-      {
-        "name": "non-interactive",
-        "usage": "--non-interactive",
-        "help": "Disable prompts and browser-based auth flows; use cached/non-interactive auth only (env: FNOX_NON_INTERACTIVE)",
-        "help_first_line": "Disable prompts and browser-based auth flows; use cached/non-interactive auth only (env: FNOX_NON_INTERACTIVE)",
-        "short": [],
-        "long": ["non-interactive"],
-        "hide": false,
-        "global": true
       }
     ],
     "mounts": [],

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -1637,11 +1637,12 @@
       },
       {
         "name": "profile",
-        "usage": "-P --profile <PROFILE>",
-        "help": "Profile to use (default: default, or FNOX_PROFILE env var)",
-        "help_first_line": "Profile to use (default: default, or FNOX_PROFILE env var)",
+        "usage": "-P --profile… <PROFILE>",
+        "help": "Profile to use (default: default, or FNOX_PROFILE env var). Supports multiple profiles separated by commas or repeated flags; later profiles overlay earlier ones",
+        "help_first_line": "Profile to use (default: default, or FNOX_PROFILE env var). Supports multiple profiles separated by commas or repeated flags; later profiles overlay earlier ones",
         "short": ["P"],
         "long": ["profile"],
+        "var": true,
         "hide": false,
         "global": true,
         "arg": {

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -40,13 +40,13 @@ Disable daemon-backed resolution for this invocation
 
 Do not merge top-level secrets into the selected profile
 
-### `--write-profile <WRITE_PROFILE>`
-
-Target profile for write commands (set, remove, import, sync, provider add/remove). Required when multiple profiles are active; defaults to the single active profile otherwise
-
 ### `--non-interactive`
 
 Disable prompts and browser-based auth flows; use cached/non-interactive auth only (env: FNOX_NON_INTERACTIVE)
+
+### `--write-profile <WRITE_PROFILE>`
+
+Target profile for write commands (set, remove, import, sync, provider add/remove). Required when multiple profiles are active; defaults to the single active profile otherwise
 
 ## Subcommands
 

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -16,11 +16,9 @@ Path to the configuration file (default: fnox.toml, searches parent directories)
 
 **Default:** `fnox.toml`
 
-### `-P --profile <PROFILE>`
+### `-P --profile… <PROFILE>`
 
-Profile to use (default: default, or FNOX_PROFILE env var). Supports
-multiple profiles as an ordered overlay: repeat the flag or use
-comma-separated values. Later profiles override earlier ones.
+Profile to use (default: default, or FNOX_PROFILE env var). Supports multiple profiles separated by commas or repeated flags; later profiles overlay earlier ones
 
 ### `-v --verbose`
 

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -42,7 +42,7 @@ Do not merge top-level secrets into the selected profile
 
 ### `--write-profile <WRITE_PROFILE>`
 
-Target profile for write commands (set, remove, import, sync, provider add/remove). Required when multiple profiles are active; defaults to the single active profile otherwise.
+Target profile for write commands (set, remove, import, sync, provider add/remove). Required when multiple profiles are active; defaults to the single active profile otherwise
 
 ### `--non-interactive`
 

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -40,6 +40,10 @@ Disable daemon-backed resolution for this invocation
 
 Do not merge top-level secrets into the selected profile
 
+### `--write-profile <WRITE_PROFILE>`
+
+Target profile for write commands (set, remove, import, sync, provider add/remove). Required when multiple profiles are active; defaults to the single active profile otherwise.
+
 ### `--non-interactive`
 
 Disable prompts and browser-based auth flows; use cached/non-interactive auth only (env: FNOX_NON_INTERACTIVE)

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -18,7 +18,9 @@ Path to the configuration file (default: fnox.toml, searches parent directories)
 
 ### `-P --profile <PROFILE>`
 
-Profile to use (default: default, or FNOX_PROFILE env var)
+Profile to use (default: default, or FNOX_PROFILE env var). Supports
+multiple profiles as an ordered overlay: repeat the flag or use
+comma-separated values. Later profiles override earlier ones.
 
 ### `-v --verbose`
 

--- a/docs/guide/profiles.md
+++ b/docs/guide/profiles.md
@@ -61,6 +61,90 @@ export FNOX_PROFILE=staging
 # fnox detects the change on the next prompt automatically
 ```
 
+## Composing Multiple Profiles
+
+You can activate multiple profiles at the same time as an ordered overlay
+stack. Later profiles override earlier ones on key conflicts, with the
+top-level config as the base.
+
+### Via Command Line
+
+```bash
+# Repeatable flags
+fnox -P aws -P prod exec -- ./app
+
+# Comma-separated
+fnox -P aws,prod exec -- ./app
+```
+
+### Via Environment Variable
+
+```bash
+export FNOX_PROFILE=aws,prod
+fnox exec -- ./app
+```
+
+### How Overlay Works
+
+The effective configuration is built as:
+
+```
+top-level config
++ profiles.aws
++ profiles.prod
+```
+
+Each layer contributes its own providers, secrets, leases, and
+`default_provider`. When a key exists in multiple layers, the **last**
+profile wins.
+
+```toml
+# Top-level base
+[providers.base]
+type = "plain"
+
+[secrets]
+SHARED = { default = "base-value" }
+BASE_ONLY = { default = "base-only" }
+
+# aws profile: adds a provider, overrides SHARED
+[profiles.aws.providers.aws_plain]
+type = "plain"
+
+[profiles.aws.secrets]
+SHARED = { default = "aws-value" }
+AWS_ONLY = { default = "aws-only" }
+
+# prod profile: overrides SHARED again, adds prod-only secret
+[profiles.prod.secrets]
+SHARED = { default = "prod-value" }
+PROD_ONLY = { default = "prod-only" }
+```
+
+With `fnox -P aws -P prod get SHARED`, the resolved value is `prod-value`
+(the last profile wins). `AWS_ONLY` and `PROD_ONLY` are both visible, and
+`BASE_ONLY` is inherited from the top level.
+
+### Where Writes Go
+
+When multiple profiles are active, write commands (`set`, `remove`,
+`import`, `sync`, `provider add`) target the **last** active profile by
+default. For example:
+
+```bash
+# Writes to fnox.prod.toml (or [profiles.prod] section)
+fnox -P aws -P prod set NEW_SECRET "value"
+```
+
+### When to Use Composition
+
+Composition is useful when concerns are split across profiles:
+
+- `aws` provides cloud provider configuration
+- `prod` provides production secret mappings
+- `ci` adds CI-only secrets
+- `local` overrides a few values for local development
+
 ## Profile Inheritance
 
 Profiles automatically inherit secrets from the top level:

--- a/docs/guide/profiles.md
+++ b/docs/guide/profiles.md
@@ -67,74 +67,17 @@ You can activate multiple profiles at the same time as an ordered overlay
 stack. Later profiles override earlier ones on key conflicts, with the
 top-level config as the base.
 
-### Via Command Line
-
 ```bash
-# Repeatable flags
+# Repeatable flags or comma-separated
 fnox -P aws -P prod exec -- ./app
-
-# Comma-separated
 fnox -P aws,prod exec -- ./app
-```
 
-### Via Environment Variable
-
-```bash
+# Via environment variable
 export FNOX_PROFILE=aws,prod
-fnox exec -- ./app
 ```
 
-### How Overlay Works
-
-The effective configuration is built as:
-
-```
-top-level config
-+ profiles.aws
-+ profiles.prod
-```
-
-Each layer contributes its own providers, secrets, leases, and
-`default_provider`. When a key exists in multiple layers, the **last**
-profile wins.
-
-```toml
-# Top-level base
-[providers.base]
-type = "plain"
-
-[secrets]
-SHARED = { default = "base-value" }
-BASE_ONLY = { default = "base-only" }
-
-# aws profile: adds a provider, overrides SHARED
-[profiles.aws.providers.aws_plain]
-type = "plain"
-
-[profiles.aws.secrets]
-SHARED = { default = "aws-value" }
-AWS_ONLY = { default = "aws-only" }
-
-# prod profile: overrides SHARED again, adds prod-only secret
-[profiles.prod.secrets]
-SHARED = { default = "prod-value" }
-PROD_ONLY = { default = "prod-only" }
-```
-
-With `fnox -P aws -P prod get SHARED`, the resolved value is `prod-value`
-(the last profile wins). `AWS_ONLY` and `PROD_ONLY` are both visible, and
-`BASE_ONLY` is inherited from the top level.
-
-### Where Writes Go
-
-When multiple profiles are active, write commands (`set`, `remove`,
-`import`, `sync`, `provider add`) target the **last** active profile by
-default. For example:
-
-```bash
-# Writes to fnox.prod.toml (or [profiles.prod] section)
-fnox -P aws -P prod set NEW_SECRET "value"
-```
+When multiple profiles are active, write commands target the last active
+profile by default.
 
 ### When to Use Composition
 

--- a/docs/guide/profiles.md
+++ b/docs/guide/profiles.md
@@ -76,8 +76,17 @@ fnox -P aws,prod exec -- ./app
 export FNOX_PROFILE=aws,prod
 ```
 
-When multiple profiles are active, write commands target the last active
-profile by default.
+When multiple profiles are active, write commands (`set`, `remove`,
+`import`, `sync`, `provider add/remove`) require an explicit
+`--write-profile <NAME>` to choose the write target:
+
+```bash
+# Reads from aws + prod overlay, writes to prod
+fnox -P aws -P prod --write-profile prod set DATABASE_URL "value"
+```
+
+With a single active profile, the write target defaults to that profile
+and `--write-profile` is not needed.
 
 ### When to Use Composition
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -529,7 +529,9 @@ fnox.local.toml
 
 ## Profile-Specific Config Files
 
-You can create environment-specific config files that load based on the `FNOX_PROFILE` environment variable:
+You can create environment-specific config files that load based on the active
+profile(s). When multiple profiles are active, each profile's config file is
+loaded in order:
 
 ```bash
 # Directory structure
@@ -552,14 +554,18 @@ FNOX_PROFILE=production fnox exec -- ./deploy.sh
 
 # Use staging config (fnox.toml + fnox.staging.toml)
 FNOX_PROFILE=staging fnox exec -- ./deploy.sh
+
+# Compose multiple profiles (fnox.toml + fnox.aws.toml + fnox.prod.toml)
+FNOX_PROFILE=aws,prod fnox exec -- ./app
 ```
 
 **Key differences:**
 
-- `fnox.$FNOX_PROFILE.toml` files are **committed to git** (environment-specific, but shared with team)
+- `fnox.<profile>.toml` files are **committed to git** (environment-specific, but shared with team)
 - `fnox.local.toml` is **gitignored** (machine-specific, personal overrides)
 - Profile-specific files work with the default profile's secrets, not `[profiles.xxx]` sections
 - `fnox.default.toml` is **not loaded** (use `fnox.toml` instead)
+- With multiple active profiles, config files are loaded in profile order (later profiles override earlier)
 
 ## Hierarchical Configuration
 
@@ -577,10 +583,10 @@ Merge order (lowest to highest priority):
 
 1. **Global config** (`~/.config/fnox/config.toml`)
 2. Root `fnox.toml`
-3. Root `fnox.$FNOX_PROFILE.toml` (if `FNOX_PROFILE` is set and not "default")
+3. Root `fnox.<profile>.toml` for each active profile (in profile order)
 4. Root `fnox.local.toml`
 5. Child `fnox.toml`
-6. Child `fnox.$FNOX_PROFILE.toml` (if `FNOX_PROFILE` is set and not "default")
+6. Child `fnox.<profile>.toml` for each active profile (in profile order)
 7. Child `fnox.local.toml`
 
 **Note**: Global config is always loaded, even when `root = true` stops parent directory recursion.

--- a/docs/reference/environment.md
+++ b/docs/reference/environment.md
@@ -6,10 +6,15 @@ fnox uses environment variables for configuration and runtime behavior.
 
 ### `FNOX_PROFILE`
 
-Active profile name.
+Active profile name. Supports multiple profiles as a comma-separated
+list for ordered overlay composition.
 
 ```bash
+# Single profile
 export FNOX_PROFILE=production
+
+# Multiple profiles (later ones override earlier ones)
+export FNOX_PROFILE=aws,prod
 ```
 
 **Default:** `default`
@@ -21,6 +26,10 @@ export FNOX_PROFILE=production
 export FNOX_PROFILE=production
 fnox get DATABASE_URL
 fnox exec -- ./deploy.sh
+
+# Compose aws + prod profiles
+export FNOX_PROFILE=aws,prod
+fnox exec -- ./app
 ```
 
 ### `FNOX_NO_DEFAULTS`

--- a/fnox.usage.kdl
+++ b/fnox.usage.kdl
@@ -7,7 +7,7 @@ usage "Usage: fnox [OPTIONS] <COMMAND>"
 flag "-c --config" help="Path to the configuration file (default: fnox.toml, searches parent directories)" global=#true default=fnox.toml {
     arg <CONFIG>
 }
-flag "-P --profile" help="Profile to use (default: default, or FNOX_PROFILE env var)" global=#true {
+flag "-P --profile" help="Profile to use (default: default, or FNOX_PROFILE env var). Supports multiple profiles separated by commas or repeated flags; later profiles overlay earlier ones" var=#true global=#true {
     arg <PROFILE>
 }
 flag "-v --verbose" help="Enable verbose logging" global=#true

--- a/fnox.usage.kdl
+++ b/fnox.usage.kdl
@@ -20,6 +20,9 @@ flag --if-missing help="What to do if a secret is missing (error, warn, ignore)"
 flag --no-color help="Disable colored output" global=#true
 flag --no-daemon help="Disable daemon-backed resolution for this invocation" global=#true
 flag --no-defaults help="Do not merge top-level secrets into the selected profile" global=#true
+flag --write-profile help="Target profile for write commands (set, remove, import, sync, provider add/remove). Required when multiple profiles are active; defaults to the single active profile otherwise" global=#true {
+    arg <WRITE_PROFILE>
+}
 flag --non-interactive help="Disable prompts and browser-based auth flows; use cached/non-interactive auth only (env: FNOX_NON_INTERACTIVE)" global=#true
 cmd activate help="Output shell activation code to enable automatic secret loading" {
     flag --no-hook-env help="Don't automatically invoke hook-env (for testing)"

--- a/fnox.usage.kdl
+++ b/fnox.usage.kdl
@@ -20,10 +20,10 @@ flag --if-missing help="What to do if a secret is missing (error, warn, ignore)"
 flag --no-color help="Disable colored output" global=#true
 flag --no-daemon help="Disable daemon-backed resolution for this invocation" global=#true
 flag --no-defaults help="Do not merge top-level secrets into the selected profile" global=#true
+flag --non-interactive help="Disable prompts and browser-based auth flows; use cached/non-interactive auth only (env: FNOX_NON_INTERACTIVE)" global=#true
 flag --write-profile help="Target profile for write commands (set, remove, import, sync, provider add/remove). Required when multiple profiles are active; defaults to the single active profile otherwise" global=#true {
     arg <WRITE_PROFILE>
 }
-flag --non-interactive help="Disable prompts and browser-based auth flows; use cached/non-interactive auth only (env: FNOX_NON_INTERACTIVE)" global=#true
 cmd activate help="Output shell activation code to enable automatic secret loading" {
     flag --no-hook-env help="Don't automatically invoke hook-env (for testing)"
     arg "[SHELL]" help="Shell to generate activation code for (bash, zsh, fish, nu, pwsh)" required=#false

--- a/src/commands/check.rs
+++ b/src/commands/check.rs
@@ -16,10 +16,11 @@ pub struct CheckCommand {
 impl CheckCommand {
     pub async fn run(&self, cli: &Cli, config: Config) -> Result<()> {
         config.validate()?;
-        let profile = Config::get_profile(cli.profile.as_deref());
+        let profile = Config::get_profiles(cli.profile.as_slice());
+        let profile_display = Config::display_profiles(&profile);
 
         // Load config
-        println!("Checking configuration for profile: {}", profile);
+        println!("Checking configuration for profile(s): {}", profile_display);
 
         let mut issues = Vec::new();
         let mut warnings = Vec::new();
@@ -27,9 +28,9 @@ impl CheckCommand {
         // Check secrets
         if let Ok(secrets) = config.get_secrets(&profile) {
             if secrets.is_empty() {
-                warnings.push("No secrets defined in profile".to_string());
+                warnings.push("No secrets defined in profile(s)".to_string());
             } else {
-                println!("Found {} secret(s) in profile", secrets.len());
+                println!("Found {} secret(s) in profile(s)", secrets.len());
 
                 for (name, secret_config) in secrets {
                     // Check if secret has a value source
@@ -136,7 +137,7 @@ impl CheckCommand {
                 }
             }
         } else {
-            issues.push(format!("Profile '{}' not found", profile));
+            issues.push(format!("Profile(s) '{}' not found", profile_display));
         }
 
         // Check providers

--- a/src/commands/ci_redact.rs
+++ b/src/commands/ci_redact.rs
@@ -10,8 +10,11 @@ pub struct CiRedactCommand {}
 
 impl CiRedactCommand {
     pub async fn run(&self, cli: &Cli, config: Config) -> Result<()> {
-        let profile = Config::get_profile(cli.profile.as_deref());
-        tracing::debug!("Redacting secrets from profile '{}'", profile);
+        let profile = Config::get_profiles(cli.profile.as_slice());
+        tracing::debug!(
+            "Redacting secrets from profile '{}'",
+            Config::display_profiles(&profile)
+        );
 
         // Check if we're in CI and get the vendor
         let ci_info = ci_info::get();

--- a/src/commands/config_files.rs
+++ b/src/commands/config_files.rs
@@ -19,8 +19,8 @@ pub struct ConfigFilesCommand;
 
 impl ConfigFilesCommand {
     pub async fn run(&self, _cli: &Cli) -> Result<()> {
-        let profile = crate::settings::Settings::get().profile.clone();
-        let filenames = all_config_filenames(Some(&profile));
+        let profile = Config::get_profiles(&[]);
+        let filenames = all_config_filenames(&profile);
 
         let current_dir = env::current_dir().map_err(|e| {
             crate::error::FnoxError::Config(format!("Failed to get current directory: {}", e))

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -11,7 +11,8 @@ pub struct DoctorCommand {}
 
 impl DoctorCommand {
     pub async fn run(&self, cli: &Cli, config: Config) -> Result<()> {
-        let profile = Config::get_profile(cli.profile.as_deref());
+        let profile = Config::get_profiles(cli.profile.as_slice());
+        let profile_display = Config::display_profiles(&profile);
 
         println!("🏥 Fnox Doctor Report");
         println!("====================");
@@ -20,7 +21,7 @@ impl DoctorCommand {
         // Config file info
         println!("📄 Configuration:");
         println!("  File: fnox.toml");
-        println!("  Profile: {}", profile);
+        println!("  Profile: {}", profile_display);
 
         config.validate()?;
         println!("  Status: ✓ Loaded successfully");
@@ -83,8 +84,11 @@ impl DoctorCommand {
 
         // Environment info
         println!("🌍 Environment:");
-        if let Some(env_profile) = (*env::FNOX_PROFILE).clone() {
-            println!("  FNOX_PROFILE: {}", env_profile);
+        if !env::FNOX_PROFILE.is_empty() {
+            println!(
+                "  FNOX_PROFILE: {}",
+                Config::display_profiles(&env::FNOX_PROFILE)
+            );
         } else {
             println!("  FNOX_PROFILE: (not set)");
         }

--- a/src/commands/edit.rs
+++ b/src/commands/edit.rs
@@ -212,7 +212,8 @@ impl EditCommand {
                 let providers = config.get_providers(&profile_stack);
                 if let Some(provider_config) = providers.get(prov_name) {
                     let provider =
-                        get_provider_resolved(config, &profile_stack, prov_name, provider_config).await?;
+                        get_provider_resolved(config, &profile_stack, prov_name, provider_config)
+                            .await?;
                     let capabilities = provider.capabilities();
                     let is_read_only = capabilities.contains(&ProviderCapability::RemoteRead)
                         && !capabilities.contains(&ProviderCapability::Encryption)

--- a/src/commands/edit.rs
+++ b/src/commands/edit.rs
@@ -47,8 +47,11 @@ struct SecretEntry {
 
 impl EditCommand {
     pub async fn run(&self, cli: &Cli, config: Config) -> Result<()> {
-        let profile = Config::get_profile(cli.profile.as_deref());
-        tracing::debug!("Starting enhanced edit with profile: {}", profile);
+        let profile = Config::get_profiles(cli.profile.as_slice());
+        tracing::debug!(
+            "Starting enhanced edit with profile: {}",
+            Config::display_profiles(&profile)
+        );
 
         // Step 1: Load raw TOML with toml_edit to preserve formatting
         let toml_content =
@@ -99,8 +102,9 @@ impl EditCommand {
         let mut resolved_by_profile: IndexMap<String, IndexMap<String, Option<String>>> =
             IndexMap::new();
         for (profile_name, secrets) in secrets_by_profile {
+            let profile_stack = vec![profile_name.clone()];
             let resolved =
-                secret_resolver::resolve_secrets_batch(&config, &profile_name, &secrets).await?;
+                secret_resolver::resolve_secrets_batch(&config, &profile_stack, &secrets).await?;
             resolved_by_profile.insert(profile_name, resolved);
         }
 
@@ -194,20 +198,21 @@ impl EditCommand {
         secrets: &IndexMap<String, SecretConfig>,
         all_secrets: &mut Vec<SecretEntry>,
     ) -> Result<()> {
+        let profile_stack = vec![profile.to_string()];
         for (key, secret_config) in secrets {
             // Determine provider and check if read-only
             let provider_name = if let Some(prov) = secret_config.provider() {
                 Some(prov.to_string())
             } else {
-                config.get_default_provider(profile)?
+                config.get_default_provider(&profile_stack)?
             };
 
             let (is_read_only, resolved_provider_name) = if let Some(ref prov_name) = provider_name
             {
-                let providers = config.get_providers(profile);
+                let providers = config.get_providers(&profile_stack);
                 if let Some(provider_config) = providers.get(prov_name) {
                     let provider =
-                        get_provider_resolved(config, profile, prov_name, provider_config).await?;
+                        get_provider_resolved(config, &profile_stack, prov_name, provider_config).await?;
                     let capabilities = provider.capabilities();
                     let is_read_only = capabilities.contains(&ProviderCapability::RemoteRead)
                         && !capabilities.contains(&ProviderCapability::Encryption)
@@ -397,6 +402,7 @@ impl EditCommand {
         secret_profile: &str,
         secrets_map: &HashMap<(String, String), &SecretEntry>,
     ) -> Result<()> {
+        let profile_stack = vec![secret_profile.to_string()];
         // Collect keys first to avoid borrow issues when mutating
         let keys: Vec<_> = secrets_table.iter().map(|(k, _)| k.to_string()).collect();
 
@@ -469,14 +475,14 @@ impl EditCommand {
                 let provider_to_use = if let Some(ref prov) = explicit_provider {
                     Some(prov.clone())
                 } else {
-                    config.get_default_provider(secret_profile)?
+                    config.get_default_provider(&profile_stack)?
                 };
                 let encrypted_value = if let Some(provider_name) = provider_to_use {
-                    let providers = config.get_providers(secret_profile);
+                    let providers = config.get_providers(&profile_stack);
                     if let Some(provider_config) = providers.get(&provider_name) {
                         let provider = get_provider_resolved(
                             config,
-                            secret_profile,
+                            &profile_stack,
                             &provider_name,
                             provider_config,
                         )
@@ -497,7 +503,7 @@ impl EditCommand {
                 // Determine provider to use (from this secret's profile)
                 let provider_name = if let Some(prov) = explicit_provider {
                     prov
-                } else if let Some(default_prov) = config.get_default_provider(secret_profile)? {
+                } else if let Some(default_prov) = config.get_default_provider(&profile_stack)? {
                     default_prov
                 } else {
                     // No provider - keep as plaintext
@@ -509,7 +515,7 @@ impl EditCommand {
                 };
 
                 // Encrypt with the provider from this secret's profile
-                let providers = config.get_providers(secret_profile);
+                let providers = config.get_providers(&profile_stack);
                 let Some(provider_config) = providers.get(&provider_name) else {
                     return Err(FnoxError::Config(format!(
                         "Provider '{}' not found for new secret '{}'",
@@ -518,7 +524,7 @@ impl EditCommand {
                 };
 
                 let provider =
-                    get_provider_resolved(config, secret_profile, &provider_name, provider_config)
+                    get_provider_resolved(config, &profile_stack, &provider_name, provider_config)
                         .await?;
                 let encrypted_value = provider.put_secret(&key_str, plaintext).await?;
 

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -21,8 +21,11 @@ impl ExecCommand {
             return Err(FnoxError::CommandNotSpecified);
         }
 
-        let profile = Config::get_profile(cli.profile.as_deref());
-        tracing::debug!("Running command with secrets from profile '{}'", profile);
+        let profile = Config::get_profiles(cli.profile.as_slice());
+        tracing::debug!(
+            "Running command with secrets from profiles '{}'",
+            Config::display_profiles(&profile)
+        );
 
         // Get the profile secrets
         let profile_secrets = config.get_secrets(&profile)?;

--- a/src/commands/export.rs
+++ b/src/commands/export.rs
@@ -66,8 +66,11 @@ struct ExportMetadata {
 
 impl ExportCommand {
     pub async fn run(&self, cli: &Cli, config: Config) -> Result<()> {
-        let profile = Config::get_profile(cli.profile.as_deref());
-        tracing::debug!("Exporting secrets from profile '{}'", profile);
+        let profile = Config::get_profiles(cli.profile.as_slice());
+        tracing::debug!(
+            "Exporting secrets from profiles '{}'",
+            Config::display_profiles(&profile)
+        );
 
         let mut profile_secrets = config.get_secrets(&profile)?;
 
@@ -123,7 +126,7 @@ impl ExportCommand {
         }
 
         let metadata = Some(ExportMetadata {
-            profile: profile.clone(),
+            profile: Config::display_profiles(&profile),
             exported_at: chrono::Utc::now().to_rfc3339(),
             total_secrets: secrets.len(),
         });

--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -19,8 +19,12 @@ pub struct GetCommand {
 
 impl GetCommand {
     pub async fn run(&self, cli: &Cli, config: Config) -> Result<()> {
-        let profile = Config::get_profile(cli.profile.as_deref());
-        tracing::debug!("Getting secret '{}' from profile '{}'", self.key, profile);
+        let profile = Config::get_profiles(cli.profile.as_slice());
+        tracing::debug!(
+            "Getting secret '{}' from profiles '{}'",
+            self.key,
+            Config::display_profiles(&profile)
+        );
 
         // Validate the configuration first
         config.validate()?;
@@ -54,7 +58,7 @@ impl GetCommand {
 
             FnoxError::SecretNotFound {
                 key: self.key.clone(),
-                profile: profile.clone(),
+                profile: Config::display_profiles(&profile),
                 config_path: config.secret_sources.get(&self.key).cloned(),
                 suggestion,
             }
@@ -115,7 +119,7 @@ impl GetCommand {
         &self,
         cli: &Cli,
         config: &Config,
-        profile: &str,
+        profile: &[String],
     ) -> Result<Option<(String, IndexMap<String, SecretConfig>)>> {
         let leases = config.get_leases(profile);
 

--- a/src/commands/hook_env.rs
+++ b/src/commands/hook_env.rs
@@ -183,7 +183,8 @@ async fn load_secrets_from_config(cli: &Cli) -> Result<LoadedSecrets> {
     // This handles fnox.toml and fnox.local.toml with proper recursion
     let settings =
         Settings::try_get().map_err(|e| anyhow::anyhow!("Failed to get settings: {}", e))?;
-    let filenames = crate::config::all_config_filenames(Some(&settings.profile));
+    let profiles = Config::get_profiles(&[]);
+    let filenames = crate::config::all_config_filenames(&profiles);
     let mut last_error = None;
     let mut config = None;
     for filename in &filenames {

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -65,7 +65,7 @@ pub struct ImportCommand {
 impl ImportCommand {
     pub async fn run(&self, cli: &Cli, merged_config: Config) -> Result<()> {
         let profile = Config::get_profiles(cli.profile.as_slice());
-        let write_profile = Config::write_profile(&profile);
+        let write_profile = Config::resolve_write_profile(&profile, cli.write_profile.as_deref())?;
         tracing::debug!(
             "Importing secrets in {} format into profile '{}'",
             self.format,
@@ -151,7 +151,7 @@ impl ImportCommand {
         // (provider and capability validation above ensures dry-run fails on invalid provider)
         if self.dry_run {
             let dry_run_label = console::style("[dry-run]").yellow().bold();
-            let styled_profile = console::style(write_profile).magenta();
+            let styled_profile = console::style(&write_profile).magenta();
             let styled_provider = console::style(&self.provider).green();
             let global_suffix = if self.global { " (global)" } else { "" };
 
@@ -246,7 +246,7 @@ impl ImportCommand {
         }
 
         // Save secrets directly to the TOML document, preserving comments
-        Config::save_secrets_to_source(&import_secrets, write_profile, &target_path)?;
+        Config::save_secrets_to_source(&import_secrets, &write_profile, &target_path)?;
 
         let global_suffix = if self.global { " (global)" } else { "" };
         println!(

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -64,11 +64,12 @@ pub struct ImportCommand {
 
 impl ImportCommand {
     pub async fn run(&self, cli: &Cli, merged_config: Config) -> Result<()> {
-        let profile = Config::get_profile(cli.profile.as_deref());
+        let profile = Config::get_profiles(cli.profile.as_slice());
+        let write_profile = Config::write_profile(&profile);
         tracing::debug!(
             "Importing secrets in {} format into profile '{}'",
             self.format,
-            profile
+            write_profile
         );
 
         let input = self.read_input()?;
@@ -112,7 +113,7 @@ impl ImportCommand {
                 .get(&self.provider)
                 .ok_or_else(|| FnoxError::ProviderNotConfigured {
                     provider: self.provider.clone(),
-                    profile: profile.to_string(),
+                    profile: Config::display_profiles(&profile),
                     config_path: None,
                     suggestion: None,
                 })?;
@@ -150,7 +151,7 @@ impl ImportCommand {
         // (provider and capability validation above ensures dry-run fails on invalid provider)
         if self.dry_run {
             let dry_run_label = console::style("[dry-run]").yellow().bold();
-            let styled_profile = console::style(&profile).magenta();
+            let styled_profile = console::style(write_profile).magenta();
             let styled_provider = console::style(&self.provider).green();
             let global_suffix = if self.global { " (global)" } else { "" };
 
@@ -169,7 +170,7 @@ impl ImportCommand {
             println!(
                 "\nReady to import {} secrets into profile '{}':",
                 secrets.len(),
-                profile
+                write_profile
             );
             for key in secrets.keys().take(10) {
                 println!("  {}", key);
@@ -245,12 +246,12 @@ impl ImportCommand {
         }
 
         // Save secrets directly to the TOML document, preserving comments
-        Config::save_secrets_to_source(&import_secrets, &profile, &target_path)?;
+        Config::save_secrets_to_source(&import_secrets, write_profile, &target_path)?;
 
         let global_suffix = if self.global { " (global)" } else { "" };
         println!(
             "✓ Imported {} secrets into profile '{}' using provider '{}'{}",
-            total_secrets, profile, self.provider, global_suffix
+            total_secrets, write_profile, self.provider, global_suffix
         );
 
         Ok(())

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -1,5 +1,5 @@
 use crate::commands::Cli;
-use crate::config::Config;
+use crate::config::{self, Config};
 use crate::error::{FnoxError, Result};
 use clap::{Args, ValueEnum};
 use console;
@@ -203,7 +203,16 @@ impl ImportCommand {
             }
             global_path
         } else {
-            cli.config.clone()
+            // Match set.rs: use find_local_config when --config is the default,
+            // so profile-specific files (fnox.<profile>.toml) are found.
+            if cli.config == std::path::Path::new(config::DEFAULT_CONFIG_FILENAME) {
+                let current_dir = std::env::current_dir().map_err(|e| {
+                    FnoxError::Config(format!("Failed to get current directory: {}", e))
+                })?;
+                config::find_local_config(&current_dir, std::slice::from_ref(&write_profile))
+            } else {
+                cli.config.clone()
+            }
         };
 
         // Load existing target config to preserve metadata on re-import

--- a/src/commands/lease.rs
+++ b/src/commands/lease.rs
@@ -104,7 +104,7 @@ impl LeaseCommand {
 
 impl LeaseCreateCommand {
     pub async fn run(&self, cli: &Cli, config: Config) -> Result<()> {
-        let profile = Config::get_profile(cli.profile.as_deref());
+        let profile = Config::get_profiles(cli.profile.as_slice());
         let project_dir = lease::project_dir_from_config(&config, &cli.config);
         let leases = config.get_leases(&profile);
 
@@ -161,7 +161,7 @@ impl LeaseCreateCommand {
         &self,
         _cli: &Cli,
         config: &Config,
-        profile: &str,
+        profile: &[String],
         project_dir: &std::path::Path,
         leases: &IndexMap<String, crate::lease_backends::LeaseBackendConfig>,
         resolved_secrets: &indexmap::IndexMap<String, Option<String>>,
@@ -213,7 +213,7 @@ impl LeaseCreateCommand {
         backend_name: &str,
         backend_config: &crate::lease_backends::LeaseBackendConfig,
         config: &Config,
-        profile: &str,
+        profile: &[String],
         project_dir: &std::path::Path,
         resolved_secrets: &indexmap::IndexMap<String, Option<String>>,
         temp_env_guard: &mut TempEnvGuard,
@@ -434,7 +434,7 @@ impl LeaseRevokeCommand {
         let backend_name = record.backend_name.clone();
         let cached_credentials = record.cached_credentials.clone();
         let encryption_provider_name = record.encryption_provider.clone();
-        let profile = Config::get_profile(cli.profile.as_deref());
+        let profile = Config::get_profiles(cli.profile.as_slice());
         let leases = config.get_leases(&profile);
 
         // Decrypt cached credentials (if encrypted) so backends can use
@@ -527,7 +527,7 @@ impl LeaseCleanupCommand {
             return Ok(());
         }
 
-        let profile = Config::get_profile(cli.profile.as_deref());
+        let profile = Config::get_profiles(cli.profile.as_slice());
         let leases = config.get_leases(&profile);
         let mut cleaned = 0;
 

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -87,15 +87,21 @@ struct SecretRowWithValuesAndSources {
 
 impl ListCommand {
     pub async fn run(&self, cli: &Cli, config: Config) -> Result<()> {
-        let profile = Config::get_profile(cli.profile.as_deref());
-        tracing::debug!("Listing secrets in profile '{}'", profile);
+        let profile = Config::get_profiles(cli.profile.as_slice());
+        tracing::debug!(
+            "Listing secrets in profiles '{}'",
+            Config::display_profiles(&profile)
+        );
 
         // Get the profile secrets
         let profile_secrets = config.get_secrets(&profile)?;
 
         if profile_secrets.is_empty() {
             if !self.complete {
-                println!("No secrets defined in profile '{}'", profile);
+                println!(
+                    "No secrets defined in profiles '{}'",
+                    Config::display_profiles(&profile)
+                );
             }
             return Ok(());
         }

--- a/src/commands/mcp.rs
+++ b/src/commands/mcp.rs
@@ -16,7 +16,7 @@ impl McpCommand {
         // corrupt the JSON-RPC stream on stdout.
         env::set_non_interactive(true);
 
-        let profile = Config::get_profile(cli.profile.as_deref());
+        let profile = Config::get_profiles(cli.profile.as_slice());
         let mcp_config = config.mcp.clone().unwrap_or_default();
 
         // Warn about allowlist entries that don't match any configured secret

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -46,9 +46,10 @@ pub struct Cli {
     #[arg(short, long, default_value = crate::config::DEFAULT_CONFIG_FILENAME, global = true)]
     pub config: PathBuf,
 
-    /// Profile to use (default: default, or FNOX_PROFILE env var)
-    #[arg(short = 'P', long, global = true)]
-    pub profile: Option<String>,
+    /// Profile to use (default: default, or FNOX_PROFILE env var). Supports multiple
+    /// profiles separated by commas or repeated flags; later profiles overlay earlier ones.
+    #[arg(short = 'P', long, action = clap::ArgAction::Append, global = true)]
+    pub profile: Vec<String>,
 
     /// Enable verbose logging
     #[arg(short, long, global = true)]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -75,14 +75,14 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub no_defaults: bool,
 
+    /// Disable prompts and browser-based auth flows; use cached/non-interactive auth only (env: FNOX_NON_INTERACTIVE)
+    #[arg(long, global = true, env = "FNOX_NON_INTERACTIVE")]
+    pub non_interactive: bool,
+
     /// Target profile for write commands (set, remove, import, sync, provider add/remove).
     /// Required when multiple profiles are active; defaults to the single active profile otherwise.
     #[arg(long, global = true)]
     pub write_profile: Option<String>,
-
-    /// Disable prompts and browser-based auth flows; use cached/non-interactive auth only (env: FNOX_NON_INTERACTIVE)
-    #[arg(long, global = true, env = "FNOX_NON_INTERACTIVE")]
-    pub non_interactive: bool,
 
     #[command(subcommand)]
     pub command: Commands,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -75,6 +75,11 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub no_defaults: bool,
 
+    /// Target profile for write commands (set, remove, import, sync, provider add/remove).
+    /// Required when multiple profiles are active; defaults to the single active profile otherwise.
+    #[arg(long, global = true)]
+    pub write_profile: Option<String>,
+
     /// Disable prompts and browser-based auth flows; use cached/non-interactive auth only (env: FNOX_NON_INTERACTIVE)
     #[arg(long, global = true, env = "FNOX_NON_INTERACTIVE")]
     pub non_interactive: bool,

--- a/src/commands/profiles.rs
+++ b/src/commands/profiles.rs
@@ -28,7 +28,7 @@ impl ProfilesCommand {
             println!("Available profiles:");
             for name in profile_names {
                 let secret_count = config
-                    .get_secrets(&[name.clone()])
+                    .get_secrets(std::slice::from_ref(&name))
                     .map(|s| s.len())
                     .unwrap_or(0);
                 println!("  {} ({} secrets)", name, secret_count);

--- a/src/commands/profiles.rs
+++ b/src/commands/profiles.rs
@@ -27,7 +27,10 @@ impl ProfilesCommand {
             // Normal output
             println!("Available profiles:");
             for name in profile_names {
-                let secret_count = config.get_secrets(&name).map(|s| s.len()).unwrap_or(0);
+                let secret_count = config
+                    .get_secrets(&[name.clone()])
+                    .map(|s| s.len())
+                    .unwrap_or(0);
                 println!("  {} ({} secrets)", name, secret_count);
             }
         }

--- a/src/commands/provider/add.rs
+++ b/src/commands/provider/add.rs
@@ -77,21 +77,24 @@ impl AddCommand {
             Config::new()
         };
 
-        let target_providers = if self.global || write_profile == "default" {
-            &mut config.providers
+        if self.global || write_profile == "default" {
+            if config.providers.contains_key(&self.provider) {
+                return Err(FnoxError::Config(format!(
+                    "Provider '{}' already exists",
+                    self.provider
+                )));
+            }
         } else {
-            &mut config
+            if config
                 .profiles
-                .entry(write_profile.to_string())
-                .or_default()
-                .providers
-        };
-
-        if target_providers.contains_key(&self.provider) {
-            return Err(FnoxError::Config(format!(
-                "Provider '{}' already exists",
-                self.provider
-            )));
+                .get(write_profile)
+                .is_some_and(|p| p.providers.contains_key(&self.provider))
+            {
+                return Err(FnoxError::Config(format!(
+                    "Provider '{}' already exists",
+                    self.provider
+                )));
+            }
         }
 
         // Create a template provider config based on type
@@ -287,7 +290,20 @@ impl AddCommand {
             },
         };
 
-        target_providers.insert(self.provider.clone(), provider_config);
+        // Insert into the appropriate section — after the match so no
+        // mutable borrow is held across the (potentially async) match.
+        if self.global || write_profile == "default" {
+            config
+                .providers
+                .insert(self.provider.clone(), provider_config);
+        } else {
+            config
+                .profiles
+                .entry(write_profile.to_string())
+                .or_default()
+                .providers
+                .insert(self.provider.clone(), provider_config);
+        }
         config.save(&target_path)?;
 
         let global_suffix = if self.global { " (global)" } else { "" };

--- a/src/commands/provider/add.rs
+++ b/src/commands/provider/add.rs
@@ -39,6 +39,12 @@ impl AddCommand {
             ));
         }
 
+        // Provider add only respects explicit CLI --profile flags, not
+        // FNOX_PROFILE env or Settings, so the default behavior (writing to
+        // top-level [providers]) stays unchanged unless the user opts in.
+        let profiles = Config::normalize_profiles(&cli.profile);
+        let write_profile = Config::write_profile(&profiles);
+
         // Determine the target config file
         let target_path = if self.global {
             let global_path = Config::global_config_path();
@@ -57,7 +63,11 @@ impl AddCommand {
             let current_dir = std::env::current_dir().map_err(|e| {
                 FnoxError::Config(format!("Failed to get current directory: {}", e))
             })?;
-            current_dir.join(&cli.config)
+            if cli.config == std::path::Path::new(crate::config::DEFAULT_CONFIG_FILENAME) {
+                crate::config::find_local_config(&current_dir, &profiles)
+            } else {
+                current_dir.join(&cli.config)
+            }
         };
 
         // Load the target config file (or create new if it doesn't exist)
@@ -67,7 +77,17 @@ impl AddCommand {
             Config::new()
         };
 
-        if config.providers.contains_key(&self.provider) {
+        let target_providers = if self.global || write_profile == "default" {
+            &mut config.providers
+        } else {
+            &mut config
+                .profiles
+                .entry(write_profile.to_string())
+                .or_default()
+                .providers
+        };
+
+        if target_providers.contains_key(&self.provider) {
             return Err(FnoxError::Config(format!(
                 "Provider '{}' already exists",
                 self.provider
@@ -267,9 +287,7 @@ impl AddCommand {
             },
         };
 
-        config
-            .providers
-            .insert(self.provider.clone(), provider_config);
+        target_providers.insert(self.provider.clone(), provider_config);
         config.save(&target_path)?;
 
         let global_suffix = if self.global { " (global)" } else { "" };

--- a/src/commands/provider/add.rs
+++ b/src/commands/provider/add.rs
@@ -43,7 +43,7 @@ impl AddCommand {
         // FNOX_PROFILE env or Settings, so the default behavior (writing to
         // top-level [providers]) stays unchanged unless the user opts in.
         let profiles = Config::normalize_profiles(&cli.profile);
-        let write_profile = Config::write_profile(&profiles);
+        let write_profile = Config::resolve_write_profile(&profiles, cli.write_profile.as_deref())?;
 
         // Determine the target config file
         let target_path = if self.global {
@@ -64,7 +64,7 @@ impl AddCommand {
                 FnoxError::Config(format!("Failed to get current directory: {}", e))
             })?;
             if cli.config == std::path::Path::new(crate::config::DEFAULT_CONFIG_FILENAME) {
-                crate::config::find_local_config(&current_dir, &profiles)
+                crate::config::find_local_config(&current_dir, std::slice::from_ref(&write_profile))
             } else {
                 current_dir.join(&cli.config)
             }
@@ -87,7 +87,7 @@ impl AddCommand {
         } else {
             if config
                 .profiles
-                .get(write_profile)
+                .get(&write_profile)
                 .is_some_and(|p| p.providers.contains_key(&self.provider))
             {
                 return Err(FnoxError::Config(format!(
@@ -299,7 +299,7 @@ impl AddCommand {
         } else {
             config
                 .profiles
-                .entry(write_profile.to_string())
+                .entry(write_profile.clone())
                 .or_default()
                 .providers
                 .insert(self.provider.clone(), provider_config);

--- a/src/commands/provider/list.rs
+++ b/src/commands/provider/list.rs
@@ -12,15 +12,17 @@ pub struct ListCommand {
 }
 
 impl ListCommand {
-    pub async fn run(&self, _cli: &Cli, config: Config) -> Result<()> {
+    pub async fn run(&self, cli: &Cli, config: Config) -> Result<()> {
         tracing::debug!("Listing providers");
+        let profiles = Config::get_profiles(cli.profile.as_slice());
+        let providers = config.get_providers(&profiles);
 
-        if config.providers.is_empty() {
+        if providers.is_empty() {
             return Ok(());
         }
 
         // Always just output provider names, one per line
-        let mut names: Vec<_> = config.providers.keys().collect();
+        let mut names: Vec<_> = providers.keys().collect();
         names.sort();
         for name in names {
             println!("{}", name);

--- a/src/commands/provider/remove.rs
+++ b/src/commands/provider/remove.rs
@@ -17,6 +17,10 @@ pub struct RemoveCommand {
 impl RemoveCommand {
     pub async fn run(&self, cli: &Cli) -> Result<()> {
         tracing::debug!("Removing provider '{}'", self.provider);
+        // Provider remove only respects explicit CLI --profile flags, matching
+        // provider add's behavior (see add.rs).
+        let profiles = Config::normalize_profiles(&cli.profile);
+        let write_profile = Config::write_profile(&profiles);
 
         // Determine the target config file
         let target_path = if self.global {
@@ -25,7 +29,11 @@ impl RemoveCommand {
             let current_dir = std::env::current_dir().map_err(|e| {
                 FnoxError::Config(format!("Failed to get current directory: {}", e))
             })?;
-            current_dir.join(&cli.config)
+            if cli.config == std::path::Path::new(crate::config::DEFAULT_CONFIG_FILENAME) {
+                crate::config::find_local_config(&current_dir, &profiles)
+            } else {
+                current_dir.join(&cli.config)
+            }
         };
 
         // Load the target config file directly
@@ -38,7 +46,17 @@ impl RemoveCommand {
 
         let mut config = Config::load(&target_path)?;
 
-        if config.providers.shift_remove(&self.provider).is_some() {
+        let removed = if self.global || write_profile == "default" {
+            config.providers.shift_remove(&self.provider).is_some()
+        } else {
+            config
+                .profiles
+                .get_mut(write_profile)
+                .and_then(|profile| profile.providers.shift_remove(&self.provider))
+                .is_some()
+        };
+
+        if removed {
             config.save(&target_path)?;
             let global_suffix = if self.global { " (global)" } else { "" };
             println!("✓ Removed provider '{}'{}", self.provider, global_suffix);

--- a/src/commands/provider/remove.rs
+++ b/src/commands/provider/remove.rs
@@ -20,7 +20,7 @@ impl RemoveCommand {
         // Provider remove only respects explicit CLI --profile flags, matching
         // provider add's behavior (see add.rs).
         let profiles = Config::normalize_profiles(&cli.profile);
-        let write_profile = Config::write_profile(&profiles);
+        let write_profile = Config::resolve_write_profile(&profiles, cli.write_profile.as_deref())?;
 
         // Determine the target config file
         let target_path = if self.global {
@@ -30,7 +30,7 @@ impl RemoveCommand {
                 FnoxError::Config(format!("Failed to get current directory: {}", e))
             })?;
             if cli.config == std::path::Path::new(crate::config::DEFAULT_CONFIG_FILENAME) {
-                crate::config::find_local_config(&current_dir, &profiles)
+                crate::config::find_local_config(&current_dir, std::slice::from_ref(&write_profile))
             } else {
                 current_dir.join(&cli.config)
             }
@@ -51,7 +51,7 @@ impl RemoveCommand {
         } else {
             config
                 .profiles
-                .get_mut(write_profile)
+                .get_mut(&write_profile)
                 .and_then(|profile| profile.providers.shift_remove(&self.provider))
                 .is_some()
         };

--- a/src/commands/provider/test.rs
+++ b/src/commands/provider/test.rs
@@ -61,7 +61,12 @@ impl TestCommand {
         Ok(())
     }
 
-    async fn test_all_providers(&self, cli: &Cli, config: &Config, profile: &[String]) -> Result<()> {
+    async fn test_all_providers(
+        &self,
+        cli: &Cli,
+        config: &Config,
+        profile: &[String],
+    ) -> Result<()> {
         let providers = config.get_providers(profile);
 
         if providers.is_empty() {

--- a/src/commands/provider/test.rs
+++ b/src/commands/provider/test.rs
@@ -16,7 +16,7 @@ pub struct TestCommand {
 
 impl TestCommand {
     pub async fn run(&self, cli: &Cli, config: Config) -> Result<()> {
-        let profile = Config::get_profile(cli.profile.as_deref());
+        let profile = Config::get_profiles(cli.profile.as_slice());
 
         if self.all {
             self.test_all_providers(cli, &config, &profile).await
@@ -33,13 +33,13 @@ impl TestCommand {
     async fn test_single_provider(
         &self,
         config: &Config,
-        profile: &str,
+        profile: &[String],
         provider_name: &str,
     ) -> Result<()> {
         tracing::debug!("Testing provider '{}'", provider_name);
 
-        let provider_config = config
-            .providers
+        let providers = config.get_providers(profile);
+        let provider_config = providers
             .get(provider_name)
             .ok_or_else(|| FnoxError::Config(format!("Provider '{}' not found", provider_name)))?;
 
@@ -61,7 +61,7 @@ impl TestCommand {
         Ok(())
     }
 
-    async fn test_all_providers(&self, cli: &Cli, config: &Config, profile: &str) -> Result<()> {
+    async fn test_all_providers(&self, cli: &Cli, config: &Config, profile: &[String]) -> Result<()> {
         let providers = config.get_providers(profile);
 
         if providers.is_empty() {

--- a/src/commands/reencrypt.rs
+++ b/src/commands/reencrypt.rs
@@ -40,8 +40,13 @@ pub struct ReencryptCommand {
 
 impl ReencryptCommand {
     pub async fn run(&self, cli: &Cli, merged_config: Config) -> Result<()> {
-        let profile = Config::get_profile(cli.profile.as_deref());
-        tracing::debug!("Re-encrypting secrets for profile '{}'", profile);
+        let profile = Config::get_profiles(cli.profile.as_slice());
+        tracing::debug!(
+            "Re-encrypting secrets for profiles '{}'",
+            Config::display_profiles(&profile)
+        );
+
+        let profile_display = Config::display_profiles(&profile);
 
         let providers = merged_config.get_providers(&profile);
         let all_secrets = merged_config.get_secrets(&profile)?;
@@ -143,7 +148,7 @@ impl ReencryptCommand {
             if !secrets_to_reencrypt.contains_key(key) {
                 return Err(FnoxError::SecretNotFound {
                     key: key.clone(),
-                    profile: profile.to_string(),
+                    profile: profile_display.clone(),
                     config_path: None,
                     suggestion: Some(format!(
                         "The key was not found, does not use an encryption provider, or was excluded by filters{}{}",
@@ -168,7 +173,7 @@ impl ReencryptCommand {
         // Dry-run mode
         if self.dry_run {
             let dry_run_label = console::style("[dry-run]").yellow().bold();
-            let styled_profile = console::style(&profile).magenta();
+            let styled_profile = console::style(&profile_display).magenta();
 
             println!(
                 "{dry_run_label} Would re-encrypt {} secrets in profile {styled_profile}:",
@@ -189,7 +194,7 @@ impl ReencryptCommand {
             println!(
                 "\nReady to re-encrypt {} secrets in profile '{}':",
                 secrets_to_reencrypt.len(),
-                profile
+                profile_display
             );
             for (key, (provider_name, _)) in secrets_to_reencrypt.iter().take(10) {
                 println!("  {} ({})", key, provider_name);
@@ -262,7 +267,7 @@ impl ReencryptCommand {
             let provider = provider_cache.get(provider_name.as_str()).ok_or_else(|| {
                 FnoxError::ProviderNotConfigured {
                     provider: provider_name.clone(),
-                    profile: profile.to_string(),
+                    profile: profile_display.clone(),
                     config_path: None,
                     suggestion: None,
                 }
@@ -282,14 +287,13 @@ impl ReencryptCommand {
                             ))
                         })?;
 
-                    // Use source_is_profile to determine the correct TOML section.
+                    // Use source_profile to determine the correct TOML section.
                     // Secrets loaded from root [secrets] must be saved back there,
                     // not to [profiles.X.secrets].
-                    let save_profile = if secret_config.source_is_profile {
-                        profile.clone()
-                    } else {
-                        "default".to_string()
-                    };
+                    let save_profile = secret_config
+                        .source_profile
+                        .clone()
+                        .unwrap_or_else(|| "default".to_string());
 
                     by_source
                         .entry((source_path, save_profile))

--- a/src/commands/remove.rs
+++ b/src/commands/remove.rs
@@ -49,23 +49,31 @@ impl RemoveCommand {
 
         // Check existence in the write-target profile only, since removal
         // also targets that specific profile — not the merged stack.
-        let write_profile_secrets = if write_profile == "default" {
-            &config.secrets
+        if write_profile == "default" {
+            if !config.secrets.contains_key(&self.key) {
+                return Err(FnoxError::SecretNotFound {
+                    key: self.key.clone(),
+                    profile: write_profile.to_string(),
+                    config_path: Some(target_path),
+                    suggestion: None,
+                });
+            }
         } else {
-            config
-                .profiles
-                .get(write_profile)
-                .map(|p| &p.secrets)
-                .unwrap_or(&config.secrets)
-        };
-
-        if !write_profile_secrets.contains_key(&self.key) {
-            return Err(FnoxError::SecretNotFound {
-                key: self.key.clone(),
-                profile: write_profile.to_string(),
-                config_path: Some(target_path),
-                suggestion: None,
-            });
+            let Some(profile_config) = config.profiles.get(write_profile) else {
+                return Err(FnoxError::Config(format!(
+                    "Profile '{}' is not defined in '{}'",
+                    write_profile,
+                    target_path.display()
+                )));
+            };
+            if !profile_config.secrets.contains_key(&self.key) {
+                return Err(FnoxError::SecretNotFound {
+                    key: self.key.clone(),
+                    profile: write_profile.to_string(),
+                    config_path: Some(target_path),
+                    suggestion: None,
+                });
+            }
         }
 
         if self.dry_run {

--- a/src/commands/remove.rs
+++ b/src/commands/remove.rs
@@ -35,7 +35,13 @@ impl RemoveCommand {
             let current_dir = std::env::current_dir().map_err(|e| {
                 FnoxError::Config(format!("Failed to get current directory: {}", e))
             })?;
-            current_dir.join(&cli.config)
+            // Match set.rs: use find_local_config when --config is the default,
+            // so profile-specific files (fnox.<profile>.toml) are found.
+            if cli.config == std::path::Path::new(crate::config::DEFAULT_CONFIG_FILENAME) {
+                crate::config::find_local_config(&current_dir, std::slice::from_ref(&write_profile))
+            } else {
+                current_dir.join(&cli.config)
+            }
         };
 
         // Load the target config file directly (not the merged config)

--- a/src/commands/remove.rs
+++ b/src/commands/remove.rs
@@ -75,7 +75,8 @@ impl RemoveCommand {
             }
         } else {
             // Remove secret directly from the TOML document, preserving comments
-            let removed = Config::remove_secret_from_source(&self.key, write_profile, &target_path)?;
+            let removed =
+                Config::remove_secret_from_source(&self.key, write_profile, &target_path)?;
             if !removed {
                 return Err(FnoxError::SecretNotFound {
                     key: self.key.clone(),

--- a/src/commands/remove.rs
+++ b/src/commands/remove.rs
@@ -53,33 +53,27 @@ impl RemoveCommand {
 
         let config = Config::load(&target_path)?;
 
-        // Check existence in the write-target profile only, since removal
-        // also targets that specific profile — not the merged stack.
-        if write_profile == "default" {
-            if !config.secrets.contains_key(&self.key) {
-                return Err(FnoxError::SecretNotFound {
-                    key: self.key.clone(),
-                    profile: write_profile.clone(),
-                    config_path: Some(target_path),
-                    suggestion: None,
-                });
-            }
+        // Check existence in the write-target profile. For profile-specific
+        // files (fnox.<profile>.toml), secrets are at top-level [secrets].
+        let has_profile_section =
+            write_profile != "default" && !crate::config::is_profile_file(&target_path);
+
+        let found = if has_profile_section {
+            config
+                .profiles
+                .get(&write_profile)
+                .is_some_and(|p| p.secrets.contains_key(&self.key))
         } else {
-            let Some(profile_config) = config.profiles.get(&write_profile) else {
-                return Err(FnoxError::Config(format!(
-                    "Profile '{}' is not defined in '{}'",
-                    write_profile,
-                    target_path.display()
-                )));
-            };
-            if !profile_config.secrets.contains_key(&self.key) {
-                return Err(FnoxError::SecretNotFound {
-                    key: self.key.clone(),
-                    profile: write_profile.clone(),
-                    config_path: Some(target_path),
-                    suggestion: None,
-                });
-            }
+            config.secrets.contains_key(&self.key)
+        };
+
+        if !found {
+            return Err(FnoxError::SecretNotFound {
+                key: self.key.clone(),
+                profile: write_profile.clone(),
+                config_path: Some(target_path),
+                suggestion: None,
+            });
         }
 
         if self.dry_run {

--- a/src/commands/remove.rs
+++ b/src/commands/remove.rs
@@ -21,7 +21,7 @@ pub struct RemoveCommand {
 impl RemoveCommand {
     pub async fn run(&self, cli: &Cli) -> Result<()> {
         let profile = Config::get_profiles(cli.profile.as_slice());
-        let write_profile = Config::write_profile(&profile);
+        let write_profile = Config::resolve_write_profile(&profile, cli.write_profile.as_deref())?;
         tracing::debug!(
             "Removing secret '{}' from profile '{}'",
             self.key,
@@ -53,13 +53,13 @@ impl RemoveCommand {
             if !config.secrets.contains_key(&self.key) {
                 return Err(FnoxError::SecretNotFound {
                     key: self.key.clone(),
-                    profile: write_profile.to_string(),
+                    profile: write_profile.clone(),
                     config_path: Some(target_path),
                     suggestion: None,
                 });
             }
         } else {
-            let Some(profile_config) = config.profiles.get(write_profile) else {
+            let Some(profile_config) = config.profiles.get(&write_profile) else {
                 return Err(FnoxError::Config(format!(
                     "Profile '{}' is not defined in '{}'",
                     write_profile,
@@ -69,7 +69,7 @@ impl RemoveCommand {
             if !profile_config.secrets.contains_key(&self.key) {
                 return Err(FnoxError::SecretNotFound {
                     key: self.key.clone(),
-                    profile: write_profile.to_string(),
+                    profile: write_profile.clone(),
                     config_path: Some(target_path),
                     suggestion: None,
                 });
@@ -79,7 +79,7 @@ impl RemoveCommand {
         if self.dry_run {
             let dry_run_label = console::style("[dry-run]").yellow().bold();
             let styled_key = console::style(&self.key).cyan();
-            let styled_profile = console::style(write_profile).magenta();
+            let styled_profile = console::style(&write_profile).magenta();
             let styled_path = console::style(target_path.display()).dim();
             let global_suffix = if self.global { " (global)" } else { "" };
             if write_profile == "default" {
@@ -94,7 +94,7 @@ impl RemoveCommand {
         } else {
             // Remove secret directly from the TOML document, preserving comments
             let removed =
-                Config::remove_secret_from_source(&self.key, write_profile, &target_path)?;
+                Config::remove_secret_from_source(&self.key, &write_profile, &target_path)?;
             if !removed {
                 return Err(FnoxError::SecretNotFound {
                     key: self.key.clone(),
@@ -105,7 +105,7 @@ impl RemoveCommand {
             }
             let check = console::style("✓").green();
             let styled_key = console::style(&self.key).cyan();
-            let styled_profile = console::style(write_profile).magenta();
+            let styled_profile = console::style(&write_profile).magenta();
             let global_suffix = if self.global { " (global)" } else { "" };
             if write_profile == "default" {
                 println!("{check} Removed secret {styled_key}{global_suffix}");

--- a/src/commands/remove.rs
+++ b/src/commands/remove.rs
@@ -52,7 +52,7 @@ impl RemoveCommand {
         let write_profile_secrets = if write_profile == "default" {
             &config.secrets
         } else {
-            &config
+            config
                 .profiles
                 .get(write_profile)
                 .map(|p| &p.secrets)

--- a/src/commands/remove.rs
+++ b/src/commands/remove.rs
@@ -20,8 +20,13 @@ pub struct RemoveCommand {
 
 impl RemoveCommand {
     pub async fn run(&self, cli: &Cli) -> Result<()> {
-        let profile = Config::get_profile(cli.profile.as_deref());
-        tracing::debug!("Removing secret '{}' from profile '{}'", self.key, profile);
+        let profile = Config::get_profiles(cli.profile.as_slice());
+        let write_profile = Config::write_profile(&profile);
+        tracing::debug!(
+            "Removing secret '{}' from profile '{}'",
+            self.key,
+            write_profile
+        );
 
         // Determine the target config file
         let target_path = if self.global {
@@ -47,7 +52,7 @@ impl RemoveCommand {
         if !profile_secrets.contains_key(&self.key) {
             return Err(FnoxError::SecretNotFound {
                 key: self.key.clone(),
-                profile: profile.to_string(),
+                profile: Config::display_profiles(&profile),
                 config_path: Some(target_path),
                 suggestion: None,
             });
@@ -56,10 +61,10 @@ impl RemoveCommand {
         if self.dry_run {
             let dry_run_label = console::style("[dry-run]").yellow().bold();
             let styled_key = console::style(&self.key).cyan();
-            let styled_profile = console::style(&profile).magenta();
+            let styled_profile = console::style(write_profile).magenta();
             let styled_path = console::style(target_path.display()).dim();
             let global_suffix = if self.global { " (global)" } else { "" };
-            if profile == "default" {
+            if write_profile == "default" {
                 println!(
                     "{dry_run_label} Would remove secret {styled_key}{global_suffix} from {styled_path}"
                 );
@@ -70,20 +75,20 @@ impl RemoveCommand {
             }
         } else {
             // Remove secret directly from the TOML document, preserving comments
-            let removed = Config::remove_secret_from_source(&self.key, &profile, &target_path)?;
+            let removed = Config::remove_secret_from_source(&self.key, write_profile, &target_path)?;
             if !removed {
                 return Err(FnoxError::SecretNotFound {
                     key: self.key.clone(),
-                    profile: profile.to_string(),
+                    profile: Config::display_profiles(&profile),
                     config_path: Some(target_path),
                     suggestion: None,
                 });
             }
             let check = console::style("✓").green();
             let styled_key = console::style(&self.key).cyan();
-            let styled_profile = console::style(&profile).magenta();
+            let styled_profile = console::style(write_profile).magenta();
             let global_suffix = if self.global { " (global)" } else { "" };
-            if profile == "default" {
+            if write_profile == "default" {
                 println!("{check} Removed secret {styled_key}{global_suffix}");
             } else {
                 println!(

--- a/src/commands/remove.rs
+++ b/src/commands/remove.rs
@@ -45,14 +45,24 @@ impl RemoveCommand {
             });
         }
 
-        // Check the secret exists before attempting removal
         let config = Config::load(&target_path)?;
-        let profile_secrets = config.get_secrets(&profile)?;
 
-        if !profile_secrets.contains_key(&self.key) {
+        // Check existence in the write-target profile only, since removal
+        // also targets that specific profile — not the merged stack.
+        let write_profile_secrets = if write_profile == "default" {
+            &config.secrets
+        } else {
+            &config
+                .profiles
+                .get(write_profile)
+                .map(|p| &p.secrets)
+                .unwrap_or(&config.secrets)
+        };
+
+        if !write_profile_secrets.contains_key(&self.key) {
             return Err(FnoxError::SecretNotFound {
                 key: self.key.clone(),
-                profile: Config::display_profiles(&profile),
+                profile: write_profile.to_string(),
                 config_path: Some(target_path),
                 suggestion: None,
             });

--- a/src/commands/set.rs
+++ b/src/commands/set.rs
@@ -54,8 +54,13 @@ pub struct SetCommand {
 
 impl SetCommand {
     pub async fn run(&self, cli: &Cli, mut config: Config) -> Result<()> {
-        let profile = Config::get_profile(cli.profile.as_deref());
-        tracing::debug!("Setting secret '{}' in profile '{}'", self.key, profile);
+        let profile = Config::get_profiles(cli.profile.as_slice());
+        let write_profile = Config::write_profile(&profile);
+        tracing::debug!(
+            "Setting secret '{}' in profile '{}'",
+            self.key,
+            write_profile
+        );
 
         // Check if we're only setting metadata (no actual secret value)
         let has_metadata =
@@ -263,7 +268,7 @@ impl SetCommand {
             // Only use auto-detection when --config is the clap default ("fnox.toml").
             // Any other value means the user explicitly chose a config file.
             if cli.config == std::path::Path::new(config::DEFAULT_CONFIG_FILENAME) {
-                config::find_local_config(&current_dir, Some(&profile))
+                config::find_local_config(&current_dir, &profile)
             } else {
                 current_dir.join(&cli.config)
             }
@@ -273,11 +278,11 @@ impl SetCommand {
             // Show what would be done
             let dry_run_label = console::style("[dry-run]").yellow().bold();
             let styled_key = console::style(&self.key).cyan();
-            let styled_profile = console::style(&profile).magenta();
+            let styled_profile = console::style(write_profile).magenta();
             let styled_path = console::style(target_path.display()).dim();
             let global_suffix = if self.global { " (global)" } else { "" };
 
-            if profile == "default" {
+            if write_profile == "default" {
                 println!(
                     "{dry_run_label} Would set secret {styled_key}{global_suffix} in {styled_path}"
                 );
@@ -313,13 +318,13 @@ impl SetCommand {
                 );
             }
         } else {
-            config.save_secret_to_source(&self.key, &secret_config, &profile, &target_path)?;
+            config.save_secret_to_source(&self.key, &secret_config, write_profile, &target_path)?;
 
             let check = console::style("✓").green();
             let styled_key = console::style(&self.key).cyan();
-            let styled_profile = console::style(&profile).magenta();
+            let styled_profile = console::style(write_profile).magenta();
             let global_suffix = if self.global { " (global)" } else { "" };
-            if profile == "default" {
+            if write_profile == "default" {
                 println!("{check} Set secret {styled_key}{global_suffix}");
             } else {
                 println!(

--- a/src/commands/set.rs
+++ b/src/commands/set.rs
@@ -55,7 +55,7 @@ pub struct SetCommand {
 impl SetCommand {
     pub async fn run(&self, cli: &Cli, mut config: Config) -> Result<()> {
         let profile = Config::get_profiles(cli.profile.as_slice());
-        let write_profile = Config::write_profile(&profile);
+        let write_profile = Config::resolve_write_profile(&profile, cli.write_profile.as_deref())?;
         tracing::debug!(
             "Setting secret '{}' in profile '{}'",
             self.key,
@@ -195,8 +195,10 @@ impl SetCommand {
             (None, None)
         };
 
-        // Now update the config
-        let profile_secrets = config.get_secrets_mut(&profile);
+        // Now update the config — use the resolved write_profile, not the
+        // full stack, so the secret lands in the correct TOML section.
+        let write_profile_stack = vec![write_profile.clone()];
+        let profile_secrets = config.get_secrets_mut(&write_profile_stack);
 
         // Get or create the secret config
         let secret_config = profile_secrets.entry(self.key.clone()).or_default();
@@ -268,7 +270,7 @@ impl SetCommand {
             // Only use auto-detection when --config is the clap default ("fnox.toml").
             // Any other value means the user explicitly chose a config file.
             if cli.config == std::path::Path::new(config::DEFAULT_CONFIG_FILENAME) {
-                config::find_local_config(&current_dir, &profile)
+                config::find_local_config(&current_dir, std::slice::from_ref(&write_profile))
             } else {
                 current_dir.join(&cli.config)
             }
@@ -278,7 +280,7 @@ impl SetCommand {
             // Show what would be done
             let dry_run_label = console::style("[dry-run]").yellow().bold();
             let styled_key = console::style(&self.key).cyan();
-            let styled_profile = console::style(write_profile).magenta();
+            let styled_profile = console::style(&write_profile).magenta();
             let styled_path = console::style(target_path.display()).dim();
             let global_suffix = if self.global { " (global)" } else { "" };
 
@@ -318,11 +320,16 @@ impl SetCommand {
                 );
             }
         } else {
-            config.save_secret_to_source(&self.key, &secret_config, write_profile, &target_path)?;
+            config.save_secret_to_source(
+                &self.key,
+                &secret_config,
+                &write_profile,
+                &target_path,
+            )?;
 
             let check = console::style("✓").green();
             let styled_key = console::style(&self.key).cyan();
-            let styled_profile = console::style(write_profile).magenta();
+            let styled_profile = console::style(&write_profile).magenta();
             let global_suffix = if self.global { " (global)" } else { "" };
             if write_profile == "default" {
                 println!("{check} Set secret {styled_key}{global_suffix}");

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -55,13 +55,7 @@ impl SyncCommand {
                 let current_dir = std::env::current_dir().map_err(|e| {
                     FnoxError::Config(format!("Failed to get current directory: {}", e))
                 })?;
-                let candidate =
-                    config::find_local_config(&current_dir, std::slice::from_ref(&write_profile));
-                if local_override_filename(&candidate).is_some() {
-                    candidate
-                } else {
-                    cli.config.clone()
-                }
+                config::find_local_config(&current_dir, std::slice::from_ref(&write_profile))
             } else {
                 cli.config.clone()
             };

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -46,15 +46,16 @@ pub struct SyncCommand {
 
 impl SyncCommand {
     pub async fn run(&self, cli: &Cli, merged_config: Config) -> Result<()> {
-        let profile = Config::get_profile(cli.profile.as_deref());
-        tracing::debug!("Syncing secrets for profile '{}'", profile);
+        let profile = Config::get_profiles(cli.profile.as_slice());
+        let write_profile = Config::write_profile(&profile);
+        tracing::debug!("Syncing secrets for profile '{}'", write_profile);
 
         let effective_config_path =
             if cli.config == std::path::Path::new(config::DEFAULT_CONFIG_FILENAME) {
                 let current_dir = std::env::current_dir().map_err(|e| {
                     FnoxError::Config(format!("Failed to get current directory: {}", e))
                 })?;
-                let candidate = config::find_local_config(&current_dir, Some(&profile));
+                let candidate = config::find_local_config(&current_dir, &profile);
                 if local_override_filename(&candidate).is_some() {
                     candidate
                 } else {
@@ -92,7 +93,7 @@ impl SyncCommand {
         let provider_config = providers.get(&target_provider_name).ok_or_else(|| {
             FnoxError::ProviderNotConfigured {
                 provider: target_provider_name.clone(),
-                profile: profile.to_string(),
+                profile: Config::display_profiles(&profile),
                 config_path: None,
                 suggestion: None,
             }
@@ -178,7 +179,7 @@ impl SyncCommand {
         // Dry-run mode: show what would be done and exit
         if self.dry_run {
             let dry_run_label = console::style("[dry-run]").yellow().bold();
-            let styled_profile = console::style(&profile).magenta();
+            let styled_profile = console::style(write_profile).magenta();
             let styled_provider = console::style(&target_provider_name).green();
 
             println!(
@@ -302,7 +303,7 @@ impl SyncCommand {
         }
 
         // Save to config
-        Config::save_secrets_to_source(&synced_secrets, &profile, &target_path)?;
+        Config::save_secrets_to_source(&synced_secrets, write_profile, &target_path)?;
 
         println!(
             "Synced {} secrets to provider '{}'{}",

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -47,7 +47,7 @@ pub struct SyncCommand {
 impl SyncCommand {
     pub async fn run(&self, cli: &Cli, merged_config: Config) -> Result<()> {
         let profile = Config::get_profiles(cli.profile.as_slice());
-        let write_profile = Config::write_profile(&profile);
+        let write_profile = Config::resolve_write_profile(&profile, cli.write_profile.as_deref())?;
         tracing::debug!("Syncing secrets for profile '{}'", write_profile);
 
         let effective_config_path =
@@ -55,7 +55,8 @@ impl SyncCommand {
                 let current_dir = std::env::current_dir().map_err(|e| {
                     FnoxError::Config(format!("Failed to get current directory: {}", e))
                 })?;
-                let candidate = config::find_local_config(&current_dir, &profile);
+                let candidate =
+                    config::find_local_config(&current_dir, std::slice::from_ref(&write_profile));
                 if local_override_filename(&candidate).is_some() {
                     candidate
                 } else {
@@ -179,7 +180,7 @@ impl SyncCommand {
         // Dry-run mode: show what would be done and exit
         if self.dry_run {
             let dry_run_label = console::style("[dry-run]").yellow().bold();
-            let styled_profile = console::style(write_profile).magenta();
+            let styled_profile = console::style(&write_profile).magenta();
             let styled_provider = console::style(&target_provider_name).green();
 
             println!(
@@ -303,7 +304,7 @@ impl SyncCommand {
         }
 
         // Save to config
-        Config::save_secrets_to_source(&synced_secrets, write_profile, &target_path)?;
+        Config::save_secrets_to_source(&synced_secrets, &write_profile, &target_path)?;
 
         println!(
             "Synced {} secrets to provider '{}'{}",

--- a/src/commands/tui.rs
+++ b/src/commands/tui.rs
@@ -26,7 +26,7 @@ pub struct TuiCommand;
 
 impl TuiCommand {
     pub async fn run(&self, cli: &Cli, config: Config) -> Result<()> {
-        let profile = Config::get_profile(cli.profile.as_deref());
+        let profile = Config::get_profiles(cli.profile.as_slice());
 
         // Mark as non-interactive so providers that need physical interaction are skipped
         crate::env::set_non_interactive(true);

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -907,10 +907,10 @@ fn cache_policy_default_provider<'a>(
     providers: &'a IndexMap<String, ProviderConfig>,
 ) -> Option<&'a str> {
     for p in profile.iter().filter(|p| *p != "default").rev() {
-        if let Some(profile_config) = config.profiles.get(p) {
-            if let Some(default_provider) = profile_config.default_provider() {
-                return Some(default_provider);
-            }
+        if let Some(profile_config) = config.profiles.get(p)
+            && let Some(default_provider) = profile_config.default_provider()
+        {
+            return Some(default_provider);
         }
     }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1038,8 +1038,14 @@ fn socket_path(cli: &Cli) -> Result<PathBuf> {
     socket_path_for_context(&ResolveContext::from_cli(cli))
 }
 
+/// Wire-protocol version tag included in the socket path hash.
+/// Incrementing this ensures new clients don't connect to stale daemons
+/// running an incompatible wire format.
+const WIRE_VERSION: u8 = 2;
+
 fn socket_path_for_context(ctx: &ResolveContext) -> Result<PathBuf> {
     let mut hasher = blake3::Hasher::new();
+    hasher.update(&[WIRE_VERSION]);
     let profile_str = ctx.profile.join(",");
     hasher.update(profile_str.as_bytes());
     hasher.update(ctx.no_defaults.to_string().as_bytes());

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -24,7 +24,7 @@ const SHUTDOWN_GRACE_PERIOD: Duration = Duration::from_secs(30);
 #[derive(Debug, Clone)]
 pub struct ResolveContext {
     pub config: PathBuf,
-    pub profile: Option<String>,
+    pub profile: Vec<String>,
     pub age_key_file: Option<PathBuf>,
     pub if_missing: Option<String>,
     pub no_defaults: bool,
@@ -37,12 +37,7 @@ impl ResolveContext {
         let settings = crate::settings::Settings::try_get().ok();
         Self {
             config: cli.config.clone(),
-            profile: cli.profile.clone().or_else(|| {
-                settings
-                    .as_ref()
-                    .map(|settings| settings.profile.clone())
-                    .filter(|profile| profile != "default")
-            }),
+            profile: Config::get_profiles(cli.profile.as_slice()),
             age_key_file: cli.age_key_file.clone().or_else(|| {
                 settings
                     .as_ref()
@@ -106,7 +101,7 @@ enum Request {
 struct ResolveBatchRequest {
     cwd: PathBuf,
     config: PathBuf,
-    profile: String,
+    profile: Vec<String>,
     age_key_file: Option<PathBuf>,
     if_missing: Option<String>,
     no_defaults: bool,
@@ -128,7 +123,7 @@ struct ResolveBatchRequest {
 struct ResolveOneRequest {
     cwd: PathBuf,
     config: PathBuf,
-    profile: String,
+    profile: Vec<String>,
     age_key_file: Option<PathBuf>,
     if_missing: Option<String>,
     no_defaults: bool,
@@ -197,7 +192,7 @@ struct DaemonState {
 pub async fn resolve_batch(
     cli: &Cli,
     config: &Config,
-    profile: &str,
+    profile: &[String],
     secrets: &IndexMap<String, SecretConfig>,
     purpose: Purpose,
     include_all_modes: bool,
@@ -216,7 +211,7 @@ pub async fn resolve_batch(
 pub async fn resolve_batch_with_context(
     ctx: &ResolveContext,
     config: &Config,
-    profile: &str,
+    profile: &[String],
     secrets: &IndexMap<String, SecretConfig>,
     purpose: Purpose,
     include_all_modes: bool,
@@ -239,7 +234,7 @@ pub async fn resolve_batch_with_context(
         cwd: std::env::current_dir()
             .map_err(|e| FnoxError::Config(format!("Failed to get current directory: {e}")))?,
         config: ctx.config.clone(),
-        profile: profile.to_string(),
+        profile: profile.to_vec(),
         age_key_file: ctx.age_key_file.clone(),
         if_missing: ctx.if_missing.clone(),
         no_defaults: ctx.no_defaults,
@@ -262,7 +257,7 @@ pub async fn resolve_batch_with_context(
 pub async fn resolve_one(
     cli: &Cli,
     config: &Config,
-    profile: &str,
+    profile: &[String],
     key: &str,
     secret_config: &SecretConfig,
     purpose: Purpose,
@@ -281,7 +276,7 @@ pub async fn resolve_one(
 pub async fn resolve_one_with_context(
     ctx: &ResolveContext,
     config: &Config,
-    profile: &str,
+    profile: &[String],
     key: &str,
     secret_config: &SecretConfig,
     purpose: Purpose,
@@ -294,7 +289,7 @@ pub async fn resolve_one_with_context(
         cwd: std::env::current_dir()
             .map_err(|e| FnoxError::Config(format!("Failed to get current directory: {e}")))?,
         config: ctx.config.clone(),
-        profile: profile.to_string(),
+        profile: profile.to_vec(),
         age_key_file: ctx.age_key_file.clone(),
         if_missing: ctx.if_missing.clone(),
         no_defaults: ctx.no_defaults,
@@ -424,8 +419,9 @@ async fn start_background_for_context(
     let exe = std::env::current_exe()
         .map_err(|e| FnoxError::Config(format!("Failed to locate fnox executable: {e}")))?;
     let mut cmd = std::process::Command::new(exe);
-    cmd.arg("--profile")
-        .arg(Config::get_profile(ctx.profile.as_deref()));
+    for p in &ctx.profile {
+        cmd.arg("--profile").arg(p);
+    }
     if ctx.no_defaults {
         cmd.arg("--no-defaults");
     }
@@ -777,7 +773,7 @@ async fn process_request(
             let _cwd = CwdGuard::change_to(&req.cwd)?;
             apply_request_settings(
                 req.age_key_file.clone(),
-                Some(req.profile.clone()),
+                req.profile.clone(),
                 req.if_missing.clone(),
                 req.no_defaults,
                 req.non_interactive,
@@ -800,7 +796,7 @@ async fn process_request(
             let _cwd = CwdGuard::change_to(&req.cwd)?;
             apply_request_settings(
                 req.age_key_file.clone(),
-                Some(req.profile.clone()),
+                req.profile.clone(),
                 req.if_missing.clone(),
                 req.no_defaults,
                 req.non_interactive,
@@ -839,7 +835,7 @@ async fn process_request(
 
 fn apply_request_settings(
     age_key_file: Option<PathBuf>,
-    profile: Option<String>,
+    profile: Vec<String>,
     if_missing: Option<String>,
     no_defaults: bool,
     non_interactive: bool,
@@ -855,7 +851,7 @@ fn apply_request_settings(
 
 async fn resolve_with_cache(
     config: &Config,
-    profile: &str,
+    profile: &[String],
     secrets: IndexMap<String, SecretConfig>,
     req: &ResolveBatchRequest,
     state: std::sync::Arc<Mutex<DaemonState>>,
@@ -907,14 +903,15 @@ async fn resolve_with_cache(
 
 fn cache_policy_default_provider<'a>(
     config: &'a Config,
-    profile: &str,
+    profile: &[String],
     providers: &'a IndexMap<String, ProviderConfig>,
 ) -> Option<&'a str> {
-    if profile != "default"
-        && let Some(profile_config) = config.profiles.get(profile)
-        && let Some(default_provider) = profile_config.default_provider()
-    {
-        return Some(default_provider);
+    for p in profile.iter().filter(|p| *p != "default").rev() {
+        if let Some(profile_config) = config.profiles.get(p) {
+            if let Some(default_provider) = profile_config.default_provider() {
+                return Some(default_provider);
+            }
+        }
     }
 
     config.default_provider().or_else(|| {
@@ -946,14 +943,15 @@ fn provider_daemon_cache_enabled(
 
 fn cache_key(
     fingerprint: &str,
-    profile: &str,
+    profile: &[String],
     key: &str,
     secret: &SecretConfig,
     req: &ResolveBatchRequest,
 ) -> CacheKey {
     let mut hasher = blake3::Hasher::new();
+    let profile_str = profile.join(",");
     hasher.update(fingerprint.as_bytes());
-    hasher.update(profile.as_bytes());
+    hasher.update(profile_str.as_bytes());
     hasher.update(req.no_defaults.to_string().as_bytes());
     hasher.update(key.as_bytes());
     hasher.update(req.purpose.as_bytes());
@@ -974,7 +972,7 @@ fn config_fingerprint(config: &Config, env: &[(String, String)]) -> Result<Strin
         paths.insert(path.clone());
     }
     if let Some(project_dir) = &config.project_dir {
-        for name in crate::config::all_config_filenames(None) {
+        for name in crate::config::all_config_filenames(&[]) {
             let path = project_dir.join(name);
             if path.exists() {
                 paths.insert(path);
@@ -1042,8 +1040,8 @@ fn socket_path(cli: &Cli) -> Result<PathBuf> {
 
 fn socket_path_for_context(ctx: &ResolveContext) -> Result<PathBuf> {
     let mut hasher = blake3::Hasher::new();
-    let profile = Config::get_profile(ctx.profile.as_deref());
-    hasher.update(profile.as_bytes());
+    let profile_str = ctx.profile.join(",");
+    hasher.update(profile_str.as_bytes());
     hasher.update(ctx.no_defaults.to_string().as_bytes());
     if let Some(if_missing) = &ctx.if_missing {
         hasher.update(if_missing.as_bytes());
@@ -1445,7 +1443,7 @@ mod tests {
         ResolveBatchRequest {
             cwd: PathBuf::from("."),
             config: PathBuf::from("fnox.toml"),
-            profile: "default".to_string(),
+            profile: vec!["default".to_string()],
             age_key_file: None,
             if_missing: None,
             no_defaults: false,
@@ -1543,7 +1541,7 @@ daemon_cache = false
         .unwrap();
         let secret = default_provider_secret("fresh");
         let mut req = test_batch_request();
-        req.profile = "prod".to_string();
+        req.profile = vec!["prod".to_string()];
         let state = state_with_cached_secret(&config, &secret, &req);
 
         let resolved = resolve_with_cache(

--- a/src/hook_env.rs
+++ b/src/hook_env.rs
@@ -212,8 +212,8 @@ fn collect_config_files(start_dir: &Path) -> Vec<(PathBuf, u128)> {
     let mut current = start_dir.to_path_buf();
 
     // Get profile name using Settings system which respects: CLI flag > Env var > Default
-    let profile_name = crate::settings::Settings::get().profile.clone();
-    let filenames = crate::config::all_config_filenames(Some(&profile_name));
+    let profile_name = crate::config::Config::get_profiles(&[]);
+    let filenames = crate::config::all_config_filenames(&profile_name);
 
     loop {
         // Check all config filenames (fnox.toml, .fnox.toml, fnox.$PROFILE.toml, etc.)
@@ -287,8 +287,8 @@ fn hash_fnox_env_vars() -> String {
 pub fn find_config() -> Option<PathBuf> {
     use crate::config::{Config, all_config_filenames};
 
-    let profile = crate::settings::Settings::get().profile.clone();
-    let filenames = all_config_filenames(Some(&profile));
+    let profile = crate::config::Config::get_profiles(&[]);
+    let filenames = all_config_filenames(&profile);
 
     let mut current = std::env::current_dir().ok()?;
 

--- a/src/mcp_server.rs
+++ b/src/mcp_server.rs
@@ -50,7 +50,7 @@ pub struct ExecParams {
 #[derive(Clone)]
 pub struct FnoxMcpServer {
     config: Arc<Config>,
-    profile: Arc<String>,
+    profile: Arc<Vec<String>>,
     mcp_config: Arc<McpConfig>,
     daemon_context: Arc<ResolveContext>,
     profile_secrets: Arc<IndexMap<String, SecretConfig>>,
@@ -67,7 +67,7 @@ pub struct FnoxMcpServer {
 impl FnoxMcpServer {
     pub fn new(
         config: Config,
-        profile: String,
+        profile: Vec<String>,
         mcp_config: McpConfig,
         daemon_context: ResolveContext,
         profile_secrets: IndexMap<String, SecretConfig>,

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -86,6 +86,9 @@ pub struct App {
     /// Current profile name
     pub profile: String,
 
+    /// Active profile overlay stack used for secret resolution.
+    pub profile_stack: Vec<String>,
+
     /// Available profiles
     pub available_profiles: Vec<String>,
 
@@ -145,9 +148,10 @@ pub struct App {
 
 impl App {
     /// Create a new app with the given config and profile
-    pub fn new(config: Config, profile: String, daemon_context: ResolveContext) -> Result<Self> {
-        let providers: Vec<String> = config.get_providers(&profile).keys().cloned().collect();
-        let secrets = config.get_secrets(&profile)?;
+    pub fn new(config: Config, profile_stack: Vec<String>, daemon_context: ResolveContext) -> Result<Self> {
+        let profile = Config::display_profiles(&profile_stack);
+        let providers: Vec<String> = config.get_providers(&profile_stack).keys().cloned().collect();
+        let secrets = config.get_secrets(&profile_stack)?;
 
         // Build list of available profiles
         let mut available_profiles = vec!["default".to_string()];
@@ -162,6 +166,7 @@ impl App {
             config,
             daemon_context,
             profile,
+            profile_stack,
             available_profiles,
             profile_picker_index: 0,
             providers,
@@ -244,14 +249,14 @@ impl App {
 
         let config = self.config.clone();
         let daemon_context = self.daemon_context.clone();
-        let profile = self.profile.clone();
+        let profile_stack = self.profile_stack.clone();
         let secrets = self.secrets.clone();
 
         tokio::spawn(async move {
             match crate::daemon::resolve_batch_with_context(
                 &daemon_context,
                 &config,
-                &profile,
+                &profile_stack,
                 &secrets,
                 Purpose::Tui,
                 true,
@@ -796,13 +801,15 @@ impl App {
         }
 
         // Try to load secrets first before committing to the change
-        match self.config.get_secrets(&new_profile) {
+        let profile_stack = vec![new_profile.clone()];
+        match self.config.get_secrets(&profile_stack) {
             Ok(secrets) => {
                 // Success - now update all state
                 self.profile = new_profile;
+                self.profile_stack = profile_stack.clone();
                 self.providers = self
                     .config
-                    .get_providers(&self.profile)
+                    .get_providers(&profile_stack)
                     .keys()
                     .cloned()
                     .collect();

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -148,9 +148,17 @@ pub struct App {
 
 impl App {
     /// Create a new app with the given config and profile
-    pub fn new(config: Config, profile_stack: Vec<String>, daemon_context: ResolveContext) -> Result<Self> {
+    pub fn new(
+        config: Config,
+        profile_stack: Vec<String>,
+        daemon_context: ResolveContext,
+    ) -> Result<Self> {
         let profile = Config::display_profiles(&profile_stack);
-        let providers: Vec<String> = config.get_providers(&profile_stack).keys().cloned().collect();
+        let providers: Vec<String> = config
+            .get_providers(&profile_stack)
+            .keys()
+            .cloned()
+            .collect();
         let secrets = config.get_secrets(&profile_stack)?;
 
         // Build list of available profiles

--- a/test/config_hierarchy_set.bats
+++ b/test/config_hierarchy_set.bats
@@ -246,6 +246,58 @@ EOF
 	assert_output --partial "LOCAL_OVERRIDE"
 }
 
+@test "fnox set with multiple active profiles writes to last profile file" {
+	cat >fnox.toml <<EOF
+[providers.plain]
+type = "plain"
+
+[secrets]
+BASE = { default = "base" }
+EOF
+
+	cat >fnox.staging.toml <<EOF
+[secrets]
+STAGING_EXISTING = { default = "staging" }
+EOF
+
+	# With two active profiles, set should write to the last (staging)
+	run "$FNOX_BIN" -P staging set NEW_SECRET "new-value"
+	assert_success
+
+	# Secret lands in the staging profile file
+	run cat fnox.staging.toml
+	assert_success
+	assert_output --partial "NEW_SECRET"
+	assert_output --partial "STAGING_EXISTING"
+
+	# Base file is untouched
+	run cat fnox.toml
+	assert_success
+	refute_output --partial "NEW_SECRET"
+	assert_output --partial "BASE"
+}
+
+@test "fnox set with comma-separated profiles writes to last profile file" {
+	cat >fnox.toml <<EOF
+[providers.plain]
+type = "plain"
+EOF
+
+	cat >fnox.dev.toml <<EOF
+[secrets]
+DEV = { default = "dev" }
+EOF
+
+	# Comma-separated: last profile is the write target
+	run "$FNOX_BIN" -P dev set SHARED "val"
+	assert_success
+
+	run cat fnox.dev.toml
+	assert_success
+	assert_output --partial "SHARED"
+	assert_output --partial "DEV"
+}
+
 @test "fnox set --profile staging writes to fnox.staging.toml when it exists alongside fnox.toml" {
 	cat >fnox.toml <<EOF
 [providers.plain]

--- a/test/config_hierarchy_set.bats
+++ b/test/config_hierarchy_set.bats
@@ -246,7 +246,7 @@ EOF
 	assert_output --partial "LOCAL_OVERRIDE"
 }
 
-@test "fnox set with multiple active profiles writes to last profile file" {
+@test "fnox set with multiple profiles requires --write-profile" {
 	cat >fnox.toml <<EOF
 [providers.plain]
 type = "plain"
@@ -260,11 +260,16 @@ EOF
 STAGING_EXISTING = { default = "staging" }
 EOF
 
-	# With two active profiles, set should write to the last (staging)
-	run "$FNOX_BIN" -P staging set NEW_SECRET "new-value"
+	# Multiple profiles without --write-profile should error
+	run "$FNOX_BIN" -P staging -P extra set NEW_SECRET "new-value"
+	assert_failure
+	assert_output --partial "Multiple profiles are active"
+	assert_output --partial "--write-profile"
+
+	# With --write-profile staging, the secret lands in staging
+	run "$FNOX_BIN" -P staging -P extra --write-profile staging set NEW_SECRET "new-value"
 	assert_success
 
-	# Secret lands in the staging profile file
 	run cat fnox.staging.toml
 	assert_success
 	assert_output --partial "NEW_SECRET"

--- a/test/profile_config.bats
+++ b/test/profile_config.bats
@@ -334,6 +334,104 @@ EOF
 	assert_output --partial "not found"
 }
 
+@test 'multiple active profiles overlay in order' {
+	# Base config with a shared secret and a base-only secret
+	cat >fnox.toml <<EOF
+root = true
+
+[providers.base]
+type = "plain"
+
+[secrets]
+SHARED = { default = "base-value" }
+BASE_ONLY = { default = "base-only" }
+EOF
+
+	# aws profile: adds a provider + an aws-only secret, overrides SHARED
+	cat >fnox.aws.toml <<EOF
+[providers.aws_plain]
+type = "plain"
+
+[secrets]
+SHARED = { default = "aws-value" }
+AWS_ONLY = { default = "aws-only" }
+EOF
+
+	# prod profile: overrides SHARED again, adds a prod-only secret
+	cat >fnox.prod.toml <<EOF
+[secrets]
+SHARED = { default = "prod-value" }
+PROD_ONLY = { default = "prod-only" }
+EOF
+
+	# Two profiles via repeated --profile: later wins
+	run "$FNOX_BIN" -P aws -P prod get SHARED
+	assert_success
+	assert_output --partial "prod-value"
+
+	# Both profile-only secrets are visible
+	run "$FNOX_BIN" -P aws -P prod get AWS_ONLY
+	assert_success
+	assert_output --partial "aws-only"
+
+	run "$FNOX_BIN" -P aws -P prod get PROD_ONLY
+	assert_success
+	assert_output --partial "prod-only"
+
+	# Base secret still visible (top-level merged)
+	run "$FNOX_BIN" -P aws -P prod get BASE_ONLY
+	assert_success
+	assert_output --partial "base-only"
+
+	# Comma-separated form should behave identically
+	run "$FNOX_BIN" -P aws,prod get SHARED
+	assert_success
+	assert_output --partial "prod-value"
+
+	# FNOX_PROFILE env var with comma also works
+	run env FNOX_PROFILE=aws,prod "$FNOX_BIN" get SHARED
+	assert_success
+	assert_output --partial "prod-value"
+
+	# list shows all merged secrets
+	run "$FNOX_BIN" -P aws -P prod list --complete
+	assert_success
+	assert_output --partial "SHARED"
+	assert_output --partial "AWS_ONLY"
+	assert_output --partial "PROD_ONLY"
+	assert_output --partial "BASE_ONLY"
+}
+
+@test 'multiple active profiles compose providers' {
+	cat >fnox.toml <<EOF
+root = true
+
+[providers.base]
+type = "plain"
+
+[secrets]
+S1 = { default = "v1" }
+EOF
+
+	cat >fnox.extra.toml <<EOF
+[providers.extra]
+type = "plain"
+
+[secrets]
+S2 = { provider = "extra", default = "v2" }
+EOF
+
+	# Without extra profile: S2 references unknown provider
+	run "$FNOX_BIN" -P extra get S2
+	assert_success
+	assert_output --partial "v2"
+
+	# With both base + extra: both providers available
+	run "$FNOX_BIN" -P extra get S1
+	assert_success
+	assert_output --partial "v1"
+}
+
 @test 'fnox.$FNOX_PROFILE.toml can override default_provider' {
 	# Create main config with default provider (use plain to avoid encryption)
 	cat >fnox.toml <<EOF

--- a/test/provider_add.bats
+++ b/test/provider_add.bats
@@ -76,11 +76,64 @@ vault|vault|vault"
 	assert_output --partial 'vault = "MyVault"'
 }
 
-@test "fnox provider add --vault fails for non-proton provider types" {
+@test "fnox provider add writes to top-level without --profile" {
+	# Clear any inherited FNOX_PROFILE so provider add targets the top-level
+	unset FNOX_PROFILE
+
 	run "$FNOX_BIN" init --skip-wizard
 	assert_success
 
-	run "$FNOX_BIN" provider add myage age --vault "bad-vault"
-	assert_failure
-	assert_output --partial "--vault is only supported for provider type"
+	run "$FNOX_BIN" provider add myage age
+	assert_success
+
+	run cat "$FNOX_CONFIG_FILE"
+	assert_success
+	assert_output --partial "[providers.myage]"
+}
+
+@test "fnox provider add with --profile writes to profile section" {
+	run "$FNOX_BIN" init --skip-wizard
+	assert_success
+
+	# Add a provider scoped to the prod profile
+	run "$FNOX_BIN" -P prod provider add scoped age
+	assert_success
+	assert_output --partial "Added provider 'scoped'"
+
+	# Provider should appear under [profiles.prod.providers.scoped]
+	run cat "$FNOX_CONFIG_FILE"
+	assert_success
+	assert_output --partial "[profiles.prod.providers.scoped]"
+	assert_output --partial 'type = "age"'
+
+	# It should NOT be in the top-level [providers] section
+	refute_output --partial "[providers.scoped]"
+}
+
+@test "fnox provider list shows composed providers from multiple profiles" {
+	# Clear any inherited FNOX_PROFILE so the "no profile" case is deterministic
+	unset FNOX_PROFILE
+
+	run "$FNOX_BIN" init --skip-wizard
+	assert_success
+
+	# Top-level provider
+	run "$FNOX_BIN" provider add base age
+	assert_success
+
+	# Profile-scoped provider
+	run "$FNOX_BIN" -P extra provider add extra age
+	assert_success
+
+	# Without profile: only base visible
+	run "$FNOX_BIN" provider list
+	assert_success
+	assert_output --partial "base"
+	refute_output --partial "extra"
+
+	# With extra profile: both visible
+	run "$FNOX_BIN" -P extra provider list
+	assert_success
+	assert_output --partial "base"
+	assert_output --partial "extra"
 }


### PR DESCRIPTION
## Summary

Allow activating multiple profiles simultaneously as an ordered overlay stack. Later profiles override earlier ones on key conflicts, with top-level config as the base.

This was discussed in the project discussions and the approach was agreed upon with the maintainer.

## Usage

```sh
# Repeatable flags
fnox -P aws -P prod exec -- ./app

# Comma-separated
fnox -P aws,prod exec -- ./app

# Environment variable
FNOX_PROFILE=aws,prod fnox exec -- ./app
```

The effective configuration is resolved as:

```
top-level config
+ profiles.aws
+ profiles.prod
```

Later profiles override earlier ones on key conflicts.

## Changes

- **CLI**: `--profile/-P` is now repeatable (`Vec<String>`), also accepts comma-separated values
- **Settings/env**: `FNOX_PROFILE` supports comma-separated values; `profile` setting type changed from `string` to `vec_string`
- **Config layer**: `get_secrets`, `get_providers`, `get_leases`, `get_default_provider`, `get_secret` all accept `&[String]` profile stack
- **Config loading**: `all_config_filenames` loads `fnox.<profile>.toml` for each active profile in order
- **Write targeting**: `set`, `remove`, `import`, `sync`, `provider add/remove` write to the last active profile by default
- **Provider add/remove**: only respect explicit `--profile` CLI flags (not `FNOX_PROFILE` env), preserving existing top-level write behavior unless the user opts in
- **Daemon**: request wire protocol, socket path hash, and cache key all include the full profile stack
- **Library API**: `Fnox` gains `with_profiles()` builder; `with_profile()` delegates to it
- **TUI/MCP**: adapted to profile stack; TUI keeps existing single-profile picker UI

## Test plan

- [x] `cargo test` (240 tests pass)
- [x] `mise run build` passes
- [x] bats: `profile_config.bats` (11 tests, 2 new)
- [x] bats: `provider_add.bats` (6 tests, 3 new)
- [x] bats: `config_hierarchy_set.bats` (9 tests, 2 new)
- [x] New unit test: `test_profile_stack_overlays_in_order`

_This PR was created with Claude Code._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ordered multi-profile overlays across CLI, config loading, secret/provider resolution, daemon, and TUI.
  * `--profile/-P` and `FNOX_PROFILE` now accept comma-separated values or repeated flags; later profiles override earlier ones.
  * Added typed list support in settings (`vec<string>`).
  * Introduced `--write-profile` to control where write commands persist when multiple profiles are active.
* **Bug Fixes**
  * Improved profile-aware config discovery, provider/secret visibility, and clearer pluralized messaging.
* **Documentation**
  * Updated CLI flags and profile/config/environment guides with composition/precedence and write-target behavior.
* **Tests**
  * Added/updated coverage for overlay precedence, provider composition, and correct profile-scoped writes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->