### PR TITLE
chore(deps): simplify cargo version requirements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,12 @@ will fail), pin that dependency to its last MSRV-compatible version instead.
 `.cargo/config.toml` sets `resolver.incompatible-rust-versions = "fallback"` so
 `cargo update`/`cargo add` prefer MSRV-compatible versions automatically.
 
+## Dependency Updates
+
+- Use the lowest compatibility-significant specificity in `Cargo.toml` (for example, `"1"` for stable 1.x dependencies).
+- When the existing manifest requirement accepts a routine dependency update, change only `Cargo.lock`.
+- Keep lockfile updates focused and avoid unrelated transitive dependency churn.
+
 ## Build & Test
 
 ```bash

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.91.1"
 [workspace.dependencies]
 aes-gcm = "0.11.0-rc.3"
 age = { version = "0.12", features = ["ssh", "plugin", "cli-common"] }
-aho-corasick = "1.1.4"
+aho-corasick = "1"
 anyhow = "1"
 arboard = "3"
 arc-swap = "1"
@@ -49,7 +49,7 @@ futures = "0.3"
 gcp_auth = { version = "0.12" }
 globset = "0.4"
 google-cloud-kms = { version = "0.6" }
-google-cloud-secretmanager-v1 = { version = "1.1" }
+google-cloud-secretmanager-v1 = { version = "1" }
 hex = "0.4"
 hkdf = "0.13"
 ignore = "0.4"
@@ -121,7 +121,7 @@ name = "fnox"
 path = "src/main.rs"
 
 [dependencies]
-fnox-core = { path = "crates/fnox-core", version = "1.33.0" }
+fnox-core = { path = "crates/fnox-core", version = "1" }
 
 # Direct dependencies of the CLI binary (commands, MCP server, TUI, hook-env,
 # shell integration). Provider/config/secret-resolver crates are pulled in


### PR DESCRIPTION
## Summary
- normalize stable Cargo requirements to their lowest compatibility-significant specificity
- document that routine compatible updates should only change `Cargo.lock`
- preserve the deliberate aes-gcm prerelease requirement and MSRV policy

`Cargo.lock` is unchanged.

## Validation
- `cargo check --locked`
- `cargo fmt --check`
- `cargo test --locked` (43 passed)

The Bats suite ran all 712 cases; environment-dependent cases fail here because the checkout is not trusted by mise and `secret-tool` is unavailable.

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Manifest and documentation only; semver-compatible requirement widening with an unchanged lockfile does not alter built dependency versions.
> 
> **Overview**
> Documents **dependency update** conventions in `AGENTS.md`: prefer the lowest compatibility-significant version in `Cargo.toml` (e.g. `"1"` for 1.x), bump only `Cargo.lock` when the manifest already allows a routine update, and avoid unrelated transitive churn.
> 
> **Normalizes** a few workspace and binary manifest pins—`aho-corasick`, `google-cloud-secretmanager-v1`, and the path `fnox-core` crate—to broader `"1"` requirements instead of patch/minor-specific strings. **`Cargo.lock` is unchanged**, so resolved versions stay the same; `aes-gcm` prerelease and MSRV policy are untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8d34e91832e061bc4b13385d1d092ad64063177. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency version constraints for improved compatibility.
  * Relaxed the required version range for a core internal dependency.
  * Added documentation describing dependency update practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->