### PR TITLE
fix(set): preserve file secret newlines

### DIFF
--- a/crates/fnox-core/src/error.rs
+++ b/crates/fnox-core/src/error.rs
@@ -636,6 +636,17 @@ pub enum FnoxError {
         source: std::io::Error,
     },
 
+    #[error("Failed to read secret file: {}", path.display())]
+    #[diagnostic(
+        code(fnox::io::secret_file_read_failed),
+        help("Ensure the file exists, contains valid UTF-8, and you have read permissions")
+    )]
+    SecretFileReadFailed {
+        path: std::path::PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
     // ========================================================================
     // Generic I/O Errors (fallback)
     // ========================================================================

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -1454,6 +1454,23 @@
             }
           },
           {
+            "name": "from-file",
+            "usage": "--from-file <FROM_FILE>",
+            "help": "Read the secret value verbatim from a UTF-8 file",
+            "help_first_line": "Read the secret value verbatim from a UTF-8 file",
+            "short": [],
+            "long": ["from-file"],
+            "hide": false,
+            "global": false,
+            "arg": {
+              "name": "FROM_FILE",
+              "usage": "<FROM_FILE>",
+              "required": true,
+              "double_dash": "Optional",
+              "hide": false
+            }
+          },
+          {
             "name": "base64-encode",
             "usage": "--base64-encode",
             "help": "Base64 encode the secret",

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -1454,23 +1454,6 @@
             }
           },
           {
-            "name": "from-file",
-            "usage": "--from-file <FROM_FILE>",
-            "help": "Read the secret value verbatim from a UTF-8 file",
-            "help_first_line": "Read the secret value verbatim from a UTF-8 file",
-            "short": [],
-            "long": ["from-file"],
-            "hide": false,
-            "global": false,
-            "arg": {
-              "name": "FROM_FILE",
-              "usage": "<FROM_FILE>",
-              "required": true,
-              "double_dash": "Optional",
-              "hide": false
-            }
-          },
-          {
             "name": "base64-encode",
             "usage": "--base64-encode",
             "help": "Base64 encode the secret",
@@ -1492,6 +1475,23 @@
             "arg": {
               "name": "DEFAULT",
               "usage": "<DEFAULT>",
+              "required": true,
+              "double_dash": "Optional",
+              "hide": false
+            }
+          },
+          {
+            "name": "from-file",
+            "usage": "--from-file <FROM_FILE>",
+            "help": "Read the secret value verbatim from a UTF-8 file",
+            "help_first_line": "Read the secret value verbatim from a UTF-8 file",
+            "short": [],
+            "long": ["from-file"],
+            "hide": false,
+            "global": false,
+            "arg": {
+              "name": "FROM_FILE",
+              "usage": "<FROM_FILE>",
               "required": true,
               "double_dash": "Optional",
               "hide": false

--- a/docs/cli/set.md
+++ b/docs/cli/set.md
@@ -43,10 +43,6 @@ Show what would be done without making changes
 
 Provider to fetch from
 
-### `--from-file <FROM_FILE>`
-
-Read the secret value verbatim from a UTF-8 file
-
 ### `--base64-encode`
 
 Base64 encode the secret
@@ -54,6 +50,10 @@ Base64 encode the secret
 ### `--default <DEFAULT>`
 
 Default value to use if secret is not found
+
+### `--from-file <FROM_FILE>`
+
+Read the secret value verbatim from a UTF-8 file
 
 ### `--if-missing <IF_MISSING>`
 

--- a/docs/cli/set.md
+++ b/docs/cli/set.md
@@ -43,6 +43,10 @@ Show what would be done without making changes
 
 Provider to fetch from
 
+### `--from-file <FROM_FILE>`
+
+Read the secret value verbatim from a UTF-8 file
+
 ### `--base64-encode`
 
 Base64 encode the secret

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -454,6 +454,16 @@ Write the secret to an ephemeral temp file and set the env var to the file path 
 GOOGLE_APPLICATION_CREDENTIALS = { provider = "op", value = "GCP Service Account/key file", as_file = true }
 ```
 
+When setting a secret whose contents come from a file, use `--from-file` to
+preserve the file exactly, including trailing newlines:
+
+```bash
+fnox set SSH_PRIVATE_KEY --from-file ~/.ssh/id_ed25519
+```
+
+With `as_file = true`, fnox writes those exact contents to a restricted temporary
+file and injects its path instead of the secret value.
+
 #### `json_path`
 
 Extract a field from a JSON secret value (dot notation for nesting).

--- a/fnox.usage.kdl
+++ b/fnox.usage.kdl
@@ -220,6 +220,9 @@ cmd set help="Set a secret value" {
     flag "-p --provider" help="Provider to fetch from" {
         arg <PROVIDER>
     }
+    flag --from-file help="Read the secret value verbatim from a UTF-8 file" {
+        arg <FROM_FILE>
+    }
     flag --base64-encode help="Base64 encode the secret"
     flag --default help="Default value to use if secret is not found" {
         arg <DEFAULT>

--- a/fnox.usage.kdl
+++ b/fnox.usage.kdl
@@ -220,12 +220,12 @@ cmd set help="Set a secret value" {
     flag "-p --provider" help="Provider to fetch from" {
         arg <PROVIDER>
     }
-    flag --from-file help="Read the secret value verbatim from a UTF-8 file" {
-        arg <FROM_FILE>
-    }
     flag --base64-encode help="Base64 encode the secret"
     flag --default help="Default value to use if secret is not found" {
         arg <DEFAULT>
+    }
+    flag --from-file help="Read the secret value verbatim from a UTF-8 file" {
+        arg <FROM_FILE>
     }
     flag --if-missing help="What to do if the secret is missing (error, warn, ignore)" {
         arg <IF_MISSING> {

--- a/src/commands/set.rs
+++ b/src/commands/set.rs
@@ -3,7 +3,7 @@ use crate::config::{self, Config, IfMissing};
 use crate::error::{FnoxError, Result};
 use clap::Args;
 use std::io::{self, Read};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 /// Resolve a remote key without carrying a reference across providers.
 fn resolve_remote_key_name<'a>(
@@ -73,6 +73,10 @@ pub struct SetCommand {
     #[arg(short = 'p', long)]
     pub provider: Option<String>,
 
+    /// Read the secret value verbatim from a UTF-8 file
+    #[arg(long, value_hint = clap::ValueHint::FilePath, conflicts_with = "value")]
+    pub from_file: Option<PathBuf>,
+
     /// Base64 encode the secret
     #[arg(long)]
     pub base64_encode: bool,
@@ -117,7 +121,14 @@ impl SetCommand {
             self.description.is_some() || self.if_missing.is_some() || self.default.is_some();
 
         // Get the secret value if provided
-        let secret_value = if let Some(ref v) = self.value {
+        let secret_value = if let Some(ref path) = self.from_file {
+            Some(std::fs::read_to_string(path).map_err(|source| {
+                FnoxError::SecretFileReadFailed {
+                    path: path.clone(),
+                    source,
+                }
+            })?)
+        } else if let Some(ref v) = self.value {
             // Value provided as argument
             Some(v.clone())
         } else if has_metadata && self.key_name.is_none() {

--- a/src/commands/set.rs
+++ b/src/commands/set.rs
@@ -73,10 +73,6 @@ pub struct SetCommand {
     #[arg(short = 'p', long)]
     pub provider: Option<String>,
 
-    /// Read the secret value verbatim from a UTF-8 file
-    #[arg(long, value_hint = clap::ValueHint::FilePath, conflicts_with = "value")]
-    pub from_file: Option<PathBuf>,
-
     /// Base64 encode the secret
     #[arg(long)]
     pub base64_encode: bool,
@@ -84,6 +80,10 @@ pub struct SetCommand {
     /// Default value to use if secret is not found
     #[arg(long)]
     pub default: Option<String>,
+
+    /// Read the secret value verbatim from a UTF-8 file
+    #[arg(long, value_hint = clap::ValueHint::FilePath, conflicts_with = "value")]
+    pub from_file: Option<PathBuf>,
 
     /// What to do if the secret is missing (error, warn, ignore)
     #[arg(long)]

--- a/test/set_from_file.bats
+++ b/test/set_from_file.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+
+setup() {
+	load 'test_helper/common_setup'
+	_common_setup
+}
+
+teardown() {
+	_common_teardown
+}
+
+@test "set --from-file preserves a trailing newline for as_file secrets" {
+	cat >fnox.toml <<'EOF'
+root = true
+
+[providers.plain]
+type = "plain"
+
+[secrets]
+SSH_PRIVATE_KEY = { provider = "plain", value = "placeholder", as_file = true }
+EOF
+
+	cat >ssh_key <<'EOF'
+-----BEGIN OPENSSH PRIVATE KEY-----
+test-key-data
+-----END OPENSSH PRIVATE KEY-----
+EOF
+
+	run "$FNOX_BIN" set SSH_PRIVATE_KEY --from-file ssh_key
+	assert_success
+
+	run "$FNOX_BIN" exec sh -c 'cmp -s "$SSH_PRIVATE_KEY" ssh_key'
+	assert_success
+}
+
+@test "set --from-file reports a missing input file" {
+	cat >fnox.toml <<'EOF'
+root = true
+
+[providers.plain]
+type = "plain"
+
+[secrets]
+EOF
+
+	run "$FNOX_BIN" set MY_SECRET --from-file does-not-exist --provider plain
+	assert_failure
+	assert_output --partial "Failed to read secret file: does-not-exist"
+}


### PR DESCRIPTION
## Summary

- add `fnox set --from-file <path>` to read UTF-8 secret files verbatim
- preserve trailing newlines when storing file-backed secrets
- document the `--from-file` and `as_file` workflow
- add regression coverage that compares the generated secret file byte-for-byte with the input

## Root cause

`fnox set` trims values read from stdin, and shell command substitution also removes trailing newlines. As a result, SSH private keys could lose their required final newline before `as_file` wrote the stored value to a temporary file. `--base64-encode` did not help when fnox read the source from stdin because normalization happened before encoding.

This adds an explicit file input path without changing the documented `echo "x" | fnox set KEY` behavior.

Related to https://github.com/jdx/fnox/discussions/728

## Validation

- `mise run test:bats -- test/set_from_file.bats`
- `mise run lint-fix`
- `mise run render:usage`
- `cargo test --locked --bin fnox`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped CLI addition on `set` with clear error handling; stdin and argument paths are unchanged aside from the new flag priority.
> 
> **Overview**
> Adds **`fnox set --from-file <path>`** so secret values can be loaded from a UTF-8 file **without trimming** (including trailing newlines), which stdin and shell substitution could strip—important for **`as_file`** secrets like SSH keys.
> 
> The **`set`** command resolves file input ahead of the value/stdin/prompt path, maps read failures to **`SecretFileReadFailed`**, and **clap** blocks combining **`--from-file`** with a positional **`VALUE`**. CLI usage docs, **`as_file`** configuration guidance, and Bats coverage (byte-for-byte **`as_file`** output and missing-file errors) are updated; existing piped-stdin **`set`** behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 807f6e6391d720788a0596e8ca07547247e21b90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `fnox set --from-file` to read secret values verbatim from UTF-8 files.
  * Preserves file contents, including trailing newlines.
  * Supports writing exact contents to restricted temporary files for file-based secrets.
  * Prevents combining `--from-file` with direct value input.

* **Bug Fixes**
  * Improved error reporting when the specified secret file cannot be read.

* **Documentation**
  * Updated command help and configuration documentation with the new option and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->