### PR TITLE
fix(bitwarden): support slashes in custom fields

### DIFF
--- a/crates/fnox-core/src/providers/bitwarden.rs
+++ b/crates/fnox-core/src/providers/bitwarden.rs
@@ -42,6 +42,10 @@ impl fmt::Display for BitwardenBackend {
 }
 
 impl BitwardenProvider {
+    fn parse_reference(value: &str) -> (&str, &str) {
+        value.split_once('/').unwrap_or((value, "password"))
+    }
+
     pub fn new(
         collection: Option<String>,
         organization_id: Option<String>,
@@ -317,20 +321,7 @@ impl crate::providers::Provider for BitwardenProvider {
 
         // Parse value as "item/field" or just "item"
         // Default field is "password" if not specified
-        let parts: Vec<&str> = value.split('/').collect();
-
-        let (item_name, field_name) = match parts.len() {
-            1 => (parts[0], "password"),
-            2 => (parts[0], parts[1]),
-            _ => {
-                return Err(FnoxError::ProviderInvalidResponse {
-                    provider: "Bitwarden".to_string(),
-                    details: format!("Invalid secret reference format: '{}'", value),
-                    hint: "Expected 'item' or 'item/field'".to_string(),
-                    url: "https://fnox.jdx.dev/providers/bitwarden".to_string(),
-                });
-            }
-        };
+        let (item_name, field_name) = Self::parse_reference(value);
 
         tracing::debug!(
             "Reading Bitwarden item '{}' field '{}'",
@@ -375,13 +366,13 @@ mod tests {
     fn extracts_custom_field_from_bw_item() {
         let json = r#"{
             "fields": [
-                {"name": "API Key", "value": "secret-value", "type": 1},
+                {"name": "API/Key", "value": "secret-value", "type": 1},
                 {"name": "Region", "value": "us-east-1", "type": 0}
             ]
         }"#;
 
         let value = provider(BitwardenBackend::Bw)
-            .extract_custom_field("Database", "API Key", json)
+            .extract_custom_field("Database", "API/Key", json)
             .unwrap();
 
         assert_eq!(value, "secret-value");
@@ -403,10 +394,18 @@ mod tests {
     #[test]
     fn rbw_uses_field_flag_for_custom_fields() {
         let command = provider(BitwardenBackend::Rbw)
-            .build_rbw_command(Some("API Key"), "Database")
+            .build_rbw_command(Some("API/Key"), "Database")
             .unwrap();
         let args: Vec<_> = command.as_std().get_args().collect();
 
-        assert_eq!(args, ["get", "Database", "--field", "API Key"]);
+        assert_eq!(args, ["get", "Database", "--field", "API/Key"]);
+    }
+
+    #[test]
+    fn parses_custom_field_name_with_slashes() {
+        assert_eq!(
+            BitwardenProvider::parse_reference("Database/API/Key"),
+            ("Database", "API/Key")
+        );
     }
 }

--- a/docs/providers/bitwarden.md
+++ b/docs/providers/bitwarden.md
@@ -169,7 +169,7 @@ API_KEY = { provider = "bitwarden", value = "Database/API Key" }
 
 Supported standard fields are `username`, `password`, `notes`, `uri`, and
 `totp`. Any other field name is resolved as a custom field. Custom field names
-are case-sensitive when using the default `bw` backend.
+may contain `/` and are case-sensitive when using the default `bw` backend.
 
 ## Usage
 

--- a/test/bitwarden.bats
+++ b/test/bitwarden.bats
@@ -97,6 +97,11 @@ create_test_bw_item() {
       "name": "API Key",
       "value": "custom-secret-value-${BATS_TEST_NUMBER:-0}",
       "type": 1
+    },
+    {
+      "name": "API/Key",
+      "value": "slash-field-value-${BATS_TEST_NUMBER:-0}",
+      "type": 1
     }
   ]
 }
@@ -210,6 +215,27 @@ EOF
 	delete_test_bw_item "$item_id"
 }
 
+@test "fnox get retrieves custom field containing a slash" {
+	create_bitwarden_config
+
+	item_info=$(create_test_bw_item)
+	item_id=$(echo "$item_info" | cut -d'|' -f1)
+	item_name=$(echo "$item_info" | cut -d'|' -f2)
+
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
+
+[secrets.TEST_SLASH_FIELD]
+provider = "bitwarden"
+value = "$item_name/API/Key"
+EOF
+
+	run "$FNOX_BIN" get TEST_SLASH_FIELD
+	assert_success
+	assert_output "slash-field-value-${BATS_TEST_NUMBER:-0}"
+
+	delete_test_bw_item "$item_id"
+}
+
 @test "fnox get fails with invalid item name" {
 	create_bitwarden_config
 
@@ -224,21 +250,6 @@ EOF
 	run "$FNOX_BIN" get INVALID_ITEM
 	assert_failure
 	assert_output --partial "cli_failed"
-}
-
-@test "fnox get handles invalid secret reference format" {
-	create_bitwarden_config
-
-	cat >>"${FNOX_CONFIG_FILE}" <<EOF
-
-[secrets.INVALID_FORMAT]
-provider = "bitwarden"
-value = "invalid/format/with/too/many/slashes"
-EOF
-
-	run "$FNOX_BIN" get INVALID_FORMAT
-	assert_failure
-	assert_output --partial "Invalid secret reference format"
 }
 
 @test "fnox list shows Bitwarden secrets" {


### PR DESCRIPTION
## Summary

- preserve slashes after the first item/field delimiter in Bitwarden references
- cover slash-containing custom fields for both `bw` and `rbw`
- add vault-backed regression coverage and document the supported syntax

## Root cause

Bitwarden references were split on every `/` and rejected unless they contained at most two segments. A reference such as `item/A/B` therefore failed before either Bitwarden backend ran, even though both backends can resolve a custom field named `A/B`.

The parser now treats only the first slash as the item/field delimiter and preserves the remainder as the exact custom field name.

Fixes the follow-up in [discussion #689](https://github.com/jdx/fnox/discussions/689#discussioncomment-17939433).

## Validation

- `cargo test -p fnox-core providers::bitwarden`
- `mise run build`
- `mise run test:cargo`
- `mise run lint`
- `mise run test:bats -- test/bitwarden.bats` (vault-backed tests skipped without `BW_SESSION`)

The full Bats suite was also run; unrelated environment-dependent tests failed in keychain, GitHub lease, signal, and file-secret coverage.

*AI-assisted — Tool: Codex; model: unavailable/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized parser change in the Bitwarden provider with regression tests; no auth or broader secret-handling changes.
> 
> **Overview**
> **Bitwarden reference parsing** no longer rejects values with more than one `/` or splits on every slash. Only the **first** `/` separates item from field; everything after it is the field name (e.g. `Database/API/Key` → item `Database`, field `API/Key`). The previous `Invalid secret reference format` path for extra segments is removed.
> 
> **`get_secret`** uses a new `parse_reference` helper (`split_once` with default field `password` when no slash). **`bw`** custom-field JSON lookup and **`rbw`** `--field` args now receive the full slash-containing name.
> 
> **Docs** note that custom field names may contain `/`. **Tests** add unit coverage for parsing and slash fields, vault-backed Bats for `item/API/Key`, and drop the Bats case that expected failure on `invalid/format/with/too/many/slashes`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0904efdc082f7440128ceb06ba235a0fcb9f8db7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bitwarden secret references now support custom field names containing `/`.
  * Custom field names remain case-sensitive when using the default backend.
* **Tests**
  * Added coverage for retrieving secrets from slash-containing custom fields.
* **Documentation**
  * Updated Bitwarden reference-format guidance to describe slash-containing field names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->