### PR TITLE
chore: release v1.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,40 @@
 # Changelog
 
-## [1.32.0](https://github.com/jdx/fnox/compare/v1.31.1..v1.32.0) - 2026-07-31
+## [1.33.0](https://github.com/jdx/fnox/compare/v1.32.0..v1.33.0) - 2026-08-08
+
+### 🚀 Features
+
+- **(bitwarden)** support custom fields by [@jdx](https://github.com/jdx) in [#690](https://github.com/jdx/fnox/pull/690)
+
+### 🐛 Bug Fixes
+
+- **(bitwarden)** support slashes in custom fields by [@jdx](https://github.com/jdx) in [#693](https://github.com/jdx/fnox/pull/693)
+- **(ci)** update Infisical project bootstrap by [@jdx](https://github.com/jdx) in [#675](https://github.com/jdx/fnox/pull/675)
+
+### 📚 Documentation
+
+- **(sync)** clarify personal age provider setup by [@jdx](https://github.com/jdx) in [#692](https://github.com/jdx/fnox/pull/692)
+
+### 🔍 Other Changes
+
+- run perf jobs on bamboo by [@jdx](https://github.com/jdx) in [#672](https://github.com/jdx/fnox/pull/672)
+- build perf binaries on bamboo by [@jdx](https://github.com/jdx) in [#674](https://github.com/jdx/fnox/pull/674)
+
+### 📦️ Dependency Updates
+
+- update jdx/mise-action action to v4.2.3 by [@renovate[bot]](https://github.com/renovate[bot]) in [#677](https://github.com/jdx/fnox/pull/677)
+- update rust crate keepass to v0.13.18 by [@renovate[bot]](https://github.com/renovate[bot]) in [#678](https://github.com/jdx/fnox/pull/678)
+- update rust crate schemars to v1.2.2 by [@renovate[bot]](https://github.com/renovate[bot]) in [#679](https://github.com/jdx/fnox/pull/679)
+- update dependency github:jdx/tak to v0.0.5 by [@renovate[bot]](https://github.com/renovate[bot]) in [#676](https://github.com/jdx/fnox/pull/676)
+- update rust crate jsonwebtoken to v11 by [@renovate[bot]](https://github.com/renovate[bot]) in [#685](https://github.com/jdx/fnox/pull/685)
+- update zizmorcore/zizmor-action action to v0.6.1 by [@renovate[bot]](https://github.com/renovate[bot]) in [#680](https://github.com/jdx/fnox/pull/680)
+- update rust crate base64 to 0.23 by [@renovate[bot]](https://github.com/renovate[bot]) in [#683](https://github.com/jdx/fnox/pull/683)
+- update rust crate usage-lib to v4.1.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#684](https://github.com/jdx/fnox/pull/684)
+- update dependency @anthropic-ai/claude-code to v2.1.220 by [@renovate[bot]](https://github.com/renovate[bot]) in [#681](https://github.com/jdx/fnox/pull/681)
+- update rust crate usage-lib to v5 by [@renovate[bot]](https://github.com/renovate[bot]) in [#687](https://github.com/jdx/fnox/pull/687)
+- update rust crate rmcp to v3 by [@renovate[bot]](https://github.com/renovate[bot]) in [#688](https://github.com/jdx/fnox/pull/688)
+
+## [1.32.0](https://github.com/jdx/fnox/compare/v1.31.1..v1.32.0) - 2026-08-01
 
 ### 🚀 Features
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2386,7 +2386,7 @@ dependencies = [
 
 [[package]]
 name = "fnox"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -2438,7 +2438,7 @@ dependencies = [
 
 [[package]]
 name = "fnox-core"
-version = "1.32.0"
+version = "1.33.0"
 dependencies = [
  "aes-gcm 0.11.0",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "crates/fnox-core"]
 resolver = "3"
 
 [workspace.package]
-version = "1.32.0"
+version = "1.33.0"
 edition = "2024"
 authors = ["@jdx"]
 license = "MIT"
@@ -121,7 +121,7 @@ name = "fnox"
 path = "src/main.rs"
 
 [dependencies]
-fnox-core = { path = "crates/fnox-core", version = "1.32.0" }
+fnox-core = { path = "crates/fnox-core", version = "1.33.0" }
 
 # Direct dependencies of the CLI binary (commands, MCP server, TUI, hook-env,
 # shell integration). Provider/config/secret-resolver crates are pulled in

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -1832,7 +1832,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.32.0",
+  "version": "1.33.0",
   "usage": "Usage: fnox [OPTIONS] <COMMAND>",
   "complete": {
     "key": {

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -4,7 +4,7 @@
 
 **Usage**: `fnox [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.32.0
+**Version**: 1.33.0
 
 - **Usage**: `fnox [FLAGS] <SUBCOMMAND>`
 

--- a/fnox.usage.kdl
+++ b/fnox.usage.kdl
@@ -1,7 +1,7 @@
 min_usage_version "1.3"
 name fnox
 bin fnox
-version "1.32.0"
+version "1.33.0"
 about "A flexible secret management tool by @jdx"
 usage "Usage: fnox [OPTIONS] <COMMAND>"
 flag "-c --config" help="Path to the configuration file (default: fnox.toml, searches parent directories)" global=#true default=fnox.toml {


### PR DESCRIPTION
### 🚀 Features

- **(bitwarden)** support custom fields by [@jdx](https://github.com/jdx) in [#690](https://github.com/jdx/fnox/pull/690)

### 🐛 Bug Fixes

- **(bitwarden)** support slashes in custom fields by [@jdx](https://github.com/jdx) in [#693](https://github.com/jdx/fnox/pull/693)
- **(ci)** update Infisical project bootstrap by [@jdx](https://github.com/jdx) in [#675](https://github.com/jdx/fnox/pull/675)

### 📚 Documentation

- **(sync)** clarify personal age provider setup by [@jdx](https://github.com/jdx) in [#692](https://github.com/jdx/fnox/pull/692)

### 🔍 Other Changes

- run perf jobs on bamboo by [@jdx](https://github.com/jdx) in [#672](https://github.com/jdx/fnox/pull/672)
- build perf binaries on bamboo by [@jdx](https://github.com/jdx) in [#674](https://github.com/jdx/fnox/pull/674)

### 📦️ Dependency Updates

- update jdx/mise-action action to v4.2.3 by [@renovate[bot]](https://github.com/renovate[bot]) in [#677](https://github.com/jdx/fnox/pull/677)
- update rust crate keepass to v0.13.18 by [@renovate[bot]](https://github.com/renovate[bot]) in [#678](https://github.com/jdx/fnox/pull/678)
- update rust crate schemars to v1.2.2 by [@renovate[bot]](https://github.com/renovate[bot]) in [#679](https://github.com/jdx/fnox/pull/679)
- update dependency github:jdx/tak to v0.0.5 by [@renovate[bot]](https://github.com/renovate[bot]) in [#676](https://github.com/jdx/fnox/pull/676)
- update rust crate jsonwebtoken to v11 by [@renovate[bot]](https://github.com/renovate[bot]) in [#685](https://github.com/jdx/fnox/pull/685)
- update zizmorcore/zizmor-action action to v0.6.1 by [@renovate[bot]](https://github.com/renovate[bot]) in [#680](https://github.com/jdx/fnox/pull/680)
- update rust crate base64 to 0.23 by [@renovate[bot]](https://github.com/renovate[bot]) in [#683](https://github.com/jdx/fnox/pull/683)
- update rust crate usage-lib to v4.1.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#684](https://github.com/jdx/fnox/pull/684)
- update dependency @anthropic-ai/claude-code to v2.1.220 by [@renovate[bot]](https://github.com/renovate[bot]) in [#681](https://github.com/jdx/fnox/pull/681)
- update rust crate usage-lib to v5 by [@renovate[bot]](https://github.com/renovate[bot]) in [#687](https://github.com/jdx/fnox/pull/687)
- update rust crate rmcp to v3 by [@renovate[bot]](https://github.com/renovate[bot]) in [#688](https://github.com/jdx/fnox/pull/688)