### PR TITLE
chore: release v1.32.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,53 @@
 # Changelog
 
+## [1.32.0](https://github.com/jdx/fnox/compare/v1.31.1..v1.32.0) - 2026-07-31
+
+### 🚀 Features
+
+- **(azure-ac)** add Azure App Configuration provider by [@jmoreno11](https://github.com/jmoreno11) in [#659](https://github.com/jdx/fnox/pull/659)
+- **(exec)** add process replacement mode by [@davdroman](https://github.com/davdroman) in [#654](https://github.com/jdx/fnox/pull/654)
+- **(proxy)** add destination-scoped credential brokering by [@jdx](https://github.com/jdx) in [#667](https://github.com/jdx/fnox/pull/667)
+- assume an IAM role in the AWS providers by [@halms](https://github.com/halms) in [#671](https://github.com/jdx/fnox/pull/671)
+
+### 🐛 Bug Fixes
+
+- **(config)** load global config for explicit --config paths by [@jdx](https://github.com/jdx) in [#651](https://github.com/jdx/fnox/pull/651)
+- **(config)** stabilize instruction-count benchmarks by [@jdx](https://github.com/jdx) in [#670](https://github.com/jdx/fnox/pull/670)
+- **(env)** add fnox artifact to ci path by [@jdx](https://github.com/jdx) in [#650](https://github.com/jdx/fnox/pull/650)
+
+### 📚 Documentation
+
+- **(contributing)** standardize AI disclosures by [@jdx](https://github.com/jdx) in [#660](https://github.com/jdx/fnox/pull/660)
+
+### ⚡ Performance
+
+- track instruction counts, and gate pull requests on them by [@jdx](https://github.com/jdx) in [#656](https://github.com/jdx/fnox/pull/656)
+
+### 🧪 Testing
+
+- **(config)** assert the parse-error diagnostic in config-files test by [@jdx](https://github.com/jdx) in [#653](https://github.com/jdx/fnox/pull/653)
+
+### 📦️ Dependency Updates
+
+- update rust crate age to 0.12 by [@renovate[bot]](https://github.com/renovate[bot]) in [#645](https://github.com/jdx/fnox/pull/645)
+- update rust crate ignore to v0.4.30 by [@renovate[bot]](https://github.com/renovate[bot]) in [#649](https://github.com/jdx/fnox/pull/649)
+- update jdx/mise-action action to v4.2.1 by [@renovate[bot]](https://github.com/renovate[bot]) in [#633](https://github.com/jdx/fnox/pull/633)
+- update demand by [@jdx](https://github.com/jdx) in [#655](https://github.com/jdx/fnox/pull/655)
+- lock file maintenance by [@renovate[bot]](https://github.com/renovate[bot]) in [#657](https://github.com/jdx/fnox/pull/657)
+- update actions/checkout action to v7.0.1 by [@renovate[bot]](https://github.com/renovate[bot]) in [#662](https://github.com/jdx/fnox/pull/662)
+- update dependency @anthropic-ai/claude-code to v2.1.216 by [@renovate[bot]](https://github.com/renovate[bot]) in [#664](https://github.com/jdx/fnox/pull/664)
+- update jdx/pr-closer action to v1.2.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#665](https://github.com/jdx/fnox/pull/665)
+- update jdx/renovate-config digest to aa7a43b by [@renovate[bot]](https://github.com/renovate[bot]) in [#661](https://github.com/jdx/fnox/pull/661)
+- update rust crate usage-lib to v4 by [@renovate[bot]](https://github.com/renovate[bot]) in [#666](https://github.com/jdx/fnox/pull/666)
+- update jdx/mise-action action to v4.2.1 by [@renovate[bot]](https://github.com/renovate[bot]) in [#663](https://github.com/jdx/fnox/pull/663)
+- update jdx/renovate-config digest to d4f71e1 by [@renovate[bot]](https://github.com/renovate[bot]) in [#668](https://github.com/jdx/fnox/pull/668)
+- update dependency @anthropic-ai/claude-code to v2.1.217 by [@renovate[bot]](https://github.com/renovate[bot]) in [#669](https://github.com/jdx/fnox/pull/669)
+
+### New Contributors
+
+- @jmoreno11 made their first contribution in [#659](https://github.com/jdx/fnox/pull/659)
+- @davdroman made their first contribution in [#654](https://github.com/jdx/fnox/pull/654)
+
 ## [1.31.1](https://github.com/jdx/fnox/compare/v1.31.0..v1.31.1) - 2026-07-24
 
 ### 🛡️ Security
@@ -33,6 +81,7 @@
 - update zizmorcore/zizmor-action action to v0.6.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#647](https://github.com/jdx/fnox/pull/647)
 - update dependency @anthropic-ai/claude-code to v2.1.212 by [@renovate[bot]](https://github.com/renovate[bot]) in [#644](https://github.com/jdx/fnox/pull/644)
 - update rust crate ignore to v0.4.29 by [@renovate[bot]](https://github.com/renovate[bot]) in [#637](https://github.com/jdx/fnox/pull/637)
+- update rust crate google-cloud-secretmanager-v1 to v1.11.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#646](https://github.com/jdx/fnox/pull/646)
 
 ## [1.31.0](https://github.com/jdx/fnox/compare/v1.30.0..v1.31.0) - 2026-07-17
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2380,7 +2380,7 @@ dependencies = [
 
 [[package]]
 name = "fnox"
-version = "1.31.1"
+version = "1.32.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -2432,7 +2432,7 @@ dependencies = [
 
 [[package]]
 name = "fnox-core"
-version = "1.31.1"
+version = "1.32.0"
 dependencies = [
  "aes-gcm 0.11.0",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "crates/fnox-core"]
 resolver = "3"
 
 [workspace.package]
-version = "1.31.1"
+version = "1.32.0"
 edition = "2024"
 authors = ["@jdx"]
 license = "MIT"
@@ -121,7 +121,7 @@ name = "fnox"
 path = "src/main.rs"
 
 [dependencies]
-fnox-core = { path = "crates/fnox-core", version = "1.31.1" }
+fnox-core = { path = "crates/fnox-core", version = "1.32.0" }
 
 # Direct dependencies of the CLI binary (commands, MCP server, TUI, hook-env,
 # shell integration). Provider/config/secret-resolver crates are pulled in

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -1832,7 +1832,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.31.1",
+  "version": "1.32.0",
   "usage": "Usage: fnox [OPTIONS] <COMMAND>",
   "complete": {
     "key": {

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -4,7 +4,7 @@
 
 **Usage**: `fnox [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.31.1
+**Version**: 1.32.0
 
 - **Usage**: `fnox [FLAGS] <SUBCOMMAND>`
 

--- a/fnox.usage.kdl
+++ b/fnox.usage.kdl
@@ -1,7 +1,7 @@
 min_usage_version "1.3"
 name fnox
 bin fnox
-version "1.31.1"
+version "1.32.0"
 about "A flexible secret management tool by @jdx"
 usage "Usage: fnox [OPTIONS] <COMMAND>"
 flag "-c --config" help="Path to the configuration file (default: fnox.toml, searches parent directories)" global=#true default=fnox.toml {


### PR DESCRIPTION
### 🚀 Features

- **(azure-ac)** add Azure App Configuration provider by [@jmoreno11](https://github.com/jmoreno11) in [#659](https://github.com/jdx/fnox/pull/659)
- **(exec)** add process replacement mode by [@davdroman](https://github.com/davdroman) in [#654](https://github.com/jdx/fnox/pull/654)
- **(proxy)** add destination-scoped credential brokering by [@jdx](https://github.com/jdx) in [#667](https://github.com/jdx/fnox/pull/667)
- assume an IAM role in the AWS providers by [@halms](https://github.com/halms) in [#671](https://github.com/jdx/fnox/pull/671)

### 🐛 Bug Fixes

- **(config)** load global config for explicit --config paths by [@jdx](https://github.com/jdx) in [#651](https://github.com/jdx/fnox/pull/651)
- **(config)** stabilize instruction-count benchmarks by [@jdx](https://github.com/jdx) in [#670](https://github.com/jdx/fnox/pull/670)
- **(env)** add fnox artifact to ci path by [@jdx](https://github.com/jdx) in [#650](https://github.com/jdx/fnox/pull/650)

### 📚 Documentation

- **(contributing)** standardize AI disclosures by [@jdx](https://github.com/jdx) in [#660](https://github.com/jdx/fnox/pull/660)

### ⚡ Performance

- track instruction counts, and gate pull requests on them by [@jdx](https://github.com/jdx) in [#656](https://github.com/jdx/fnox/pull/656)

### 🧪 Testing

- **(config)** assert the parse-error diagnostic in config-files test by [@jdx](https://github.com/jdx) in [#653](https://github.com/jdx/fnox/pull/653)

### 📦️ Dependency Updates

- update rust crate age to 0.12 by [@renovate[bot]](https://github.com/renovate[bot]) in [#645](https://github.com/jdx/fnox/pull/645)
- update rust crate ignore to v0.4.30 by [@renovate[bot]](https://github.com/renovate[bot]) in [#649](https://github.com/jdx/fnox/pull/649)
- update jdx/mise-action action to v4.2.1 by [@renovate[bot]](https://github.com/renovate[bot]) in [#633](https://github.com/jdx/fnox/pull/633)
- update demand by [@jdx](https://github.com/jdx) in [#655](https://github.com/jdx/fnox/pull/655)
- lock file maintenance by [@renovate[bot]](https://github.com/renovate[bot]) in [#657](https://github.com/jdx/fnox/pull/657)
- update actions/checkout action to v7.0.1 by [@renovate[bot]](https://github.com/renovate[bot]) in [#662](https://github.com/jdx/fnox/pull/662)
- update dependency @anthropic-ai/claude-code to v2.1.216 by [@renovate[bot]](https://github.com/renovate[bot]) in [#664](https://github.com/jdx/fnox/pull/664)
- update jdx/pr-closer action to v1.2.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#665](https://github.com/jdx/fnox/pull/665)
- update jdx/renovate-config digest to aa7a43b by [@renovate[bot]](https://github.com/renovate[bot]) in [#661](https://github.com/jdx/fnox/pull/661)
- update rust crate usage-lib to v4 by [@renovate[bot]](https://github.com/renovate[bot]) in [#666](https://github.com/jdx/fnox/pull/666)
- update jdx/mise-action action to v4.2.1 by [@renovate[bot]](https://github.com/renovate[bot]) in [#663](https://github.com/jdx/fnox/pull/663)
- update jdx/renovate-config digest to d4f71e1 by [@renovate[bot]](https://github.com/renovate[bot]) in [#668](https://github.com/jdx/fnox/pull/668)
- update dependency @anthropic-ai/claude-code to v2.1.217 by [@renovate[bot]](https://github.com/renovate[bot]) in [#669](https://github.com/jdx/fnox/pull/669)

### New Contributors

- @jmoreno11 made their first contribution in [#659](https://github.com/jdx/fnox/pull/659)
- @davdroman made their first contribution in [#654](https://github.com/jdx/fnox/pull/654)