### PR TITLE
chore(deps): hold minor/major aws-sdk bumps to protect MSRV

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,19 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>jdx/renovate-config"]
+  "extends": ["local>jdx/renovate-config"],
+  "packageRules": [
+    {
+      "description": "AWS SDK crates track near-latest-stable rustc, and their minor/major bumps regularly outrun fnox's MSRV (see AGENTS.md), auto-opening PRs that can only pass by raising rust-version. Disable minor/major updates for them; bump these by hand when we're ready to raise the MSRV too. Patch updates (which don't move MSRV) still flow. Scoped to the SDK crates only — the aws-lc-rs crypto backend is intentionally not held.",
+      "matchManagers": ["cargo"],
+      "matchPackageNames": [
+        "aws-config",
+        "aws-sdk-kms",
+        "aws-sdk-secretsmanager",
+        "aws-sdk-ssm",
+        "aws-sdk-sts"
+      ],
+      "matchUpdateTypes": ["major", "minor"],
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
## Why

The `aws-*` SDK crates set their MSRV to essentially latest-stable `rustc`. So every so often a minor/major renovate bump (e.g. [#622](https://github.com/jdx/fnox/pull/622): aws-sdk → 1.9.0 needs **rustc 1.94.1**) requires a newer compiler than fnox's declared MSRV, and the only way to make CI's `msrv` job pass is to raise `rust-version` — which we deliberately don't do, because fnox is built from source by packagers on an older shared `rustc` (distro `cargo install`, nixpkgs). See #627 for the policy.

Today those bumps auto-open PRs that are red on arrival and just sit there.

## What

Add a fnox-scoped renovate `packageRule` (layered on top of `local>jdx/renovate-config`) that **disables minor/major updates** for the five direct AWS SDK crates:

- `aws-config`, `aws-sdk-kms`, `aws-sdk-secretsmanager`, `aws-sdk-ssm`, `aws-sdk-sts`

**Patch** updates still flow automatically (they don't move MSRV), and the change is **scoped to the SDK crates only**, so `aws-lc-rs` (the rustls crypto backend) keeps getting normal updates. When we're ready to raise the MSRV, bump these by hand (or temporarily flip the rule).

### Why not dependency-dashboard approval

My first cut used `dependencyDashboardApproval`, but this repo has **issues disabled**, so there's no dependency dashboard for it to gate on — the option would silently do nothing. Disabling minor/major updates is the mechanism that actually works here.

### Notes

- Plays well with #627: for `cargo update` / lockfile-maintenance runs, `resolver.incompatible-rust-versions = "fallback"` keeps the lockfile on MSRV-compatible versions too.
- `azure_*` and `google-cloud-*` SDKs likely behave the same way; happy to extend this rule to them in a follow-up.

Pairs with #627 (MSRV-aware resolver + documented policy).

_This PR was generated by Claude Code._