### PR TITLE
test(config): assert the parse-error diagnostic in config-files test

### DIFF
--- a/test/config_files.bats
+++ b/test/config_files.bats
@@ -137,5 +137,11 @@ EOF
 
 	run "$FNOX_BIN" -c broken.toml config-files
 	assert_failure
+	assert_output --partial "fnox::config::invalid_toml"
 	refute_output --partial ".config/fnox/config.toml"
+
+	# Same failure the loader gives
+	run "$FNOX_BIN" -c broken.toml get ANY_SECRET
+	assert_failure
+	assert_output --partial "fnox::config::invalid_toml"
 }


### PR DESCRIPTION
Follow-up to #651, which merged before this last review response landed on the branch.

CodeRabbit pointed out that the `config-files fails on an unparseable explicit --config file` case accepted any failure rather than the specific one, so it didn't actually verify the loader-equivalent failure path. This asserts the `fnox::config::invalid_toml` diagnostic, and that `get` on the same file fails with the same diagnostic — matching how the missing-import case next to it is written.

Test-only; no behavior change.

_This PR description was generated by Claude Code._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Bats assertions only; no production code paths are modified.
> 
> **Overview**
> The **unparseable explicit `--config` file** test no longer treats any exit failure as sufficient. It now requires output containing **`fnox::config::invalid_toml`**, and adds a second run of **`get ANY_SECRET`** on the same broken file with the same diagnostic assertion—mirroring the **missing import** test beside it.
> 
> **Test-only; no runtime behavior change.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5aa5e759de657be804aa4465182d4b83c24266b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->