### PR TITLE
fix(config): satisfy clippy 1.97 lints

### DIFF
--- a/crates/fnox-core/src/config.rs
+++ b/crates/fnox-core/src/config.rs
@@ -1688,7 +1688,7 @@ impl Config {
 
         // Validate each profile
         for (profile_name, profile_config) in &self.profiles {
-            let providers = self.get_providers(&[profile_name.to_string()]);
+            let providers = self.get_providers(std::slice::from_ref(profile_name));
 
             // Check for profile secrets with empty values (likely a mistake, but allowed for plain provider)
             for (key, secret) in &profile_config.secrets {

--- a/src/commands/provider/test.rs
+++ b/src/commands/provider/test.rs
@@ -156,7 +156,7 @@ impl TestCommand {
                 "{} provider{} failed",
                 failed,
                 if failed == 1 { "" } else { "s" }
-            )))?;
+            )));
         }
 
         Ok(())


### PR DESCRIPTION
## Summary

- replace a temporary single-element `String` slice with `std::slice::from_ref`
- remove redundant error propagation from an explicit error return
- satisfy the new lints enabled by Clippy 1.97

## Root cause

The updated Ubuntu GitHub Actions runner includes Clippy 1.97, which reports two pre-existing patterns as warnings. CI denies warnings, so otherwise unrelated PRs began failing in the Ubuntu lint job.

## Impact

This removes an unnecessary allocation and redundant propagation without changing provider validation behavior, restoring compatibility with the updated CI toolchain.

## Validation

- `cargo +1.97.0 fmt --check --manifest-path Cargo.toml`
- `cargo +1.97.0 clippy --workspace --all-targets -- -D warnings`
- `cargo +1.97.0 test -q --workspace` (243 tests passed; doctests passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-only refactors with no intended change to validation or provider test behavior.
> 
> **Overview**
> **CI / Clippy:** Ubuntu’s updated runner (Clippy 1.97) started failing the workspace lint job because warnings are denied. This PR clears the reported lints without changing runtime behavior.
> 
> In **`Config::validate`**, profile validation now passes a single profile name into `get_providers` via `std::slice::from_ref(profile_name)` instead of allocating a one-element `Vec<String>` (`&[profile_name.to_string()]`), satisfying `cloned_ref_to_slice_refs`.
> 
> In **`provider test`**, the failure path uses `return Err(...);` without a trailing `?` on the `Err` expression (redundant with `return`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51561fe25d1b55fc0fdda6d7cf43889d341100ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->