### PR TITLE
fix(env): clean up as_file secrets on zsh exit

### DIFF
--- a/src/commands/deactivate.rs
+++ b/src/commands/deactivate.rs
@@ -31,7 +31,7 @@ impl DeactivateCommand {
 
         // Persistent as_file secrets outlive the hook-env process. Remove the
         // files before the shell discards __FNOX_SESSION, which owns their paths.
-        super::hook_env::cleanup_session_temp_files();
+        super::hook_env::cleanup_session_temp_files()?;
 
         // Generate deactivation output via the shell's trait method.
         // Eval-based shells produce shell code; structured shells (nushell)

--- a/src/commands/deactivate.rs
+++ b/src/commands/deactivate.rs
@@ -29,6 +29,10 @@ impl DeactivateCommand {
 
         let shell = shell::get_shell(None)?;
 
+        // Persistent as_file secrets outlive the hook-env process. Remove the
+        // files before the shell discards __FNOX_SESSION, which owns their paths.
+        super::hook_env::cleanup_session_temp_files();
+
         // Generate deactivation output via the shell's trait method.
         // Eval-based shells produce shell code; structured shells (nushell)
         // produce JSON that the wrapper function interprets.

--- a/src/commands/hook_env.rs
+++ b/src/commands/hook_env.rs
@@ -8,6 +8,7 @@ use anyhow::Result;
 use clap::Parser;
 use std::collections::HashMap;
 use std::fs;
+use std::path::Path;
 
 /// Output mode for shell integration
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -41,10 +42,19 @@ pub struct HookEnvCommand {
     /// Shell type (bash, zsh, fish, nu, pwsh)
     #[arg(short = 's', long)]
     pub shell: Option<String>,
+
+    /// Remove temporary files recorded by the current shell session
+    #[arg(long, hide = true)]
+    pub cleanup: bool,
 }
 
 impl HookEnvCommand {
     pub async fn run(&self, cli: &Cli) -> Result<()> {
+        if self.cleanup {
+            cleanup_session_temp_files();
+            return Ok(());
+        }
+
         // Get settings for output mode
         let settings =
             Settings::try_get().map_err(|e| anyhow::anyhow!("Failed to get settings: {}", e))?;
@@ -131,6 +141,33 @@ impl HookEnvCommand {
         print!("{}", output);
 
         Ok(())
+    }
+}
+
+/// Remove hook temp files owned by the current shell session.
+///
+/// Session data comes from the environment, so only remove files whose paths
+/// match the location and prefix used by hook-created secret files.
+pub(crate) fn cleanup_session_temp_files() {
+    let temp_dir = std::env::temp_dir();
+    for (key, path) in &PREV_SESSION.temp_files {
+        let path = Path::new(path);
+        let is_hook_temp_file = path.parent() == Some(temp_dir.as_path())
+            && path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with("fnox-hook-"));
+
+        if !is_hook_temp_file {
+            tracing::warn!("refusing to clean up invalid temp file path for '{}'", key);
+            continue;
+        }
+
+        match fs::remove_file(path) {
+            Ok(()) => tracing::debug!("cleaned up temp file for secret '{}'", key),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => tracing::debug!("failed to clean up temp file for '{}': {}", key, e),
+        }
     }
 }
 

--- a/src/commands/hook_env.rs
+++ b/src/commands/hook_env.rs
@@ -42,19 +42,10 @@ pub struct HookEnvCommand {
     /// Shell type (bash, zsh, fish, nu, pwsh)
     #[arg(short = 's', long)]
     pub shell: Option<String>,
-
-    /// Remove temporary files recorded by the current shell session
-    #[arg(long, hide = true)]
-    pub cleanup: bool,
 }
 
 impl HookEnvCommand {
     pub async fn run(&self, cli: &Cli) -> Result<()> {
-        if self.cleanup {
-            cleanup_session_temp_files();
-            return Ok(());
-        }
-
         // Get settings for output mode
         let settings =
             Settings::try_get().map_err(|e| anyhow::anyhow!("Failed to get settings: {}", e))?;
@@ -148,26 +139,45 @@ impl HookEnvCommand {
 ///
 /// Session data comes from the environment, so only remove files whose paths
 /// match the location and prefix used by hook-created secret files.
-pub(crate) fn cleanup_session_temp_files() {
-    let temp_dir = std::env::temp_dir();
+pub(crate) fn cleanup_session_temp_files() -> Result<()> {
+    let temp_dir = PREV_SESSION.hook_temp_dir.as_deref().or_else(|| {
+        PREV_SESSION
+            .temp_files
+            .values()
+            .find_map(|path| Path::new(path).parent())
+    });
+    let mut errors = Vec::new();
+
     for (key, path) in &PREV_SESSION.temp_files {
         let path = Path::new(path);
-        let is_hook_temp_file = path.parent() == Some(temp_dir.as_path())
+        let is_hook_temp_file = path.parent() == temp_dir
             && path
                 .file_name()
                 .and_then(|name| name.to_str())
                 .is_some_and(|name| name.starts_with("fnox-hook-"));
 
         if !is_hook_temp_file {
-            tracing::warn!("refusing to clean up invalid temp file path for '{}'", key);
+            errors.push(format!(
+                "refusing to clean up invalid temp file path for '{key}': {}",
+                path.display()
+            ));
             continue;
         }
 
         match fs::remove_file(path) {
             Ok(()) => tracing::debug!("cleaned up temp file for secret '{}'", key),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-            Err(e) => tracing::debug!("failed to clean up temp file for '{}': {}", key, e),
+            Err(e) => errors.push(format!(
+                "failed to clean up temp file for '{key}' at {}: {e}",
+                path.display()
+            )),
         }
+    }
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        anyhow::bail!(errors.join("; "))
     }
 }
 

--- a/src/hook_env.rs
+++ b/src/hook_env.rs
@@ -37,6 +37,9 @@ pub struct HookEnvSession {
     /// Paths to temporary files for file-based secrets (key -> file_path)
     #[serde(default)]
     pub temp_files: HashMap<String, String>,
+    /// Temp directory used to create file-based secrets
+    #[serde(default)]
+    pub hook_temp_dir: Option<PathBuf>,
 }
 
 /// Global previous session state, loaded from __FNOX_SESSION env var
@@ -98,6 +101,9 @@ impl HookEnvSession {
             .iter()
             .map(|(k, v)| (k.clone(), hash_secret_with_key(&hash_key, k, v)))
             .collect();
+        let hook_temp_dir = temp_files
+            .values()
+            .find_map(|path| Path::new(path).parent().map(Path::to_path_buf));
 
         Ok(Self {
             dir,
@@ -108,6 +114,7 @@ impl HookEnvSession {
             env_var_hash,
             config_files_hash,
             temp_files,
+            hook_temp_dir,
         })
     }
 

--- a/src/shell/zsh.rs
+++ b/src/shell/zsh.rs
@@ -11,11 +11,22 @@ impl Shell for Zsh {
         // Export shell type
         out.push_str("export FNOX_SHELL=zsh\n");
 
+        // A nested zsh inherits its parent's environment. Discard the encoded
+        // parent session so the child's first hook creates independently owned
+        // as_file paths instead of deleting the parent's paths on exit.
+        out.push_str(
+            r#"if [[ -n "${__FNOX_SESSION:-}" && "${__FNOX_ZSH_PID:-}" != "$$" ]]; then
+  unset __FNOX_SESSION
+fi
+export __FNOX_ZSH_PID=$$
+"#,
+        );
+
         // Define the fnox wrapper function
         out.push_str(&format!(
             r#"
 fnox() {{
-  local command
+  local command output status
   command="${{1:-}}"
   if [ "$#" = 0 ]; then
     {exe}
@@ -25,7 +36,12 @@ fnox() {{
 
   case "$command" in
   deactivate|shell)
-    eval "$({exe} "$command" "$@")"
+    output="$({exe} "$command" "$@")"
+    status=$?
+    if (( status != 0 )); then
+      return $status
+    fi
+    eval "$output"
     ;;
   *)
     {exe} "$command" "$@"
@@ -46,7 +62,7 @@ _fnox_hook() {{
 }}
 
 _fnox_cleanup() {{
-  {exe} hook-env --cleanup
+  {exe} deactivate >/dev/null
 }}
 "#,
             ));
@@ -98,7 +114,7 @@ add-zsh-hook -d zshexit _fnox_cleanup 2>/dev/null
 
         // Unset fnox-related variables
         out.push_str("unset -f fnox _fnox_hook _fnox_cleanup\n");
-        out.push_str("unset FNOX_SHELL __FNOX_SESSION\n");
+        out.push_str("unset FNOX_SHELL __FNOX_SESSION __FNOX_ZSH_PID\n");
 
         out
     }

--- a/src/shell/zsh.rs
+++ b/src/shell/zsh.rs
@@ -44,6 +44,10 @@ _fnox_hook() {{
   eval "$({exe} hook-env -s zsh)"
   trap - SIGINT
 }}
+
+_fnox_cleanup() {{
+  {exe} hook-env --cleanup
+}}
 "#,
             ));
 
@@ -54,6 +58,14 @@ typeset -ag precmd_functions
 if [[ -z "${precmd_functions[(r)_fnox_hook]+1}" ]]; then
   precmd_functions=( _fnox_hook ${precmd_functions[@]} )
 fi
+"#,
+            );
+
+            // Clean up persistent as_file secrets when the shell exits.
+            out.push_str(
+                r#"
+autoload -Uz add-zsh-hook
+add-zsh-hook zshexit _fnox_cleanup
 "#,
             );
 
@@ -74,16 +86,18 @@ fi
     fn deactivate(&self) -> String {
         let mut out = String::new();
 
-        // Remove hook from precmd_functions and chpwd_functions
+        // Remove prompt, directory-change, and exit hooks
         out.push_str(
             r#"
 precmd_functions=( ${precmd_functions[@]:#_fnox_hook} )
 chpwd_functions=( ${chpwd_functions[@]:#_fnox_hook} )
+autoload -Uz add-zsh-hook
+add-zsh-hook -d zshexit _fnox_cleanup 2>/dev/null
 "#,
         );
 
         // Unset fnox-related variables
-        out.push_str("unset -f fnox _fnox_hook\n");
+        out.push_str("unset -f fnox _fnox_hook _fnox_cleanup\n");
         out.push_str("unset FNOX_SHELL __FNOX_SESSION\n");
 
         out

--- a/test/file_secrets.bats
+++ b/test/file_secrets.bats
@@ -379,6 +379,52 @@ EOF
 	fi
 }
 
+@test "deactivate cleans up hook temp files" {
+	cat >fnox.toml <<EOF
+root = true
+
+[providers.plain]
+type = "plain"
+
+[secrets]
+FILE_SECRET = { provider = "plain", value = "file-secret-value", as_file = true }
+EOF
+
+	run "$FNOX_BIN" hook-env --shell bash
+	assert_success
+	local hook_output="$output"
+	local session_var file_path
+	session_var=$(echo "$hook_output" | grep "export __FNOX_SESSION=" | sed -E "s/^export __FNOX_SESSION=//; s/^'(.*)'\$/\\1/")
+	file_path=$(echo "$hook_output" | grep "export FILE_SECRET=" | sed -E "s/^export FILE_SECRET=//; s/^'(.*)'\$/\\1/" | head -1)
+	test -f "$file_path"
+
+	run env FNOX_SHELL=bash __FNOX_SESSION="$session_var" "$FNOX_BIN" deactivate
+	assert_success
+	refute test -e "$file_path"
+}
+
+@test "zsh exit cleans up hook temp files" {
+	command -v zsh >/dev/null || skip "zsh is not installed"
+
+	cat >fnox.toml <<EOF
+root = true
+
+[providers.plain]
+type = "plain"
+
+[secrets]
+FILE_SECRET = { provider = "plain", value = "file-secret-value", as_file = true }
+EOF
+
+	local file_path_file="$TEST_TEMP_DIR/file-path"
+	run zsh -dfc 'eval "$('"$FNOX_BIN"' activate zsh)"; _fnox_hook; print -r -- "$FILE_SECRET" > '"$file_path_file"
+	assert_success
+	local file_path
+	file_path=$(cat "$file_path_file")
+	[ -n "$file_path" ]
+	refute test -e "$file_path"
+}
+
 @test "export with as_file=true creates persistent file paths" {
 	# Create config with file-based secrets
 	cat >fnox.toml <<EOF

--- a/test/file_secrets.bats
+++ b/test/file_secrets.bats
@@ -403,6 +403,64 @@ EOF
 	refute test -e "$file_path"
 }
 
+@test "deactivate cleans files after TMPDIR changes" {
+	local original_tmp="$TEST_TEMP_DIR/original-tmp"
+	local replacement_tmp="$TEST_TEMP_DIR/replacement-tmp"
+	mkdir -p "$original_tmp" "$replacement_tmp"
+	cat >fnox.toml <<EOF
+root = true
+
+[providers.plain]
+type = "plain"
+
+[secrets]
+FILE_SECRET = { provider = "plain", value = "file-secret-value", as_file = true }
+EOF
+
+	run env TMPDIR="$original_tmp" "$FNOX_BIN" hook-env --shell bash
+	assert_success
+	local hook_output="$output"
+	local session_var file_path
+	session_var=$(echo "$hook_output" | grep "export __FNOX_SESSION=" | sed -E "s/^export __FNOX_SESSION=//; s/^'(.*)'\$/\\1/")
+	file_path=$(echo "$hook_output" | grep "export FILE_SECRET=" | sed -E "s/^export FILE_SECRET=//; s/^'(.*)'\$/\\1/" | head -1)
+	[[ $file_path == "$original_tmp"/* ]]
+	test -f "$file_path"
+
+	run env TMPDIR="$replacement_tmp" FNOX_SHELL=bash __FNOX_SESSION="$session_var" "$FNOX_BIN" deactivate
+	assert_success
+	refute test -e "$file_path"
+}
+
+@test "deactivate reports cleanup failures after attempting every file" {
+	cat >fnox.toml <<EOF
+root = true
+
+[providers.plain]
+type = "plain"
+
+[secrets]
+FILE_SECRET_1 = { provider = "plain", value = "file-secret-value-1", as_file = true }
+FILE_SECRET_2 = { provider = "plain", value = "file-secret-value-2", as_file = true }
+EOF
+
+	run "$FNOX_BIN" hook-env --shell bash
+	assert_success
+	local hook_output="$output"
+	local session_var first_file second_file
+	session_var=$(echo "$hook_output" | grep "export __FNOX_SESSION=" | sed -E "s/^export __FNOX_SESSION=//; s/^'(.*)'\$/\\1/")
+	first_file=$(echo "$hook_output" | grep "export FILE_SECRET_1=" | sed -E "s/^export FILE_SECRET_1=//; s/^'(.*)'\$/\\1/" | head -1)
+	second_file=$(echo "$hook_output" | grep "export FILE_SECRET_2=" | sed -E "s/^export FILE_SECRET_2=//; s/^'(.*)'\$/\\1/" | head -1)
+	rm "$first_file"
+	mkdir "$first_file"
+
+	run env FNOX_SHELL=bash __FNOX_SESSION="$session_var" "$FNOX_BIN" deactivate
+	assert_failure
+	assert_output --partial "failed to clean up temp file for 'FILE_SECRET_1'"
+	refute_output --partial "unset __FNOX_SESSION"
+	refute test -e "$second_file"
+	rmdir "$first_file"
+}
+
 @test "zsh exit cleans up hook temp files" {
 	command -v zsh >/dev/null || skip "zsh is not installed"
 
@@ -423,6 +481,42 @@ EOF
 	file_path=$(cat "$file_path_file")
 	[ -n "$file_path" ]
 	refute test -e "$file_path"
+}
+
+@test "nested zsh exit preserves parent hook temp files" {
+	command -v zsh >/dev/null || skip "zsh is not installed"
+
+	cat >fnox.toml <<EOF
+root = true
+
+[providers.plain]
+type = "plain"
+
+[secrets]
+FILE_SECRET = { provider = "plain", value = "file-secret-value", as_file = true }
+EOF
+
+	local parent_path_file="$TEST_TEMP_DIR/parent-path"
+	local child_path_file="$TEST_TEMP_DIR/child-path"
+	local parent_survived_file="$TEST_TEMP_DIR/parent-survived"
+	local script="$TEST_TEMP_DIR/nested-zsh.zsh"
+	cat >"$script" <<'ZSH'
+eval "$("$FNOX_BIN" activate zsh)"
+_fnox_hook
+print -r -- "$FILE_SECRET" >"$PARENT_PATH_FILE"
+zsh -dfc 'eval "$("$FNOX_BIN" activate zsh)"; _fnox_hook; print -r -- "$FILE_SECRET" >"$CHILD_PATH_FILE"'
+test -f "$FILE_SECRET" && print yes >"$PARENT_SURVIVED_FILE"
+ZSH
+
+	run env FNOX_BIN="$FNOX_BIN" PARENT_PATH_FILE="$parent_path_file" CHILD_PATH_FILE="$child_path_file" PARENT_SURVIVED_FILE="$parent_survived_file" zsh -df "$script"
+	assert_success
+	local parent_path child_path
+	parent_path=$(cat "$parent_path_file")
+	child_path=$(cat "$child_path_file")
+	[ "$parent_path" != "$child_path" ]
+	[ "$(cat "$parent_survived_file")" = yes ]
+	refute test -e "$parent_path"
+	refute test -e "$child_path"
 }
 
 @test "export with as_file=true creates persistent file paths" {

--- a/test/shell-integration.bats
+++ b/test/shell-integration.bats
@@ -32,7 +32,9 @@ teardown() {
 	assert_output --partial "_fnox_hook()"
 	assert_output --partial "precmd_functions"
 	assert_output --partial "chpwd_functions"
+	assert_output --partial 'export __FNOX_ZSH_PID=$$'
 	assert_output --partial "add-zsh-hook zshexit _fnox_cleanup"
+	assert_output --partial 'return $status'
 }
 
 @test "fnox activate fish generates valid fish code" {

--- a/test/shell-integration.bats
+++ b/test/shell-integration.bats
@@ -32,6 +32,7 @@ teardown() {
 	assert_output --partial "_fnox_hook()"
 	assert_output --partial "precmd_functions"
 	assert_output --partial "chpwd_functions"
+	assert_output --partial "add-zsh-hook zshexit _fnox_cleanup"
 }
 
 @test "fnox activate fish generates valid fish code" {


### PR DESCRIPTION
## Summary

- add a session-scoped cleanup path for persistent hook temp files
- remove recorded `as_file` temp files during `fnox deactivate`
- register a zsh `zshexit` hook so closing the terminal cleans up decrypted files
- validate cleanup paths before deletion and add regression coverage

## Root cause

Shell integration only removed old temp files during a later `hook-env` refresh. Shell exit never invokes the prompt or directory-change hooks, and deactivation discarded `__FNOX_SESSION` without deleting the temp files recorded in it.

## Validation

- `mise run build`
- `mise run test:cargo` — 47 passed
- `mise run lint`
- `mise run test:bats -- test/shell-integration.bats` — 35 passed
- `mise run test:bats -- test/file_secrets.bats` — cleanup regressions pass; 23/24 overall, with the unrelated JSON export test blocked by mise trust under its temporary HOME

Fixes the behavior reported in discussion #723.

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes on-disk cleanup of decrypted secret files and zsh shell hooks; path validation limits misuse, but failed cleanup now blocks deactivate output.
> 
> **Overview**
> Fixes **persistent `as_file` hook temp files** staying on disk after shell exit or `fnox deactivate`, when cleanup previously only happened on a later `hook-env` run.
> 
> **`fnox deactivate`** now deletes session-recorded hook temp files **before** emitting shell teardown, using a new **`cleanup_session_temp_files`** helper that only removes paths under the session’s hook temp dir with the **`fnox-hook-`** prefix (invalid paths are skipped; failures are aggregated and fail the command).
> 
> **`HookEnvSession`** stores **`hook_temp_dir`** so cleanup still works if **`TMPDIR`** changes between hook and deactivate.
> 
> **Zsh integration** adds a **`zshexit`** hook that runs deactivate on exit, clears an inherited **`__FNOX_SESSION`** in nested shells via **`__FNOX_ZSH_PID`**, and **propagates non-zero exit status** from `deactivate`/`shell` before `eval`.
> 
> Bats tests cover deactivate cleanup, TMPDIR changes, partial cleanup errors, zsh exit, and nested zsh parent/child file ownership.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4706497081129106c2f826534ba6fb339ece431. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Temporary secret files are now automatically cleaned up when deactivating an environment or exiting a Zsh session.
  * Nested Zsh sessions safely track their own temporary files without removing files belonging to parent sessions.
  * Cleanup continues across all tracked files and reports failures while ignoring files already removed.

* **Bug Fixes**
  * Prevented session-created secret files from remaining after shell deactivation or exit.

* **Tests**
  * Added coverage for deactivation, Zsh exit cleanup, nested sessions, and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->