### PR TITLE
feat(bitwarden): support custom fields

### DIFF
--- a/crates/fnox-core/src/providers/bitwarden.rs
+++ b/crates/fnox-core/src/providers/bitwarden.rs
@@ -20,6 +20,18 @@ pub enum BitwardenBackend {
     Rbw,
 }
 
+#[derive(Debug, Deserialize)]
+struct BitwardenItem {
+    #[serde(default)]
+    fields: Vec<BitwardenField>,
+}
+
+#[derive(Debug, Deserialize)]
+struct BitwardenField {
+    name: Option<String>,
+    value: Option<String>,
+}
+
 impl fmt::Display for BitwardenBackend {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -78,7 +90,6 @@ impl BitwardenProvider {
                 // For custom fields, we need the full item JSON
                 cmd.arg("item");
                 cmd.arg(item_name);
-                cmd.args(["--output", "json"]);
                 None // Special case handled, no field type needed
             }
         };
@@ -172,9 +183,8 @@ impl BitwardenProvider {
                 // rbw uses a separate subcommand for TOTP
                 cmd.args(["code", item_name]);
             }
-            Some(_) => {
-                // custom field path: fetch full JSON; later code can still error out
-                cmd.args(["get", item_name, "--raw"]);
+            Some(field) => {
+                cmd.args(["get", item_name, "--field", field]);
             }
         }
 
@@ -257,6 +267,47 @@ impl BitwardenProvider {
 
         Ok(stdout.trim().to_string())
     }
+
+    fn extract_custom_field(
+        &self,
+        item_name: &str,
+        field_name: &str,
+        json: &str,
+    ) -> Result<String> {
+        let item: BitwardenItem =
+            serde_json::from_str(json).map_err(|e| FnoxError::ProviderInvalidResponse {
+                provider: "Bitwarden".to_string(),
+                details: format!("Failed to parse item '{}': {}", item_name, e),
+                hint: "Check that the Bitwarden CLI returned a valid item".to_string(),
+                url: "https://fnox.jdx.dev/providers/bitwarden".to_string(),
+            })?;
+
+        let field = item
+            .fields
+            .into_iter()
+            .find(|field| field.name.as_deref() == Some(field_name))
+            .ok_or_else(|| FnoxError::ProviderInvalidResponse {
+                provider: "Bitwarden".to_string(),
+                details: format!(
+                    "Custom field '{}' not found in item '{}'",
+                    field_name, item_name
+                ),
+                hint: "Check the custom field name and capitalization".to_string(),
+                url: "https://fnox.jdx.dev/providers/bitwarden".to_string(),
+            })?;
+
+        field
+            .value
+            .ok_or_else(|| FnoxError::ProviderInvalidResponse {
+                provider: "Bitwarden".to_string(),
+                details: format!(
+                    "Custom field '{}' in item '{}' has no value",
+                    field_name, item_name
+                ),
+                hint: "Set a value for the custom field in Bitwarden".to_string(),
+                url: "https://fnox.jdx.dev/providers/bitwarden".to_string(),
+            })
+    }
 }
 
 #[async_trait]
@@ -287,8 +338,18 @@ impl crate::providers::Provider for BitwardenProvider {
             field_name
         );
 
+        let is_custom_field = !matches!(
+            field_name,
+            "password" | "username" | "notes" | "uri" | "url" | "totp"
+        );
         let mut cmd = self.build_command(Some(field_name), item_name)?;
-        self.execute_command(&mut cmd).await
+        let output = self.execute_command(&mut cmd).await?;
+
+        if is_custom_field && self.backend == BitwardenBackend::Bw {
+            self.extract_custom_field(item_name, field_name, &output)
+        } else {
+            Ok(output)
+        }
     }
 }
 
@@ -300,4 +361,52 @@ fn bw_session_token() -> Option<String> {
     env::var("FNOX_BW_SESSION")
         .or_else(|_| env::var("BW_SESSION"))
         .ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn provider(backend: BitwardenBackend) -> BitwardenProvider {
+        BitwardenProvider::new(None, None, None, Some(backend)).unwrap()
+    }
+
+    #[test]
+    fn extracts_custom_field_from_bw_item() {
+        let json = r#"{
+            "fields": [
+                {"name": "API Key", "value": "secret-value", "type": 1},
+                {"name": "Region", "value": "us-east-1", "type": 0}
+            ]
+        }"#;
+
+        let value = provider(BitwardenBackend::Bw)
+            .extract_custom_field("Database", "API Key", json)
+            .unwrap();
+
+        assert_eq!(value, "secret-value");
+    }
+
+    #[test]
+    fn errors_when_custom_field_is_missing() {
+        let error = provider(BitwardenBackend::Bw)
+            .extract_custom_field("Database", "Missing", r#"{"fields": []}"#)
+            .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("Custom field 'Missing' not found")
+        );
+    }
+
+    #[test]
+    fn rbw_uses_field_flag_for_custom_fields() {
+        let command = provider(BitwardenBackend::Rbw)
+            .build_rbw_command(Some("API Key"), "Database")
+            .unwrap();
+        let args: Vec<_> = command.as_std().get_args().collect();
+
+        assert_eq!(args, ["get", "Database", "--field", "API Key"]);
+    }
 }

--- a/docs/providers/bitwarden.md
+++ b/docs/providers/bitwarden.md
@@ -164,13 +164,12 @@ MY_SECRET = { provider = "bitwarden", value = "My Item" }  # → Gets the 'passw
 USERNAME = { provider = "bitwarden", value = "Database/username" }
 PASSWORD = { provider = "bitwarden", value = "Database/password" }
 TOTP = { provider = "bitwarden", value = "Database/totp" }
+API_KEY = { provider = "bitwarden", value = "Database/API Key" }
 ```
 
-Supported fields: `username`, `password`, `notes`, `uri`, `totp`
-
-::: info Custom Fields
-Custom field extraction is not yet implemented. Use standard fields for now.
-:::
+Supported standard fields are `username`, `password`, `notes`, `uri`, and
+`totp`. Any other field name is resolved as a custom field. Custom field names
+are case-sensitive when using the default `bw` backend.
 
 ## Usage
 

--- a/test/bitwarden.bats
+++ b/test/bitwarden.bats
@@ -91,7 +91,14 @@ create_test_bw_item() {
     "username": "$username",
     "password": "$password",
     "totp": null
-  }
+  },
+  "fields": [
+    {
+      "name": "API Key",
+      "value": "custom-secret-value-${BATS_TEST_NUMBER:-0}",
+      "type": 1
+    }
+  ]
 }
 EOF
 	)
@@ -179,6 +186,27 @@ EOF
 	assert_output --partial "test-secret-value-"
 
 	# Cleanup
+	delete_test_bw_item "$item_id"
+}
+
+@test "fnox get retrieves custom field from Bitwarden item" {
+	create_bitwarden_config
+
+	item_info=$(create_test_bw_item)
+	item_id=$(echo "$item_info" | cut -d'|' -f1)
+	item_name=$(echo "$item_info" | cut -d'|' -f2)
+
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
+
+[secrets.TEST_CUSTOM_FIELD]
+provider = "bitwarden"
+value = "$item_name/API Key"
+EOF
+
+	run "$FNOX_BIN" get TEST_CUSTOM_FIELD
+	assert_success
+	assert_output "custom-secret-value-${BATS_TEST_NUMBER:-0}"
+
 	delete_test_bw_item "$item_id"
 }
 


### PR DESCRIPTION
## Summary

- extract exact, case-sensitive custom fields from `bw get item` JSON
- use `rbw get --field` for custom fields with the rbw backend
- add unit and Bitwarden integration coverage and document the reference syntax

## Root cause

The Bitwarden provider already recognized non-standard field names, but the `bw` path returned the complete item JSON unchanged and the `rbw` path returned raw JSON. Neither path extracted the requested custom field.

This addresses [discussion #689](https://github.com/jdx/fnox/discussions/689).

## Validation

- `cargo test -p fnox-core` (231 passed)
- `mise run test:cargo` (43 passed)
- `mise run lint`
- `mise run build`
- `mise run test:bats -- test/bitwarden.bats` (1 passed, 9 credential-gated tests skipped without `BW_SESSION`)

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes secret resolution for non-standard field references in a credentials provider; behavior is more correct but could surface new errors for configs that previously received full JSON.
> 
> **Overview**
> **Custom Bitwarden fields** (`item/Field Name`) now resolve to the field value instead of returning raw JSON or failing silently.
> 
> For **`bw`**, non-standard field names still run `bw get item`, but **`get_secret`** parses the JSON and picks a matching entry from `fields` with **case-sensitive** name matching, with clear errors when the field is missing or empty. For **`rbw`**, custom fields use `rbw get <item> --field <name>` instead of `--raw` full-item output.
> 
> Docs drop the “not yet implemented” note and document custom-field syntax; **unit tests** cover JSON extraction and rbw CLI args, and **BATS** adds an integration test using an `API Key` custom field on test items.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3416d140598e94e3d290dc55685199e78551c93a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving custom Bitwarden item fields, including fields such as `API_KEY`.
  * Custom field names are matched case-sensitively.
  * Added clear errors for invalid item data, missing fields, and missing values.

* **Documentation**
  * Updated Bitwarden guidance with standard and custom field examples.
  * Added an integration example for retrieving a custom field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->