### PR TITLE
fix(hook-env): keep auth output off stdout

### DIFF
--- a/crates/fnox-core/src/auth_prompt.rs
+++ b/crates/fnox-core/src/auth_prompt.rs
@@ -51,11 +51,7 @@ pub fn prompt_and_run_auth(
     // Run the auth command
     eprintln!("Running: {}", auth_command);
 
-    let status = if cfg!(target_os = "windows") {
-        Command::new("cmd").args(["/C", auth_command]).status()
-    } else {
-        Command::new("sh").args(["-c", auth_command]).status()
-    };
+    let status = run_auth_command(auth_command);
 
     match status {
         Ok(exit_status) if exit_status.success() => {
@@ -70,6 +66,20 @@ pub fn prompt_and_run_auth(
             "Failed to run auth command: {}",
             e
         ))),
+    }
+}
+
+fn run_auth_command(auth_command: &str) -> std::io::Result<std::process::ExitStatus> {
+    if cfg!(target_os = "windows") {
+        Command::new("cmd")
+            .args(["/C", auth_command])
+            .stdout(std::io::stderr())
+            .status()
+    } else {
+        Command::new("sh")
+            .args(["-c", auth_command])
+            .stdout(std::io::stderr())
+            .status()
     }
 }
 
@@ -115,5 +125,30 @@ mod tests {
         };
         let result = prompt_and_run_auth(&config, &provider_config, "1password", &error);
         assert!(!result.unwrap());
+    }
+
+    #[test]
+    fn auth_command_stdout_is_redirected_to_stderr() {
+        const CHILD_ENV: &str = "FNOX_TEST_AUTH_COMMAND_STDOUT";
+        const MARKER: &str = "auth-command-output-marker";
+
+        if std::env::var(CHILD_ENV).ok().as_deref() == Some("1") {
+            run_auth_command(&format!("echo {MARKER}")).unwrap();
+            return;
+        }
+
+        let output = Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "auth_prompt::tests::auth_command_stdout_is_redirected_to_stderr",
+                "--nocapture",
+            ])
+            .env(CHILD_ENV, "1")
+            .output()
+            .unwrap();
+
+        assert!(output.status.success());
+        assert!(!String::from_utf8_lossy(&output.stdout).contains(MARKER));
+        assert!(String::from_utf8_lossy(&output.stderr).contains(MARKER));
     }
 }


### PR DESCRIPTION
## Why

`fnox hook-env` stdout is evaluated as shell code. Auth commands inherited that stream, so login progress could be executed as commands after an expired session prompted reauthentication.

## What changed

- Route auth-command stdout to stderr while keeping its output live for interactive logins.
- Add a regression test that checks auth-command output cannot reach fnox stdout.

## Validation

- `mise run test:cargo`
- `cargo test -p fnox-core`
- `cargo fmt --all -- --check`

*AI-assisted — Tool: Codex; model: openai/gpt-5.6-sol; version: 0.147.0.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication command output is now directed to standard error instead of standard output.
  * Preserved platform-specific authentication command behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
