### PR TITLE
feat(exec): add process replacement mode

### DIFF
--- a/crates/fnox-core/src/error.rs
+++ b/crates/fnox-core/src/error.rs
@@ -448,6 +448,29 @@ pub enum FnoxError {
         source: std::io::Error,
     },
 
+    #[error("--replace cannot be used with file-based secrets: {secrets}")]
+    #[diagnostic(
+        code(fnox::command::replace_with_file_secrets),
+        help(
+            "Run without --replace so fnox can remove temporary secret files after the command exits"
+        )
+    )]
+    ExecReplaceFileSecrets { secrets: String },
+
+    #[error("--replace cannot be used with credential leases")]
+    #[diagnostic(
+        code(fnox::command::replace_with_leases),
+        help("Run without --replace so fnox can manage the lease lifecycle")
+    )]
+    ExecReplaceLeases,
+
+    #[error("Failed to configure signal handling for --replace")]
+    #[diagnostic(code(fnox::command::replace_signal_setup))]
+    ExecReplaceSignalSetup {
+        #[source]
+        source: std::io::Error,
+    },
+
     // ========================================================================
     // Import Errors
     // ========================================================================

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -247,7 +247,7 @@
       },
       "exec": {
         "full_cmd": ["exec"],
-        "usage": "exec [COMMAND]…",
+        "usage": "exec [--replace] [COMMAND]…",
         "subcommands": {},
         "args": [
           {
@@ -261,7 +261,18 @@
             "hide": false
           }
         ],
-        "flags": [],
+        "flags": [
+          {
+            "name": "replace",
+            "usage": "--replace",
+            "help": "Run the command in fnox's process, keeping the same PID and receiving signals directly; supports environment-only secrets without leases and does not inherit ambient FNOX_AGE_KEY or FNOX_AGE_KEY_FILE values. Available on Linux, macOS, and other Unix-like systems",
+            "help_first_line": "Run the command in fnox's process, keeping the same PID and receiving signals directly; supports environment-only secrets without leases and does not inherit ambient FNOX_AGE_KEY or FNOX_AGE_KEY_FILE values. Available on Linux, macOS, and other Unix-like systems",
+            "short": [],
+            "long": ["replace"],
+            "hide": false,
+            "global": false
+          }
+        ],
         "mounts": [],
         "hide": false,
         "help": "Execute a command with secrets as environment variables",

--- a/docs/cli/exec.md
+++ b/docs/cli/exec.md
@@ -2,7 +2,7 @@
 
 # `fnox exec`
 
-- **Usage**: `fnox exec [COMMAND]…`
+- **Usage**: `fnox exec [--replace] [COMMAND]…`
 - **Aliases**: `x`
 
 Execute a command with secrets as environment variables
@@ -12,3 +12,9 @@ Execute a command with secrets as environment variables
 ### `[COMMAND]…`
 
 Command to run
+
+## Flags
+
+### `--replace`
+
+Run the command in fnox's process, keeping the same PID and receiving signals directly; supports environment-only secrets without leases and does not inherit ambient FNOX_AGE_KEY or FNOX_AGE_KEY_FILE values. Available on Linux, macOS, and other Unix-like systems

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -62,7 +62,7 @@ Target profile for write commands (set, remove, import, sync, provider add/remov
 - [`fnox deactivate`](/cli/deactivate.md)
 - [`fnox doctor`](/cli/doctor.md)
 - [`fnox edit`](/cli/edit.md)
-- [`fnox exec [COMMAND]…`](/cli/exec.md)
+- [`fnox exec [--replace] [COMMAND]…`](/cli/exec.md)
 - [`fnox export [FLAGS]`](/cli/export.md)
 - [`fnox get [--base64-decode] <KEY>`](/cli/get.md)
 - [`fnox import <FLAGS> [FORMAT]`](/cli/import.md)

--- a/fnox.usage.kdl
+++ b/fnox.usage.kdl
@@ -53,6 +53,7 @@ cmd edit help="Edit the configuration file"
 cmd exec help="Execute a command with secrets as environment variables" {
     alias x
     alias run hide=#true
+    flag --replace help="Run the command in fnox's process, keeping the same PID and receiving signals directly; supports environment-only secrets without leases and does not inherit ambient FNOX_AGE_KEY or FNOX_AGE_KEY_FILE values. Available on Linux, macOS, and other Unix-like systems"
     arg "[COMMAND]…" help="Command to run" required=#false double_dash=automatic var=#true
 }
 cmd export help="Export secrets in various formats" {

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -10,6 +10,14 @@ use tempfile::NamedTempFile;
 #[derive(Debug, Args)]
 #[command(visible_alias = "x", alias = "run")]
 pub struct ExecCommand {
+    /// Run the command in fnox's process, keeping the same PID and receiving signals
+    /// directly; supports environment-only secrets without leases and does not inherit
+    /// ambient FNOX_AGE_KEY or FNOX_AGE_KEY_FILE values. Available on Linux,
+    /// macOS, and other Unix-like systems
+    #[cfg(unix)]
+    #[arg(long)]
+    pub replace: bool,
+
     /// Command to run
     #[arg(trailing_var_arg = true, allow_hyphen_values = true, value_hint = ValueHint::CommandWithArguments)]
     pub command: Vec<String>,
@@ -21,6 +29,11 @@ impl ExecCommand {
             return Err(FnoxError::CommandNotSpecified);
         }
 
+        #[cfg(unix)]
+        if self.replace {
+            install_replace_signal_handlers()?;
+        }
+
         let profile = Config::get_profiles(cli.profile.as_slice());
         tracing::debug!(
             "Running command with secrets from profiles '{}'",
@@ -29,6 +42,24 @@ impl ExecCommand {
 
         // Get the profile secrets
         let profile_secrets = config.get_secrets(&profile)?;
+        let leases = config.get_leases(&profile);
+
+        #[cfg(unix)]
+        if self.replace {
+            let file_secrets = profile_secrets
+                .iter()
+                .filter(|(_, secret)| secret.as_file && secret.env_mode().in_exec())
+                .map(|(key, _)| key.as_str())
+                .collect::<Vec<_>>();
+            if !file_secrets.is_empty() {
+                return Err(FnoxError::ExecReplaceFileSecrets {
+                    secrets: file_secrets.join(", "),
+                });
+            }
+            if !leases.is_empty() {
+                return Err(FnoxError::ExecReplaceLeases);
+            }
+        }
 
         let cmd_name = &self.command[0];
 
@@ -65,7 +96,6 @@ impl ExecCommand {
         // Temporarily set resolved secrets as process env vars so lease backend
         // SDKs (AWS, GCP, Azure) can find master credentials during lease creation.
         // The TempEnvGuard ensures cleanup on all exit paths (including errors).
-        let leases = config.get_leases(&profile);
         let mut _temp_env_guard = lease::TempEnvGuard::default();
         if !leases.is_empty() {
             _temp_files.extend(lease::set_secrets_as_env(
@@ -119,6 +149,15 @@ impl ExecCommand {
                     cmd.env(cred_key, cred_value);
                 }
             }
+        }
+
+        // The target should receive resolved secrets, not the age identity that
+        // decrypts other values in the configuration. Explicitly configured
+        // secrets with these names are added back by the loop below.
+        #[cfg(unix)]
+        if self.replace {
+            cmd.env_remove("FNOX_AGE_KEY");
+            cmd.env_remove("FNOX_AGE_KEY_FILE");
         }
 
         // Add resolved secrets as environment variables
@@ -176,6 +215,17 @@ impl ExecCommand {
         // from the parent process environment so the child doesn't inherit them.
         drop(_temp_env_guard);
 
+        #[cfg(unix)]
+        if self.replace {
+            use std::os::unix::process::CommandExt;
+
+            let source = cmd.exec();
+            return Err(FnoxError::CommandExecutionFailed {
+                command: self.command.join(" "),
+                source,
+            });
+        }
+
         let mut child = cmd.spawn().map_err(|e| FnoxError::CommandExecutionFailed {
             command: self.command.join(" "),
             source: e,
@@ -224,4 +274,29 @@ impl ExecCommand {
 
         Ok(())
     }
+}
+
+#[cfg(unix)]
+fn install_replace_signal_handlers() -> Result<()> {
+    for signal in [signal_hook::consts::SIGINT, signal_hook::consts::SIGTERM] {
+        if !signal_uses_default_action(signal)? {
+            continue;
+        }
+        unsafe { signal_hook::low_level::register(signal, move || libc::_exit(128 + signal)) }
+            .map_err(|source| FnoxError::ExecReplaceSignalSetup { source })?;
+    }
+
+    Ok(())
+}
+
+#[cfg(unix)]
+fn signal_uses_default_action(signal: libc::c_int) -> Result<bool> {
+    let mut action = std::mem::MaybeUninit::<libc::sigaction>::uninit();
+    if unsafe { libc::sigaction(signal, std::ptr::null(), action.as_mut_ptr()) } == -1 {
+        return Err(FnoxError::ExecReplaceSignalSetup {
+            source: std::io::Error::last_os_error(),
+        });
+    }
+
+    Ok(unsafe { action.assume_init() }.sa_sigaction == libc::SIG_DFL)
 }

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -277,6 +277,7 @@ impl ExecCommand {
 }
 
 #[cfg(unix)]
+/// Installs temporary SIGINT and SIGTERM handlers while fnox resolves secrets before replacement.
 fn install_replace_signal_handlers() -> Result<()> {
     for signal in [signal_hook::consts::SIGINT, signal_hook::consts::SIGTERM] {
         if !signal_uses_default_action(signal)? {
@@ -290,6 +291,7 @@ fn install_replace_signal_handlers() -> Result<()> {
 }
 
 #[cfg(unix)]
+/// Reports whether a signal currently uses its default disposition.
 fn signal_uses_default_action(signal: libc::c_int) -> Result<bool> {
     let mut action = std::mem::MaybeUninit::<libc::sigaction>::uninit();
     if unsafe { libc::sigaction(signal, std::ptr::null(), action.as_mut_ptr()) } == -1 {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -248,4 +248,15 @@ mod tests {
         // using the published clap-sort crate.
         clap_sort::assert_sorted(&Cli::command());
     }
+
+    #[test]
+    fn exec_replace_flag_matches_platform() {
+        let command = Cli::command();
+        let exec = command.find_subcommand("exec").unwrap();
+        let has_replace = exec
+            .get_arguments()
+            .any(|argument| argument.get_long() == Some("replace"));
+
+        assert_eq!(has_replace, cfg!(unix));
+    }
 }

--- a/test/exec_replace.bats
+++ b/test/exec_replace.bats
@@ -210,6 +210,12 @@ SCRIPT
 	TARGET_PID=$(cat "$PID_FILE")
 	[ "$TARGET_PID" -eq "$REPLACEMENT_PID" ]
 	# Confirm replacement completed before checking the inherited dispositions.
+	for _ in $(seq 1 50); do
+		if [ "$(ps -p "$REPLACEMENT_PID" -o comm= 2>/dev/null)" = "sleep" ]; then
+			break
+		fi
+		sleep 0.1
+	done
 	[ "$(ps -p "$REPLACEMENT_PID" -o comm= 2>/dev/null)" = "sleep" ]
 	assert_process_survives_signal "$REPLACEMENT_PID" INT
 	assert_process_survives_signal "$REPLACEMENT_PID" TERM

--- a/test/exec_replace.bats
+++ b/test/exec_replace.bats
@@ -1,0 +1,424 @@
+#!/usr/bin/env bats
+#
+# Exec Replacement Tests
+#
+# These tests verify the process lifecycle and compatibility constraints of
+# `fnox exec --replace`. PID files and side-effect markers make behavior
+# observable after fnox replaces itself and can no longer perform cleanup.
+
+# Bound background-process regressions so one test cannot consume the CI job.
+export BATS_TEST_TIMEOUT=30
+
+setup() {
+	load 'test_helper/common_setup'
+	_common_setup
+	DAEMON_STARTED=""
+	REPLACEMENT_PID=""
+	TARGET_PID=""
+	WAIT_STATUS=""
+	unset BLOCK_RESOLUTION COMMAND_MARKER PID_FILE RESOLUTION_MARKER SIGNAL_MARKER
+}
+
+# Install a fake Bitwarden CLI so tests can observe exactly when provider
+# resolution starts. BLOCK_RESOLUTION keeps the resolver active for signal tests.
+create_fake_bw() {
+	cat >"$TEST_TEMP_DIR/bw" <<'SCRIPT'
+#!/usr/bin/env bash
+set -eu
+
+touch "$RESOLUTION_MARKER"
+if [ -n "${BLOCK_RESOLUTION:-}" ]; then
+	# Exit when fnox exits so the fake provider does not remain orphaned.
+	parent=$PPID
+	while kill -0 "$parent" 2>/dev/null; do
+		sleep 0.05
+	done
+	exit 0
+fi
+echo "resolved-value"
+SCRIPT
+	chmod +x "$TEST_TEMP_DIR/bw"
+	export PATH="$TEST_TEMP_DIR:$PATH"
+	export BW_SESSION="test-session"
+}
+
+# A completed child remains visible as a zombie until its parent calls wait.
+wait_for_process_exit() {
+	local pid="$1"
+	local state
+	for _ in $(seq 1 50); do
+		state=$(ps -p "$pid" -o stat= 2>/dev/null || true)
+		if [ -z "$state" ] || [[ "$state" == *Z* ]]; then
+			WAIT_STATUS=0
+			wait "$pid" 2>/dev/null || WAIT_STATUS=$?
+			return 0
+		fi
+		sleep 0.1
+	done
+	return 1
+}
+
+# `kill -0` also succeeds for zombies, so inspect process state after each signal.
+assert_process_survives_signal() {
+	local pid="$1"
+	local signal="$2"
+	local state
+
+	kill -"$signal" "$pid"
+	for _ in $(seq 1 5); do
+		sleep 0.1
+		state=$(ps -p "$pid" -o stat= 2>/dev/null || true)
+		if [ -z "$state" ] || [[ "$state" == *Z* ]]; then
+			return 1
+		fi
+	done
+}
+
+teardown() {
+	# Stop resources that may survive if an assertion fails before normal cleanup.
+	if [ -n "$DAEMON_STARTED" ]; then
+		"$FNOX_BIN" daemon stop >/dev/null 2>&1 || true
+	fi
+	# TARGET_PID differs from REPLACEMENT_PID only if process replacement regresses.
+	if [ -n "$TARGET_PID" ] && [ "$TARGET_PID" != "$REPLACEMENT_PID" ]; then
+		kill -KILL "$TARGET_PID" 2>/dev/null || true
+	fi
+	if [ -n "$REPLACEMENT_PID" ]; then
+		kill -KILL "$REPLACEMENT_PID" 2>/dev/null || true
+		wait "$REPLACEMENT_PID" 2>/dev/null || true
+	fi
+	_common_teardown
+}
+
+@test "exec --replace preserves pid, injects secrets, omits ambient age identities, and returns target status" {
+	cat >fnox.toml <<'TOML'
+root = true
+
+[providers.plain]
+type = "plain"
+
+[secrets.INJECTED_SECRET]
+provider = "plain"
+value = "injected-value"
+TOML
+
+	cat >check-replacement.sh <<'SCRIPT'
+#!/usr/bin/env bash
+set -eu
+
+test "$$" = "$EXPECTED_PID"
+test "$INJECTED_SECRET" = "injected-value"
+test -z "${FNOX_AGE_KEY+x}"
+test -z "${FNOX_AGE_KEY_FILE+x}"
+echo "replacement-ok"
+exit 42
+SCRIPT
+	chmod +x check-replacement.sh
+
+	# These ambient values may resolve fnox secrets but must not reach the target.
+	export FNOX_AGE_KEY="AGE-SECRET-KEY-TEST"
+	export FNOX_AGE_KEY_FILE="$TEST_TEMP_DIR/age-key.txt"
+
+	# Record the wrapper PID before it execs fnox; the final script must see it unchanged.
+	run sh -c 'EXPECTED_PID=$$; export EXPECTED_PID; exec "$1" --no-daemon exec --replace -- "$2"' \
+		_ "$FNOX_BIN" "$TEST_TEMP_DIR/check-replacement.sh"
+
+	[ "$status" -eq 42 ]
+	assert_output "replacement-ok"
+}
+
+@test "exec --replace delivers signals directly to the replacement process" {
+	cat >fnox.toml <<'TOML'
+root = true
+TOML
+
+	cat >wait-for-term.sh <<'SCRIPT'
+#!/usr/bin/env bash
+set -eu
+
+trap 'echo terminated >"$SIGNAL_MARKER"; exit 0' TERM
+echo "$$" >"$PID_FILE"
+while :; do
+	sleep 1
+done
+SCRIPT
+	chmod +x wait-for-term.sh
+
+	export PID_FILE="$TEST_TEMP_DIR/replacement.pid"
+	export SIGNAL_MARKER="$TEST_TEMP_DIR/terminated"
+
+	# The target writes its PID only after installing the TERM handler.
+	sh -c 'exec "$1" --no-daemon exec --replace -- "$2"' \
+		_ "$FNOX_BIN" "$TEST_TEMP_DIR/wait-for-term.sh" &
+	REPLACEMENT_PID=$!
+
+	for _ in $(seq 1 50); do
+		if [ -f "$PID_FILE" ]; then
+			break
+		fi
+		sleep 0.1
+	done
+
+	assert_file_exists "$PID_FILE"
+	TARGET_PID=$(cat "$PID_FILE")
+	# A spawned child would have a different PID and would fail this assertion.
+	[ "$TARGET_PID" -eq "$REPLACEMENT_PID" ]
+	kill -TERM "$REPLACEMENT_PID"
+	for _ in $(seq 1 50); do
+		if [ -f "$SIGNAL_MARKER" ]; then
+			break
+		fi
+		sleep 0.1
+	done
+	assert_file_exists "$SIGNAL_MARKER"
+	wait_for_process_exit "$REPLACEMENT_PID"
+	exit_status="$WAIT_STATUS"
+	REPLACEMENT_PID=""
+	TARGET_PID=""
+	[ "$exit_status" -eq 0 ]
+	assert_file_contains "$SIGNAL_MARKER" "terminated"
+}
+
+@test "exec --replace preserves inherited ignored termination signals" {
+	cat >fnox.toml <<'TOML'
+root = true
+TOML
+
+	cat >wait-with-ignored-signals.sh <<'SCRIPT'
+#!/usr/bin/env bash
+set -eu
+
+echo "$$" >"$PID_FILE"
+exec sleep 30
+SCRIPT
+	chmod +x wait-with-ignored-signals.sh
+	export PID_FILE="$TEST_TEMP_DIR/replacement.pid"
+
+	# POSIX preserves ignored dispositions across exec; fnox must not replace them.
+	sh -c 'trap "" INT TERM; exec "$1" --no-daemon exec --replace -- "$2"' \
+		_ "$FNOX_BIN" "$TEST_TEMP_DIR/wait-with-ignored-signals.sh" &
+	REPLACEMENT_PID=$!
+
+	for _ in $(seq 1 50); do
+		if [ -f "$PID_FILE" ]; then
+			break
+		fi
+		sleep 0.1
+	done
+
+	assert_file_exists "$PID_FILE"
+	TARGET_PID=$(cat "$PID_FILE")
+	[ "$TARGET_PID" -eq "$REPLACEMENT_PID" ]
+	# Confirm replacement completed before checking the inherited dispositions.
+	[ "$(ps -p "$REPLACEMENT_PID" -o comm= 2>/dev/null)" = "sleep" ]
+	assert_process_survives_signal "$REPLACEMENT_PID" INT
+	assert_process_survives_signal "$REPLACEMENT_PID" TERM
+	kill -KILL "$REPLACEMENT_PID"
+	wait "$REPLACEMENT_PID" || true
+	REPLACEMENT_PID=""
+	TARGET_PID=""
+}
+
+@test "exec --replace allows explicit secrets to restore scrubbed variables" {
+	cat >fnox.toml <<'TOML'
+root = true
+
+[providers.plain]
+type = "plain"
+
+[secrets.FNOX_AGE_KEY]
+provider = "plain"
+value = "selected-value"
+
+[secrets.FNOX_AGE_KEY_FILE]
+provider = "plain"
+value = "selected-file"
+TOML
+
+	export FNOX_AGE_KEY="ambient-value"
+	export FNOX_AGE_KEY_FILE="ambient-file"
+
+	# Selected secrets are applied after ambient resolver credentials are removed.
+	run "$FNOX_BIN" --no-daemon exec --replace -- \
+		bash -c 'test "$FNOX_AGE_KEY" = "selected-value" && test "$FNOX_AGE_KEY_FILE" = "selected-file"'
+	assert_success
+}
+
+@test "exec --replace rejects file-based secrets" {
+	create_fake_bw
+	export RESOLUTION_MARKER="$TEST_TEMP_DIR/resolution-started"
+
+	cat >fnox.toml <<'TOML'
+root = true
+
+[providers.bitwarden]
+type = "bitwarden"
+
+[secrets.FILE_SECRET]
+provider = "bitwarden"
+value = "file-secret"
+as_file = true
+TOML
+
+	# The absent marker proves rejection happened before provider resolution.
+	run "$FNOX_BIN" --no-daemon exec --replace -- true
+	assert_failure
+	assert_output --partial "--replace"
+	assert_output --partial "file-based secrets"
+	assert_output --partial "FILE_SECRET"
+	assert_file_not_exists "$RESOLUTION_MARKER"
+}
+
+@test "exec --replace handles signals received during secret resolution" {
+	create_fake_bw
+	export BLOCK_RESOLUTION=1
+	export COMMAND_MARKER="$TEST_TEMP_DIR/command-started"
+
+	cat >fnox.toml <<'TOML'
+root = true
+
+[providers.bitwarden]
+type = "bitwarden"
+
+[secrets.REMOTE_SECRET]
+provider = "bitwarden"
+value = "remote-secret"
+TOML
+
+	# Shell wait statuses cannot distinguish `_exit(143)` from default SIGTERM
+	# termination. Python exposes 143 for the installed handler and -15 for
+	# default signal death, proving the pre-exec handlers are active.
+	cat >signal-during-resolution.py <<'PYTHON'
+import os
+import signal
+import subprocess
+import sys
+import time
+
+fnox, marker_prefix = sys.argv[1:]
+
+
+def reset_termination_signals():
+    # GNU Parallel workers may inherit ignored signals from their parent shell.
+    signal.signal(signal.SIGINT, signal.SIG_DFL)
+    signal.signal(signal.SIGTERM, signal.SIG_DFL)
+
+
+for sig in (signal.SIGINT, signal.SIGTERM):
+    marker = f"{marker_prefix}-{sig.name}"
+    env = os.environ.copy()
+    env["RESOLUTION_MARKER"] = marker
+    # Own the process group so timeout cleanup also terminates the fake provider.
+    process = subprocess.Popen(
+        [fnox, "--no-daemon", "exec", "--replace", "--", "bash", "-c", 'touch "$COMMAND_MARKER"'],
+        env=env,
+        preexec_fn=reset_termination_signals,
+        start_new_session=True,
+    )
+    try:
+        deadline = time.monotonic() + 5
+        while not os.path.exists(marker):
+            if process.poll() is not None:
+                raise RuntimeError(f"fnox exited before resolving secrets: {process.returncode}")
+            if time.monotonic() >= deadline:
+                raise TimeoutError("timed out waiting for secret resolution")
+            time.sleep(0.1)
+
+        os.kill(process.pid, sig)
+        returncode = process.wait(timeout=5)
+        print(f"{sig.name}={returncode}")
+    finally:
+        if process.poll() is None:
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            process.wait()
+PYTHON
+
+	run python3 signal-during-resolution.py "$FNOX_BIN" "$TEST_TEMP_DIR/resolution-started"
+	assert_success
+	assert_line "SIGINT=130"
+	assert_line "SIGTERM=143"
+	assert_file_not_exists "$COMMAND_MARKER"
+}
+
+@test "exec --replace does not start the command when a required secret is missing" {
+	cat >fnox.toml <<'TOML'
+root = true
+
+[providers.age]
+type = "age"
+recipients = ["age1cdk0klj88zzhg0ncfhe4ul9ja5k58w2st3fpkhmy0f46vlsuh5wq0s0gr9"]
+
+[secrets.REQUIRED_SECRET]
+provider = "age"
+value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaaTFhczNBYnN3S1c0NjZwZnlDN2NUMTVaSTFXd2k1OWhnWUJvckVxYmh3CjNRSmhxSWJiYXU3eHoyNlcyOVVLRWNnUlFJeFBjL2N0YlA5K2hUaU04VDQKLS0tIGN6UVYzMHZJUUhKNmlkQjFOaXRXYUpjbzBOaHRMZkFFVVRPa3FaQUs2dHcKf3AcueEBLdl8lzRwKXik+OvDVg48g44QoPZu0j0NLV4lPLDqoq0="
+if_missing = "error"
+TOML
+
+	export FNOX_AGE_KEY="$TEST_TEMP_DIR/missing-age-key.txt"
+	export COMMAND_MARKER="$TEST_TEMP_DIR/command-started"
+
+	# The marker distinguishes a resolution error from accidentally starting the target.
+	run "$FNOX_BIN" --no-daemon exec --replace -- \
+		bash -c 'touch "$COMMAND_MARKER"'
+	assert_failure
+	assert_output --partial "REQUIRED_SECRET"
+	assert_file_not_exists "$COMMAND_MARKER"
+}
+
+@test "exec --replace supports daemon-backed resolution" {
+	export XDG_RUNTIME_DIR="$TEST_TEMP_DIR/runtime"
+	mkdir -p "$XDG_RUNTIME_DIR"
+	DAEMON_STARTED=1
+
+	cat >fnox.toml <<'TOML'
+root = true
+
+[daemon]
+enabled = true
+
+[providers.plain]
+type = "plain"
+
+[secrets.DAEMON_SECRET]
+provider = "plain"
+value = "daemon-value"
+TOML
+
+	# Omit --no-daemon so this invocation exercises daemon-backed resolution.
+	run "$FNOX_BIN" exec --replace -- \
+		bash -c 'test "$DAEMON_SECRET" = "daemon-value"'
+	assert_success
+
+	run "$FNOX_BIN" daemon status
+	assert_success
+	# A populated cache proves the daemon resolved DAEMON_SECRET.
+	assert_output --partial "fnox daemon running"
+	assert_output --partial "cached_entries: 1"
+}
+
+@test "exec --replace rejects leases before creating credentials" {
+	cat >create-credentials.sh <<SCRIPT
+#!/usr/bin/env bash
+touch "$TEST_TEMP_DIR/lease-created"
+echo '{"credentials":{"LEASE_TOKEN":"value"},"lease_id":"test"}'
+SCRIPT
+	chmod +x create-credentials.sh
+
+	cat >fnox.toml <<TOML
+root = true
+
+[leases.test]
+type = "command"
+create_command = "$TEST_TEMP_DIR/create-credentials.sh"
+TOML
+
+	# The absent marker proves rejection happened before lease creation.
+	run "$FNOX_BIN" --no-daemon exec --replace -- true
+	assert_failure
+	assert_output --partial "--replace"
+	assert_output --partial "credential leases"
+	assert_file_not_exists "$TEST_TEMP_DIR/lease-created"
+}


### PR DESCRIPTION
## Summary

- add `fnox exec --replace` on Linux, macOS, and other Unix-like systems so environment-only workloads can replace fnox while retaining the same PID
- reject file-based secrets and credential leases before secret resolution because replacement prevents post-command cleanup
- omit ambient `FNOX_AGE_KEY` and `FNOX_AGE_KEY_FILE` values while allowing explicitly selected secrets with those names
- preserve inherited ignored `SIGINT` and `SIGTERM` dispositions and handle those signals during secret resolution
- document the flag and add Bats coverage for PID preservation, signals, exit status, missing secrets, daemon-backed resolution, and unsupported resources

Discussion: https://github.com/jdx/fnox/discussions/652

_This pull request was prepared with AI assistance and reviewed by the author._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Unix-only `fnox exec --replace` to run the command via process replacement, preserving the PID and enabling direct signal delivery.
  * Allows environment-only secrets without creating credential leases; scrubs ambient age credentials while supporting explicit age credential selection.
* **Bug Fixes**
  * Improved error reporting for unsupported `--replace` scenarios (file-based secrets, credential leases, and signal setup failures) and missing secret failures.
* **Documentation**
  * Updated `exec` CLI docs, command reference, and usage synopsis to document `--replace` behavior and platform availability.
* **Tests**
  * Added Bats coverage for PID/signal behavior, compatibility checks, and failure modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->