### PR TITLE
ci: build perf binaries on bamboo

### DIFF
--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -57,8 +57,8 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-
+      # Compile inside this disposable VM. Restoring target/ can relabel a
+      # binary built on a different runner class as a Bamboo measurement.
       - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
           cache: false

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -45,8 +45,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-
+      # Compile inside this disposable VM. Restoring target/ can relabel a
+      # binary built on a different runner class as a Bamboo measurement.
       - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
           cache: false


### PR DESCRIPTION
## Summary

- compile benchmark binaries from scratch inside each disposable Bamboo VM
- prevent a cached `target/` built on Namespace from being measured and labeled as Bamboo
- document the runner-class integrity requirement beside the build setup

## Validation

- `actionlint` on the affected performance workflows
- `git diff --check`

Generated with AI assistance and manually validated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change affecting build caching for perf jobs; no application, auth, or data-path changes.
> 
> **Overview**
> **Perf CI (`perf.yml`, `perf-pr.yml`) no longer restores `target/` via `Swatinem/rust-cache`.** Benchmark binaries are built from scratch on each disposable `bamboo-perf` run so instruction counts are not attributed to Bamboo when artifacts were produced on another runner class (e.g. Namespace).
> 
> Inline comments were added next to the `mise-action` step to document that requirement. Regular CI workflows still use `rust-cache`; only the tak measurement paths changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9ff3de8ea479e49bbb05840afe47601d161be06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated performance workflows to compile directly in disposable measurement environments.
  * Removed restoration of cached build artifacts to improve consistency of performance measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->