### PR TITLE
feat(azure-ac): add Azure App Configuration provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Your `fnox.toml` config file either contains encrypted secrets or references to 
 
 - [**aws-ps**](https://fnox.jdx.dev/providers/aws-ps) - AWS Parameter Store
 - [**aws-sm**](https://fnox.jdx.dev/providers/aws-sm) - AWS Secrets Manager
+- [**azure-ac**](https://fnox.jdx.dev/providers/azure-ac) - Azure App Configuration
 - [**azure-sm**](https://fnox.jdx.dev/providers/azure-sm) - Azure Key Vault Secrets
 - [**gcp-sm**](https://fnox.jdx.dev/providers/gcp-sm) - Google Cloud Secret Manager
 - [**bitwarden-sm**](https://fnox.jdx.dev/providers/bitwarden-sm) - Bitwarden Secrets Manager

--- a/crates/fnox-core/providers/azure-ac.toml
+++ b/crates/fnox-core/providers/azure-ac.toml
@@ -1,0 +1,30 @@
+# Azure App Configuration provider - remote key-value configuration, read-only
+display_name = "Azure App Configuration"
+serde_rename = "azure-ac"
+rust_variant = "AzureAppConfiguration"
+category = "CloudSecretsManager"
+description = "Azure App Configuration key-values"
+default_name = "azure-ac"
+auth_command = "az login"
+setup_instructions = """
+Reads key-values from an Azure App Configuration store.
+Requires Azure credentials configured.
+Login: az login"""
+
+[fields.endpoint]
+type = "required"
+placeholder = "https://my-store.azconfig.io"
+label = "Store endpoint:"
+wizard = true
+
+[fields.label]
+type = "optional"
+placeholder = ""
+label = "Label (optional):"
+wizard = true
+
+[fields.prefix]
+type = "optional"
+placeholder = ""
+label = "Key prefix (optional):"
+wizard = true

--- a/crates/fnox-core/src/providers/azure_ac.rs
+++ b/crates/fnox-core/src/providers/azure_ac.rs
@@ -2,23 +2,44 @@ use crate::error::{FnoxError, Result};
 use async_trait::async_trait;
 use azure_core::credentials::TokenCredential;
 use azure_identity::DeveloperToolsCredential;
+use reqwest::Url;
 use serde::Deserialize;
 
 const PROVIDER_NAME: &str = "Azure App Configuration";
 const PROVIDER_URL: &str = "https://fnox.jdx.dev/providers/azure-ac";
 const API_VERSION: &str = "2023-11-01";
 
-/// Sovereign clouds have their own audience, keyed off the endpoint suffix as
-/// the Azure SDKs do. Public cloud stores are `*.azconfig.io`.
-fn scope_for(endpoint: &str) -> &'static str {
-    let endpoint = endpoint.to_ascii_lowercase();
-    if endpoint.ends_with("azconfig.azure.us") || endpoint.ends_with("appconfig.azure.us") {
-        "https://appconfig.azure.us/.default"
-    } else if endpoint.ends_with("azconfig.azure.cn") || endpoint.ends_with("appconfig.azure.cn") {
-        "https://appconfig.azure.cn/.default"
-    } else {
-        "https://appconfig.azure.com/.default"
-    }
+/// App Configuration domains and the Entra audience each cloud expects. Sending
+/// a token anywhere else would hand it to whoever the endpoint points at, so an
+/// unlisted domain is rejected rather than defaulted.
+const CLOUDS: &[(&str, &str)] = &[
+    ("azconfig.io", "https://appconfig.azure.com/.default"),
+    (
+        "appconfig.azure.com",
+        "https://appconfig.azure.com/.default",
+    ),
+    ("azconfig.azure.us", "https://appconfig.azure.us/.default"),
+    ("appconfig.azure.us", "https://appconfig.azure.us/.default"),
+    ("azconfig.azure.cn", "https://appconfig.azure.cn/.default"),
+    ("appconfig.azure.cn", "https://appconfig.azure.cn/.default"),
+];
+
+/// The audience for a store host, or None if the host is not an App Configuration domain.
+fn scope_for(host: &str) -> Option<&'static str> {
+    let host = host.to_ascii_lowercase();
+    CLOUDS.iter().find_map(|(domain, scope)| {
+        // Require a label boundary so evilazconfig.io does not pass as azconfig.io.
+        host.strip_suffix(domain)
+            .is_some_and(|store| store.ends_with('.'))
+            .then_some(*scope)
+    })
+}
+
+fn invalid_endpoint(endpoint: &str, reason: &str) -> FnoxError {
+    FnoxError::Config(format!(
+        "{PROVIDER_NAME}: endpoint '{endpoint}' {reason}. \
+         Expected an App Configuration store such as https://my-store.azconfig.io"
+    ))
 }
 
 pub fn env_dependencies() -> &'static [&'static str] {
@@ -34,15 +55,28 @@ pub struct AzureAppConfigurationProvider {
     endpoint: String,
     label: Option<String>,
     prefix: Option<String>,
+    scope: &'static str,
 }
 
 impl AzureAppConfigurationProvider {
     pub fn new(endpoint: String, label: Option<String>, prefix: Option<String>) -> Result<Self> {
+        let url = Url::parse(&endpoint).map_err(|e| invalid_endpoint(&endpoint, &e.to_string()))?;
+        if url.scheme() != "https" {
+            return Err(invalid_endpoint(&endpoint, "must use https"));
+        }
+        // host_str() ignores userinfo, so https://store.azconfig.io@example.com is example.com.
+        let scope = url
+            .host_str()
+            .and_then(scope_for)
+            .ok_or_else(|| invalid_endpoint(&endpoint, "is not an App Configuration domain"))?;
+
         // App Configuration has no empty label: the unlabelled key-value is the \0 label.
         Ok(Self {
-            endpoint: endpoint.trim_end_matches('/').to_string(),
+            // The origin drops any path, query or fragment the endpoint carried.
+            endpoint: url.origin().ascii_serialization(),
             label: label.filter(|l| !l.is_empty()),
             prefix: prefix.filter(|p| !p.is_empty()),
+            scope,
         })
     }
 
@@ -106,15 +140,16 @@ impl AzureAppConfigurationProvider {
             }
         })?;
 
-        let token = credential
-            .get_token(&[scope_for(&self.endpoint)], None)
-            .await
-            .map_err(|e: azure_core::Error| FnoxError::ProviderAuthFailed {
-                provider: PROVIDER_NAME.to_string(),
-                details: e.to_string(),
-                hint: "Run 'az login' to authenticate with Azure".to_string(),
-                url: PROVIDER_URL.to_string(),
-            })?;
+        let token =
+            credential
+                .get_token(&[self.scope], None)
+                .await
+                .map_err(|e: azure_core::Error| FnoxError::ProviderAuthFailed {
+                    provider: PROVIDER_NAME.to_string(),
+                    details: e.to_string(),
+                    hint: "Run 'az login' to authenticate with Azure".to_string(),
+                    url: PROVIDER_URL.to_string(),
+                })?;
 
         Ok(token.token.secret().to_string())
     }
@@ -226,21 +261,50 @@ mod tests {
     #[test]
     fn scope_follows_the_endpoint_cloud() {
         assert_eq!(
-            scope_for("https://store.azconfig.io"),
-            "https://appconfig.azure.com/.default"
+            scope_for("store.azconfig.io"),
+            Some("https://appconfig.azure.com/.default")
         );
         assert_eq!(
-            scope_for("https://store.azconfig.azure.us"),
-            "https://appconfig.azure.us/.default"
+            scope_for("store.azconfig.azure.us"),
+            Some("https://appconfig.azure.us/.default")
         );
         assert_eq!(
-            scope_for("https://STORE.APPCONFIG.AZURE.CN"),
-            "https://appconfig.azure.cn/.default"
+            scope_for("STORE.APPCONFIG.AZURE.CN"),
+            Some("https://appconfig.azure.cn/.default")
         );
     }
 
     #[test]
-    fn trailing_slash_is_stripped_from_the_endpoint() {
+    fn endpoint_is_reduced_to_its_origin() {
         assert_eq!(provider(None, None).endpoint, "https://store.azconfig.io");
+
+        let with_path = AzureAppConfigurationProvider::new(
+            "https://store.azconfig.io/some/path?q=1#frag".to_string(),
+            None,
+            None,
+        )
+        .unwrap();
+        assert_eq!(with_path.endpoint, "https://store.azconfig.io");
+    }
+
+    /// The token is only ever sent to the endpoint, so anything that is not a real
+    /// App Configuration host has to be refused before a token is acquired.
+    #[test]
+    fn untrusted_endpoints_are_rejected() {
+        for endpoint in [
+            "http://store.azconfig.io",              // not https
+            "https://example.com",                   // arbitrary host
+            "https://evilazconfig.io",               // no label boundary
+            "https://azconfig.io",                   // bare domain, no store
+            "https://store.azconfig.io@example.com", // userinfo, host is example.com
+            "https://example.com/store.azconfig.io", // domain hidden in the path
+            "https://example.com/?x=store.azconfig.io",
+            "not a url",
+        ] {
+            assert!(
+                AzureAppConfigurationProvider::new(endpoint.to_string(), None, None).is_err(),
+                "expected {endpoint} to be rejected"
+            );
+        }
     }
 }

--- a/crates/fnox-core/src/providers/azure_ac.rs
+++ b/crates/fnox-core/src/providers/azure_ac.rs
@@ -51,6 +51,25 @@ struct KeyValue {
     value: Option<String>,
 }
 
+/// A store always answers the list endpoint with an `items` array, so a 200 that
+/// does not deserialise came from something that is not App Configuration.
+fn validate_kv_list(body: &str) -> Result<()> {
+    #[derive(Deserialize)]
+    struct KeyValueList {
+        #[allow(dead_code)]
+        items: Vec<serde::de::IgnoredAny>,
+    }
+
+    serde_json::from_str::<KeyValueList>(body)
+        .map(|_| ())
+        .map_err(|e| FnoxError::ProviderInvalidResponse {
+            provider: PROVIDER_NAME.to_string(),
+            details: format!("Endpoint did not return a key-value list: {}", e),
+            hint: "Check that the endpoint is your App Configuration store".to_string(),
+            url: PROVIDER_URL.to_string(),
+        })
+}
+
 pub struct AzureAppConfigurationProvider {
     endpoint: String,
     label: Option<String>,
@@ -225,7 +244,17 @@ impl crate::providers::Provider for AzureAppConfigurationProvider {
                 url: PROVIDER_URL.to_string(),
             });
         }
-        Ok(())
+
+        let body = response
+            .text()
+            .await
+            .map_err(|e| FnoxError::ProviderInvalidResponse {
+                provider: PROVIDER_NAME.to_string(),
+                details: format!("Failed to read the key-value list: {}", e),
+                hint: "Check that the endpoint is your App Configuration store".to_string(),
+                url: PROVIDER_URL.to_string(),
+            })?;
+        validate_kv_list(&body)
     }
 }
 
@@ -304,6 +333,26 @@ mod tests {
             assert!(
                 AzureAppConfigurationProvider::new(endpoint.to_string(), None, None).is_err(),
                 "expected {endpoint} to be rejected"
+            );
+        }
+    }
+
+    /// A 200 alone does not prove the endpoint is a store, so the connection test
+    /// has to recognise the list payload itself.
+    #[test]
+    fn connection_test_requires_a_key_value_list() {
+        assert!(validate_kv_list(r#"{"items":[]}"#).is_ok());
+        assert!(validate_kv_list(r#"{"items":[{"key":"a","value":"b"}]}"#).is_ok());
+
+        for body in [
+            r#"<html><body>Sign in to continue</body></html>"#,
+            r#"{"ok":true}"#,
+            r#"{"items":{}}"#,
+            "",
+        ] {
+            assert!(
+                validate_kv_list(body).is_err(),
+                "expected {body:?} to be rejected"
             );
         }
     }

--- a/crates/fnox-core/src/providers/azure_ac.rs
+++ b/crates/fnox-core/src/providers/azure_ac.rs
@@ -26,7 +26,7 @@ pub struct AzureAppConfigurationProvider {
 
 impl AzureAppConfigurationProvider {
     pub fn new(endpoint: String, label: Option<String>, prefix: Option<String>) -> Result<Self> {
-        // An empty label is a distinct label in App Configuration, not the absence of one.
+        // App Configuration has no empty label: the unlabelled key-value is the \0 label.
         Ok(Self {
             endpoint: endpoint.trim_end_matches('/').to_string(),
             label: label.filter(|l| !l.is_empty()),
@@ -167,7 +167,18 @@ impl crate::providers::Provider for AzureAppConfigurationProvider {
 
         // Filtered list: proves the store is reachable and the token is accepted
         // without depending on any particular key existing.
-        self.get("/kv", &[("key", "fnox-connection-test")]).await?;
+        let response = self.get("/kv", &[("key", "fnox-connection-test")]).await?;
+
+        // get() passes 404 through for get_secret; on the list endpoint it means
+        // the endpoint is not an App Configuration store.
+        if !response.status().is_success() {
+            return Err(FnoxError::ProviderApiError {
+                provider: PROVIDER_NAME.to_string(),
+                details: format!("HTTP {}", response.status()),
+                hint: "Check the store endpoint".to_string(),
+                url: PROVIDER_URL.to_string(),
+            });
+        }
         Ok(())
     }
 }

--- a/crates/fnox-core/src/providers/azure_ac.rs
+++ b/crates/fnox-core/src/providers/azure_ac.rs
@@ -6,8 +6,20 @@ use serde::Deserialize;
 
 const PROVIDER_NAME: &str = "Azure App Configuration";
 const PROVIDER_URL: &str = "https://fnox.jdx.dev/providers/azure-ac";
-const SCOPE: &str = "https://appconfig.azure.com/.default";
 const API_VERSION: &str = "2023-11-01";
+
+/// Sovereign clouds have their own audience, keyed off the endpoint suffix as
+/// the Azure SDKs do. Public cloud stores are `*.azconfig.io`.
+fn scope_for(endpoint: &str) -> &'static str {
+    let endpoint = endpoint.to_ascii_lowercase();
+    if endpoint.ends_with("azconfig.azure.us") || endpoint.ends_with("appconfig.azure.us") {
+        "https://appconfig.azure.us/.default"
+    } else if endpoint.ends_with("azconfig.azure.cn") || endpoint.ends_with("appconfig.azure.cn") {
+        "https://appconfig.azure.cn/.default"
+    } else {
+        "https://appconfig.azure.com/.default"
+    }
+}
 
 pub fn env_dependencies() -> &'static [&'static str] {
     &[]
@@ -94,16 +106,15 @@ impl AzureAppConfigurationProvider {
             }
         })?;
 
-        let token =
-            credential
-                .get_token(&[SCOPE], None)
-                .await
-                .map_err(|e: azure_core::Error| FnoxError::ProviderAuthFailed {
-                    provider: PROVIDER_NAME.to_string(),
-                    details: e.to_string(),
-                    hint: "Run 'az login' to authenticate with Azure".to_string(),
-                    url: PROVIDER_URL.to_string(),
-                })?;
+        let token = credential
+            .get_token(&[scope_for(&self.endpoint)], None)
+            .await
+            .map_err(|e: azure_core::Error| FnoxError::ProviderAuthFailed {
+                provider: PROVIDER_NAME.to_string(),
+                details: e.to_string(),
+                hint: "Run 'az login' to authenticate with Azure".to_string(),
+                url: PROVIDER_URL.to_string(),
+            })?;
 
         Ok(token.token.secret().to_string())
     }
@@ -210,6 +221,22 @@ mod tests {
         let provider = provider(Some(""), Some(""));
         assert_eq!(provider.label, None);
         assert_eq!(provider.prefix, None);
+    }
+
+    #[test]
+    fn scope_follows_the_endpoint_cloud() {
+        assert_eq!(
+            scope_for("https://store.azconfig.io"),
+            "https://appconfig.azure.com/.default"
+        );
+        assert_eq!(
+            scope_for("https://store.azconfig.azure.us"),
+            "https://appconfig.azure.us/.default"
+        );
+        assert_eq!(
+            scope_for("https://STORE.APPCONFIG.AZURE.CN"),
+            "https://appconfig.azure.cn/.default"
+        );
     }
 
     #[test]

--- a/crates/fnox-core/src/providers/azure_ac.rs
+++ b/crates/fnox-core/src/providers/azure_ac.rs
@@ -1,0 +1,208 @@
+use crate::error::{FnoxError, Result};
+use async_trait::async_trait;
+use azure_core::credentials::TokenCredential;
+use azure_identity::DeveloperToolsCredential;
+use serde::Deserialize;
+
+const PROVIDER_NAME: &str = "Azure App Configuration";
+const PROVIDER_URL: &str = "https://fnox.jdx.dev/providers/azure-ac";
+const SCOPE: &str = "https://appconfig.azure.com/.default";
+const API_VERSION: &str = "2023-11-01";
+
+pub fn env_dependencies() -> &'static [&'static str] {
+    &[]
+}
+
+#[derive(Deserialize)]
+struct KeyValue {
+    value: Option<String>,
+}
+
+pub struct AzureAppConfigurationProvider {
+    endpoint: String,
+    label: Option<String>,
+    prefix: Option<String>,
+}
+
+impl AzureAppConfigurationProvider {
+    pub fn new(endpoint: String, label: Option<String>, prefix: Option<String>) -> Result<Self> {
+        // An empty label is a distinct label in App Configuration, not the absence of one.
+        Ok(Self {
+            endpoint: endpoint.trim_end_matches('/').to_string(),
+            label: label.filter(|l| !l.is_empty()),
+            prefix: prefix.filter(|p| !p.is_empty()),
+        })
+    }
+
+    fn get_key_name(&self, key: &str) -> String {
+        match &self.prefix {
+            Some(prefix) => format!("{}{}", prefix, key),
+            None => key.to_string(),
+        }
+    }
+
+    /// Send an authenticated GET to the App Configuration data plane
+    async fn get(&self, path: &str, query: &[(&str, &str)]) -> Result<reqwest::Response> {
+        let token = self.get_token().await?;
+
+        let response = crate::http::http_client()
+            .get(format!("{}{}", self.endpoint, path))
+            .query(&[("api-version", API_VERSION)])
+            .query(query)
+            .bearer_auth(token)
+            .send()
+            .await
+            .map_err(|e| FnoxError::ProviderApiError {
+                provider: PROVIDER_NAME.to_string(),
+                details: format!("HTTP request failed: {}", e),
+                hint: "Check network connectivity to the App Configuration store".to_string(),
+                url: PROVIDER_URL.to_string(),
+            })?;
+
+        let status = response.status();
+        // 404 goes back to the caller, which knows what was being looked up.
+        if status.is_success() || status.as_u16() == 404 {
+            return Ok(response);
+        }
+
+        let body = response.text().await.unwrap_or_default();
+        if status.as_u16() == 401 || status.as_u16() == 403 {
+            return Err(FnoxError::ProviderAuthFailed {
+                provider: PROVIDER_NAME.to_string(),
+                details: format!("HTTP {}: {}", status, body),
+                hint: "Grant the 'App Configuration Data Reader' role and check the store's network access rules"
+                    .to_string(),
+                url: PROVIDER_URL.to_string(),
+            });
+        }
+        Err(FnoxError::ProviderApiError {
+            provider: PROVIDER_NAME.to_string(),
+            details: format!("HTTP {}: {}", status, body),
+            hint: "Check the store endpoint and your configuration".to_string(),
+            url: PROVIDER_URL.to_string(),
+        })
+    }
+
+    /// Acquire a Microsoft Entra ID token for the App Configuration data plane
+    async fn get_token(&self) -> Result<String> {
+        let credential = DeveloperToolsCredential::new(None).map_err(|e: azure_core::Error| {
+            FnoxError::ProviderAuthFailed {
+                provider: PROVIDER_NAME.to_string(),
+                details: e.to_string(),
+                hint: "Run 'az login' to authenticate with Azure".to_string(),
+                url: PROVIDER_URL.to_string(),
+            }
+        })?;
+
+        let token =
+            credential
+                .get_token(&[SCOPE], None)
+                .await
+                .map_err(|e: azure_core::Error| FnoxError::ProviderAuthFailed {
+                    provider: PROVIDER_NAME.to_string(),
+                    details: e.to_string(),
+                    hint: "Run 'az login' to authenticate with Azure".to_string(),
+                    url: PROVIDER_URL.to_string(),
+                })?;
+
+        Ok(token.token.secret().to_string())
+    }
+}
+
+#[async_trait]
+impl crate::providers::Provider for AzureAppConfigurationProvider {
+    fn capabilities(&self) -> Vec<crate::providers::ProviderCapability> {
+        vec![crate::providers::ProviderCapability::RemoteRead]
+    }
+
+    async fn get_secret(&self, value: &str) -> Result<String> {
+        let key = self.get_key_name(value);
+        tracing::debug!(
+            "Getting key '{}' from Azure App Configuration '{}'",
+            key,
+            self.endpoint
+        );
+
+        // Omitting the label selects the key-value that has no label.
+        let query: Vec<(&str, &str)> = match &self.label {
+            Some(label) => vec![("label", label)],
+            None => vec![],
+        };
+        let path = format!("/kv/{}", urlencoding::encode(&key));
+        let response = self.get(&path, &query).await?;
+
+        if response.status().as_u16() == 404 {
+            return Err(FnoxError::ProviderSecretNotFound {
+                provider: PROVIDER_NAME.to_string(),
+                secret: key,
+                hint: "Check the key name, prefix and label".to_string(),
+                url: PROVIDER_URL.to_string(),
+            });
+        }
+
+        let kv: KeyValue =
+            response
+                .json()
+                .await
+                .map_err(|e| FnoxError::ProviderInvalidResponse {
+                    provider: PROVIDER_NAME.to_string(),
+                    details: format!("Failed to parse key-value response: {}", e),
+                    hint: "This is an unexpected error".to_string(),
+                    url: PROVIDER_URL.to_string(),
+                })?;
+
+        kv.value.ok_or_else(|| FnoxError::ProviderInvalidResponse {
+            provider: PROVIDER_NAME.to_string(),
+            details: format!("Key '{}' has no value", key),
+            hint: "The key exists but has no value set".to_string(),
+            url: PROVIDER_URL.to_string(),
+        })
+    }
+
+    async fn test_connection(&self) -> Result<()> {
+        tracing::debug!(
+            "Testing connection to Azure App Configuration '{}'",
+            self.endpoint
+        );
+
+        // Filtered list: proves the store is reachable and the token is accepted
+        // without depending on any particular key existing.
+        self.get("/kv", &[("key", "fnox-connection-test")]).await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn provider(label: Option<&str>, prefix: Option<&str>) -> AzureAppConfigurationProvider {
+        AzureAppConfigurationProvider::new(
+            "https://store.azconfig.io/".to_string(),
+            label.map(String::from),
+            prefix.map(String::from),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn prefix_is_prepended_to_the_key() {
+        assert_eq!(provider(None, None).get_key_name("api-url"), "api-url");
+        assert_eq!(
+            provider(None, Some("myapp/")).get_key_name("api-url"),
+            "myapp/api-url"
+        );
+    }
+
+    #[test]
+    fn empty_label_and_prefix_are_treated_as_unset() {
+        let provider = provider(Some(""), Some(""));
+        assert_eq!(provider.label, None);
+        assert_eq!(provider.prefix, None);
+    }
+
+    #[test]
+    fn trailing_slash_is_stripped_from_the_endpoint() {
+        assert_eq!(provider(None, None).endpoint, "https://store.azconfig.io");
+    }
+}

--- a/crates/fnox-core/src/providers/mod.rs
+++ b/crates/fnox-core/src/providers/mod.rs
@@ -8,6 +8,7 @@ pub mod age;
 pub mod aws_kms;
 pub mod aws_ps;
 pub mod aws_sm;
+pub mod azure_ac;
 pub mod azure_kms;
 pub mod azure_sm;
 pub mod bitwarden;
@@ -143,9 +144,9 @@ mod generated {
         #[cfg(not(target_env = "musl"))]
         use super::super::fido2;
         use super::super::{
-            age, aws_kms, aws_ps, aws_sm, azure_kms, azure_sm, bitwarden, bitwarden_sm, doppler,
-            foks, gcp_kms, gcp_sm, infisical, keepass, keychain, onepassword, password_store,
-            passwordstate, plain, proton_pass, vault, yubikey,
+            age, aws_kms, aws_ps, aws_sm, azure_ac, azure_kms, azure_sm, bitwarden, bitwarden_sm,
+            doppler, foks, gcp_kms, gcp_sm, infisical, keepass, keychain, onepassword,
+            password_store, passwordstate, plain, proton_pass, vault, yubikey,
         };
         include!(concat!(
             env!("OUT_DIR"),

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -123,6 +123,7 @@ export default defineConfig({
             items: [
               { text: "AWS Parameter Store", link: "/providers/aws-ps" },
               { text: "AWS Secrets Manager", link: "/providers/aws-sm" },
+              { text: "Azure App Configuration", link: "/providers/azure-ac" },
               { text: "Azure Key Vault Secrets", link: "/providers/azure-sm" },
               { text: "Doppler", link: "/providers/doppler" },
               { text: "FOKS", link: "/providers/foks" },

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -920,6 +920,7 @@
                     "aws",
                     "aws-kms",
                     "aws-ps",
+                    "azure-ac",
                     "azure-kms",
                     "azure-sm",
                     "gcp",

--- a/docs/cli/provider/add.md
+++ b/docs/cli/provider/add.md
@@ -24,6 +24,7 @@ Provider type
 - `aws`
 - `aws-kms`
 - `aws-ps`
+- `azure-ac`
 - `azure-kms`
 - `azure-sm`
 - `gcp`

--- a/docs/index.md
+++ b/docs/index.md
@@ -91,6 +91,7 @@ API_KEY = { default = "dev-key-12345" }  # ← plain default value for local dev
 
 - **aws-ps** - AWS Parameter Store
 - **aws-sm** - AWS Secrets Manager
+- **azure-ac** - Azure App Configuration
 - **azure-sm** - Azure Key Vault Secrets
 - **gcp-sm** - Google Cloud Secret Manager
 - **bitwarden-sm** - Bitwarden Secrets Manager

--- a/docs/providers/azure-ac.md
+++ b/docs/providers/azure-ac.md
@@ -1,0 +1,87 @@
+# Azure App Configuration
+
+Azure App Configuration is the Azure store for non-secret configuration: endpoints, feature toggles, tuning values. This provider reads key-values from it, so configuration your infrastructure owns can be resolved instead of hardcoded in `fnox.toml`.
+
+Read-only. Use [Azure Key Vault Secrets](/providers/azure-sm) for anything sensitive.
+
+## Quick Start
+
+```bash
+# 1. Create the store
+az appconfig create --name "myapp-config" --resource-group "myapp-rg" --location westeurope
+
+# 2. Configure provider
+cat >> fnox.toml << 'EOF'
+[providers]
+appconfig = { type = "azure-ac", endpoint = "https://myapp-config.azconfig.io" }
+EOF
+
+# 3. Set a key-value
+az appconfig kv set --name "myapp-config" --key "api-url" --value "https://api.example.com"
+
+# 4. Reference in fnox
+cat >> fnox.toml << 'EOF'
+[secrets]
+API_URL = { provider = "appconfig", value = "api-url" }
+EOF
+
+# 5. Get value
+fnox get API_URL
+```
+
+## Authentication
+
+```bash
+# Azure CLI
+az login
+
+# Azure Developer CLI
+azd auth login
+```
+
+## Permissions
+
+Grant read access via RBAC:
+
+```bash
+az role assignment create \
+  --role "App Configuration Data Reader" \
+  --assignee "user@example.com" \
+  --scope "/subscriptions/SUB-ID/resourceGroups/myapp-rg/providers/Microsoft.AppConfiguration/configurationStores/myapp-config"
+```
+
+## Configuration
+
+```toml
+[providers]
+appconfig = { type = "azure-ac", endpoint = "https://myapp-config.azconfig.io", label = "dev", prefix = "myapp/" }  # label and prefix are optional
+```
+
+A key in App Configuration can carry several values distinguished by a label, so `label` maps naturally onto profiles:
+
+```toml
+[profiles.dev.providers]
+appconfig = { type = "azure-ac", endpoint = "https://myapp-config.azconfig.io", label = "dev" }
+
+[profiles.prod.providers]
+appconfig = { type = "azure-ac", endpoint = "https://myapp-config.azconfig.io", label = "prod" }
+```
+
+Without `label`, the key-value with no label is returned.
+
+## Pros
+
+- ✅ Keeps non-secret configuration out of Key Vault
+- ✅ One key serves every environment via labels
+- ✅ Integrated with Azure RBAC
+
+## Cons
+
+- ❌ Read-only: write key-values with `az appconfig kv set`, not `fnox set`
+- ❌ Values are not secrets: anyone with Data Reader sees them
+- ❌ Requires Azure subscription
+
+## Next Steps
+
+- [Azure Key Vault Secrets](/providers/azure-sm) - For actual secrets
+- [Profiles](/guide/profiles) - Per-environment labels

--- a/docs/providers/azure-ac.md
+++ b/docs/providers/azure-ac.md
@@ -69,6 +69,8 @@ appconfig = { type = "azure-ac", endpoint = "https://myapp-config.azconfig.io", 
 
 Without `label`, the key-value with no label is returned.
 
+The Entra audience follows the endpoint, so Azure Government (`*.azconfig.azure.us`) and Azure China (`*.azconfig.azure.cn`) stores work without extra configuration.
+
 ## Pros
 
 - ✅ Keeps non-secret configuration out of Key Vault

--- a/docs/providers/azure-ac.md
+++ b/docs/providers/azure-ac.md
@@ -69,7 +69,7 @@ appconfig = { type = "azure-ac", endpoint = "https://myapp-config.azconfig.io", 
 
 Without `label`, the key-value with no label is returned.
 
-The Entra audience follows the endpoint, so Azure Government (`*.azconfig.azure.us`) and Azure China (`*.azconfig.azure.cn`) stores work without extra configuration.
+The `endpoint` must be an HTTPS App Configuration domain: `*.azconfig.io`, or `*.azconfig.azure.us` and `*.azconfig.azure.cn` for Azure Government and Azure China. Anything else is rejected, since the endpoint is where fnox sends your Entra token. The audience follows the domain, so sovereign stores work without extra configuration.
 
 ## Pros
 

--- a/docs/providers/overview.md
+++ b/docs/providers/overview.md
@@ -23,6 +23,7 @@ Store secrets remotely in cloud providers. Your `fnox.toml` contains only refere
 | ---------------------------------------------------- | ----------------------------------- | ---------------------------------------- |
 | [AWS Parameter Store](/providers/aws-ps)             | AWS SSM Parameter Store             | Config values, simple secrets            |
 | [AWS Secrets Manager](/providers/aws-sm)             | AWS centralized secrets             | Production AWS workloads                 |
+| [Azure App Configuration](/providers/azure-ac)       | Azure non-secret configuration      | Endpoints and toggles owned by Azure IaC |
 | [Azure Key Vault Secrets](/providers/azure-sm)       | Azure secret storage                | Production Azure workloads               |
 | [GCP Secret Manager](/providers/gcp-sm)              | Google Cloud secrets                | Production GCP workloads                 |
 | [Bitwarden Secrets Manager](/providers/bitwarden-sm) | Bitwarden Secrets Manager (bws CLI) | Teams using Bitwarden for DevOps secrets |

--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -1003,6 +1003,32 @@
             "daemon_cache": {
               "type": ["boolean", "null"]
             },
+            "endpoint": {
+              "$ref": "#/$defs/StringOrSecretRef"
+            },
+            "label": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "prefix": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
+            "type": {
+              "type": "string",
+              "const": "azure-ac"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type", "endpoint"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "auth_command": {
+              "type": ["string", "null"]
+            },
+            "daemon_cache": {
+              "type": ["boolean", "null"]
+            },
             "prefix": {
               "$ref": "#/$defs/OptionStringOrSecretRef"
             },

--- a/fnox.usage.kdl
+++ b/fnox.usage.kdl
@@ -153,7 +153,7 @@ cmd provider help="Manage providers (defaults to list)" {
         }
         arg <PROVIDER> help="Provider name"
         arg <PROVIDER_TYPE> help="Provider type" {
-            choices "1password" age aws aws-kms aws-ps azure-kms azure-sm gcp gcp-kms fido2 bitwarden doppler foks bitwarden-sm infisical keepass keychain password-store passwordstate plain proton-pass vault yubikey
+            choices "1password" age aws aws-kms aws-ps azure-ac azure-kms azure-sm gcp gcp-kms fido2 bitwarden doppler foks bitwarden-sm infisical keepass keychain password-store passwordstate plain proton-pass vault yubikey
         }
     }
     cmd list help="List available providers" {

--- a/src/commands/provider/add.rs
+++ b/src/commands/provider/add.rs
@@ -144,6 +144,15 @@ impl AddCommand {
                 auth_command: None,
                 daemon_cache: None,
             },
+            ProviderType::AzureAppConfiguration => {
+                crate::config::ProviderConfig::AzureAppConfiguration {
+                    endpoint: StringOrSecretRef::from("https://my-store.azconfig.io"),
+                    label: OptionStringOrSecretRef::none(),
+                    prefix: OptionStringOrSecretRef::none(),
+                    auth_command: None,
+                    daemon_cache: None,
+                }
+            }
             ProviderType::AzureKms => crate::config::ProviderConfig::AzureKms {
                 vault_url: StringOrSecretRef::from("https://my-vault.vault.azure.net/"),
                 key_name: StringOrSecretRef::from("my-key"),

--- a/src/commands/provider/mod.rs
+++ b/src/commands/provider/mod.rs
@@ -36,6 +36,10 @@ pub enum ProviderType {
     #[value(name = "aws-ps")]
     #[strum(serialize = "aws-ps")]
     AwsParameterStore,
+    /// Azure App Configuration
+    #[value(name = "azure-ac")]
+    #[strum(serialize = "azure-ac")]
+    AzureAppConfiguration,
     /// Azure Key Vault KMS
     #[value(name = "azure-kms")]
     #[strum(serialize = "azure-kms")]

--- a/test/provider_add.bats
+++ b/test/provider_add.bats
@@ -17,6 +17,7 @@ agep|age|age
 awssm|aws|aws-sm
 awskms|aws-kms|aws-kms
 awsps|aws-ps|aws-ps
+azureac|azure-ac|azure-ac
 azurekms|azure-kms|azure-kms
 azuresm|azure-sm|azure-sm
 gcpsm|gcp|gcp-sm


### PR DESCRIPTION
Adds a read-only `azure-ac` provider for Azure App Configuration. Discussed in #658.

Azure splits its config surface in two: Key Vault for secrets, which `azure-sm` already covers, and App Configuration for everything that is not a secret — endpoints, feature toggles, tuning values. Without the second half, those values get hardcoded in `fnox.toml` or exported from a shell script sitting next to it, and `fnox.toml` stops being the one place to look.

`RemoteRead` only, so nothing writes back. Optional `label` and `prefix`. A key in App Configuration can carry several values distinguished by a label, which maps onto profiles:

```toml
[profiles.dev.providers]
appconfig = { type = "azure-ac", endpoint = "https://myapp-config.azconfig.io", label = "dev" }

[profiles.prod.providers]
appconfig = { type = "azure-ac", endpoint = "https://myapp-config.azconfig.io", label = "prod" }
```

Omitting `label` returns the key-value that has no label.

## Notes

No new dependencies — `azure_identity` and `azure_core` are already in the tree for `azure-sm`. Auth is `DeveloperToolsCredential`, same as `azure-sm`.

The scope constant is `https://appconfig.azure.com/.default`. Azure's own TypeSpec still says `azconfig.io`, but the Go, Python, .NET, Java and JS SDKs all use `appconfig.azure.com`, and the live test below confirms the SDKs are right.

`fnox set` against a `RemoteRead` provider writes the plaintext into `fnox.toml` rather than erroring (`src/commands/set.rs:141-183`). That is pre-existing behaviour shared with `passwordstate`, so I documented it in the provider page rather than change it here.

## Verification

`cargo test --workspace` 249 passed, `cargo clippy --all-targets -D warnings` clean, `cargo fmt` clean, `bats test/provider_add.bats` 6/6, `mise run render` idempotent. All at MSRV 1.91.1.

Also ran against a real store, since a few things could not be confirmed from the docs. Flat keys, hierarchical keys (`myapp/api-url`, confirming `/` percent-encodes correctly in the path), the same key reached via `prefix`, and label vs no-label all resolved. The 404, 403 and connection-failure paths each produced the right error variant. The store has been deleted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **Azure App Configuration** (`azure-ac`) as a read-only remote configuration provider.
  * Enabled **`fnox provider add`** for `azure-ac`, including starter template generation.
  * Added stricter endpoint validation and enhanced connection checks; configuration schema now requires `endpoint` with optional `label`/`prefix`.
* **Documentation**
  * Documented `azure-ac` and linked it in provider listings/navigation and CLI docs.
* **Tests**
  * Expanded provider-add coverage for `azure-ac`, plus added unit test coverage for connection validation and endpoint handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->