### PR TITLE
Update sync workflow example

### DIFF
--- a/docs/guide/sync.md
+++ b/docs/guide/sync.md
@@ -143,11 +143,14 @@ fi
 export FNOX_AGE_KEY=$(grep "AGE-SECRET-KEY" ~/.config/fnox/age.txt)
 
 # 3. Add age provider to your local config, replacing the recipient with your public key from step 2
-cat >fnox.local.toml << EOF
+recipient=$(grep 'public key:' ~/.config/fnox/age.txt | awk '{print $NF}')
+if ! [ -f fnox.local.toml ] && ! grep -qF "$recipient" fnox.local.toml; then
+	cat >fnox.local.toml <<EOF
 [providers.age]
 type = "age"
-recipients = ["$(grep 'public key:' ~/.config/fnox/age.txt | awk '{print $NF}')"]
+recipients = ["$recipient"]
 EOF
+fi
 
 # 4. Sync all 1Password secrets to local age encryption
 fnox sync --provider age --config fnox.local.toml --force

--- a/docs/guide/sync.md
+++ b/docs/guide/sync.md
@@ -144,7 +144,7 @@ export FNOX_AGE_KEY=$(grep "AGE-SECRET-KEY" ~/.config/fnox/age.txt)
 
 # 3. Add age provider to your local config, replacing the recipient with your public key from step 2
 recipient=$(grep 'public key:' ~/.config/fnox/age.txt | awk '{print $NF}')
-if ! [ -f fnox.local.toml ] && ! grep -qF "$recipient" fnox.local.toml; then
+if [ ! -f fnox.local.toml ] || ! grep -qF "$recipient" fnox.local.toml; then
 	cat >fnox.local.toml <<EOF
 [providers.age]
 type = "age"

--- a/docs/guide/sync.md
+++ b/docs/guide/sync.md
@@ -135,29 +135,24 @@ The `--force` flag skips the confirmation prompt. fnox re-fetches from the origi
 # 1. Clone a project with 1Password secrets in fnox.toml
 git clone https://github.com/myorg/my-api && cd my-api
 
-# 2. Make sure fnox.local.toml is gitignored
-if ! grep -qxF "fnox.local.toml" .gitignore 2>/dev/null; then
-	echo "fnox.local.toml" >>.gitignore
-fi
-
-# 3. Set up your age key (if it doesn't already exist) — note the public key printed to your terminal
+# 2. Set up your age key (if it doesn't already exist) — note the public key printed to your terminal
 mkdir -p ~/.config/fnox
 if [ ! -f ~/.config/fnox/age.txt ]; then
 	age-keygen -o ~/.config/fnox/age.txt
 fi
 export FNOX_AGE_KEY=$(grep "AGE-SECRET-KEY" ~/.config/fnox/age.txt)
 
-# 4. Add age provider to your local config, replacing the recipient with your public key from step 3
+# 3. Add age provider to your local config, replacing the recipient with your public key from step 3
 cat >fnox.local.toml << EOF
 [providers.age]
 type = "age"
 recipients = ["$(grep 'public key:' ~/.config/fnox/age.txt | awk '{print $NF}')"]
 EOF
 
-# 5. Sync all 1Password secrets to local age encryption
+# 4. Sync all 1Password secrets to local age encryption
 fnox sync --provider age --config fnox.local.toml --force
 
-# 6. Done — entering the directory is now instant
+# 5. Done — entering the directory is now instant
 cd .. && cd my-api
 # Secrets load from local age cache, no 1Password calls
 ```

--- a/docs/guide/sync.md
+++ b/docs/guide/sync.md
@@ -136,21 +136,26 @@ The `--force` flag skips the confirmation prompt. fnox re-fetches from the origi
 git clone https://github.com/myorg/my-api && cd my-api
 
 # 2. Make sure fnox.local.toml is gitignored
-echo "fnox.local.toml" >> .gitignore
+if ! grep -qxF "fnox.local.toml" .gitignore 2>/dev/null; then
+	echo "fnox.local.toml" >>.gitignore
+fi
 
-# 3. Set up your age key (one-time) — note the public key printed to your terminal
-age-keygen -o ~/.config/fnox/age.txt
+# 3. Set up your age key (if it doesn't already exist) — note the public key printed to your terminal
+mkdir -p ~/.config/fnox
+if [ ! -f ~/.config/fnox/age.txt ]; then
+	age-keygen -o ~/.config/fnox/age.txt
+fi
 export FNOX_AGE_KEY=$(grep "AGE-SECRET-KEY" ~/.config/fnox/age.txt)
 
-# 4. Add age provider to your config, replacing the recipient with your public key from step 3
-cat >> fnox.toml << EOF
+# 4. Add age provider to your local config, replacing the recipient with your public key from step 3
+cat >fnox.local.toml << EOF
 [providers.age]
 type = "age"
 recipients = ["$(grep 'public key:' ~/.config/fnox/age.txt | awk '{print $NF}')"]
 EOF
 
 # 5. Sync all 1Password secrets to local age encryption
-fnox sync --provider age --config fnox.local.toml
+fnox sync --provider age --config fnox.local.toml --force
 
 # 6. Done — entering the directory is now instant
 cd .. && cd my-api

--- a/docs/guide/sync.md
+++ b/docs/guide/sync.md
@@ -142,7 +142,7 @@ if [ ! -f ~/.config/fnox/age.txt ]; then
 fi
 export FNOX_AGE_KEY=$(grep "AGE-SECRET-KEY" ~/.config/fnox/age.txt)
 
-# 3. Add age provider to your local config, replacing the recipient with your public key from step 3
+# 3. Add age provider to your local config, replacing the recipient with your public key from step 2
 cat >fnox.local.toml << EOF
 [providers.age]
 type = "age"


### PR DESCRIPTION
Made a few changes here that made sense for my workflow and I think it makes a sensible default, I've now added this as a mise task in my repo (excluding step 1 and 6)

Two main goals here:
1. Make it idempotent-ish so it can be run multiple times without causing issues
2. Move the age provider to the local file so the `recipients` don't get version controlled

Also:
- Made it force the sync because I can't think when/why I would want to review it
- Overwrites `fnox.local.toml` each run, making it safe to run multiple times
- Don't create an `~/.config/fnox/age.txt` if it already exists
- Don't ignore `fnox.local.toml` if its already ignored



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the “Full Workflow Example” for syncing secrets to be more repeatable on local setup.
  * Removed steps related to editing `.gitignore` and the reminder about ensuring the cache file is ignored.
  * The example now uses `~/.config/fnox`, generates the age key only if it’s missing, and writes local age provider configuration to `fnox.local.toml` only when needed.
  * The sync command example now includes `--force` to skip the confirmation prompt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->