### PR TITLE
fix(mcp): include cache hints in tool list

### DIFF
--- a/src/mcp_server.rs
+++ b/src/mcp_server.rs
@@ -84,6 +84,20 @@ impl FnoxMcpServer {
         }
     }
 
+    fn list_tools_result(&self) -> ListToolsResult {
+        let all_tools = self.tool_router.list_all();
+        let tools = self.mcp_config.tools();
+        let enabled: Vec<&str> = tools.iter().map(|t| t.tool_name()).collect();
+        let filtered = all_tools
+            .into_iter()
+            .filter(|t| enabled.contains(&t.name.as_ref()))
+            .collect();
+
+        ListToolsResult::with_all_items(filtered)
+            .with_ttl_ms(0)
+            .with_cache_scope(CacheScope::Private)
+    }
+
     /// Ensure env-injectable secrets are resolved and cached. First call
     /// resolves the batch (amortizes yubikey/SSO cost); subsequent calls are
     /// no-ops.
@@ -576,14 +590,7 @@ impl ServerHandler for FnoxMcpServer {
         _request: Option<PaginatedRequestParams>,
         _context: RequestContext<RoleServer>,
     ) -> Result<ListToolsResult, McpError> {
-        let all_tools = self.tool_router.list_all();
-        let tools = self.mcp_config.tools();
-        let enabled: Vec<&str> = tools.iter().map(|t| t.tool_name()).collect();
-        let filtered = all_tools
-            .into_iter()
-            .filter(|t| enabled.contains(&t.name.as_ref()))
-            .collect();
-        Ok(ListToolsResult::with_all_items(filtered))
+        Ok(self.list_tools_result())
     }
 
     fn get_tool(&self, name: &str) -> Option<Tool> {
@@ -619,6 +626,29 @@ impl ServerHandler for FnoxMcpServer {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn list_tools_includes_conservative_cache_hints() {
+        let server = FnoxMcpServer::new(
+            Config::default(),
+            vec!["default".into()],
+            McpConfig::default(),
+            ResolveContext {
+                config: "fnox.toml".into(),
+                profile: vec!["default".into()],
+                age_key_file: None,
+                if_missing: None,
+                no_defaults: false,
+                non_interactive: true,
+                no_daemon: true,
+            },
+            IndexMap::new(),
+        );
+
+        let result = server.list_tools_result();
+        assert_eq!(result.ttl_ms, Some(0));
+        assert_eq!(result.cache_scope, Some(CacheScope::Private));
+    }
 
     #[test]
     fn redact_replaces_secret_values() {


### PR DESCRIPTION
## Summary

- include `ttlMs: 0` and `cacheScope: "private"` in MCP `tools/list` results
- preserve the existing no-cache behavior while satisfying the MCP `2026-07-28` response schema
- add a regression test for the conservative cache hints

## Root cause

The rmcp 3 upgrade allows fnox to negotiate MCP `2026-07-28` and emits `resultType: "complete"`, but fnox constructed `ListToolsResult` without that protocol version's required cache hints. Strict clients such as Claude Code rejected the entire tool list.

## Impact

Claude Code and other strict-schema MCP clients can fetch fnox tools again while tool lists remain immediately stale and privately scoped.

Reported in https://github.com/jdx/fnox/discussions/726.

## Validation

- `mise run build`
- `mise run test:cargo`
- `mise run lint`
- direct MCP `2026-07-28` initialize + `tools/list` JSON-RPC handshake

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 880d7fc1e32bcc3524df76c2f65a870665351040. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated tool-list responses to include private, non-cacheable metadata.
  * Ensured only enabled tools are included when listing available tools.
  * Added validation for the tool-list caching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->