### PR TITLE
chore: release v1.31.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,40 @@
 # Changelog
 
-## [1.31.0](https://github.com/jdx/fnox/compare/v1.30.0..v1.31.0) - 2026-07-16
+## [1.31.1](https://github.com/jdx/fnox/compare/v1.31.0..v1.31.1) - 2026-07-24
+
+### 🛡️ Security
+
+- **(deps)** update dependency @anthropic-ai/claude-code to v2.1.207 by [@renovate[bot]](https://github.com/renovate[bot]) in [#625](https://github.com/jdx/fnox/pull/625)
+
+### 🔍 Other Changes
+
+- regenerate aube-lock.yaml on renovate branches by [@jdx](https://github.com/jdx) in [#626](https://github.com/jdx/fnox/pull/626)
+- exclude aube-lock.yaml from prettier by [@jdx](https://github.com/jdx) in [#629](https://github.com/jdx/fnox/pull/629)
+
+### 📦️ Dependency Updates
+
+- update rust crate bytes to v1.12.1 by [@renovate[bot]](https://github.com/renovate[bot]) in [#617](https://github.com/jdx/fnox/pull/617)
+- update rust crate usage-lib to v3.5.5 by [@renovate[bot]](https://github.com/renovate[bot]) in [#620](https://github.com/jdx/fnox/pull/620)
+- update dependency @anthropic-ai/claude-code to v2.1.206 by [@renovate[bot]](https://github.com/renovate[bot]) in [#621](https://github.com/jdx/fnox/pull/621)
+- update rust crate keepass to v0.13.16 by [@renovate[bot]](https://github.com/renovate[bot]) in [#619](https://github.com/jdx/fnox/pull/619)
+- update rust crate ignore to v0.4.28 by [@renovate[bot]](https://github.com/renovate[bot]) in [#618](https://github.com/jdx/fnox/pull/618)
+- update rust crate regex to v1.13.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#623](https://github.com/jdx/fnox/pull/623)
+- enable MSRV-aware resolution and document MSRV policy by [@jdx](https://github.com/jdx) in [#627](https://github.com/jdx/fnox/pull/627)
+- update rust crate globset to v0.4.19 by [@renovate[bot]](https://github.com/renovate[bot]) in [#636](https://github.com/jdx/fnox/pull/636)
+- update rust crate clap to v4.6.2 by [@renovate[bot]](https://github.com/renovate[bot]) in [#635](https://github.com/jdx/fnox/pull/635)
+- update rust crate regex to v1.13.1 by [@renovate[bot]](https://github.com/renovate[bot]) in [#638](https://github.com/jdx/fnox/pull/638)
+- update rust crate toml_edit to v0.25.13 by [@renovate[bot]](https://github.com/renovate[bot]) in [#641](https://github.com/jdx/fnox/pull/641)
+- update jdx/renovate-config digest to 5fee46e by [@renovate[bot]](https://github.com/renovate[bot]) in [#632](https://github.com/jdx/fnox/pull/632)
+- update rust crate which to v8.0.5 by [@renovate[bot]](https://github.com/renovate[bot]) in [#643](https://github.com/jdx/fnox/pull/643)
+- update rust crate usage-lib to v3.5.6 by [@renovate[bot]](https://github.com/renovate[bot]) in [#642](https://github.com/jdx/fnox/pull/642)
+- update rust crate tokio to v1.52.4 by [@renovate[bot]](https://github.com/renovate[bot]) in [#640](https://github.com/jdx/fnox/pull/640)
+- update rust crate rustls to v0.23.42 by [@renovate[bot]](https://github.com/renovate[bot]) in [#639](https://github.com/jdx/fnox/pull/639)
+- update rust crate apple-native-keyring-store to v1.0.1 by [@renovate[bot]](https://github.com/renovate[bot]) in [#634](https://github.com/jdx/fnox/pull/634)
+- update zizmorcore/zizmor-action action to v0.6.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#647](https://github.com/jdx/fnox/pull/647)
+- update dependency @anthropic-ai/claude-code to v2.1.212 by [@renovate[bot]](https://github.com/renovate[bot]) in [#644](https://github.com/jdx/fnox/pull/644)
+- update rust crate ignore to v0.4.29 by [@renovate[bot]](https://github.com/renovate[bot]) in [#637](https://github.com/jdx/fnox/pull/637)
+
+## [1.31.0](https://github.com/jdx/fnox/compare/v1.30.0..v1.31.0) - 2026-07-17
 
 ### 🚀 Features
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2373,7 +2373,7 @@ dependencies = [
 
 [[package]]
 name = "fnox"
-version = "1.31.0"
+version = "1.31.1"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -2421,7 +2421,7 @@ dependencies = [
 
 [[package]]
 name = "fnox-core"
-version = "1.31.0"
+version = "1.31.1"
 dependencies = [
  "aes-gcm 0.11.0",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "crates/fnox-core"]
 resolver = "3"
 
 [workspace.package]
-version = "1.31.0"
+version = "1.31.1"
 edition = "2024"
 authors = ["@jdx"]
 license = "MIT"
@@ -118,7 +118,7 @@ name = "fnox"
 path = "src/main.rs"
 
 [dependencies]
-fnox-core = { path = "crates/fnox-core", version = "1.31.0" }
+fnox-core = { path = "crates/fnox-core", version = "1.31.1" }
 
 # Direct dependencies of the CLI binary (commands, MCP server, TUI, hook-env,
 # shell integration). Provider/config/secret-resolver crates are pulled in

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -1765,7 +1765,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.31.0",
+  "version": "1.31.1",
   "usage": "Usage: fnox [OPTIONS] <COMMAND>",
   "complete": {
     "key": {

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -4,7 +4,7 @@
 
 **Usage**: `fnox [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.31.0
+**Version**: 1.31.1
 
 - **Usage**: `fnox [FLAGS] <SUBCOMMAND>`
 

--- a/fnox.usage.kdl
+++ b/fnox.usage.kdl
@@ -1,7 +1,7 @@
 min_usage_version "1.3"
 name fnox
 bin fnox
-version "1.31.0"
+version "1.31.1"
 about "A flexible secret management tool by @jdx"
 usage "Usage: fnox [OPTIONS] <COMMAND>"
 flag "-c --config" help="Path to the configuration file (default: fnox.toml, searches parent directories)" global=#true default=fnox.toml {


### PR DESCRIPTION
### 🛡️ Security

- **(deps)** update dependency @anthropic-ai/claude-code to v2.1.207 by [@renovate[bot]](https://github.com/renovate[bot]) in [#625](https://github.com/jdx/fnox/pull/625)

### 🔍 Other Changes

- regenerate aube-lock.yaml on renovate branches by [@jdx](https://github.com/jdx) in [#626](https://github.com/jdx/fnox/pull/626)
- exclude aube-lock.yaml from prettier by [@jdx](https://github.com/jdx) in [#629](https://github.com/jdx/fnox/pull/629)

### 📦️ Dependency Updates

- update rust crate bytes to v1.12.1 by [@renovate[bot]](https://github.com/renovate[bot]) in [#617](https://github.com/jdx/fnox/pull/617)
- update rust crate usage-lib to v3.5.5 by [@renovate[bot]](https://github.com/renovate[bot]) in [#620](https://github.com/jdx/fnox/pull/620)
- update dependency @anthropic-ai/claude-code to v2.1.206 by [@renovate[bot]](https://github.com/renovate[bot]) in [#621](https://github.com/jdx/fnox/pull/621)
- update rust crate keepass to v0.13.16 by [@renovate[bot]](https://github.com/renovate[bot]) in [#619](https://github.com/jdx/fnox/pull/619)
- update rust crate ignore to v0.4.28 by [@renovate[bot]](https://github.com/renovate[bot]) in [#618](https://github.com/jdx/fnox/pull/618)
- update rust crate regex to v1.13.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#623](https://github.com/jdx/fnox/pull/623)
- enable MSRV-aware resolution and document MSRV policy by [@jdx](https://github.com/jdx) in [#627](https://github.com/jdx/fnox/pull/627)
- update rust crate globset to v0.4.19 by [@renovate[bot]](https://github.com/renovate[bot]) in [#636](https://github.com/jdx/fnox/pull/636)
- update rust crate clap to v4.6.2 by [@renovate[bot]](https://github.com/renovate[bot]) in [#635](https://github.com/jdx/fnox/pull/635)
- update rust crate regex to v1.13.1 by [@renovate[bot]](https://github.com/renovate[bot]) in [#638](https://github.com/jdx/fnox/pull/638)
- update rust crate toml_edit to v0.25.13 by [@renovate[bot]](https://github.com/renovate[bot]) in [#641](https://github.com/jdx/fnox/pull/641)
- update jdx/renovate-config digest to 5fee46e by [@renovate[bot]](https://github.com/renovate[bot]) in [#632](https://github.com/jdx/fnox/pull/632)
- update rust crate which to v8.0.5 by [@renovate[bot]](https://github.com/renovate[bot]) in [#643](https://github.com/jdx/fnox/pull/643)
- update rust crate usage-lib to v3.5.6 by [@renovate[bot]](https://github.com/renovate[bot]) in [#642](https://github.com/jdx/fnox/pull/642)
- update rust crate tokio to v1.52.4 by [@renovate[bot]](https://github.com/renovate[bot]) in [#640](https://github.com/jdx/fnox/pull/640)
- update rust crate rustls to v0.23.42 by [@renovate[bot]](https://github.com/renovate[bot]) in [#639](https://github.com/jdx/fnox/pull/639)
- update rust crate apple-native-keyring-store to v1.0.1 by [@renovate[bot]](https://github.com/renovate[bot]) in [#634](https://github.com/jdx/fnox/pull/634)
- update zizmorcore/zizmor-action action to v0.6.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#647](https://github.com/jdx/fnox/pull/647)
- update dependency @anthropic-ai/claude-code to v2.1.212 by [@renovate[bot]](https://github.com/renovate[bot]) in [#644](https://github.com/jdx/fnox/pull/644)
- update rust crate ignore to v0.4.29 by [@renovate[bot]](https://github.com/renovate[bot]) in [#637](https://github.com/jdx/fnox/pull/637)