### PR TITLE
feat: assume an IAM role in the AWS providers

### DIFF
--- a/crates/fnox-core/providers/aws-kms.toml
+++ b/crates/fnox-core/providers/aws-kms.toml
@@ -23,6 +23,18 @@ placeholder = "us-east-1"
 label = "AWS Region:"
 wizard = true
 
+[fields.profile]
+type = "optional"
+placeholder = "my-aws-profile"
+label = "AWS profile (optional):"
+wizard = true
+
+[fields.role_arn]
+type = "optional"
+placeholder = "arn:aws:iam::123456789012:role/my-role"
+label = "IAM role to assume (optional):"
+wizard = true
+
 [fields.endpoint]
 type = "optional"
 placeholder = "http://localhost:4566"

--- a/crates/fnox-core/providers/aws-ps.toml
+++ b/crates/fnox-core/providers/aws-ps.toml
@@ -22,6 +22,12 @@ placeholder = "my-aws-profile"
 label = "AWS profile (optional):"
 wizard = true
 
+[fields.role_arn]
+type = "optional"
+placeholder = "arn:aws:iam::123456789012:role/my-role"
+label = "IAM role to assume (optional):"
+wizard = true
+
 [fields.prefix]
 type = "optional"
 placeholder = "/myapp/prod/"

--- a/crates/fnox-core/providers/aws-sm.toml
+++ b/crates/fnox-core/providers/aws-sm.toml
@@ -22,6 +22,12 @@ placeholder = "my-aws-profile"
 label = "AWS profile (optional):"
 wizard = true
 
+[fields.role_arn]
+type = "optional"
+placeholder = "arn:aws:iam::123456789012:role/my-role"
+label = "IAM role to assume (optional):"
+wizard = true
+
 [fields.prefix]
 type = "optional"
 placeholder = "fnox/"

--- a/crates/fnox-core/src/providers/aws_kms.rs
+++ b/crates/fnox-core/src/providers/aws_kms.rs
@@ -148,6 +148,7 @@ impl AwsKmsProvider {
             &self.region,
             self.profile.as_deref(),
             self.role_arn.as_deref(),
+            self.endpoint.as_deref(),
         )
         .await?;
 

--- a/crates/fnox-core/src/providers/aws_kms.rs
+++ b/crates/fnox-core/src/providers/aws_kms.rs
@@ -1,6 +1,5 @@
 use crate::error::{FnoxError, Result};
 use async_trait::async_trait;
-use aws_config::BehaviorVersion;
 use aws_sdk_kms::Client;
 use aws_sdk_kms::primitives::Blob;
 
@@ -121,25 +120,36 @@ where
 pub struct AwsKmsProvider {
     key_id: String,
     region: String,
+    profile: Option<String>,
+    role_arn: Option<String>,
     endpoint: Option<String>,
 }
 
 impl AwsKmsProvider {
-    pub fn new(key_id: String, region: String, endpoint: Option<String>) -> Result<Self> {
+    pub fn new(
+        key_id: String,
+        region: String,
+        profile: Option<String>,
+        role_arn: Option<String>,
+        endpoint: Option<String>,
+    ) -> Result<Self> {
         Ok(Self {
             key_id,
             region,
+            profile,
+            role_arn,
             endpoint,
         })
     }
 
     /// Create an AWS KMS client
     async fn create_client(&self) -> Result<Client> {
-        // Load AWS config with the specified region
-        let config = aws_config::defaults(BehaviorVersion::latest())
-            .region(aws_sdk_kms::config::Region::new(self.region.clone()))
-            .load()
-            .await;
+        let config = super::aws_shared::load_sdk_config(
+            &self.region,
+            self.profile.as_deref(),
+            self.role_arn.as_deref(),
+        )
+        .await?;
 
         let mut kms_config_builder = aws_sdk_kms::config::Builder::from(&config);
         if let Some(endpoint) = &self.endpoint {

--- a/crates/fnox-core/src/providers/aws_ps.rs
+++ b/crates/fnox-core/src/providers/aws_ps.rs
@@ -154,6 +154,7 @@ impl AwsParameterStoreProvider {
             &self.region,
             self.profile.as_deref(),
             self.role_arn.as_deref(),
+            self.endpoint.as_deref(),
         )
         .await?;
 

--- a/crates/fnox-core/src/providers/aws_ps.rs
+++ b/crates/fnox-core/src/providers/aws_ps.rs
@@ -1,6 +1,5 @@
 use crate::error::{FnoxError, Result};
 use async_trait::async_trait;
-use aws_config::BehaviorVersion;
 use aws_sdk_ssm::Client;
 use std::collections::HashMap;
 
@@ -120,6 +119,7 @@ where
 pub struct AwsParameterStoreProvider {
     region: String,
     profile: Option<String>,
+    role_arn: Option<String>,
     prefix: Option<String>,
     endpoint: Option<String>,
 }
@@ -128,12 +128,14 @@ impl AwsParameterStoreProvider {
     pub fn new(
         region: String,
         profile: Option<String>,
+        role_arn: Option<String>,
         prefix: Option<String>,
         endpoint: Option<String>,
     ) -> Result<Self> {
         Ok(Self {
             region,
             profile,
+            role_arn,
             prefix,
             endpoint,
         })
@@ -148,14 +150,12 @@ impl AwsParameterStoreProvider {
 
     /// Create an AWS SSM client
     async fn create_client(&self) -> Result<Client> {
-        let mut builder = aws_config::defaults(BehaviorVersion::latest())
-            .region(aws_sdk_ssm::config::Region::new(self.region.clone()));
-
-        if let Some(profile) = &self.profile {
-            builder = builder.profile_name(profile);
-        }
-
-        let config = builder.load().await;
+        let config = super::aws_shared::load_sdk_config(
+            &self.region,
+            self.profile.as_deref(),
+            self.role_arn.as_deref(),
+        )
+        .await?;
 
         let mut ssm_config_builder = aws_sdk_ssm::config::Builder::from(&config);
         if let Some(endpoint) = &self.endpoint {

--- a/crates/fnox-core/src/providers/aws_shared.rs
+++ b/crates/fnox-core/src/providers/aws_shared.rs
@@ -1,0 +1,64 @@
+use crate::error::{FnoxError, Result};
+use aws_config::{BehaviorVersion, SdkConfig, sts::AssumeRoleProvider};
+use aws_sdk_sts::config::{Region, SharedCredentialsProvider};
+
+/// Build the base `SdkConfig` for an AWS provider, optionally assuming a role.
+///
+/// `profile` selects the source credentials (including SSO). When `role_arn` is set, those
+/// credentials are only used to call `sts:AssumeRole`, and the returned config carries the
+/// assumed role's credentials instead.
+pub async fn load_sdk_config(
+    region: &str,
+    profile: Option<&str>,
+    role_arn: Option<&str>,
+) -> Result<SdkConfig> {
+    let region = Region::new(region.to_string());
+
+    let mut builder = aws_config::defaults(BehaviorVersion::latest()).region(region.clone());
+    if let Some(profile) = profile {
+        builder = builder.profile_name(profile);
+    }
+    let base = builder.load().await;
+
+    let Some(role_arn) = role_arn else {
+        return Ok(base);
+    };
+
+    validate_role_arn(role_arn)?;
+
+    let credentials = AssumeRoleProvider::builder(role_arn)
+        .configure(&base)
+        .region(region)
+        .session_name("fnox")
+        .build()
+        .await;
+
+    Ok(base
+        .into_builder()
+        .credentials_provider(SharedCredentialsProvider::new(credentials))
+        .build())
+}
+
+fn validate_role_arn(role_arn: &str) -> Result<()> {
+    if role_arn.starts_with("arn:") && role_arn.contains(":iam:") && role_arn.contains(":role/") {
+        return Ok(());
+    }
+    Err(FnoxError::Config(format!(
+        "'{role_arn}' is not a valid IAM role ARN - expected arn:aws:iam::123456789012:role/my-role"
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_role_arn() {
+        assert!(validate_role_arn("arn:aws:iam::123456789012:role/my-role").is_ok());
+        assert!(validate_role_arn("arn:aws-us-gov:iam::123456789012:role/my-role").is_ok());
+        assert!(validate_role_arn("arn:aws:iam::123456789012:role/path/to/my-role").is_ok());
+        assert!(validate_role_arn("my-role").is_err());
+        assert!(validate_role_arn("arn:aws:iam::123456789012:user/me").is_err());
+        assert!(validate_role_arn("arn:aws:kms:us-east-1:123456789012:key/abc").is_err());
+    }
+}

--- a/crates/fnox-core/src/providers/aws_shared.rs
+++ b/crates/fnox-core/src/providers/aws_shared.rs
@@ -7,16 +7,23 @@ use aws_sdk_sts::config::{Region, SharedCredentialsProvider};
 /// `profile` selects the source credentials (including SSO). When `role_arn` is set, those
 /// credentials are only used to call `sts:AssumeRole`, and the returned config carries the
 /// assumed role's credentials instead.
+///
+/// `endpoint` is applied to the config itself, not just to the caller's service client, so the
+/// AssumeRole call also goes to that endpoint rather than to real AWS.
 pub async fn load_sdk_config(
     region: &str,
     profile: Option<&str>,
     role_arn: Option<&str>,
+    endpoint: Option<&str>,
 ) -> Result<SdkConfig> {
     let region = Region::new(region.to_string());
 
     let mut builder = aws_config::defaults(BehaviorVersion::latest()).region(region.clone());
     if let Some(profile) = profile {
         builder = builder.profile_name(profile);
+    }
+    if let Some(endpoint) = endpoint {
+        builder = builder.endpoint_url(endpoint);
     }
     let base = builder.load().await;
 
@@ -39,13 +46,30 @@ pub async fn load_sdk_config(
         .build())
 }
 
+/// IAM role ARNs are `arn:<partition>:iam::<account>:role/<name>` - the region segment is always
+/// empty and the account is always 12 digits.
 fn validate_role_arn(role_arn: &str) -> Result<()> {
-    if role_arn.starts_with("arn:") && role_arn.contains(":iam:") && role_arn.contains(":role/") {
-        return Ok(());
+    let invalid = || {
+        FnoxError::Config(format!(
+            "'{role_arn}' is not a valid IAM role ARN - expected arn:aws:iam::123456789012:role/my-role"
+        ))
+    };
+
+    let segments: Vec<&str> = role_arn.splitn(6, ':').collect();
+    let [arn, partition, service, region, account, resource] = segments[..] else {
+        return Err(invalid());
+    };
+
+    if arn != "arn" || partition.is_empty() || service != "iam" || !region.is_empty() {
+        return Err(invalid());
     }
-    Err(FnoxError::Config(format!(
-        "'{role_arn}' is not a valid IAM role ARN - expected arn:aws:iam::123456789012:role/my-role"
-    )))
+    if account.len() != 12 || !account.bytes().all(|b| b.is_ascii_digit()) {
+        return Err(invalid());
+    }
+    match resource.strip_prefix("role/") {
+        Some(name) if !name.is_empty() => Ok(()),
+        _ => Err(invalid()),
+    }
 }
 
 #[cfg(test)]
@@ -53,12 +77,25 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_validate_role_arn() {
+    fn test_validate_role_arn_accepts_valid() {
         assert!(validate_role_arn("arn:aws:iam::123456789012:role/my-role").is_ok());
         assert!(validate_role_arn("arn:aws-us-gov:iam::123456789012:role/my-role").is_ok());
+        assert!(validate_role_arn("arn:aws-cn:iam::123456789012:role/my-role").is_ok());
         assert!(validate_role_arn("arn:aws:iam::123456789012:role/path/to/my-role").is_ok());
+    }
+
+    #[test]
+    fn test_validate_role_arn_rejects_invalid() {
         assert!(validate_role_arn("my-role").is_err());
         assert!(validate_role_arn("arn:aws:iam::123456789012:user/me").is_err());
         assert!(validate_role_arn("arn:aws:kms:us-east-1:123456789012:key/abc").is_err());
+        // Substrings alone are not enough: a region, a short or non-numeric account, an empty
+        // role name, or a missing segment all make the ARN unusable.
+        assert!(validate_role_arn("arn:aws:iam:us-east-1:123456789012:role/my-role").is_err());
+        assert!(validate_role_arn("arn:aws:iam::not-an-account:role/my-role").is_err());
+        assert!(validate_role_arn("arn:aws:iam::12345:role/my-role").is_err());
+        assert!(validate_role_arn("arn:aws:iam::123456789012:role/").is_err());
+        assert!(validate_role_arn("arn::iam::123456789012:role/my-role").is_err());
+        assert!(validate_role_arn("arn:aws:iam::123456789012").is_err());
     }
 }

--- a/crates/fnox-core/src/providers/aws_sm.rs
+++ b/crates/fnox-core/src/providers/aws_sm.rs
@@ -182,6 +182,7 @@ impl AwsSecretsManagerProvider {
             &self.region,
             self.profile.as_deref(),
             self.role_arn.as_deref(),
+            self.endpoint.as_deref(),
         )
         .await?;
 

--- a/crates/fnox-core/src/providers/aws_sm.rs
+++ b/crates/fnox-core/src/providers/aws_sm.rs
@@ -1,6 +1,5 @@
 use crate::error::{FnoxError, Result};
 use async_trait::async_trait;
-use aws_config::BehaviorVersion;
 use aws_sdk_secretsmanager::Client;
 use std::collections::HashMap;
 
@@ -148,6 +147,7 @@ fn extract_name_from_arn(arn_or_name: &str) -> String {
 pub struct AwsSecretsManagerProvider {
     region: String,
     profile: Option<String>,
+    role_arn: Option<String>,
     prefix: Option<String>,
     endpoint: Option<String>,
 }
@@ -156,12 +156,14 @@ impl AwsSecretsManagerProvider {
     pub fn new(
         region: String,
         profile: Option<String>,
+        role_arn: Option<String>,
         prefix: Option<String>,
         endpoint: Option<String>,
     ) -> Result<Self> {
         Ok(Self {
             region,
             profile,
+            role_arn,
             prefix,
             endpoint,
         })
@@ -176,15 +178,12 @@ impl AwsSecretsManagerProvider {
 
     /// Create an AWS Secrets Manager client
     async fn create_client(&self) -> Result<Client> {
-        let mut builder = aws_config::defaults(BehaviorVersion::latest()).region(
-            aws_sdk_secretsmanager::config::Region::new(self.region.clone()),
-        );
-
-        if let Some(profile) = &self.profile {
-            builder = builder.profile_name(profile);
-        }
-
-        let config = builder.load().await;
+        let config = super::aws_shared::load_sdk_config(
+            &self.region,
+            self.profile.as_deref(),
+            self.role_arn.as_deref(),
+        )
+        .await?;
 
         let mut sm_config_builder = aws_sdk_secretsmanager::config::Builder::from(&config);
         if let Some(endpoint) = &self.endpoint {

--- a/crates/fnox-core/src/providers/mod.rs
+++ b/crates/fnox-core/src/providers/mod.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 pub mod age;
 pub mod aws_kms;
 pub mod aws_ps;
+mod aws_shared;
 pub mod aws_sm;
 pub mod azure_ac;
 pub mod azure_kms;

--- a/docs/providers/aws-kms.md
+++ b/docs/providers/aws-kms.md
@@ -95,6 +95,24 @@ The `key_id` can be:
 - Key ID: `12345678-1234-1234-1234-123456789012`
 - Alias: `alias/my-key`
 
+### Credentials
+
+| Field      | Required | Description                                                                                       |
+| ---------- | -------- | ------------------------------------------------------------------------------------------------- |
+| `profile`  | No       | AWS CLI profile name from `~/.aws/config`. Falls back to the default credential chain if omitted. |
+| `role_arn` | No       | IAM role to assume before calling KMS                                                             |
+
+With `role_arn` set, fnox calls `sts:AssumeRole` and uses the resulting credentials for encrypt and decrypt. The credentials from `profile` (or the default chain) are the source credentials for that call, which covers the SOPS pattern of an SSO profile plus a key-holding role in another account:
+
+```toml
+[providers.kms]
+type = "aws-kms"
+key_id = "alias/my-key"
+region = "eu-west-1"
+profile = "sso-dev"
+role_arn = "arn:aws:iam::123456789012:role/kms-user"
+```
+
 ## Usage
 
 ### Encrypt and Store

--- a/docs/providers/aws-ps.md
+++ b/docs/providers/aws-ps.md
@@ -130,13 +130,21 @@ ps = { type = "aws-ps", region = "us-east-1" }  # minimal config
 ps = { type = "aws-ps", region = "us-east-1", profile = "my-aws-profile", prefix = "/myapp/prod/" }
 ```
 
-| Field     | Required | Description                                                                                       |
-| --------- | -------- | ------------------------------------------------------------------------------------------------- |
-| `region`  | Yes      | AWS region (e.g. `us-east-1`)                                                                     |
-| `profile` | No       | AWS CLI profile name from `~/.aws/config`. Falls back to the default credential chain if omitted. |
-| `prefix`  | No       | Prepended to all parameter names                                                                  |
+| Field      | Required | Description                                                                                       |
+| ---------- | -------- | ------------------------------------------------------------------------------------------------- |
+| `region`   | Yes      | AWS region (e.g. `us-east-1`)                                                                     |
+| `profile`  | No       | AWS CLI profile name from `~/.aws/config`. Falls back to the default credential chain if omitted. |
+| `role_arn` | No       | IAM role to assume before reading parameters                                                      |
+| `prefix`   | No       | Prepended to all parameter names                                                                  |
 
 The `profile` field is useful when you have multiple AWS accounts or roles configured and want to pin a provider to a specific one without relying on `AWS_PROFILE` in the environment.
+
+Set `role_arn` to have fnox call `sts:AssumeRole` and use the resulting credentials for every request. The credentials from `profile` (or the default chain) are the source credentials for that call:
+
+```toml
+[providers]
+ps = { type = "aws-ps", region = "eu-west-1", profile = "sso-dev", role_arn = "arn:aws:iam::123456789012:role/param-reader" }
+```
 
 ## Creating Parameters
 

--- a/docs/providers/aws-sm.md
+++ b/docs/providers/aws-sm.md
@@ -140,13 +140,27 @@ aws = { type = "aws-sm", region = "us-east-1" }  # minimal config
 aws = { type = "aws-sm", region = "us-east-1", profile = "my-aws-profile", prefix = "myapp/" }
 ```
 
-| Field     | Required | Description                                                                                       |
-| --------- | -------- | ------------------------------------------------------------------------------------------------- |
-| `region`  | Yes      | AWS region (e.g. `us-east-1`)                                                                     |
-| `profile` | No       | AWS CLI profile name from `~/.aws/config`. Falls back to the default credential chain if omitted. |
-| `prefix`  | No       | Prepended to all secret names                                                                     |
+| Field      | Required | Description                                                                                       |
+| ---------- | -------- | ------------------------------------------------------------------------------------------------- |
+| `region`   | Yes      | AWS region (e.g. `us-east-1`)                                                                     |
+| `profile`  | No       | AWS CLI profile name from `~/.aws/config`. Falls back to the default credential chain if omitted. |
+| `role_arn` | No       | IAM role to assume before reading secrets                                                         |
+| `prefix`   | No       | Prepended to all secret names                                                                     |
 
 The `profile` field is useful when you have multiple AWS accounts or roles configured and want to pin a provider to a specific one without relying on `AWS_PROFILE` in the environment.
+
+### Assuming a Role
+
+Set `role_arn` to have fnox call `sts:AssumeRole` and use the resulting credentials for every request. The credentials from `profile` (or the default chain) are the source credentials for that call, so an SSO profile plus a cross-account role works in one step:
+
+```toml
+[providers]
+aws = { type = "aws-sm", region = "eu-west-1", profile = "sso-dev", role_arn = "arn:aws:iam::123456789012:role/secrets-reader" }
+```
+
+This mirrors the `role` option in SOPS. If your `~/.aws/config` profile already declares `role_arn` and `source_profile`, the AWS SDK assumes that role on its own and you do not need this field.
+
+The session name is always `fnox`, and the role must trust the source identity for `sts:AssumeRole`.
 
 ## Creating Secrets
 

--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -884,8 +884,14 @@
             "key_id": {
               "$ref": "#/$defs/StringOrSecretRef"
             },
+            "profile": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
             "region": {
               "$ref": "#/$defs/StringOrSecretRef"
+            },
+            "role_arn": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
             },
             "type": {
               "type": "string",
@@ -968,6 +974,9 @@
             "region": {
               "$ref": "#/$defs/StringOrSecretRef"
             },
+            "role_arn": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
+            },
             "type": {
               "type": "string",
               "const": "aws-ps"
@@ -996,6 +1005,9 @@
             },
             "region": {
               "$ref": "#/$defs/StringOrSecretRef"
+            },
+            "role_arn": {
+              "$ref": "#/$defs/OptionStringOrSecretRef"
             },
             "type": {
               "type": "string",

--- a/src/commands/provider/add.rs
+++ b/src/commands/provider/add.rs
@@ -109,6 +109,7 @@ impl AddCommand {
             ProviderType::Aws => crate::config::ProviderConfig::AwsSecretsManager {
                 region: StringOrSecretRef::from("us-east-1"),
                 profile: OptionStringOrSecretRef::none(),
+                role_arn: OptionStringOrSecretRef::none(),
                 prefix: OptionStringOrSecretRef::none(),
                 endpoint: OptionStringOrSecretRef::none(),
                 auth_command: None,
@@ -132,6 +133,8 @@ impl AddCommand {
             ProviderType::AwsKms => crate::config::ProviderConfig::AwsKms {
                 region: StringOrSecretRef::from("us-east-1"),
                 key_id: StringOrSecretRef::from("alias/my-key"),
+                profile: OptionStringOrSecretRef::none(),
+                role_arn: OptionStringOrSecretRef::none(),
                 endpoint: OptionStringOrSecretRef::none(),
                 auth_command: None,
                 daemon_cache: None,
@@ -139,6 +142,7 @@ impl AddCommand {
             ProviderType::AwsParameterStore => crate::config::ProviderConfig::AwsParameterStore {
                 region: StringOrSecretRef::from("us-east-1"),
                 profile: OptionStringOrSecretRef::none(),
+                role_arn: OptionStringOrSecretRef::none(),
                 prefix: OptionStringOrSecretRef::literal("/myapp/prod/"),
                 endpoint: OptionStringOrSecretRef::none(),
                 auth_command: None,

--- a/test/aws_role_arn.bats
+++ b/test/aws_role_arn.bats
@@ -1,0 +1,63 @@
+#!/usr/bin/env bats
+#
+# AWS role_arn validation tests
+#
+# A malformed role_arn is rejected before any AWS call, so these tests need no
+# credentials and no LocalStack.
+
+setup() {
+	load 'test_helper/common_setup'
+	_common_setup
+}
+
+teardown() {
+	_common_teardown
+}
+
+write_role_arn_config() {
+	local provider_type="$1"
+	local role_arn="$2"
+	local key_id=""
+
+	if [ "$provider_type" = "aws-kms" ]; then
+		key_id='key_id = "alias/my-key"'
+	fi
+
+	cat >"${FNOX_CONFIG_FILE:-fnox.toml}" <<EOF
+root = true
+
+[providers.aws]
+type = "$provider_type"
+region = "us-east-1"
+$key_id
+role_arn = "$role_arn"
+
+[secrets.SOME_SECRET]
+provider = "aws"
+value = "some-secret"
+EOF
+}
+
+@test "aws-sm rejects a malformed role ARN" {
+	write_role_arn_config "aws-sm" "fnox-test-role"
+
+	run "$FNOX_BIN" get SOME_SECRET
+	assert_failure
+	assert_output --partial "IAM role ARN"
+}
+
+@test "aws-ps rejects a role ARN with a region segment" {
+	write_role_arn_config "aws-ps" "arn:aws:iam:us-east-1:123456789012:role/my-role"
+
+	run "$FNOX_BIN" get SOME_SECRET
+	assert_failure
+	assert_output --partial "IAM role ARN"
+}
+
+@test "aws-kms rejects a role ARN with a non-numeric account" {
+	write_role_arn_config "aws-kms" "arn:aws:iam::not-an-account:role/my-role"
+
+	run "$FNOX_BIN" get SOME_SECRET
+	assert_failure
+	assert_output --partial "IAM role ARN"
+}

--- a/test/aws_secrets_manager.bats
+++ b/test/aws_secrets_manager.bats
@@ -228,6 +228,29 @@ EOF
 	assert_output "$SHARED_SECRET_VALUE"
 }
 
+@test "fnox get assumes the configured role" {
+	local secret_suffix="${SHARED_SECRET_NAME#fnox-test/}"
+
+	cat >"${FNOX_CONFIG_FILE:-fnox.toml}" <<EOF
+root = true
+
+[providers.sm]
+type = "aws-sm"
+region = "us-east-1"
+prefix = "fnox-test/"
+role_arn = "arn:aws:iam::123456789012:role/fnox-test-role"
+endpoint = "$LOCALSTACK_ENDPOINT"
+
+[secrets.ASSUMED_SECRET]
+provider = "sm"
+value = "${secret_suffix}"
+EOF
+
+	run "$FNOX_BIN" get ASSUMED_SECRET
+	assert_success
+	assert_output "$SHARED_SECRET_VALUE"
+}
+
 @test "AWS Secrets Manager works with existing fnox/test-secret" {
 	create_sm_config "us-east-1" "fnox/"
 

--- a/test/aws_secrets_manager.bats
+++ b/test/aws_secrets_manager.bats
@@ -231,6 +231,9 @@ EOF
 @test "fnox get assumes the configured role" {
 	local secret_suffix="${SHARED_SECRET_NAME#fnox-test/}"
 
+	# LocalStack scopes resources per account, so the role has to live in the default
+	# account for the secret created in setup_file to be visible after AssumeRole.
+
 	cat >"${FNOX_CONFIG_FILE:-fnox.toml}" <<EOF
 root = true
 
@@ -238,7 +241,7 @@ root = true
 type = "aws-sm"
 region = "us-east-1"
 prefix = "fnox-test/"
-role_arn = "arn:aws:iam::123456789012:role/fnox-test-role"
+role_arn = "arn:aws:iam::000000000000:role/fnox-test-role"
 endpoint = "$LOCALSTACK_ENDPOINT"
 
 [secrets.ASSUMED_SECRET]


### PR DESCRIPTION
## Why

Using an AWS SSO profile to assume a role in another account is a rather standard [`sops`](https://github.com/getsops/sops) setup, but `fnox` could only name the profile. `sts:AssumeRole` existed solely in the aws-sts lease backend, whose credentials go to the child process and never reach fnox's own AWS clients, so there was no way to express "log in with this profile, read secrets as that role".

## What changed

- Add an optional `role_arn` to `aws-sm`, `aws-ps`, and `aws-kms`.
  When set, fnox calls `sts:AssumeRole` using the credentials from `profile` (or the default chain) and uses the result for every request.
- Add the `profile` field to `aws-kms`, which the other two AWS providers already had.
- Move client config into one shared helper, replacing three copies of the region/profile setup.
- Reject a malformed role ARN before any AWS call.

```toml
[providers.sm]
type = "aws-sm"
region = "eu-west-1"
profile = "sso-dev"
role_arn = "arn:aws:iam::123456789012:role/secrets-reader"
```

## Notes for reviewers

The session name is hardcoded to `fnox`; `external_id` and a custom session name are not implemented. Coverage: `test/aws_role_arn.bats` rejects malformed ARNs without needing credentials, and `test/aws_secrets_manager.bats` exercises a successful assume-role against LocalStack. A profile that already declares `role_arn`/`source_profile` in `~/.aws/config` keeps working through the SDK as before.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5[1m]; version: 2.1.220.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - AWS KMS, Parameter Store, and Secrets Manager now support optional IAM role assumption.
  - AWS KMS supports selecting an AWS profile for credential sourcing.
  - Cross-account AWS access is supported through profiles and assumed roles.
  - Provider templates and schemas include the new settings.

- **Documentation**
  - Added configuration guidance and examples for profiles, roles, and cross-account access.

- **Bug Fixes**
  - Added validation for invalid IAM role ARN formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
