### PR TITLE
fix(env): add fnox artifact to ci path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,10 @@ jobs:
         with:
           name: fnox-${{ matrix.os }}
           path: target/debug
-      - run: chmod +x target/debug/fnox
+      - name: Add fnox to PATH
+        run: |
+          chmod +x target/debug/fnox
+          echo "$GITHUB_WORKSPACE/target/debug" >> "$GITHUB_PATH"
       - name: Setup age key for fnox
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         run: mkdir -p ~/.config/fnox && echo "${{ secrets.AGE_SECRET }}" > ~/.config/fnox/age.txt
@@ -275,7 +278,10 @@ jobs:
         with:
           name: fnox-${{ matrix.os }}
           path: target/debug
-      - run: chmod +x target/debug/fnox
+      - name: Add fnox to PATH
+        run: |
+          chmod +x target/debug/fnox
+          echo "$GITHUB_WORKSPACE/target/debug" >> "$GITHUB_PATH"
       - name: Setup age key for fnox
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         run: mkdir -p ~/.config/fnox && echo "${{ secrets.AGE_SECRET }}" > ~/.config/fnox/age.txt


### PR DESCRIPTION
## Summary

- add the downloaded `target/debug` directory to subsequent GitHub Actions steps via `GITHUB_PATH`
- apply the explicit PATH setup to both jobs that consume the fnox build artifact

## Root cause

`jdx/mise-action` v4.2.1 no longer exports the `PATH` returned by `mise env`. The CI workflow implicitly relied on that behavior to expose `target/debug/fnox`, causing the `ci-other` jobs to fail with `fnox: command not found` after the action update.

## Validation

- `mise exec -- actionlint .github/workflows/ci.yml`
- `mise run lint`

This unblocks https://github.com/jdx/fnox/pull/633.

_This pull request was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change with no application or secret-handling logic changes; low blast radius beyond CI reliability.
> 
> **Overview**
> Restores **`fnox` on PATH** in the **`ci-bats`** and **`ci-other`** jobs after the build artifact is downloaded. The old step only ran **`chmod +x target/debug/fnox`**; it now also appends **`$GITHUB_WORKSPACE/target/debug`** to **`GITHUB_PATH`** so later steps can invoke **`fnox`** by name (e.g. **`fnox ci-redact`**, bats).
> 
> This replaces implicit PATH setup from **`mise-action`** (no longer exporting **`mise env`** PATH in v4.2.1), which had caused **`fnox: command not found`** failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f91578a11b0c63bd6996d6e115b1c3ecbd30c70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->