### PR TITLE
fix(config): load global config for explicit --config paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,9 @@ src/env.rs          # Centralized env var handling (LazyLock, FNOX_* prefix)
 4. `fnox.$FNOX_PROFILE.toml` (profile-specific, if not "default")
 5. `fnox.local.toml` (local overrides, gitignored)
 
+An explicit `-c/--config` path skips steps 2-5 (no directory recursion, no local
+overrides) but still loads the global config and the file's own `import`s.
+
 **Secret options:**
 
 - `if_missing`: `"error"` | `"warn"` (default) | `"ignore"`

--- a/crates/fnox-core/src/config.rs
+++ b/crates/fnox-core/src/config.rs
@@ -749,8 +749,11 @@ impl Config {
         }
     }
 
-    /// Load an imported config file
-    fn load_import(import_path: &str, base_dir: &Path) -> Result<Self> {
+    /// Load an imported config file.
+    ///
+    /// Public so `fnox config-files` can report the same errors loading
+    /// would hit instead of reimplementing the resolve-and-read rules.
+    pub fn load_import(import_path: &str, base_dir: &Path) -> Result<Self> {
         let absolute_path =
             crate::config_path::resolve_relative_to_dir(import_path, Some(base_dir));
 

--- a/crates/fnox-core/src/config.rs
+++ b/crates/fnox-core/src/config.rs
@@ -35,6 +35,18 @@ pub fn all_config_filenames(profiles: &[String]) -> Vec<String> {
     files
 }
 
+/// Whether a `--config` value triggers the upward directory search.
+///
+/// Only the bare default filenames do; anything else (including
+/// `./fnox.toml` or an absolute path to a `fnox.toml`) is treated as an
+/// explicit path and loads just that file, its imports, and the global
+/// config.
+pub fn uses_config_discovery(path: &Path) -> bool {
+    all_config_filenames(&[])
+        .iter()
+        .any(|f| path == Path::new(f))
+}
+
 /// Returns the local override filename for a supported config basename.
 ///
 /// Only `fnox.toml` and `.fnox.toml` have corresponding local override files.
@@ -528,8 +540,7 @@ impl Config {
         let path_ref = path.as_ref();
 
         // If the path is one of the default config filenames, use recursive loading
-        let default_filenames = all_config_filenames(&[]);
-        if default_filenames.iter().any(|f| path_ref == Path::new(f)) {
+        if uses_config_discovery(path_ref) {
             Self::load_with_recursion(path_ref)
         } else {
             // For explicit paths, resolve relative paths against current directory first
@@ -542,9 +553,39 @@ impl Config {
             } else {
                 path_ref.to_path_buf()
             };
-            // For explicit paths, use direct loading
-            Self::load(resolved_path)
+            Self::load_explicit(&resolved_path)
         }
+    }
+
+    /// Load an explicitly specified config file.
+    ///
+    /// Unlike [`Self::load_with_recursion`] this does not search parent
+    /// directories, but the file's own imports and the global config are
+    /// still layered underneath it — the global config is the base for
+    /// every project, and `root = true` doesn't disable it either.
+    fn load_explicit(path: &Path) -> Result<Self> {
+        let mut config = Self::load(path)?;
+
+        // Imports are resolved relative to the config file's directory and
+        // are overridden by the file that imports them.
+        let dir = path.parent().unwrap_or_else(|| Path::new(""));
+        for import_path in &config.import.clone() {
+            let import_config = Self::load_import(import_path, dir)?;
+            config = Self::merge_configs(import_config, config)?;
+        }
+
+        // Nothing to layer under the global config when it *is* the
+        // explicitly requested file.
+        if path == Self::global_config_path() {
+            return Ok(config);
+        }
+
+        let (global_config, global_found) = Self::load_global()?;
+        if global_found {
+            config = Self::merge_configs(global_config, config)?;
+        }
+
+        Ok(config)
     }
 
     /// Load configuration from a file
@@ -2105,6 +2146,22 @@ mod tests {
             !toml.contains("[profiles]\n"),
             "Should not have standalone [profiles] header"
         );
+    }
+
+    #[test]
+    fn test_uses_config_discovery() {
+        // Bare default filenames trigger the upward search
+        assert!(uses_config_discovery(Path::new("fnox.toml")));
+        assert!(uses_config_discovery(Path::new(".fnox.toml")));
+        assert!(uses_config_discovery(Path::new("fnox.local.toml")));
+
+        // Anything with a directory component, or a non-default name, is an
+        // explicit path
+        assert!(!uses_config_discovery(Path::new("./fnox.toml")));
+        assert!(!uses_config_discovery(Path::new("../fnox.toml")));
+        assert!(!uses_config_discovery(Path::new("/etc/fnox.toml")));
+        assert!(!uses_config_discovery(Path::new("custom.toml")));
+        assert!(!uses_config_discovery(Path::new("fnox.prod.toml")));
     }
 
     #[test]

--- a/crates/fnox-core/src/library.rs
+++ b/crates/fnox-core/src/library.rs
@@ -75,7 +75,7 @@ impl Fnox {
     pub fn discover() -> Result<Self> {
         // CONFIG_FILENAME is bare (no directory prefix) so load_smart
         // takes its upward-recursion path — this is what unlocks the
-        // parent + local + global merging that load(absolute) would
+        // parent + local-override merging that an explicit path would
         // bypass. Per AGENTS.md "Loading order".
         let config = Config::load_smart(CONFIG_FILENAME)?;
         let profiles = Self::env_profiles();

--- a/docs/guide/hierarchical-config.md
+++ b/docs/guide/hierarchical-config.md
@@ -137,7 +137,7 @@ EOF
 
 - Always add `fnox.local.toml` to `.gitignore`
 - Provide a `fnox.local.toml.example` (committed) for team guidance
-- Use explicit paths to bypass local overrides: `fnox -c ./fnox.toml get SECRET`
+- Use explicit paths to bypass parent configs and local overrides: `fnox -c ./fnox.toml get SECRET` (the file's own `import`s and the global config are still loaded)
 - `fnox sync --local-file` only supports `fnox.toml` and `.fnox.toml`. Other config filenames are rejected because adjacent local override files are not loaded.
 
 ## Global Configuration
@@ -164,7 +164,7 @@ fnox provider add age age --global
 - Machine-specific credentials
 - Default encryption provider available everywhere
 
-**Note**: Global config is always loaded, even when `root = true` stops parent directory recursion.
+**Note**: Global config is always loaded, even when `root = true` stops parent directory recursion or `-c/--config` points at an explicit file.
 
 ## Tips
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -34,6 +34,24 @@ fnox looks for configuration files in this order (lowest to highest priority):
 5. `fnox.local.toml` alongside each `fnox.toml` (for local overrides)
 6. Path specified via `-c, --config` flag
 
+### Explicit Config Paths
+
+Passing `-c, --config` with anything other than the bare default filename turns
+off the hierarchical search: fnox loads that one file plus any files it
+`import`s, and skips parent directories and their local overrides. The global
+config is still loaded as the base layer, the same way `root = true` stops
+recursion without disabling it.
+
+To load a config in complete isolation, point `FNOX_CONFIG_DIR` at a directory
+with no `config.toml`:
+
+```bash
+FNOX_CONFIG_DIR=/nonexistent fnox -c ./ci.toml get MY_SECRET
+```
+
+Use `fnox config-files` to see exactly which files a given directory and set of
+flags will load.
+
 ### Global Configuration
 
 The global config file stores machine-wide secrets and providers that apply to all projects:

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -32,7 +32,7 @@ fnox looks for configuration files in this order (lowest to highest priority):
 3. `fnox.toml` in current directory
 4. `fnox.$FNOX_PROFILE.toml` alongside each `fnox.toml` (profile-specific)
 5. `fnox.local.toml` alongside each `fnox.toml` (for local overrides)
-6. Path specified via `-c, --config` flag
+6. Path specified via `-c, --config` flag — for non-default filenames this replaces steps 2-5 instead of stacking on top of them, see [Explicit Config Paths](#explicit-config-paths)
 
 ### Explicit Config Paths
 

--- a/src/commands/config_files.rs
+++ b/src/commands/config_files.rs
@@ -38,6 +38,18 @@ impl ConfigFilesCommand {
             } else {
                 cli.config.clone()
             };
+            // Loading fails outright on a missing explicit config, before the
+            // global layer is reached — don't report a load order that can't
+            // happen.
+            if !explicit.exists() {
+                return Err(crate::error::FnoxError::ConfigReadFailed {
+                    path: explicit,
+                    source: std::io::Error::new(
+                        std::io::ErrorKind::NotFound,
+                        "No such file or directory",
+                    ),
+                });
+            }
             self.collect_file(&explicit, &mut printed)?;
         }
 

--- a/src/commands/config_files.rs
+++ b/src/commands/config_files.rs
@@ -1,4 +1,4 @@
-use crate::config::{Config, all_config_filenames};
+use crate::config::{Config, all_config_filenames, uses_config_discovery};
 use crate::env;
 use crate::error::Result;
 use std::collections::HashSet;
@@ -18,7 +18,7 @@ struct PartialConfig {
 pub struct ConfigFilesCommand;
 
 impl ConfigFilesCommand {
-    pub async fn run(&self, _cli: &Cli) -> Result<()> {
+    pub async fn run(&self, cli: &Cli) -> Result<()> {
         let profile = Config::get_profiles(&[]);
         let filenames = all_config_filenames(&profile);
 
@@ -27,7 +27,19 @@ impl ConfigFilesCommand {
         })?;
 
         let mut printed = HashSet::new();
-        self.collect_recursive(&current_dir, &filenames, &mut printed)?;
+
+        // An explicit --config path skips the upward search entirely, so
+        // list only that file (plus its imports) and the global config.
+        if uses_config_discovery(&cli.config) {
+            self.collect_recursive(&current_dir, &filenames, &mut printed)?;
+        } else {
+            let explicit = if cli.config.is_relative() {
+                current_dir.join(&cli.config)
+            } else {
+                cli.config.clone()
+            };
+            self.collect_file(&explicit, &mut printed)?;
+        }
 
         // Global config is always checked
         let global = Config::global_config_path();
@@ -47,26 +59,8 @@ impl ConfigFilesCommand {
         let mut found_root = false;
 
         for filename in filenames {
-            let path = dir.join(filename);
-            if path.exists() && printed.insert(path.clone()) {
-                println!("{}", path.display());
-
-                if let Ok(content) = std::fs::read_to_string(&path)
-                    && let Ok(partial) = toml_edit::de::from_str::<PartialConfig>(&content)
-                {
-                    // Print imported config files
-                    for import_path in &partial.import {
-                        let import =
-                            crate::config_path::resolve_relative_to_dir(import_path, Some(dir));
-                        if import.exists() && printed.insert(import.clone()) {
-                            println!("{}", import.display());
-                        }
-                    }
-
-                    if partial.root {
-                        found_root = true;
-                    }
-                }
+            if self.collect_file(&dir.join(filename), printed)? {
+                found_root = true;
             }
         }
 
@@ -79,5 +73,31 @@ impl ConfigFilesCommand {
         }
 
         Ok(())
+    }
+
+    /// Print `path` and any files it imports. Returns whether it sets `root = true`.
+    fn collect_file(&self, path: &Path, printed: &mut HashSet<PathBuf>) -> Result<bool> {
+        if !path.exists() || !printed.insert(path.to_path_buf()) {
+            return Ok(false);
+        }
+        println!("{}", path.display());
+
+        let Ok(content) = std::fs::read_to_string(path) else {
+            return Ok(false);
+        };
+        let Ok(partial) = toml_edit::de::from_str::<PartialConfig>(&content) else {
+            return Ok(false);
+        };
+
+        // Print imported config files
+        let dir = path.parent().unwrap_or_else(|| Path::new(""));
+        for import_path in &partial.import {
+            let import = crate::config_path::resolve_relative_to_dir(import_path, Some(dir));
+            if import.exists() && printed.insert(import.clone()) {
+                println!("{}", import.display());
+            }
+        }
+
+        Ok(partial.root)
     }
 }

--- a/src/commands/config_files.rs
+++ b/src/commands/config_files.rs
@@ -38,13 +38,22 @@ impl ConfigFilesCommand {
             } else {
                 cli.config.clone()
             };
-            // A missing or unparseable explicit config makes loading fail
-            // before the global layer is reached, so surface the same error
-            // rather than reporting a load order that can't happen.
+            // A missing or unparseable explicit config — or import of one —
+            // makes loading fail before the global layer is reached, so
+            // surface the same errors rather than reporting a load order
+            // that can't happen.
             let config = Config::load(&explicit)?;
             println!("{}", explicit.display());
             printed.insert(explicit.clone());
-            self.collect_imports(&explicit, &config.import, &mut printed);
+
+            let dir = explicit.parent().unwrap_or_else(|| Path::new(""));
+            for import_path in &config.import {
+                Config::load_import(import_path, dir)?;
+                let import = crate::config_path::resolve_relative_to_dir(import_path, Some(dir));
+                if printed.insert(import.clone()) {
+                    println!("{}", import.display());
+                }
+            }
         }
 
         // Global config is always checked
@@ -101,6 +110,9 @@ impl ConfigFilesCommand {
     }
 
     /// Print the files `path` imports, resolved relative to its directory.
+    ///
+    /// Tolerant of missing imports, matching how the discovery walk has
+    /// always reported them.
     fn collect_imports(&self, path: &Path, imports: &[String], printed: &mut HashSet<PathBuf>) {
         let dir = path.parent().unwrap_or_else(|| Path::new(""));
         for import_path in imports {

--- a/src/commands/config_files.rs
+++ b/src/commands/config_files.rs
@@ -38,19 +38,13 @@ impl ConfigFilesCommand {
             } else {
                 cli.config.clone()
             };
-            // Loading fails outright on a missing explicit config, before the
-            // global layer is reached — don't report a load order that can't
-            // happen.
-            if !explicit.exists() {
-                return Err(crate::error::FnoxError::ConfigReadFailed {
-                    path: explicit,
-                    source: std::io::Error::new(
-                        std::io::ErrorKind::NotFound,
-                        "No such file or directory",
-                    ),
-                });
-            }
-            self.collect_file(&explicit, &mut printed)?;
+            // A missing or unparseable explicit config makes loading fail
+            // before the global layer is reached, so surface the same error
+            // rather than reporting a load order that can't happen.
+            let config = Config::load(&explicit)?;
+            println!("{}", explicit.display());
+            printed.insert(explicit.clone());
+            self.collect_imports(&explicit, &config.import, &mut printed);
         }
 
         // Global config is always checked
@@ -101,15 +95,19 @@ impl ConfigFilesCommand {
             return Ok(false);
         };
 
-        // Print imported config files
+        self.collect_imports(path, &partial.import, printed);
+
+        Ok(partial.root)
+    }
+
+    /// Print the files `path` imports, resolved relative to its directory.
+    fn collect_imports(&self, path: &Path, imports: &[String], printed: &mut HashSet<PathBuf>) {
         let dir = path.parent().unwrap_or_else(|| Path::new(""));
-        for import_path in &partial.import {
+        for import_path in imports {
             let import = crate::config_path::resolve_relative_to_dir(import_path, Some(dir));
             if import.exists() && printed.insert(import.clone()) {
                 println!("{}", import.display());
             }
         }
-
-        Ok(partial.root)
     }
 }

--- a/test/config_files.bats
+++ b/test/config_files.bats
@@ -1,0 +1,100 @@
+#!/usr/bin/env bats
+
+setup() {
+	load 'test_helper/common_setup'
+	_common_setup
+}
+
+teardown() {
+	_common_teardown
+}
+
+@test "config-files lists the discovery chain" {
+	mkdir -p "$HOME/.config/fnox"
+	cat >"$HOME/.config/fnox/config.toml" <<EOF
+[secrets]
+GLOBAL_SECRET = { default = "global-value" }
+EOF
+
+	mkdir -p parent/child
+	cat >parent/fnox.toml <<EOF
+[secrets]
+PARENT_SECRET = { default = "parent-value" }
+EOF
+	cat >parent/child/fnox.toml <<EOF
+[secrets]
+CHILD_SECRET = { default = "child-value" }
+EOF
+
+	cd parent/child
+
+	run "$FNOX_BIN" config-files
+	assert_success
+	assert_output --partial "parent/child/fnox.toml"
+	assert_output --partial "parent/fnox.toml"
+	assert_output --partial ".config/fnox/config.toml"
+}
+
+@test "config-files with explicit --config lists only that file and global" {
+	mkdir -p "$HOME/.config/fnox"
+	cat >"$HOME/.config/fnox/config.toml" <<EOF
+[secrets]
+GLOBAL_SECRET = { default = "global-value" }
+EOF
+
+	mkdir -p parent/child
+	cat >parent/fnox.toml <<EOF
+[secrets]
+PARENT_SECRET = { default = "parent-value" }
+EOF
+	cat >parent/child/fnox.toml <<EOF
+[secrets]
+CHILD_SECRET = { default = "child-value" }
+EOF
+	cat >parent/child/custom.toml <<EOF
+[secrets]
+CUSTOM_SECRET = { default = "custom-value" }
+EOF
+
+	cd parent/child
+
+	run "$FNOX_BIN" -c custom.toml config-files
+	assert_success
+	assert_output --partial "custom.toml"
+	assert_output --partial ".config/fnox/config.toml"
+
+	# Files that are not actually loaded must not be listed
+	refute_output --partial "child/fnox.toml"
+	refute_output --partial "parent/fnox.toml"
+}
+
+@test "config-files with explicit --config lists imports" {
+	cat >imported.toml <<EOF
+[secrets]
+IMPORTED_SECRET = { default = "imported-value" }
+EOF
+	cat >custom.toml <<EOF
+import = ["./imported.toml"]
+
+[secrets]
+CUSTOM_SECRET = { default = "custom-value" }
+EOF
+
+	run "$FNOX_BIN" -c custom.toml config-files
+	assert_success
+	assert_output --partial "custom.toml"
+	assert_output --partial "imported.toml"
+}
+
+@test "config-files omits a missing explicit --config file" {
+	mkdir -p "$HOME/.config/fnox"
+	cat >"$HOME/.config/fnox/config.toml" <<EOF
+[secrets]
+GLOBAL_SECRET = { default = "global-value" }
+EOF
+
+	run "$FNOX_BIN" -c missing.toml config-files
+	assert_success
+	refute_output --partial "missing.toml"
+	assert_output --partial ".config/fnox/config.toml"
+}

--- a/test/config_files.bats
+++ b/test/config_files.bats
@@ -86,15 +86,17 @@ EOF
 	assert_output --partial "imported.toml"
 }
 
-@test "config-files omits a missing explicit --config file" {
+@test "config-files fails on a missing explicit --config file" {
 	mkdir -p "$HOME/.config/fnox"
 	cat >"$HOME/.config/fnox/config.toml" <<EOF
 [secrets]
 GLOBAL_SECRET = { default = "global-value" }
 EOF
 
+	# Loading would fail before reaching the global layer, so listing the
+	# global config here would describe a load that cannot happen
 	run "$FNOX_BIN" -c missing.toml config-files
-	assert_success
-	refute_output --partial "missing.toml"
-	assert_output --partial ".config/fnox/config.toml"
+	assert_failure
+	assert_output --partial "Failed to read configuration file"
+	refute_output --partial ".config/fnox/config.toml"
 }

--- a/test/config_files.bats
+++ b/test/config_files.bats
@@ -100,3 +100,17 @@ EOF
 	assert_output --partial "Failed to read configuration file"
 	refute_output --partial ".config/fnox/config.toml"
 }
+
+@test "config-files fails on an unparseable explicit --config file" {
+	mkdir -p "$HOME/.config/fnox"
+	cat >"$HOME/.config/fnox/config.toml" <<EOF
+[secrets]
+GLOBAL_SECRET = { default = "global-value" }
+EOF
+
+	echo "this is not valid toml {{{" >broken.toml
+
+	run "$FNOX_BIN" -c broken.toml config-files
+	assert_failure
+	refute_output --partial ".config/fnox/config.toml"
+}

--- a/test/config_files.bats
+++ b/test/config_files.bats
@@ -101,6 +101,31 @@ EOF
 	refute_output --partial ".config/fnox/config.toml"
 }
 
+@test "config-files fails when an explicit --config imports a missing file" {
+	mkdir -p "$HOME/.config/fnox"
+	cat >"$HOME/.config/fnox/config.toml" <<EOF
+[secrets]
+GLOBAL_SECRET = { default = "global-value" }
+EOF
+
+	cat >custom.toml <<EOF
+import = ["./missing.toml"]
+
+[secrets]
+CUSTOM_SECRET = { default = "custom-value" }
+EOF
+
+	run "$FNOX_BIN" -c custom.toml config-files
+	assert_failure
+	assert_output --partial "Import file not found"
+	refute_output --partial ".config/fnox/config.toml"
+
+	# Same failure the loader gives
+	run "$FNOX_BIN" -c custom.toml get CUSTOM_SECRET
+	assert_failure
+	assert_output --partial "Import file not found"
+}
+
 @test "config-files fails on an unparseable explicit --config file" {
 	mkdir -p "$HOME/.config/fnox"
 	cat >"$HOME/.config/fnox/config.toml" <<EOF

--- a/test/config_recursion.bats
+++ b/test/config_recursion.bats
@@ -259,7 +259,7 @@ EOF
 	# Change to child directory and test explicit path
 	cd parent/child
 
-	# Use explicit path - should only load that file
+	# Use explicit path - should not walk the directory tree
 	run "$FNOX_BIN" -c ../fnox.toml get PARENT_SECRET
 	assert_success
 	assert_output --partial "parent-value"
@@ -268,4 +268,37 @@ EOF
 	run "$FNOX_BIN" -c ../fnox.toml get CHILD_SECRET
 	assert_failure
 	assert_output --partial "not found"
+}
+
+@test "explicit config path still loads imports" {
+	cat >imported.toml <<EOF
+[secrets]
+IMPORTED_SECRET = { description = "Imported secret", default = "imported-value" }
+SHARED_SECRET = { description = "Imported version", default = "imported-override-me" }
+EOF
+
+	cat >custom.toml <<EOF
+import = ["./imported.toml"]
+
+[providers.test]
+type = "age"
+recipients = ["age1test"]
+
+[secrets]
+CUSTOM_SECRET = { description = "Custom secret", default = "custom-value" }
+SHARED_SECRET = { description = "Custom version", default = "custom-wins" }
+EOF
+
+	run "$FNOX_BIN" -c custom.toml get IMPORTED_SECRET
+	assert_success
+	assert_output --partial "imported-value"
+
+	run "$FNOX_BIN" -c custom.toml get CUSTOM_SECRET
+	assert_success
+	assert_output --partial "custom-value"
+
+	# The importing file wins over what it imports
+	run "$FNOX_BIN" -c custom.toml get SHARED_SECRET
+	assert_success
+	assert_output --partial "custom-wins"
 }

--- a/test/global_config.bats
+++ b/test/global_config.bats
@@ -258,6 +258,60 @@ EOF
 	assert_output --partial "not found"
 }
 
+@test "explicit --config still loads global config" {
+	mkdir -p "$HOME/.config/fnox"
+	cat >"$HOME/.config/fnox/config.toml" <<EOF
+[providers.global]
+type = "age"
+recipients = ["age1global"]
+
+[secrets]
+GLOBAL_SECRET = { description = "Global secret", default = "global-value" }
+SHARED_SECRET = { description = "Global version", default = "global-loses" }
+EOF
+
+	cat >custom.toml <<EOF
+[secrets]
+CUSTOM_SECRET = { description = "Custom secret", default = "custom-value" }
+SHARED_SECRET = { description = "Custom version", default = "custom-wins" }
+EOF
+
+	# Global secrets and providers are the base layer for explicit configs too
+	run "$FNOX_BIN" -c custom.toml get GLOBAL_SECRET
+	assert_success
+	assert_output --partial "global-value"
+
+	run "$FNOX_BIN" -c custom.toml get CUSTOM_SECRET
+	assert_success
+	assert_output --partial "custom-value"
+
+	# The explicit config still wins over global
+	run "$FNOX_BIN" -c custom.toml get SHARED_SECRET
+	assert_success
+	assert_output --partial "custom-wins"
+
+	# Providers defined globally are usable from an explicit config
+	run "$FNOX_BIN" -c custom.toml provider list
+	assert_success
+	assert_output --partial "global"
+}
+
+@test "explicit --config pointing at the global config works" {
+	mkdir -p "$HOME/.config/fnox"
+	cat >"$HOME/.config/fnox/config.toml" <<EOF
+[providers.global]
+type = "age"
+recipients = ["age1global"]
+
+[secrets]
+GLOBAL_SECRET = { description = "Global secret", default = "global-value" }
+EOF
+
+	run "$FNOX_BIN" -c "$HOME/.config/fnox/config.toml" get GLOBAL_SECRET
+	assert_success
+	assert_output --partial "global-value"
+}
+
 @test "no global config works fine" {
 	# Don't create any global config
 	# Create project config


### PR DESCRIPTION
Reported in chat: with `-c/--config` pointing at anything other than a bare default filename, the global config is silently skipped, and `fnox config-files` lists it anyway.

## Problem

`Config::load_smart` decides between discovery and direct loading by string-comparing the `--config` value against the default filenames. Anything else fell through to a bare `Config::load`, which loads exactly one file — no global config, and no handling of that file's own `import = [...]`.

That contradicts what's documented:

- `docs/reference/configuration.md` lists the global config as layer 1 of a six-layer merge with `--config` on top, i.e. merging, not replacement.
- `root = true` explicitly stops parent recursion *without* disabling the global config, and that's documented as intended. An explicit path shouldn't be stricter than the opt-out designed for this.

It also made `-c fnox.toml` and `-c ./fnox.toml` behave differently for the same file, since the check is on the argument string rather than the resolved path.

Separately, `fnox config-files` ignored `--config` entirely: it always walked up from the cwd and always printed the global config, so it listed files that were never loaded and, in the explicit-path case, described a load order that didn't happen.

## Changes

- An explicit `--config` path now loads that file, its imports, and the global config underneath it.
- `fnox config-files` mirrors whichever path loading actually takes.
- Extracted the branch predicate into `config::uses_config_discovery` so the two can't drift apart again.
- Docs updated in `docs/reference/configuration.md`, `docs/guide/hierarchical-config.md`, and `AGENTS.md`.

## Unchanged, deliberately

- An explicit path still does not walk parent directories or pick up sibling `fnox.local.toml` / profile files. That was intentional and stays.
- `-c fnox.toml` vs `-c ./fnox.toml` still differ in whether the directory walk happens. Only the global-config gap is closed here; making the walk depend on clap's value source is a separate question.
- `Fnox::open()` in the library API is untouched — it's documented as a strict single-file load with no global layer, which is the right contract for a library.
- Consequence worth flagging: `fnox -c custom.toml sync -p <provider>` can now pull globally-declared secrets into `custom.toml`, the same way it already does for a discovered `fnox.toml`. Consistent, but new for explicit paths.
- For full isolation, point `FNOX_CONFIG_DIR` at a directory with no `config.toml`; documented in the reference. No `--no-global` flag added.

## Testing

- New `test/config_files.bats` covering the discovery chain, explicit `--config`, imports, and a missing explicit file.
- New cases in `test/global_config.bats` (explicit `--config` still layers global; `-c` pointing at the global config itself) and `test/config_recursion.bats` (imports resolve for explicit paths).
- `cargo test --workspace` passes. Full bats suite: 678 pass, 18 fail — all pre-existing environment failures in my container (17 keychain tests needing `secret-tool`, and `sync does not create parent directory for explicit default config path`, which fails on `main` too because the long worktree path makes miette wrap the asserted substring).

_This PR description was generated by Claude Code._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core config merge semantics for explicit `-c` paths (global secrets/providers now apply), which can surprise CI/custom configs but aligns with documented behavior; `fnox config-files` output changes accordingly.
> 
> **Overview**
> Fixes a gap where **non-default** `-c/--config` values only loaded a single file—no global layer and no `import` resolution—while docs and `root = true` behavior implied global config should always be the base.
> 
> **Config loading:** `Config::load_smart` routes explicit paths through new `load_explicit`, which loads the file, merges its `import`s underneath it, then merges global config (skipped when `-c` points at the global file itself). Discovery vs explicit is centralized in `uses_config_discovery` so the CLI and loader stay aligned. Parent directory walk and sibling `fnox.local.toml` / profile files remain skipped for explicit paths.
> 
> **`fnox config-files`:** Honors `--config` the same way—discovery walk vs explicit file + imports—and fails early on missing/broken explicit configs without listing global config when loading would never reach it.
> 
> Docs (`AGENTS.md`, hierarchical guide, configuration reference) describe explicit-path semantics and isolation via `FNOX_CONFIG_DIR`. Bats coverage added for `config-files`, explicit-path imports, and global layering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fbfa8fee4883bce91cb68ee6de62f3ce6675322. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Explicit `-c/--config` paths now disable upward config discovery, skipping parent-directory configs and local overrides while still loading the specified file and its `import`s.
  - Global configuration is always loaded as the base layer; project config takes precedence on conflicts.
  - `config-files` reports the exact resolved set of configs for both explicit paths and discovered hierarchies.
- **Documentation**
  - Clarified “explicit config paths” and global/local merge behavior in the configuration guides and reference.
- **Tests**
  - Added/expanded Bats coverage for explicit paths, imports, global config precedence, and failure cases (missing/unparseable configs).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->