### PR TITLE
chore: prettier-ignore aube-lock.yaml and make supportedArchitectures explicit

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,6 @@
 tmp
 CLAUDE.md
 CHANGELOG.md
+
+# aube-generated lockfile (not prettier-formatted)
+**/aube-lock.yaml

--- a/package.json
+++ b/package.json
@@ -15,15 +15,14 @@
   "pnpm": {
     "supportedArchitectures": {
       "os": [
-        "current",
-        "linux"
+        "linux",
+        "darwin"
       ],
       "cpu": [
-        "current",
-        "x64"
+        "x64",
+        "arm64"
       ],
       "libc": [
-        "current",
         "glibc"
       ]
     },


### PR DESCRIPTION
## Why

The shared `aube-lock` workflow ([jdx/renovate-config](https://github.com/jdx/renovate-config)) commits aube-regenerated lockfiles on `renovate/**` branches. But aube's generated `aube-lock.yaml` is **not** prettier-formatted, and this repo prettier-checks `**/*.yaml`, so those auto-fix commits would fail the prettier lint step.

Generated lockfiles shouldn't be prettier-checked (this repo already ignores other lockfiles). Add `aube-lock.yaml` to `.prettierignore`.

Discovered while fixing the equivalent issue in [jdx/hk#1095](https://github.com/jdx/hk/pull/1095).

*This PR was generated by Claude Code.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint ignore and pnpm metadata only; no runtime, auth, or application logic changes.
> 
> **Overview**
> **Prettier** now skips `**/aube-lock.yaml`, so lockfiles committed by the Renovate `aube-lock` workflow are not reformatted and CI prettier checks stay green.
> 
> **pnpm** `supportedArchitectures` no longer uses `"current"` for OS/CPU/libc; it lists explicit targets (`linux`/`darwin`, `x64`/`arm64`, `glibc` only) so cross-platform lock resolution is pinned the same way on every machine.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5906e29666ccdf75b3603e783900ad0cd51c45eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->