### PR TITLE
fix(set): preserve existing remote key name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,6 +223,7 @@ jobs:
       - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
         with:
           cache: false
+          fetch_from_github: false
       # save-if: only saves on main pushes, so PRs cannot poison the cache.
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 # zizmor: ignore[cache-poisoning]
         with:

--- a/crates/fnox-core/src/providers/vault.rs
+++ b/crates/fnox-core/src/providers/vault.rs
@@ -24,6 +24,14 @@ fn parse_secret_reference(value: &str) -> Result<(&str, &str)> {
     }
 }
 
+fn is_missing_secret_error(error: &FnoxError) -> bool {
+    let FnoxError::ProviderCliFailed { details, .. } = error else {
+        return false;
+    };
+    let details = details.to_ascii_lowercase();
+    details.contains("no data found") || details.contains("no value found")
+}
+
 pub struct HashiCorpVaultProvider {
     address: Option<String>,
     path: Option<String>,
@@ -239,10 +247,19 @@ impl crate::providers::Provider for HashiCorpVaultProvider {
 
         // Patch explicit fields so updating one value does not replace its siblings.
         let value_arg = format!("{field_name}={value}");
-        let operation = if key.contains('/') { "patch" } else { "put" };
-        let args = vec!["kv", operation, &secret_path, &value_arg];
-
-        self.execute_vault_command(&args).await?;
+        if key.contains('/') {
+            let patch_args = vec!["kv", "patch", &secret_path, &value_arg];
+            if let Err(error) = self.execute_vault_command(&patch_args).await {
+                if !is_missing_secret_error(&error) {
+                    return Err(error);
+                }
+                let put_args = vec!["kv", "put", &secret_path, &value_arg];
+                self.execute_vault_command(&put_args).await?;
+            }
+        } else {
+            let put_args = vec!["kv", "put", &secret_path, &value_arg];
+            self.execute_vault_command(&put_args).await?;
+        }
 
         tracing::debug!("Successfully wrote secret '{}' to Vault", secret_path);
 
@@ -295,5 +312,24 @@ mod tests {
             ("database", "password")
         );
         assert!(parse_secret_reference("database/nested/password").is_err());
+    }
+
+    #[test]
+    fn recognizes_missing_secret_errors() {
+        let error = FnoxError::ProviderCliFailed {
+            provider: PROVIDER_NAME.to_string(),
+            details: "No data found at secret/data/database".to_string(),
+            hint: String::new(),
+            url: URL.to_string(),
+        };
+        assert!(is_missing_secret_error(&error));
+
+        let error = FnoxError::ProviderCliFailed {
+            provider: PROVIDER_NAME.to_string(),
+            details: "permission denied".to_string(),
+            hint: String::new(),
+            url: URL.to_string(),
+        };
+        assert!(!is_missing_secret_error(&error));
     }
 }

--- a/crates/fnox-core/src/providers/vault.rs
+++ b/crates/fnox-core/src/providers/vault.rs
@@ -31,7 +31,9 @@ fn is_missing_secret_error(error: &FnoxError) -> bool {
         return false;
     };
     let details = details.to_ascii_lowercase();
-    details.contains("no data found") || details.contains("no value found")
+    details.contains("no data found")
+        || details.contains("no value found")
+        || details.contains("code: 404")
 }
 
 fn deleted_secret_version(metadata: &str) -> Result<Option<u64>> {
@@ -461,6 +463,14 @@ mod tests {
         let error = FnoxError::ProviderCliFailed {
             provider: PROVIDER_NAME.to_string(),
             details: "No data found at secret/data/database".to_string(),
+            hint: String::new(),
+            url: URL.to_string(),
+        };
+        assert!(is_missing_secret_error(&error));
+
+        let error = FnoxError::ProviderCliFailed {
+            provider: PROVIDER_NAME.to_string(),
+            details: "Error making API request. Code: 404. Errors:".to_string(),
             hint: String::new(),
             url: URL.to_string(),
         };

--- a/crates/fnox-core/src/providers/vault.rs
+++ b/crates/fnox-core/src/providers/vault.rs
@@ -34,6 +34,52 @@ fn is_missing_secret_error(error: &FnoxError) -> bool {
     details.contains("no data found") || details.contains("no value found")
 }
 
+fn deleted_secret_version(metadata: &str) -> Result<Option<u64>> {
+    let metadata: serde_json::Value =
+        serde_json::from_str(metadata).map_err(|error| FnoxError::ProviderInvalidResponse {
+            provider: PROVIDER_NAME.to_string(),
+            details: format!("Invalid Vault metadata response: {error}"),
+            hint: "Check that the Vault CLI returned JSON metadata".to_string(),
+            url: URL.to_string(),
+        })?;
+    let data = metadata
+        .get("data")
+        .ok_or_else(|| FnoxError::ProviderInvalidResponse {
+            provider: PROVIDER_NAME.to_string(),
+            details: "Vault metadata response did not contain data".to_string(),
+            hint: "Check that the Vault CLI returned KV v2 metadata".to_string(),
+            url: URL.to_string(),
+        })?;
+    let current_version = data
+        .get("current_version")
+        .and_then(serde_json::Value::as_u64)
+        .ok_or_else(|| FnoxError::ProviderInvalidResponse {
+            provider: PROVIDER_NAME.to_string(),
+            details: "Vault metadata response did not contain current_version".to_string(),
+            hint: "Check that the Vault CLI returned KV v2 metadata".to_string(),
+            url: URL.to_string(),
+        })?;
+    let version = data
+        .get("versions")
+        .and_then(|versions| versions.get(current_version.to_string()))
+        .ok_or_else(|| FnoxError::ProviderInvalidResponse {
+            provider: PROVIDER_NAME.to_string(),
+            details: format!("Vault metadata did not contain version {current_version}"),
+            hint: "Check that the Vault CLI returned KV v2 metadata".to_string(),
+            url: URL.to_string(),
+        })?;
+    let deleted = version
+        .get("deletion_time")
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|time| !time.is_empty())
+        || version
+            .get("destroyed")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false);
+
+    Ok(deleted.then_some(current_version))
+}
+
 pub struct HashiCorpVaultProvider {
     address: Option<String>,
     path: Option<String>,
@@ -243,6 +289,12 @@ impl HashiCorpVaultProvider {
 
         Ok(stdout.trim().to_string())
     }
+
+    async fn deleted_secret_version(&self, secret_path: &str) -> Result<Option<u64>> {
+        let args = ["kv", "metadata", "get", "-format=json", secret_path];
+        let metadata = self.execute_vault_command(&args).await?;
+        deleted_secret_version(&metadata)
+    }
 }
 
 #[async_trait]
@@ -316,8 +368,33 @@ impl crate::providers::Provider for HashiCorpVaultProvider {
                 {
                     // A concurrent writer may have created the secret after the
                     // failed patch. Retry the non-destructive patch in that case.
-                    self.execute_vault_command_with_stdin(&patch_args, Some(value))
-                        .await?;
+                    if let Err(retry_error) = self
+                        .execute_vault_command_with_stdin(&patch_args, Some(value))
+                        .await
+                    {
+                        if !is_missing_secret_error(&retry_error) {
+                            return Err(retry_error);
+                        }
+
+                        // CAS 0 cannot write over a soft-deleted KV v2 path. Use
+                        // its deleted current version without risking a live path.
+                        if let Some(version) = self.deleted_secret_version(&secret_path).await? {
+                            let cas_arg = format!("-cas={version}");
+                            let recreate_args =
+                                vec!["kv", "put", &cas_arg, &secret_path, &value_arg];
+                            if self
+                                .execute_vault_command_with_stdin(&recreate_args, Some(value))
+                                .await
+                                .is_err()
+                            {
+                                self.execute_vault_command_with_stdin(&patch_args, Some(value))
+                                    .await?;
+                            }
+                        } else {
+                            self.execute_vault_command_with_stdin(&patch_args, Some(value))
+                                .await?;
+                        }
+                    }
                 }
             }
         } else {
@@ -396,5 +473,14 @@ mod tests {
             url: URL.to_string(),
         };
         assert!(!is_missing_secret_error(&error));
+    }
+
+    #[test]
+    fn recognizes_deleted_metadata_versions() {
+        let deleted = r#"{"data":{"current_version":2,"versions":{"2":{"deletion_time":"2026-08-12T00:00:00Z","destroyed":false}}}}"#;
+        assert_eq!(deleted_secret_version(deleted).unwrap(), Some(2));
+
+        let live = r#"{"data":{"current_version":3,"versions":{"3":{"deletion_time":"","destroyed":false}}}}"#;
+        assert_eq!(deleted_secret_version(live).unwrap(), None);
     }
 }

--- a/crates/fnox-core/src/providers/vault.rs
+++ b/crates/fnox-core/src/providers/vault.rs
@@ -2,6 +2,8 @@ use crate::env;
 use crate::error::{FnoxError, Result};
 use async_trait::async_trait;
 use serde_json::json;
+use std::process::Stdio;
+use tokio::io::AsyncWriteExt;
 use tokio::process::Command;
 
 const URL: &str = "https://fnox.jdx.dev/providers/vault";
@@ -101,6 +103,15 @@ impl HashiCorpVaultProvider {
 
     /// Execute vault CLI command with proper authentication
     async fn execute_vault_command(&self, args: &[&str]) -> Result<String> {
+        self.execute_vault_command_with_stdin(args, None).await
+    }
+
+    /// Execute a vault CLI command, optionally supplying its standard input.
+    async fn execute_vault_command_with_stdin(
+        &self,
+        args: &[&str],
+        stdin: Option<&str>,
+    ) -> Result<String> {
         tracing::debug!("Executing vault command with args: {:?}", args);
 
         let mut cmd = Command::new("vault");
@@ -138,9 +149,16 @@ impl HashiCorpVaultProvider {
         );
         cmd.env("VAULT_TOKEN", token);
 
-        cmd.args(args);
+        cmd.args(args)
+            .stdin(if stdin.is_some() {
+                Stdio::piped()
+            } else {
+                Stdio::null()
+            })
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
 
-        let output = cmd.output().await.map_err(|e| {
+        let mut child = cmd.spawn().map_err(|e| {
             if e.kind() == std::io::ErrorKind::NotFound {
                 FnoxError::ProviderCliNotFound {
                     provider: "HashiCorp Vault".to_string(),
@@ -157,6 +175,38 @@ impl HashiCorpVaultProvider {
                 }
             }
         })?;
+
+        if let Some(input) = stdin {
+            let mut child_stdin =
+                child
+                    .stdin
+                    .take()
+                    .ok_or_else(|| FnoxError::ProviderCliFailed {
+                        provider: PROVIDER_NAME.to_string(),
+                        details: "Vault child process did not expose piped stdin".to_string(),
+                        hint: "This is an internal error".to_string(),
+                        url: URL.to_string(),
+                    })?;
+            child_stdin.write_all(input.as_bytes()).await.map_err(|e| {
+                FnoxError::ProviderCliFailed {
+                    provider: PROVIDER_NAME.to_string(),
+                    details: format!("Failed to write secret to Vault stdin: {e}"),
+                    hint: "This is an internal error".to_string(),
+                    url: URL.to_string(),
+                }
+            })?;
+            drop(child_stdin);
+        }
+
+        let output = child
+            .wait_with_output()
+            .await
+            .map_err(|e| FnoxError::ProviderCliFailed {
+                provider: PROVIDER_NAME.to_string(),
+                details: format!("Failed to wait for Vault command: {e}"),
+                hint: "Check your Vault configuration".to_string(),
+                url: URL.to_string(),
+            })?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -246,19 +296,34 @@ impl crate::providers::Provider for HashiCorpVaultProvider {
         tracing::debug!("Writing secret '{}' to HashiCorp Vault", secret_path);
 
         // Patch explicit fields so updating one value does not replace its siblings.
-        let value_arg = format!("{field_name}={value}");
+        // Passing values through stdin prevents Vault from interpreting leading
+        // `@` as file input or `-` as an instruction to read uncontrolled stdin.
+        let value_arg = format!("{field_name}=-");
         if key.contains('/') {
             let patch_args = vec!["kv", "patch", &secret_path, &value_arg];
-            if let Err(error) = self.execute_vault_command(&patch_args).await {
+            if let Err(error) = self
+                .execute_vault_command_with_stdin(&patch_args, Some(value))
+                .await
+            {
                 if !is_missing_secret_error(&error) {
                     return Err(error);
                 }
-                let put_args = vec!["kv", "put", &secret_path, &value_arg];
-                self.execute_vault_command(&put_args).await?;
+                let put_args = vec!["kv", "put", "-cas=0", &secret_path, &value_arg];
+                if self
+                    .execute_vault_command_with_stdin(&put_args, Some(value))
+                    .await
+                    .is_err()
+                {
+                    // A concurrent writer may have created the secret after the
+                    // failed patch. Retry the non-destructive patch in that case.
+                    self.execute_vault_command_with_stdin(&patch_args, Some(value))
+                        .await?;
+                }
             }
         } else {
             let put_args = vec!["kv", "put", &secret_path, &value_arg];
-            self.execute_vault_command(&put_args).await?;
+            self.execute_vault_command_with_stdin(&put_args, Some(value))
+                .await?;
         }
 
         tracing::debug!("Successfully wrote secret '{}' to Vault", secret_path);

--- a/crates/fnox-core/src/providers/vault.rs
+++ b/crates/fnox-core/src/providers/vault.rs
@@ -5,6 +5,24 @@ use serde_json::json;
 use tokio::process::Command;
 
 const URL: &str = "https://fnox.jdx.dev/providers/vault";
+const PROVIDER_NAME: &str = "HashiCorp Vault";
+
+fn parse_secret_reference(value: &str) -> Result<(&str, &str)> {
+    match value.split_once('/') {
+        None => Ok((value, "value")),
+        Some((secret, field))
+            if !secret.is_empty() && !field.is_empty() && !field.contains('/') =>
+        {
+            Ok((secret, field))
+        }
+        _ => Err(FnoxError::ProviderInvalidResponse {
+            provider: PROVIDER_NAME.to_string(),
+            details: format!("Invalid secret reference format: '{value}'"),
+            hint: "Expected 'secret' or 'secret/field'".to_string(),
+            url: URL.to_string(),
+        }),
+    }
+}
 
 pub struct HashiCorpVaultProvider {
     address: Option<String>,
@@ -178,22 +196,7 @@ impl crate::providers::Provider for HashiCorpVaultProvider {
     async fn get_secret(&self, value: &str) -> Result<String> {
         tracing::debug!("Getting secret '{}' from HashiCorp Vault", value);
 
-        // Parse value as "secret-name/field" or just "secret-name"
-        // Default field is "value" if not specified (Vault KV v2 convention)
-        let parts: Vec<&str> = value.split('/').collect();
-
-        let (secret_name, field_name) = match parts.len() {
-            1 => (parts[0], "value"),
-            2 => (parts[0], parts[1]),
-            _ => {
-                return Err(FnoxError::ProviderInvalidResponse {
-                    provider: "HashiCorp Vault".to_string(),
-                    details: format!("Invalid secret reference format: '{}'", value),
-                    hint: "Expected 'secret' or 'secret/field'".to_string(),
-                    url: URL.to_string(),
-                });
-            }
-        };
+        let (secret_name, field_name) = parse_secret_reference(value)?;
 
         let secret_path = self.get_secret_path(secret_name);
 
@@ -229,13 +232,15 @@ impl crate::providers::Provider for HashiCorpVaultProvider {
     }
 
     async fn put_secret(&self, key: &str, value: &str) -> Result<String> {
-        let secret_path = self.get_secret_path(key);
+        let (secret_name, field_name) = parse_secret_reference(key)?;
+        let secret_path = self.get_secret_path(secret_name);
 
         tracing::debug!("Writing secret '{}' to HashiCorp Vault", secret_path);
 
-        // Use vault kv put command: vault kv put <path> value=<value>
-        let value_arg = format!("value={}", value);
-        let args = vec!["kv", "put", &secret_path, &value_arg];
+        // Patch explicit fields so updating one value does not replace its siblings.
+        let value_arg = format!("{field_name}={value}");
+        let operation = if key.contains('/') { "patch" } else { "put" };
+        let args = vec!["kv", operation, &secret_path, &value_arg];
 
         self.execute_vault_command(&args).await?;
 
@@ -273,4 +278,22 @@ fn vault_namespace() -> Option<String> {
     env::var("FNOX_VAULT_NAMESPACE")
         .or_else(|_| env::var("VAULT_NAMESPACE"))
         .ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_secret_references() {
+        assert_eq!(
+            parse_secret_reference("database").unwrap(),
+            ("database", "value")
+        );
+        assert_eq!(
+            parse_secret_reference("database/password").unwrap(),
+            ("database", "password")
+        );
+        assert!(parse_secret_reference("database/nested/password").is_err());
+    }
 }

--- a/src/commands/set.rs
+++ b/src/commands/set.rs
@@ -3,7 +3,9 @@ use crate::config::{self, Config, IfMissing};
 use crate::error::{FnoxError, Result};
 use clap::Args;
 use std::io::{self, Read};
+use std::path::Path;
 
+/// Resolve a remote key without carrying a reference across providers.
 fn resolve_remote_key_name<'a>(
     key: &'a str,
     key_name: Option<&'a str>,
@@ -17,6 +19,23 @@ fn resolve_remote_key_name<'a>(
                 .and_then(config::SecretConfig::value)
         })
         .unwrap_or(key)
+}
+
+/// Return whether a loaded secret came from the table this command will update.
+fn secret_belongs_to_target(
+    secret: &config::SecretConfig,
+    target_path: &Path,
+    write_profile: &str,
+) -> bool {
+    if secret.source_path.as_deref() != Some(target_path) {
+        return false;
+    }
+
+    if write_profile == "default" || config::is_profile_file(target_path) {
+        !secret.source_is_profile
+    } else {
+        secret.source_profile.as_deref() == Some(write_profile)
+    }
 }
 
 #[derive(Debug, Args)]
@@ -77,6 +96,22 @@ impl SetCommand {
             write_profile
         );
 
+        let target_path = if self.global {
+            Config::global_config_path()
+        } else {
+            let current_dir = std::env::current_dir().map_err(|e| {
+                FnoxError::Config(format!("Failed to get current directory: {}", e))
+            })?;
+            // Only use auto-detection when --config is the clap default ("fnox.toml").
+            // Any other value means the user explicitly chose a config file.
+            if cli.config == std::path::Path::new(config::DEFAULT_CONFIG_FILENAME) {
+                config::find_local_config(&current_dir, std::slice::from_ref(&write_profile))
+            } else {
+                current_dir.join(&cli.config)
+            }
+        };
+        let write_profile_stack = vec![write_profile.clone()];
+
         // Check if we're only setting metadata (no actual secret value)
         let has_metadata =
             self.description.is_some() || self.if_missing.is_some() || self.default.is_some();
@@ -106,12 +141,16 @@ impl SetCommand {
             Some(value)
         };
 
-        let existing_secret = config.get_secret(&profile, &self.key).cloned();
+        let effective_secret = config.get_secret(&write_profile_stack, &self.key).cloned();
+        let existing_secret = effective_secret
+            .as_ref()
+            .filter(|secret| secret_belongs_to_target(secret, &target_path, &write_profile))
+            .cloned();
 
         // Determine which provider to use
         let provider_name_to_use = if let Some(ref provider_name) = self.provider {
             Some(provider_name.clone())
-        } else if let Some(existing) = existing_secret
+        } else if let Some(existing) = effective_secret
             .as_ref()
             .and_then(|s| s.provider().map(str::to_string))
         {
@@ -119,7 +158,7 @@ impl SetCommand {
         } else {
             // Try to use default provider if available, but it's OK if there isn't one
             // (will store as plaintext)
-            config.get_default_provider(&profile)?
+            config.get_default_provider(&write_profile_stack)?
         };
 
         // Check if secret should be base64 encoded
@@ -135,12 +174,12 @@ impl SetCommand {
         let (encrypted_value, remote_key_name) = if let Some(ref value) = secret_value {
             if let Some(ref provider_name) = provider_name_to_use {
                 // Get the provider config
-                let providers = config.get_providers(&profile);
+                let providers = config.get_providers(&write_profile_stack);
                 if let Some(provider_config) = providers.get(provider_name) {
                     // Get the provider (resolving any secret refs) and check its capabilities
                     let provider = crate::providers::get_provider_resolved(
                         &config,
-                        &profile,
+                        &write_profile_stack,
                         provider_name,
                         provider_config,
                     )
@@ -219,7 +258,6 @@ impl SetCommand {
 
         // Now update the config — use the resolved write_profile, not the
         // full stack, so the secret lands in the correct TOML section.
-        let write_profile_stack = vec![write_profile.clone()];
         let profile_secrets = config.get_secrets_mut(&write_profile_stack);
 
         // Get or create the secret config
@@ -269,11 +307,9 @@ impl SetCommand {
         let _ = profile_secrets; // Release the mutable borrow
 
         // Save the secret to the appropriate config file
-        let target_path = if self.global {
-            // Save to global config
-            let global_path = Config::global_config_path();
+        if self.global {
             // Create parent directory if it doesn't exist
-            if let Some(parent) = global_path.parent()
+            if let Some(parent) = target_path.parent()
                 && !self.dry_run
             {
                 std::fs::create_dir_all(parent).map_err(|e| {
@@ -284,19 +320,7 @@ impl SetCommand {
                     ))
                 })?;
             }
-            global_path
-        } else {
-            let current_dir = std::env::current_dir().map_err(|e| {
-                FnoxError::Config(format!("Failed to get current directory: {}", e))
-            })?;
-            // Only use auto-detection when --config is the clap default ("fnox.toml").
-            // Any other value means the user explicitly chose a config file.
-            if cli.config == std::path::Path::new(config::DEFAULT_CONFIG_FILENAME) {
-                config::find_local_config(&current_dir, std::slice::from_ref(&write_profile))
-            } else {
-                current_dir.join(&cli.config)
-            }
-        };
+        }
 
         if self.dry_run {
             // Show what would be done
@@ -405,5 +429,17 @@ mod tests {
             resolve_remote_key_name("ENV_NAME", None, Some(&existing), "gcp"),
             "ENV_NAME"
         );
+    }
+
+    #[test]
+    fn inherited_secret_does_not_supply_remote_key_name() {
+        let mut existing = secret("gcp", "shared-name");
+        existing.source_path = Some("/parent/fnox.toml".into());
+
+        assert!(!secret_belongs_to_target(
+            &existing,
+            Path::new("/child/fnox.toml"),
+            "default"
+        ));
     }
 }

--- a/src/commands/set.rs
+++ b/src/commands/set.rs
@@ -4,6 +4,21 @@ use crate::error::{FnoxError, Result};
 use clap::Args;
 use std::io::{self, Read};
 
+fn resolve_remote_key_name<'a>(
+    key: &'a str,
+    key_name: Option<&'a str>,
+    existing_secret: Option<&'a config::SecretConfig>,
+    provider_name: &str,
+) -> &'a str {
+    key_name
+        .or_else(|| {
+            existing_secret
+                .filter(|secret| secret.provider() == Some(provider_name))
+                .and_then(config::SecretConfig::value)
+        })
+        .unwrap_or(key)
+}
+
 #[derive(Debug, Args)]
 #[command(visible_aliases = ["s"])]
 pub struct SetCommand {
@@ -91,11 +106,13 @@ impl SetCommand {
             Some(value)
         };
 
+        let existing_secret = config.get_secret(&profile, &self.key).cloned();
+
         // Determine which provider to use
         let provider_name_to_use = if let Some(ref provider_name) = self.provider {
             Some(provider_name.clone())
-        } else if let Some(existing) = config
-            .get_secret(&profile, &self.key)
+        } else if let Some(existing) = existing_secret
+            .as_ref()
             .and_then(|s| s.provider().map(str::to_string))
         {
             Some(existing)
@@ -165,13 +182,18 @@ impl SetCommand {
                             provider_name
                         );
 
+                        let key_name = resolve_remote_key_name(
+                            &self.key,
+                            self.key_name.as_deref(),
+                            existing_secret.as_ref(),
+                            provider_name,
+                        );
+
                         if self.dry_run {
                             // In dry-run mode, skip actual remote storage
-                            let key_name = self.key_name.as_deref().unwrap_or(&self.key);
                             (None, Some(key_name.to_string()))
                         } else {
                             // Use the already-resolved provider to store the secret
-                            let key_name = self.key_name.as_deref().unwrap_or(&self.key);
                             let stored_key = provider.put_secret(key_name, value).await?;
 
                             // Store just the key name (without prefix) in config
@@ -341,5 +363,47 @@ impl SetCommand {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn secret(provider: &str, value: &str) -> config::SecretConfig {
+        let mut secret = config::SecretConfig::default();
+        secret.set_provider(Some(provider.to_string()));
+        secret.set_value(Some(value.to_string()));
+        secret
+    }
+
+    #[test]
+    fn remote_key_name_prefers_explicit_key_name() {
+        let existing = secret("gcp", "existing-name");
+
+        assert_eq!(
+            resolve_remote_key_name("ENV_NAME", Some("explicit-name"), Some(&existing), "gcp"),
+            "explicit-name"
+        );
+    }
+
+    #[test]
+    fn remote_key_name_reuses_existing_value_for_same_provider() {
+        let existing = secret("gcp", "existing-name");
+
+        assert_eq!(
+            resolve_remote_key_name("ENV_NAME", None, Some(&existing), "gcp"),
+            "existing-name"
+        );
+    }
+
+    #[test]
+    fn remote_key_name_uses_env_key_when_switching_providers() {
+        let existing = secret("aws", "existing-name");
+
+        assert_eq!(
+            resolve_remote_key_name("ENV_NAME", None, Some(&existing), "gcp"),
+            "ENV_NAME"
+        );
     }
 }

--- a/test/gcp_secret_manager.bats
+++ b/test/gcp_secret_manager.bats
@@ -271,7 +271,7 @@ EOF
 	secret_value="my-test-secret-value-$(date +%s)-$$-${BATS_TEST_NUMBER:-0}"
 
 	# Set the secret name for teardown cleanup
-	export TEST_SECRET_NAME="fnox-test-create-GCP_SM_CREATE_TEST"
+	export TEST_SECRET_NAME="$secret_name"
 
 	# Add secret to config so fnox set will use GCP SM provider
 	cat >>"${FNOX_CONFIG_FILE}" <<EOF
@@ -282,8 +282,9 @@ value = "$secret_name"
 EOF
 
 	# Create the secret using fnox set (should use GCP SM provider)
-	run "$FNOX_BIN" set GCP_SM_CREATE_TEST "$secret_value" --provider gcp_sm
+	run "$FNOX_BIN" set GCP_SM_CREATE_TEST "$secret_value"
 	assert_success
+	assert_file_contains "$FNOX_CONFIG_FILE" "value = \"$secret_name\""
 
 	# Get the secret back to verify it was created correctly
 	run "$FNOX_BIN" get GCP_SM_CREATE_TEST
@@ -291,6 +292,5 @@ EOF
 	assert_output "$secret_value"
 
 	# Cleanup - delete actual secret created by fnox set
-	# fnox set creates a secret with the provider prefix + secret key
 	gcloud secrets delete "$TEST_SECRET_NAME" --project="$GCP_PROJECT" --quiet >/dev/null 2>&1 || true
 }

--- a/test/set_remote_key.bats
+++ b/test/set_remote_key.bats
@@ -1,0 +1,98 @@
+#!/usr/bin/env bats
+
+setup() {
+	load 'test_helper/common_setup'
+	_common_setup
+
+	mkdir -p mock-bin
+	cat >mock-bin/pass <<'EOF'
+#!/bin/sh
+printf '%s\n' "$*" >"$PASS_ARGS_FILE"
+cat >"$PASS_VALUE_FILE"
+EOF
+	chmod +x mock-bin/pass
+	export PATH="$PWD/mock-bin:$PATH"
+	export PASS_ARGS_FILE="$PWD/pass-args"
+	export PASS_VALUE_FILE="$PWD/pass-value"
+}
+
+teardown() {
+	_common_teardown
+}
+
+@test "fnox set reuses an existing remote key in the write target" {
+	cat >fnox.toml <<EOF
+[providers.pass]
+type = "password-store"
+
+[secrets]
+TOKEN = { provider = "pass", value = "custom-name" }
+EOF
+
+	run "$FNOX_BIN" set TOKEN "updated-value"
+	assert_success
+	assert_file_contains "$PASS_ARGS_FILE" "insert -m -f custom-name"
+	assert_file_contains "$PASS_VALUE_FILE" "updated-value"
+	assert_file_contains fnox.toml 'value = "custom-name"'
+}
+
+@test "fnox set dry-run preserves an existing remote key without writing" {
+	cat >fnox.toml <<EOF
+[providers.pass]
+type = "password-store"
+
+[secrets]
+TOKEN = { provider = "pass", value = "custom-name" }
+EOF
+	cp fnox.toml fnox.toml.orig
+
+	run "$FNOX_BIN" set TOKEN "updated-value" --dry-run
+	assert_success
+	assert_output --partial "value: custom-name"
+	assert_file_not_exist "$PASS_ARGS_FILE"
+	diff fnox.toml fnox.toml.orig
+}
+
+@test "fnox set does not reuse an inherited remote key for a local override" {
+	mkdir -p parent/child
+	cat >parent/fnox.toml <<EOF
+[providers.pass]
+type = "password-store"
+
+[secrets]
+TOKEN = { provider = "pass", value = "shared-name" }
+EOF
+	cat >parent/child/fnox.toml <<EOF
+[secrets]
+EOF
+	cd parent/child
+
+	run "$FNOX_BIN" set TOKEN "local-value"
+	assert_success
+	assert_file_contains "$PASS_ARGS_FILE" "insert -m -f TOKEN"
+	assert_file_contains fnox.toml 'value = "TOKEN"'
+	assert_file_contains ../fnox.toml 'value = "shared-name"'
+}
+
+@test "fnox set resolves providers from the write profile" {
+	cat >fnox.toml <<EOF
+[profiles.source.providers.pass]
+type = "password-store"
+prefix = "source/"
+
+[profiles.source.secrets]
+TOKEN = { provider = "pass", value = "source-name" }
+
+[profiles.target.providers.pass]
+type = "password-store"
+prefix = "target/"
+
+[profiles.target.secrets]
+TOKEN = { provider = "pass", value = "target-name" }
+EOF
+
+	run "$FNOX_BIN" -P source --write-profile target set TOKEN "target-value"
+	assert_success
+	assert_file_contains "$PASS_ARGS_FILE" "insert -m -f target/target-name"
+	assert_file_contains fnox.toml 'value = "target-name"'
+}

--- a/test/vault.bats
+++ b/test/vault.bats
@@ -179,7 +179,7 @@ EOF
 	assert_success
 	run "$FNOX_BIN" get TEST_USERNAME
 	assert_success
-	assert_output "-"
+	assert_output -- "-"
 
 	delete_test_vault_secret "$secret_name"
 	_vault_secrets_to_cleanup=()

--- a/test/vault.bats
+++ b/test/vault.bats
@@ -16,6 +16,7 @@
 setup() {
 	load 'test_helper/common_setup'
 	_common_setup
+	_vault_secrets_to_cleanup=()
 
 	# Check if vault CLI is installed
 	if ! command -v vault >/dev/null 2>&1; then
@@ -43,6 +44,9 @@ setup() {
 }
 
 teardown() {
+	for secret_name in "${_vault_secrets_to_cleanup[@]}"; do
+		delete_test_vault_secret "$secret_name"
+	done
 	_common_teardown
 }
 
@@ -134,6 +138,7 @@ EOF
 	create_vault_config
 
 	secret_name=$(create_test_vault_secret)
+	_vault_secrets_to_cleanup+=("$secret_name")
 	cat >>"${FNOX_CONFIG_FILE}" <<EOF
 
 [secrets.TEST_USERNAME]
@@ -157,6 +162,15 @@ EOF
 	assert_output --partial "test-secret-value-"
 
 	delete_test_vault_secret "$secret_name"
+	run "$FNOX_BIN" set TEST_USERNAME "recreated-user"
+	assert_success
+
+	run "$FNOX_BIN" get TEST_USERNAME
+	assert_success
+	assert_output "recreated-user"
+
+	delete_test_vault_secret "$secret_name"
+	_vault_secrets_to_cleanup=()
 }
 
 @test "fnox get retrieves value field from Vault secret" {

--- a/test/vault.bats
+++ b/test/vault.bats
@@ -169,8 +169,59 @@ EOF
 	assert_success
 	assert_output "recreated-user"
 
+	run "$FNOX_BIN" set TEST_USERNAME "@literal-value"
+	assert_success
+	run "$FNOX_BIN" get TEST_USERNAME
+	assert_success
+	assert_output "@literal-value"
+
+	run "$FNOX_BIN" set TEST_USERNAME "-"
+	assert_success
+	run "$FNOX_BIN" get TEST_USERNAME
+	assert_success
+	assert_output "-"
+
 	delete_test_vault_secret "$secret_name"
 	_vault_secrets_to_cleanup=()
+}
+
+@test "fnox set preserves concurrent Vault fields while creating a field reference" {
+	create_vault_config
+
+	secret_name="fnox-race-$(date +%s)-$$-${BATS_TEST_NUMBER:-0}"
+	_vault_secrets_to_cleanup+=("$secret_name")
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
+
+[secrets.TEST_USERNAME]
+provider = "vault"
+value = "$secret_name/username"
+EOF
+
+	export FNOX_TEST_REAL_VAULT
+	FNOX_TEST_REAL_VAULT=$(command -v vault)
+	export FNOX_TEST_VAULT_RACE_PATH="secret/$secret_name"
+	mkdir -p "$BATS_TEST_TMPDIR/vault-race-bin"
+	cat >"$BATS_TEST_TMPDIR/vault-race-bin/vault" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" == "kv" && "$2" == "put" && "$3" == "-cas=0" ]]; then
+	cat >/dev/null
+	"$FNOX_TEST_REAL_VAULT" kv put "$FNOX_TEST_VAULT_RACE_PATH" sibling=concurrent >/dev/null
+	exit 2
+fi
+exec "$FNOX_TEST_REAL_VAULT" "$@"
+EOF
+	chmod +x "$BATS_TEST_TMPDIR/vault-race-bin/vault"
+	export PATH="$BATS_TEST_TMPDIR/vault-race-bin:$PATH"
+
+	run "$FNOX_BIN" set TEST_USERNAME "race-safe-user"
+	assert_success
+
+	run "$FNOX_TEST_REAL_VAULT" kv get -field=username "secret/$secret_name"
+	assert_success
+	assert_output "race-safe-user"
+	run "$FNOX_TEST_REAL_VAULT" kv get -field=sibling "secret/$secret_name"
+	assert_success
+	assert_output "concurrent"
 }
 
 @test "fnox get retrieves value field from Vault secret" {

--- a/test/vault.bats
+++ b/test/vault.bats
@@ -130,6 +130,35 @@ EOF
 	delete_test_vault_secret "$secret_name"
 }
 
+@test "fnox set updates a specific Vault field without replacing siblings" {
+	create_vault_config
+
+	secret_name=$(create_test_vault_secret)
+	cat >>"${FNOX_CONFIG_FILE}" <<EOF
+
+[secrets.TEST_USERNAME]
+provider = "vault"
+value = "$secret_name/username"
+
+[secrets.TEST_VALUE]
+provider = "vault"
+value = "$secret_name/value"
+EOF
+
+	run "$FNOX_BIN" set TEST_USERNAME "updated-user"
+	assert_success
+
+	run "$FNOX_BIN" get TEST_USERNAME
+	assert_success
+	assert_output "updated-user"
+
+	run "$FNOX_BIN" get TEST_VALUE
+	assert_success
+	assert_output --partial "test-secret-value-"
+
+	delete_test_vault_secret "$secret_name"
+}
+
 @test "fnox get retrieves value field from Vault secret" {
 	create_vault_config
 


### PR DESCRIPTION
## Summary

- preserve an existing remote provider key name when `fnox set` updates a secret
- keep `--key-name` as the highest-precedence override
- fall back to the environment key when creating a secret or switching providers
- repair the GCP Secret Manager integration test to assert and clean up the configured key

## Root cause

`fnox set` reused the existing provider but resolved remote key names only from `--key-name` or the environment key. It then persisted that fallback, replacing a custom `value` in the config and writing to the wrong remote secret.

## Validation

- `mise run test:cargo`
- `mise run lint`
- `mise run build`
- `mise run test:bats -- test/gcp_secret_manager.bats` (10 credential-gated tests skipped because GCP credentials are unavailable)

Fixes https://github.com/jdx/fnox/discussions/711

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how remote secrets are named and written on every `set` for storage providers, and Vault `put_secret` now has complex patch/CAS paths where a bug could corrupt or mis-route secret data.
> 
> **Overview**
> Fixes **`fnox set`** so updates to remote-backed secrets keep the configured provider **`value`** (custom remote key) instead of overwriting it with the env var name and writing to the wrong backend object. **`--key-name`** still wins; switching providers falls back to the env key. Only secrets that **belong to the file/profile being written** supply that reuse—**inherited** parent config no longer steers a child override.
> 
> **HashiCorp Vault** **`put_secret`** is reworked: **`secret/field`** references, **`kv patch`** for field updates (siblings preserved), values via **piped stdin** (so `@` and `-` are literal), plus create/retry/CAS handling for missing paths, races, and soft-deleted KV v2 metadata.
> 
> CI: Windows **`mise-action`** sets **`fetch_from_github: false`**. New **`test/set_remote_key.bats`**, expanded Vault BATS, and a GCP SM create test fix (generated secret name + cleanup).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34a60527bd1f76ff3314500c299307ad31dec9e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Secret updates now reuse an existing provider key when applicable.
  * Explicit key names take precedence, with environment-based keys used as a fallback.
  * Vault secrets can be updated by field while preserving other fields.
  * Secret references support nested paths and default fields.

* **Bug Fixes**
  * Improved handling when switching secrets between remote providers.
  * Prevented inherited keys from being reused for local overrides.
  * Preserved dry-run behavior during remote key resolution.
  * Improved Vault secret creation, recreation, concurrent updates, and cleanup.
  * Secret Manager creation and cleanup now work reliably with generated names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->