### PR TITLE
ci: run perf jobs on bamboo

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - bamboo-perf

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -27,17 +27,17 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
+  TAK_RUNNER: bamboo-v1-ubuntu24.04-x64-rust1.91.1-tokio1
   RUSTUP_TOOLCHAIN: "1.91.1"
   # Changing the measuring environment starts a new series rather than
-  # comparing incompatible counts with the old ubuntu-latest baseline.
-  TAK_RUNNER: gha-ubuntu-24.04-x64-rust-1.91.1-tokio1
+  # comparing incompatible counts with the old hosted-runner baseline.
 
 jobs:
   measure:
     name: Compare instruction counts
     # Same pinned environment as perf.yml. Absolute counts shift when the
     # runner image or compiler changes, even within one GitHub runner class.
-    runs-on: ubuntu-24.04
+    runs-on: bamboo-perf
     timeout-minutes: 40
     permissions:
       # Read only. This job builds and runs code from the pull request, so it

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -27,8 +27,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
-  TAK_RUNNER: bamboo-v1-ubuntu24.04-x64-rust1.91.1-tokio1
-  RUSTUP_TOOLCHAIN: "1.91.1"
+  TAK_RUNNER: bamboo-v1-ubuntu24.04-x64-rust1.97.1-tokio1
   # Changing the measuring environment starts a new series rather than
   # comparing incompatible counts with the old hosted-runner baseline.
 
@@ -56,9 +55,6 @@ jobs:
           # which walks twenty commits of trunk history.
           fetch-depth: 0
           persist-credentials: false
-
-      - name: Install benchmark Rust toolchain
-        run: rustup toolchain install "$RUSTUP_TOOLCHAIN" --profile minimal
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -27,7 +27,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
-  TAK_RUNNER: bamboo-v1-ubuntu24.04-x64-rust1.97.1-tokio1
+  TAK_RUNNER: bamboo-v2-ubuntu24.04-x64-30vcpu-24gb-rust1.97.1-tokio1
   # Changing the measuring environment starts a new series rather than
   # comparing incompatible counts with the old hosted-runner baseline.
 

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -34,6 +34,7 @@ env:
 jobs:
   measure:
     name: Compare instruction counts
+    if: github.event.pull_request.user.login == 'jdx'
     # Same pinned environment as perf.yml. Absolute counts shift when the
     # runner image or compiler changes, even within one GitHub runner class.
     runs-on: bamboo-perf
@@ -141,7 +142,7 @@ jobs:
   report:
     name: Report and gate
     needs: measure
-    if: always()
+    if: always() && github.event.pull_request.user.login == 'jdx'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -27,17 +27,17 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
+  TAK_RUNNER: bamboo-v1-ubuntu24.04-x64-rust1.91.1-tokio1
   RUSTUP_TOOLCHAIN: "1.91.1"
   # This is a new measurement series: the compiler, runner image and Tokio
   # worker count are part of the benchmark environment, not incidental details.
-  TAK_RUNNER: gha-ubuntu-24.04-x64-rust-1.91.1-tokio1
 
 jobs:
   measure:
     name: Measure
     # Pin the image as well as tak and Rust. Absolute instruction counts shift
     # when any part of the measuring environment moves.
-    runs-on: ubuntu-24.04
+    runs-on: bamboo-perf
     timeout-minutes: 30
     permissions:
       contents: write # pushing refs/notes/tak is a write to this repository

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -27,7 +27,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
-  TAK_RUNNER: bamboo-v1-ubuntu24.04-x64-rust1.97.1-tokio1
+  TAK_RUNNER: bamboo-v2-ubuntu24.04-x64-30vcpu-24gb-rust1.97.1-tokio1
   # This is a new measurement series: the compiler, runner image and Tokio
   # worker count are part of the benchmark environment, not incidental details.
 

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -27,8 +27,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
-  TAK_RUNNER: bamboo-v1-ubuntu24.04-x64-rust1.91.1-tokio1
-  RUSTUP_TOOLCHAIN: "1.91.1"
+  TAK_RUNNER: bamboo-v1-ubuntu24.04-x64-rust1.97.1-tokio1
   # This is a new measurement series: the compiler, runner image and Tokio
   # worker count are part of the benchmark environment, not incidental details.
 
@@ -45,9 +44,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-
-      - name: Install benchmark Rust toolchain
-        run: rustup toolchain install "$RUSTUP_TOOLCHAIN" --profile minimal
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 


### PR DESCRIPTION
## Summary

- run Tak measurement jobs on the isolated `bamboo-perf` runner
- identify the Bamboo image/toolchain as a distinct Tak runner class
- leave report and publish jobs on hosted runners

## Validation

- `actionlint` (with `bamboo-perf` registered as the expected custom label)
- `git diff --check`
- trusted `main` baseline queued on the disposable runner

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Perf baselines and PR gates now depend on a self-hosted runner and a new Tak series ID, and perf-pr only runs for one author until that guard is removed—wrong runner availability or label config would break CI signal without touching app code.
> 
> **Overview**
> Moves **Tak instruction-count measurement** in `perf.yml` and `perf-pr.yml` from GitHub-hosted `ubuntu-24.04` to the self-hosted **`bamboo-perf`** runner, and registers that label in **`.github/actionlint.yaml`** so workflow linting accepts it.
> 
> Benchmark metadata now uses **`TAK_RUNNER: bamboo-v2-ubuntu24.04-x64-30vcpu-24gb-rust1.97.1-tokio1`**, explicitly starting a **new measurement series** (comments call out incompatibility with the old hosted-runner baseline). The workflows drop **`RUSTUP_TOOLCHAIN`** and the manual **`rustup toolchain install`** step, relying on **`mise-action`** on the Bamboo image instead.
> 
> **`perf-pr`** additionally gates **`measure`** and **`report`** with **`github.event.pull_request.user.login == 'jdx'`** so only that author’s PRs run the expensive compare/comment path; report/publish-style jobs that stay on **`ubuntu-latest`** are unchanged aside from that condition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cefaafa4b1476f8894ee33558db307cfdf6794e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated performance testing workflows to use a standardized, pinned execution environment.
  * Improved consistency and comparability across performance test runs.
  * Simplified workflow setup by removing redundant environment configuration and installation steps.
  * Improved the reliability and repeatability of performance measurements across runs.
  * Added dedicated runner configuration for performance testing to support more predictable execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->