### PR TITLE
fix(ci): update Infisical project bootstrap

### DIFF
--- a/test/docker-compose.infisical-ci.yml
+++ b/test/docker-compose.infisical-ci.yml
@@ -27,7 +27,9 @@ services:
       retries: 5
 
   infisical:
-    image: infisical/infisical:latest
+    # Pin the multi-architecture image: an unannounced `latest` API change
+    # broke both Linux BATS shards at project creation.
+    image: infisical/infisical@sha256:bcb31ccb2a3784315ad9d9e180a9c53c6423f0daf3087c3bb158093de99617f2
     container_name: fnox-infisical
     depends_on:
       postgres:

--- a/test/docker-compose.infisical-ci.yml
+++ b/test/docker-compose.infisical-ci.yml
@@ -27,8 +27,8 @@ services:
       retries: 5
 
   infisical:
-    # Pin the multi-architecture image: an unannounced `latest` API change
-    # broke both Linux BATS shards at project creation.
+    # Pin the multi-architecture image so upstream API changes cannot silently
+    # break both Linux BATS shards.
     image: infisical/infisical@sha256:bcb31ccb2a3784315ad9d9e180a9c53c6423f0daf3087c3bb158093de99617f2
     container_name: fnox-infisical
     depends_on:
@@ -44,6 +44,10 @@ services:
       - REDIS_URL=redis://redis:6379
       - SITE_URL=http://localhost:8081
       - TELEMETRY_ENABLED=false
+      # The bootstrap CLI currently returns a legacy token without an `exp`
+      # claim. Keep it valid in this ephemeral test instance after Infisical's
+      # 2026-08-02 default legacy-token cutoff.
+      - MAX_MACHINE_IDENTITY_TOKEN_AGE=36500d
       - SMTP_HOST=
       - SMTP_FROM_NAME=Infisical
       - INVITE_ONLY_SIGNUP=false

--- a/test/setup-infisical-ci.sh
+++ b/test/setup-infisical-ci.sh
@@ -114,14 +114,23 @@ export INFISICAL_TOKEN="$MACHINE_TOKEN"
 
 # Create a test project using the API
 echo "Creating test project..."
-PROJECT_RESPONSE=$(curl -sf "$INFISICAL_URL/api/v2/workspace" \
+PROJECT_RESPONSE_FILE=/tmp/infisical-project-response.json
+if ! curl --fail-with-body --silent --show-error \
+	--output "$PROJECT_RESPONSE_FILE" \
+	"$INFISICAL_URL/api/v1/projects" \
 	-H "Authorization: Bearer $MACHINE_TOKEN" \
 	-H "Content-Type: application/json" \
 	-d "{
 		\"projectName\": \"$INFISICAL_PROJECT_NAME\",
 		\"type\": \"secret-manager\",
 		\"shouldCreateDefaultEnvs\": true
-	}")
+	}"; then
+	echo "Error: Failed to create project"
+	cat "$PROJECT_RESPONSE_FILE"
+	exit 1
+fi
+PROJECT_RESPONSE=$(<"$PROJECT_RESPONSE_FILE")
+rm -f "$PROJECT_RESPONSE_FILE"
 
 if [ -z "$PROJECT_RESPONSE" ]; then
 	echo "Error: Failed to create project"


### PR DESCRIPTION
## Summary

- migrate CI project creation from the removed `/api/v2/workspace` endpoint to `/api/v1/projects`
- pin the Infisical test image by multi-architecture digest instead of floating `latest`
- retain failed HTTP response bodies so future API drift is diagnosable

## Root cause

Both Ubuntu BATS shards bootstrapped Infisical successfully, then failed with curl exit 22 while creating the project. The current [Infisical Create Project API](https://infisical.com/docs/api-reference/endpoints/projects/create-project) uses `POST /api/v1/projects`.

## Validation

- `bash -n test/setup-infisical-ci.sh`
- `shellcheck test/setup-infisical-ci.sh`
- `actionlint .github/workflows/ci.yml`
- `docker compose -f test/docker-compose.infisical-ci.yml config --quiet`
- `git diff --check`

The local Docker daemon was unavailable, so the Ubuntu GitHub Actions jobs provide integration validation.

Generated with AI assistance and manually validated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI test infrastructure (Docker compose and setup script); no production runtime or application logic is affected.
> 
> **Overview**
> Fixes Ubuntu BATS Infisical setup failures after bootstrap by **creating test projects via `POST /api/v1/projects`** instead of the removed `/api/v2/workspace` endpoint, with **`curl --fail-with-body`** so failed responses are printed for debugging.
> 
> The CI compose stack **pins `infisical/infisical` to a multi-arch digest** (replacing floating `latest`) and sets **`MAX_MACHINE_IDENTITY_TOKEN_AGE=36500d`** so bootstrap’s legacy machine identity tokens without an `exp` claim remain valid in ephemeral CI past Infisical’s default cutoff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce237a9760d04a73bc5bfda24966d1b864a332c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Infisical CI setup reliability by using the compatible project creation endpoint.
  * Added clearer API response details when project creation requests fail.
  * Pinned the CI service image to a stable, multi-architecture version to prevent unexpected changes.
  * Extended machine identity token validity to support legacy bootstrap tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->