### PR TITLE
chore: release v1.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## [1.31.0](https://github.com/jdx/fnox/compare/v1.30.0..v1.31.0) - 2026-07-16
+
+### 🚀 Features
+
+- **(config)** support composing multiple active profiles by [@gaojunran](https://github.com/gaojunran) in [#605](https://github.com/jdx/fnox/pull/605)
+
+### 🐛 Bug Fixes
+
+- **(config)** satisfy clippy profile slice lint by [@jdx](https://github.com/jdx) in [#616](https://github.com/jdx/fnox/pull/616)
+- **(proton-pass)** suggest unlocking locked sessions by [@TyceHerrman](https://github.com/TyceHerrman) in [#612](https://github.com/jdx/fnox/pull/612)
+
+### 🛡️ Security
+
+- **(deps)** update node.js to v24.18.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#609](https://github.com/jdx/fnox/pull/609)
+
+### 🔍 Other Changes
+
+- Update sync workflow example by [@syhol](https://github.com/syhol) in [#614](https://github.com/jdx/fnox/pull/614)
+
+### 📦️ Dependency Updates
+
+- update rust crate usage-lib to v3.5.4 by [@renovate[bot]](https://github.com/renovate[bot]) in [#608](https://github.com/jdx/fnox/pull/608)
+- update rust crate demand to v2.0.3 by [@renovate[bot]](https://github.com/renovate[bot]) in [#607](https://github.com/jdx/fnox/pull/607)
+- update rust crate rmcp to v2 by [@renovate[bot]](https://github.com/renovate[bot]) in [#610](https://github.com/jdx/fnox/pull/610)
+- bump communique to 1.2.3 by [@jdx](https://github.com/jdx) in [#613](https://github.com/jdx/fnox/pull/613)
+
+### New Contributors
+
+- @syhol made their first contribution in [#614](https://github.com/jdx/fnox/pull/614)
+- @gaojunran made their first contribution in [#605](https://github.com/jdx/fnox/pull/605)
+
 ## [1.30.0](https://github.com/jdx/fnox/compare/v1.29.0..v1.30.0) - 2026-07-09
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2373,7 +2373,7 @@ dependencies = [
 
 [[package]]
 name = "fnox"
-version = "1.30.0"
+version = "1.31.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -2421,7 +2421,7 @@ dependencies = [
 
 [[package]]
 name = "fnox-core"
-version = "1.30.0"
+version = "1.31.0"
 dependencies = [
  "aes-gcm 0.11.0",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "crates/fnox-core"]
 resolver = "3"
 
 [workspace.package]
-version = "1.30.0"
+version = "1.31.0"
 edition = "2024"
 authors = ["@jdx"]
 license = "MIT"
@@ -114,7 +114,7 @@ name = "fnox"
 path = "src/main.rs"
 
 [dependencies]
-fnox-core = { path = "crates/fnox-core", version = "1.30.0" }
+fnox-core = { path = "crates/fnox-core", version = "1.31.0" }
 
 # Direct dependencies of the CLI binary (commands, MCP server, TUI, hook-env,
 # shell integration). Provider/config/secret-resolver crates are pulled in

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -1765,7 +1765,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.30.0",
+  "version": "1.31.0",
   "usage": "Usage: fnox [OPTIONS] <COMMAND>",
   "complete": {
     "key": {

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -4,7 +4,7 @@
 
 **Usage**: `fnox [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.30.0
+**Version**: 1.31.0
 
 - **Usage**: `fnox [FLAGS] <SUBCOMMAND>`
 

--- a/fnox.usage.kdl
+++ b/fnox.usage.kdl
@@ -1,7 +1,7 @@
 min_usage_version "1.3"
 name fnox
 bin fnox
-version "1.30.0"
+version "1.31.0"
 about "A flexible secret management tool by @jdx"
 usage "Usage: fnox [OPTIONS] <COMMAND>"
 flag "-c --config" help="Path to the configuration file (default: fnox.toml, searches parent directories)" global=#true default=fnox.toml {


### PR DESCRIPTION
### 🚀 Features

- **(config)** support composing multiple active profiles by [@gaojunran](https://github.com/gaojunran) in [#605](https://github.com/jdx/fnox/pull/605)

### 🐛 Bug Fixes

- **(config)** satisfy clippy profile slice lint by [@jdx](https://github.com/jdx) in [#616](https://github.com/jdx/fnox/pull/616)
- **(proton-pass)** suggest unlocking locked sessions by [@TyceHerrman](https://github.com/TyceHerrman) in [#612](https://github.com/jdx/fnox/pull/612)

### 🛡️ Security

- **(deps)** update node.js to v24.18.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#609](https://github.com/jdx/fnox/pull/609)

### 🔍 Other Changes

- Update sync workflow example by [@syhol](https://github.com/syhol) in [#614](https://github.com/jdx/fnox/pull/614)

### 📦️ Dependency Updates

- update rust crate usage-lib to v3.5.4 by [@renovate[bot]](https://github.com/renovate[bot]) in [#608](https://github.com/jdx/fnox/pull/608)
- update rust crate demand to v2.0.3 by [@renovate[bot]](https://github.com/renovate[bot]) in [#607](https://github.com/jdx/fnox/pull/607)
- update rust crate rmcp to v2 by [@renovate[bot]](https://github.com/renovate[bot]) in [#610](https://github.com/jdx/fnox/pull/610)
- bump communique to 1.2.3 by [@jdx](https://github.com/jdx) in [#613](https://github.com/jdx/fnox/pull/613)

### New Contributors

- @syhol made their first contribution in [#614](https://github.com/jdx/fnox/pull/614)
- @gaojunran made their first contribution in [#605](https://github.com/jdx/fnox/pull/605)