### PR TITLE
docs(sync): clarify personal age provider setup

### DIFF
--- a/docs/guide/sync.md
+++ b/docs/guide/sync.md
@@ -105,9 +105,30 @@ type = "age"
 recipients = ["age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"]
 
 [secrets]
-DATABASE_URL = { provider = "op", value = "Database/url", sync = { provider = "sync-age", value = "YWdlLWVuY3J5cHRpb24..." } }
-STRIPE_KEY = { provider = "op", value = "Stripe/secret-key", sync = { provider = "sync-age", value = "YWdlLWVuY3J5cHRpb24..." } }
-SENDGRID_KEY = { provider = "op", value = "SendGrid/api-key", sync = { provider = "sync-age", value = "YWdlLWVuY3J5cHRpb24..." } }
+DATABASE_URL = {
+  provider = "op",
+  value = "Database/url",
+  sync = {
+    provider = "sync-age",
+    value = "YWdlLWVuY3J5cHRpb24...",
+  },
+}
+STRIPE_KEY = {
+  provider = "op",
+  value = "Stripe/secret-key",
+  sync = {
+    provider = "sync-age",
+    value = "YWdlLWVuY3J5cHRpb24...",
+  },
+}
+SENDGRID_KEY = {
+  provider = "op",
+  value = "SendGrid/api-key",
+  sync = {
+    provider = "sync-age",
+    value = "YWdlLWVuY3J5cHRpb24...",
+  },
+}
 ```
 
 When you `cd` into the project, fnox sees the `sync` field and decrypts with age locally — no 1Password calls.

--- a/docs/guide/sync.md
+++ b/docs/guide/sync.md
@@ -118,7 +118,8 @@ A sync cache is personal: its recipient belongs in the global config or
 
 For age-encrypted secrets committed to git, commit a separate provider whose
 recipients include the whole team and CI. After changing that list, run
-`fnox reencrypt --provider age` to update the committed ciphertext.
+`fnox reencrypt --provider <team-provider-name>` to update the committed
+ciphertext.
 
 Provider definitions are replaced as a unit when configs are merged. A local
 `[providers.age]` does not deep-merge with a committed provider of the same
@@ -164,21 +165,22 @@ if [ ! -f ~/.config/fnox/age.txt ]; then
 fi
 export FNOX_AGE_KEY=$(grep "AGE-SECRET-KEY" ~/.config/fnox/age.txt)
 
-# 3. Add a personal age provider to your local config, replacing the recipient with your public key from step 2
-recipient=$(grep 'public key:' ~/.config/fnox/age.txt | awk '{print $NF}')
-if ! grep -q '^\[providers\.sync-age\]$' fnox.local.toml 2>/dev/null; then
-	cat >>fnox.local.toml <<EOF
-
-[providers.sync-age]
-type = "age"
-recipients = ["$recipient"]
-EOF
+# 3. Read the recipient, failing before changing any config if the key is invalid
+recipient=$(age-keygen -y ~/.config/fnox/age.txt 2>/dev/null)
+if [ -z "$recipient" ]; then
+	echo "Could not find an age public key in ~/.config/fnox/age.txt" >&2
+	exit 1
 fi
 
-# 4. Sync all 1Password secrets to local age encryption
+# 4. Add a machine-wide provider once, then replace its age1... placeholder
+# with $recipient in the file opened by the second command
+fnox provider add sync-age age --global
+"${EDITOR:-vi}" "${FNOX_CONFIG_DIR:-$HOME/.config/fnox}/config.toml"
+
+# 5. Sync all 1Password secrets to local age encryption
 fnox sync --provider sync-age --local-file --force
 
-# 5. Done — entering the directory is now instant
+# 6. Done — entering the directory is now instant
 cd .. && cd my-api
 # Secrets load from local age cache, no 1Password calls
 ```

--- a/docs/guide/sync.md
+++ b/docs/guide/sync.md
@@ -23,7 +23,7 @@ This works, but every time you `cd` into the project (with [shell integration](/
 With `fnox sync`, you pull those values once and cache them locally with a fast, offline encryption provider:
 
 ```bash
-fnox sync --provider age --config fnox.local.toml
+fnox sync --provider sync-age --local-file
 ```
 
 Now entering the directory is instant — secrets are decrypted locally from age without any remote calls.
@@ -33,47 +33,56 @@ Now entering the directory is instant — secrets are decrypted locally from age
 1. fnox reads all secrets from your merged config
 2. It resolves each secret's plaintext value from the original remote provider
 3. It encrypts each value with the target provider (e.g., age)
-4. It writes the encrypted cache into your config as a `sync` field on each secret
+4. It writes the encrypted cache into `fnox.local.toml` as a `sync` field on each secret
 
 When fnox resolves secrets, it checks for a `sync` field first and uses that instead of calling the original provider.
 
 ## Basic Usage
 
 ```bash
-# Set up an age provider if you haven't already
-fnox set --provider age  # or add [providers.age] to your config
+# Set up a personal age provider if you haven't already. Replace the generated
+# age1... placeholder in ~/.config/fnox/config.toml with your recipient.
+fnox provider add sync-age age --global
 
 # Sync everything to fnox.local.toml
-fnox sync --provider age --config fnox.local.toml
+fnox sync --provider sync-age --local-file
 ```
+
+Using a distinct name such as `sync-age` avoids colliding with an `age` provider
+that the project may already use for secrets encrypted in git. The global
+provider is machine-scoped and can be reused across checkouts. You can instead
+put the personal provider in `fnox.local.toml` if each project needs different
+settings.
 
 ### Preview what would be synced
 
 ```bash
-fnox sync --provider age --config fnox.local.toml --dry-run
+fnox sync --provider sync-age --local-file --dry-run
 ```
 
 ### Sync specific secrets
 
 ```bash
-fnox sync --provider age --config fnox.local.toml DATABASE_URL STRIPE_KEY
+fnox sync --provider sync-age --local-file DATABASE_URL STRIPE_KEY
 ```
 
 ### Sync only secrets from a specific source
 
 ```bash
-fnox sync --provider age --config fnox.local.toml --source op
+fnox sync --provider sync-age --local-file --source op
 ```
 
 ### Filter by regex pattern
 
 ```bash
-fnox sync --provider age --config fnox.local.toml --filter "^DB_"
+fnox sync --provider sync-age --local-file --filter "^DB_"
 ```
 
 ## What It Looks Like
 
-After syncing, your files look like this:
+If you keep the personal provider in the project-local override, your files
+look like this after syncing. With the global setup above, the
+`[providers.sync-age]` block lives in `~/.config/fnox/config.toml` instead.
 
 **fnox.toml** (committed — the source of truth):
 
@@ -81,10 +90,6 @@ After syncing, your files look like this:
 [providers.op]
 type = "1password"
 vault = "Engineering"
-
-[providers.age]
-type = "age"
-recipients = ["age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"]
 
 [secrets]
 DATABASE_URL = { provider = "op", value = "Database/url" }
@@ -95,26 +100,43 @@ SENDGRID_KEY = { provider = "op", value = "SendGrid/api-key" }
 **fnox.local.toml** (gitignored — your local cache):
 
 ```toml
+[providers.sync-age]
+type = "age"
+recipients = ["age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"]
+
 [secrets]
-DATABASE_URL = { provider = "op", value = "Database/url", sync = { provider = "age", value = "YWdlLWVuY3J5cHRpb24..." } }
-STRIPE_KEY = { provider = "op", value = "Stripe/secret-key", sync = { provider = "age", value = "YWdlLWVuY3J5cHRpb24..." } }
-SENDGRID_KEY = { provider = "op", value = "SendGrid/api-key", sync = { provider = "age", value = "YWdlLWVuY3J5cHRpb24..." } }
+DATABASE_URL = { provider = "op", value = "Database/url", sync = { provider = "sync-age", value = "YWdlLWVuY3J5cHRpb24..." } }
+STRIPE_KEY = { provider = "op", value = "Stripe/secret-key", sync = { provider = "sync-age", value = "YWdlLWVuY3J5cHRpb24..." } }
+SENDGRID_KEY = { provider = "op", value = "SendGrid/api-key", sync = { provider = "sync-age", value = "YWdlLWVuY3J5cHRpb24..." } }
 ```
 
 When you `cd` into the project, fnox sees the `sync` field and decrypts with age locally — no 1Password calls.
+
+::: tip Sync cache vs. encrypted secrets in git
+A sync cache is personal: its recipient belongs in the global config or
+`fnox.local.toml`.
+
+For age-encrypted secrets committed to git, commit a separate provider whose
+recipients include the whole team and CI. After changing that list, run
+`fnox reencrypt --provider age` to update the committed ciphertext.
+
+Provider definitions are replaced as a unit when configs are merged. A local
+`[providers.age]` does not deep-merge with a committed provider of the same
+name, so use a distinct name such as `sync-age` for the cache.
+:::
 
 ## Using a YubiKey
 
 If you use a YubiKey with the [age-plugin-yubikey](https://github.com/str4d/age-plugin-yubikey), syncing works the same way. Your age provider just uses the YubiKey identity:
 
 ```toml
-[providers.age]
+[providers.sync-age]
 type = "age"
 recipients = ["age1yubikey1q..."]  # YubiKey recipient
 ```
 
 ```bash
-fnox sync --provider age --config fnox.local.toml
+fnox sync --provider sync-age --local-file
 ```
 
 Secrets are encrypted to your YubiKey's age identity. Decryption requires the YubiKey to be plugged in, adding hardware-based security to your local cache. See [Age Plugin Support](/providers/age#plugin-support) for details and other plugins (TPM, FIDO2, …).
@@ -124,7 +146,7 @@ Secrets are encrypted to your YubiKey's age identity. Decryption requires the Yu
 When secrets change in the remote provider, re-run sync to update the local cache:
 
 ```bash
-fnox sync --provider age --config fnox.local.toml --force
+fnox sync --provider sync-age --local-file --force
 ```
 
 The `--force` flag skips the confirmation prompt. fnox re-fetches from the original provider and re-encrypts.
@@ -142,18 +164,19 @@ if [ ! -f ~/.config/fnox/age.txt ]; then
 fi
 export FNOX_AGE_KEY=$(grep "AGE-SECRET-KEY" ~/.config/fnox/age.txt)
 
-# 3. Add age provider to your local config, replacing the recipient with your public key from step 2
+# 3. Add a personal age provider to your local config, replacing the recipient with your public key from step 2
 recipient=$(grep 'public key:' ~/.config/fnox/age.txt | awk '{print $NF}')
-if [ ! -f fnox.local.toml ] || ! grep -qF "$recipient" fnox.local.toml; then
-	cat >fnox.local.toml <<EOF
-[providers.age]
+if ! grep -q '^\[providers\.sync-age\]$' fnox.local.toml 2>/dev/null; then
+	cat >>fnox.local.toml <<EOF
+
+[providers.sync-age]
 type = "age"
 recipients = ["$recipient"]
 EOF
 fi
 
 # 4. Sync all 1Password secrets to local age encryption
-fnox sync --provider age --config fnox.local.toml --force
+fnox sync --provider sync-age --local-file --force
 
 # 5. Done — entering the directory is now instant
 cd .. && cd my-api

--- a/docs/guide/sync.md
+++ b/docs/guide/sync.md
@@ -154,33 +154,39 @@ The `--force` flag skips the confirmation prompt. fnox re-fetches from the origi
 
 ## Full Workflow Example
 
-```bash
-# 1. Clone a project with 1Password secrets in fnox.toml
-git clone https://github.com/myorg/my-api && cd my-api
+Configure the personal provider once per machine:
 
-# 2. Set up your age key (if it doesn't already exist) — note the public key printed to your terminal
+```bash
+# 1. Set up your age key if it does not already exist
 mkdir -p ~/.config/fnox
 if [ ! -f ~/.config/fnox/age.txt ]; then
 	age-keygen -o ~/.config/fnox/age.txt
 fi
 export FNOX_AGE_KEY=$(grep "AGE-SECRET-KEY" ~/.config/fnox/age.txt)
 
-# 3. Read the recipient, failing before changing any config if the key is invalid
+# 2. Read the recipient, failing before changing any config if the key is invalid
 recipient=$(age-keygen -y ~/.config/fnox/age.txt 2>/dev/null)
 if [ -z "$recipient" ]; then
 	echo "Could not find an age public key in ~/.config/fnox/age.txt" >&2
 	exit 1
 fi
 
-# 4. Add a machine-wide provider once, then replace its age1... placeholder
+# 3. Add the machine-wide provider, then replace its age1... placeholder
 # with $recipient in the file opened by the second command
 fnox provider add sync-age age --global
 "${EDITOR:-vi}" "${FNOX_CONFIG_DIR:-$HOME/.config/fnox}/config.toml"
+```
 
-# 5. Sync all 1Password secrets to local age encryption
+Then reuse that provider in every checkout:
+
+```bash
+# 1. Clone a project with 1Password secrets in fnox.toml
+git clone https://github.com/myorg/my-api && cd my-api
+
+# 2. Sync all 1Password secrets to local age encryption
 fnox sync --provider sync-age --local-file --force
 
-# 6. Done — entering the directory is now instant
+# 3. Done — entering the directory is now instant
 cd .. && cd my-api
 # Secrets load from local age cache, no 1Password calls
 ```


### PR DESCRIPTION
## Summary

- move the personal age recipient out of the committed config example
- use a distinct `sync-age` provider and the purpose-built `--local-file` flag
- document the difference between a personal sync cache and team-encrypted secrets in git
- clarify that provider definitions replace by name instead of deep-merging
- preserve existing `fnox.local.toml` content in the workflow example

## Why

The sync guide showed conflicting locations for the age recipient and could cause developers to encrypt their local cache to another team member. It also recommended an invalid `fnox set --provider age` setup command. This addresses the report in [discussion #691](https://github.com/jdx/fnox/discussions/691).

## Validation

- `mise run lint`
- `npm run docs:build`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes with no runtime or config behavior modifications.
> 
> **Overview**
> **Updates the sync guide** so personal offline caches use a dedicated **`sync-age`** provider and **`--local-file`**, instead of putting age recipients in committed **`fnox.toml`** or passing **`--config fnox.local.toml`** everywhere.
> 
> Setup now documents **`fnox provider add sync-age age --global`** (replacing the invalid **`fnox set --provider age`**), explains why the name must differ from a team **`age`** provider, and adds a tip separating **personal sync caches** from **team age secrets in git** (including **`fnox reencrypt`** and whole-block provider merge behavior).
> 
> Examples and the full workflow were reshaped: committed config shows only remote providers; **`fnox.local.toml`** / global config hold **`sync-age`**; the shell workflow validates the age key with **`age-keygen -y`** before editing global config, then reuses **`fnox sync --provider sync-age --local-file`** per checkout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ccd84223ea051756846ab4185f8c8613adb7407. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the synchronization guide with the `sync-age` provider and `--local-file` workflow.
  * Clarified global provider setup, provider scoping, and configuration merge behavior.
  * Refined examples and YubiKey instructions.
  * Added guidance for validating age keys and preserving existing local configuration during synchronization.
  * Explained how to add synchronization settings without overwriting existing local configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->