### PR TITLE
docs: prevent mobile banner layout shifts

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -193,24 +193,26 @@ export default defineConfig({
     var c = JSON.parse(localStorage.getItem("jdx-banner-cache") || "null");
     var expires = c && c.expires ? Date.parse(c.expires) : NaN;
     var now = Date.now();
-    var valid =
+    var metadataValid =
       c &&
       typeof c.id === "string" &&
       typeof c.height === "string" &&
-      /^[1-9]\d*(?:\.\d+)?px$/.test(c.height) &&
+      /^[1-9]\\d*(?:\\.\\d+)?px$/.test(c.height) &&
       Number.isFinite(c.width) &&
-      c.width === innerWidth &&
       typeof c.fontSize === "string" &&
-      c.fontSize === getComputedStyle(d).fontSize &&
       Number.isFinite(c.pixelRatio) &&
-      c.pixelRatio === devicePixelRatio &&
       Number.isFinite(c.cachedAt) &&
       c.cachedAt <= now &&
       now - c.cachedAt < 300000 &&
       (!c.expires || (typeof c.expires === "string" && Number.isFinite(expires) && now < expires));
-    if (valid && localStorage.getItem("jdx-banner-dismissed") !== c.id)
+    var contextMatches =
+      metadataValid &&
+      c.width === innerWidth &&
+      c.fontSize === getComputedStyle(d).fontSize &&
+      c.pixelRatio === devicePixelRatio;
+    if (contextMatches && localStorage.getItem("jdx-banner-dismissed") !== c.id)
       d.style.setProperty("--vp-layout-top-height", c.height);
-    else if (c)
+    else if (c && !metadataValid)
       localStorage.removeItem("jdx-banner-cache");
   } catch (e) {}
 })();`,

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -190,10 +190,17 @@ export default defineConfig({
       `(function () {
   try {
     var d = document.documentElement;
-    var id = localStorage.getItem("jdx-banner-id");
-    var h = localStorage.getItem("jdx-banner-height");
-    if (id && h && localStorage.getItem("jdx-banner-dismissed") !== id)
-      d.style.setProperty("--vp-layout-top-height", h);
+    var c = JSON.parse(localStorage.getItem("jdx-banner-cache") || "null");
+    var expires = c && c.expires ? Date.parse(c.expires) : NaN;
+    if (
+      c &&
+      c.id &&
+      c.height &&
+      c.width === innerWidth &&
+      (!c.expires || isNaN(expires) || Date.now() < expires) &&
+      localStorage.getItem("jdx-banner-dismissed") !== c.id
+    )
+      d.style.setProperty("--vp-layout-top-height", c.height);
   } catch (e) {}
 })();`,
     ],

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -192,12 +192,17 @@ export default defineConfig({
     var d = document.documentElement;
     var c = JSON.parse(localStorage.getItem("jdx-banner-cache") || "null");
     var expires = c && c.expires ? Date.parse(c.expires) : NaN;
+    var now = Date.now();
     if (
       c &&
       c.id &&
       c.height &&
       c.width === innerWidth &&
-      (!c.expires || isNaN(expires) || Date.now() < expires) &&
+      c.fontSize === getComputedStyle(d).fontSize &&
+      c.pixelRatio === devicePixelRatio &&
+      Number.isFinite(c.cachedAt) &&
+      now - c.cachedAt < 300000 &&
+      (!c.expires || (Number.isFinite(expires) && now < expires)) &&
       localStorage.getItem("jdx-banner-dismissed") !== c.id
     )
       d.style.setProperty("--vp-layout-top-height", c.height);

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -193,19 +193,25 @@ export default defineConfig({
     var c = JSON.parse(localStorage.getItem("jdx-banner-cache") || "null");
     var expires = c && c.expires ? Date.parse(c.expires) : NaN;
     var now = Date.now();
-    if (
+    var valid =
       c &&
-      c.id &&
-      c.height &&
+      typeof c.id === "string" &&
+      typeof c.height === "string" &&
+      /^[1-9]\d*(?:\.\d+)?px$/.test(c.height) &&
+      Number.isFinite(c.width) &&
       c.width === innerWidth &&
+      typeof c.fontSize === "string" &&
       c.fontSize === getComputedStyle(d).fontSize &&
+      Number.isFinite(c.pixelRatio) &&
       c.pixelRatio === devicePixelRatio &&
       Number.isFinite(c.cachedAt) &&
+      c.cachedAt <= now &&
       now - c.cachedAt < 300000 &&
-      (!c.expires || (Number.isFinite(expires) && now < expires)) &&
-      localStorage.getItem("jdx-banner-dismissed") !== c.id
-    )
+      (!c.expires || (typeof c.expires === "string" && Number.isFinite(expires) && now < expires));
+    if (valid && localStorage.getItem("jdx-banner-dismissed") !== c.id)
       d.style.setProperty("--vp-layout-top-height", c.height);
+    else if (c)
+      localStorage.removeItem("jdx-banner-cache");
   } catch (e) {}
 })();`,
     ],

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -184,6 +184,19 @@ export default defineConfig({
     },
   },
   head: [
+    [
+      "script",
+      {},
+      `(function () {
+  try {
+    var d = document.documentElement;
+    var id = localStorage.getItem("jdx-banner-id");
+    var h = localStorage.getItem("jdx-banner-height");
+    if (id && h && localStorage.getItem("jdx-banner-dismissed") !== id)
+      d.style.setProperty("--vp-layout-top-height", h);
+  } catch (e) {}
+})();`,
+    ],
     ["link", { rel: "icon", href: "/favicon.ico", sizes: "any" }],
     [
       "link",

--- a/docs/.vitepress/theme/banner.css
+++ b/docs/.vitepress/theme/banner.css
@@ -14,6 +14,7 @@
   font-size: 0.9rem;
   line-height: 1.4;
   text-align: center;
+  min-height: 2.75rem;
 }
 .jdx-banner a {
   color: #000;
@@ -31,7 +32,11 @@
   font-size: 1.25rem;
   cursor: pointer;
   line-height: 1;
-  padding: 0 0.5rem;
+  display: grid;
+  place-items: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  padding: 0;
   opacity: 0.7;
 }
 .jdx-banner button:hover {
@@ -47,8 +52,8 @@
     text-wrap: balance;
   }
   .jdx-banner button {
-    top: 0.25rem;
-    right: 0.25rem;
-    transform: none;
+    top: 50%;
+    right: 0;
+    transform: translateY(-50%);
   }
 }

--- a/docs/.vitepress/theme/banner.css
+++ b/docs/.vitepress/theme/banner.css
@@ -49,7 +49,7 @@
     flex-direction: column;
     gap: 0.125rem;
     font-size: 0.8rem;
-    padding: 0.5rem 2.75rem;
+    padding: 0.5rem max(2.75rem, 44px);
     line-height: 1.3;
     text-wrap: balance;
   }

--- a/docs/.vitepress/theme/banner.css
+++ b/docs/.vitepress/theme/banner.css
@@ -36,6 +36,8 @@
   place-items: center;
   width: 2.75rem;
   height: 2.75rem;
+  min-width: 44px;
+  min-height: 44px;
   padding: 0;
   opacity: 0.7;
 }
@@ -47,7 +49,7 @@
     flex-direction: column;
     gap: 0.125rem;
     font-size: 0.8rem;
-    padding: 0.5rem 2.25rem;
+    padding: 0.5rem 2.75rem;
     line-height: 1.3;
     text-wrap: balance;
   }

--- a/docs/.vitepress/theme/banner.css
+++ b/docs/.vitepress/theme/banner.css
@@ -8,7 +8,7 @@
   gap: 0.75rem;
   align-items: center;
   justify-content: center;
-  padding: 0.5rem 2.75rem;
+  padding: 0.5rem 3.25rem 0.5rem 2.75rem;
   background: var(--vp-c-brand-1, #d4af37);
   color: #000;
   font-size: 0.9rem;

--- a/docs/.vitepress/theme/banner.js
+++ b/docs/.vitepress/theme/banner.js
@@ -17,7 +17,10 @@ export function initBanner() {
   const controller = new AbortController();
   const timeout = window.setTimeout(() => controller.abort(), 5000);
   fetch(ENDPOINT, { signal: controller.signal })
-    .then((r) => (r.ok ? r.json() : null))
+    .then((r) => {
+      if (!r.ok) throw new Error(`banner request failed: ${r.status}`);
+      return r.json();
+    })
     .then((b) => {
       if (
         !b ||
@@ -30,8 +33,16 @@ export function initBanner() {
       }
       render(b);
     })
-    .catch(clearCurrentReservation)
+    .catch(clearCachedReservation)
     .finally(() => window.clearTimeout(timeout));
+}
+
+function clearCachedReservation() {
+  try {
+    localStorage.removeItem(CACHE_KEY);
+  } catch {
+    // localStorage unavailable — nothing cached to clear.
+  }
 }
 
 function clearCurrentReservation() {
@@ -40,11 +51,7 @@ function clearCurrentReservation() {
 
 function clearReserved() {
   clearCurrentReservation();
-  try {
-    localStorage.removeItem(CACHE_KEY);
-  } catch {
-    // localStorage unavailable — nothing cached to clear.
-  }
+  clearCachedReservation();
 }
 
 function isExpired(expires) {
@@ -94,6 +101,9 @@ function render(b) {
           id: b.id,
           height: `${el.offsetHeight}px`,
           width: window.innerWidth,
+          fontSize: getComputedStyle(document.documentElement).fontSize,
+          pixelRatio: window.devicePixelRatio,
+          cachedAt: Date.now(),
           expires: b.expires ?? null,
         }),
       );

--- a/docs/.vitepress/theme/banner.js
+++ b/docs/.vitepress/theme/banner.js
@@ -37,7 +37,7 @@ export function initBanner() {
         return;
       }
       if (activeBanner?.id === b.id) {
-        cacheBanner(b, activeBanner.element.offsetHeight);
+        activeBanner.update(b);
         return;
       }
       render(b);
@@ -133,36 +133,53 @@ function removeActiveBanner() {
 
 function render(b, persist = true) {
   removeActiveBanner();
+  let currentBanner = b;
+  let shouldPersist = persist;
   const el = document.createElement("div");
   el.className = "jdx-banner";
   el.setAttribute("role", "region");
   el.setAttribute("aria-label", "Site announcement");
 
   const msg = document.createElement("span");
-  msg.textContent = b.message;
   el.appendChild(msg);
 
-  if (b.link && isHttpUrl(b.link)) {
-    const a = document.createElement("a");
-    a.href = b.link;
-    a.target = "_blank";
-    a.rel = "noopener";
-    a.textContent = b.linkText || "Learn more";
-    el.appendChild(a);
-  }
+  const link = document.createElement("a");
+  link.target = "_blank";
+  link.rel = "noopener";
+  el.appendChild(link);
+
+  const updateContent = (next) => {
+    currentBanner = next;
+    msg.textContent = next.message;
+    if (next.link && isHttpUrl(next.link)) {
+      link.href = next.link;
+      link.textContent = next.linkText || "Learn more";
+      link.hidden = false;
+    } else {
+      link.removeAttribute("href");
+      link.textContent = "";
+      link.hidden = true;
+    }
+  };
+  updateContent(b);
 
   const syncHeight = () => {
     document.documentElement.style.setProperty(
       "--vp-layout-top-height",
       `${el.offsetHeight}px`,
     );
-    if (persist) cacheBanner(b, el.offsetHeight);
+    if (shouldPersist) cacheBanner(currentBanner, el.offsetHeight);
   };
 
   const observer =
     typeof ResizeObserver !== "undefined"
       ? new ResizeObserver(syncHeight)
       : null;
+  const update = (next) => {
+    shouldPersist = true;
+    updateContent(next);
+    requestAnimationFrame(syncHeight);
+  };
 
   const btn = document.createElement("button");
   btn.type = "button";
@@ -170,7 +187,7 @@ function render(b, persist = true) {
   btn.textContent = "\u00d7";
   btn.addEventListener("click", () => {
     try {
-      localStorage.setItem(STORAGE_KEY, b.id);
+      localStorage.setItem(STORAGE_KEY, currentBanner.id);
     } catch {
       // Dismiss for this page even when localStorage is unavailable.
     }
@@ -180,7 +197,7 @@ function render(b, persist = true) {
   el.appendChild(btn);
 
   document.body.prepend(el);
-  activeBanner = { id: b.id, element: el, observer };
+  activeBanner = { id: b.id, element: el, observer, update };
 
   requestAnimationFrame(syncHeight);
   observer?.observe(el);

--- a/docs/.vitepress/theme/banner.js
+++ b/docs/.vitepress/theme/banner.js
@@ -126,6 +126,7 @@ function cacheBanner(b, height) {
 }
 
 function removeActiveBanner() {
+  activeBanner?.cancelExpiration();
   activeBanner?.observer?.disconnect();
   activeBanner?.element.remove();
   activeBanner = undefined;
@@ -175,9 +176,35 @@ function render(b, persist = true) {
     typeof ResizeObserver !== "undefined"
       ? new ResizeObserver(syncHeight)
       : null;
+  let expirationTimer;
+  const cancelExpiration = () => {
+    if (expirationTimer !== undefined) window.clearTimeout(expirationTimer);
+    expirationTimer = undefined;
+  };
+  const scheduleExpiration = () => {
+    cancelExpiration();
+    if (!currentBanner.expires) return;
+    const expiresAt = Date.parse(currentBanner.expires);
+    if (Number.isNaN(expiresAt)) return;
+    const expire = () => {
+      if (activeBanner?.element !== el) return;
+      const remaining = expiresAt - Date.now();
+      if (remaining <= 0) {
+        removeActiveBanner();
+        clearReserved();
+        return;
+      }
+      expirationTimer = window.setTimeout(
+        expire,
+        Math.min(remaining, 2_147_483_647),
+      );
+    };
+    expire();
+  };
   const update = (next) => {
     shouldPersist = true;
     updateContent(next);
+    scheduleExpiration();
     requestAnimationFrame(syncHeight);
   };
 
@@ -197,7 +224,14 @@ function render(b, persist = true) {
   el.appendChild(btn);
 
   document.body.prepend(el);
-  activeBanner = { id: b.id, element: el, observer, update };
+  activeBanner = {
+    id: b.id,
+    element: el,
+    observer,
+    update,
+    cancelExpiration,
+  };
+  scheduleExpiration();
 
   requestAnimationFrame(syncHeight);
   observer?.observe(el);

--- a/docs/.vitepress/theme/banner.js
+++ b/docs/.vitepress/theme/banner.js
@@ -2,33 +2,46 @@ import "./banner.css";
 
 const ENDPOINT = "https://jdx.dev/banner.json";
 const STORAGE_KEY = "jdx-banner-dismissed";
-const ID_KEY = "jdx-banner-id";
-const HEIGHT_KEY = "jdx-banner-height";
+const CACHE_KEY = "jdx-banner-cache";
+
+function getDismissedId() {
+  try {
+    return localStorage.getItem(STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
 
 export function initBanner() {
   if (typeof window === "undefined") return;
-  fetch(ENDPOINT)
+  const controller = new AbortController();
+  const timeout = window.setTimeout(() => controller.abort(), 5000);
+  fetch(ENDPOINT, { signal: controller.signal })
     .then((r) => (r.ok ? r.json() : null))
     .then((b) => {
       if (
         !b ||
         !b.enabled ||
         isExpired(b.expires) ||
-        localStorage.getItem(STORAGE_KEY) === b.id
+        getDismissedId() === b.id
       ) {
         clearReserved();
         return;
       }
       render(b);
     })
-    .catch(clearReserved);
+    .catch(clearCurrentReservation)
+    .finally(() => window.clearTimeout(timeout));
+}
+
+function clearCurrentReservation() {
+  document.documentElement.style.removeProperty("--vp-layout-top-height");
 }
 
 function clearReserved() {
-  document.documentElement.style.removeProperty("--vp-layout-top-height");
+  clearCurrentReservation();
   try {
-    localStorage.removeItem(ID_KEY);
-    localStorage.removeItem(HEIGHT_KEY);
+    localStorage.removeItem(CACHE_KEY);
   } catch {
     // localStorage unavailable — nothing cached to clear.
   }
@@ -75,8 +88,15 @@ function render(b) {
       `${el.offsetHeight}px`,
     );
     try {
-      localStorage.setItem(ID_KEY, b.id);
-      localStorage.setItem(HEIGHT_KEY, `${el.offsetHeight}px`);
+      localStorage.setItem(
+        CACHE_KEY,
+        JSON.stringify({
+          id: b.id,
+          height: `${el.offsetHeight}px`,
+          width: window.innerWidth,
+          expires: b.expires ?? null,
+        }),
+      );
     } catch {
       // localStorage unavailable — skip caching.
     }
@@ -92,7 +112,11 @@ function render(b) {
   btn.setAttribute("aria-label", "Dismiss");
   btn.textContent = "\u00d7";
   btn.addEventListener("click", () => {
-    localStorage.setItem(STORAGE_KEY, b.id);
+    try {
+      localStorage.setItem(STORAGE_KEY, b.id);
+    } catch {
+      // Dismiss for this page even when localStorage is unavailable.
+    }
     observer?.disconnect();
     el.remove();
     clearReserved();

--- a/docs/.vitepress/theme/banner.js
+++ b/docs/.vitepress/theme/banner.js
@@ -3,6 +3,7 @@ import "./banner.css";
 const ENDPOINT = "https://jdx.dev/banner.json";
 const STORAGE_KEY = "jdx-banner-dismissed";
 const CACHE_KEY = "jdx-banner-cache";
+let activeBanner;
 
 function getDismissedId() {
   try {
@@ -14,6 +15,9 @@ function getDismissedId() {
 
 export function initBanner() {
   if (typeof window === "undefined") return;
+  const cachedBanner = readCachedBanner();
+  if (cachedBanner) render(cachedBanner, false);
+
   const controller = new AbortController();
   const timeout = window.setTimeout(() => controller.abort(), 5000);
   fetch(ENDPOINT, { signal: controller.signal })
@@ -28,13 +32,40 @@ export function initBanner() {
         isExpired(b.expires) ||
         getDismissedId() === b.id
       ) {
+        removeActiveBanner();
         clearReserved();
         return;
       }
       render(b);
     })
-    .catch(clearCachedReservation)
+    .catch(() => {
+      clearCachedReservation();
+      if (!activeBanner) clearCurrentReservation();
+    })
     .finally(() => window.clearTimeout(timeout));
+}
+
+function readCachedBanner() {
+  if (
+    !document.documentElement.style.getPropertyValue("--vp-layout-top-height")
+  ) {
+    return null;
+  }
+  try {
+    const cached = JSON.parse(localStorage.getItem(CACHE_KEY) ?? "null");
+    const b = cached?.banner;
+    return b &&
+      typeof b.id === "string" &&
+      typeof b.enabled === "boolean" &&
+      typeof b.message === "string" &&
+      (!b.link || typeof b.link === "string") &&
+      (!b.linkText || typeof b.linkText === "string") &&
+      (!b.expires || typeof b.expires === "string")
+      ? b
+      : null;
+  } catch {
+    return null;
+  }
 }
 
 function clearCachedReservation() {
@@ -70,7 +101,14 @@ function isHttpUrl(value) {
   }
 }
 
-function render(b) {
+function removeActiveBanner() {
+  activeBanner?.observer?.disconnect();
+  activeBanner?.element.remove();
+  activeBanner = undefined;
+}
+
+function render(b, persist = true) {
+  removeActiveBanner();
   const el = document.createElement("div");
   el.className = "jdx-banner";
   el.setAttribute("role", "region");
@@ -95,6 +133,7 @@ function render(b) {
       `${el.offsetHeight}px`,
     );
     try {
+      if (!persist) return;
       localStorage.setItem(
         CACHE_KEY,
         JSON.stringify({
@@ -105,6 +144,7 @@ function render(b) {
           pixelRatio: window.devicePixelRatio,
           cachedAt: Date.now(),
           expires: b.expires ?? null,
+          banner: b,
         }),
       );
     } catch {
@@ -127,13 +167,13 @@ function render(b) {
     } catch {
       // Dismiss for this page even when localStorage is unavailable.
     }
-    observer?.disconnect();
-    el.remove();
+    removeActiveBanner();
     clearReserved();
   });
   el.appendChild(btn);
 
   document.body.prepend(el);
+  activeBanner = { element: el, observer };
 
   requestAnimationFrame(syncHeight);
   observer?.observe(el);

--- a/docs/.vitepress/theme/banner.js
+++ b/docs/.vitepress/theme/banner.js
@@ -36,6 +36,10 @@ export function initBanner() {
         clearReserved();
         return;
       }
+      if (activeBanner?.id === b.id) {
+        cacheBanner(b, activeBanner.element.offsetHeight);
+        return;
+      }
       render(b);
     })
     .catch(() => {
@@ -101,6 +105,26 @@ function isHttpUrl(value) {
   }
 }
 
+function cacheBanner(b, height) {
+  try {
+    localStorage.setItem(
+      CACHE_KEY,
+      JSON.stringify({
+        id: b.id,
+        height: `${height}px`,
+        width: window.innerWidth,
+        fontSize: getComputedStyle(document.documentElement).fontSize,
+        pixelRatio: window.devicePixelRatio,
+        cachedAt: Date.now(),
+        expires: b.expires ?? null,
+        banner: b,
+      }),
+    );
+  } catch {
+    // localStorage unavailable — skip caching.
+  }
+}
+
 function removeActiveBanner() {
   activeBanner?.observer?.disconnect();
   activeBanner?.element.remove();
@@ -132,24 +156,7 @@ function render(b, persist = true) {
       "--vp-layout-top-height",
       `${el.offsetHeight}px`,
     );
-    try {
-      if (!persist) return;
-      localStorage.setItem(
-        CACHE_KEY,
-        JSON.stringify({
-          id: b.id,
-          height: `${el.offsetHeight}px`,
-          width: window.innerWidth,
-          fontSize: getComputedStyle(document.documentElement).fontSize,
-          pixelRatio: window.devicePixelRatio,
-          cachedAt: Date.now(),
-          expires: b.expires ?? null,
-          banner: b,
-        }),
-      );
-    } catch {
-      // localStorage unavailable — skip caching.
-    }
+    if (persist) cacheBanner(b, el.offsetHeight);
   };
 
   const observer =
@@ -173,7 +180,7 @@ function render(b, persist = true) {
   el.appendChild(btn);
 
   document.body.prepend(el);
-  activeBanner = { element: el, observer };
+  activeBanner = { id: b.id, element: el, observer };
 
   requestAnimationFrame(syncHeight);
   observer?.observe(el);

--- a/docs/.vitepress/theme/banner.js
+++ b/docs/.vitepress/theme/banner.js
@@ -2,18 +2,36 @@ import "./banner.css";
 
 const ENDPOINT = "https://jdx.dev/banner.json";
 const STORAGE_KEY = "jdx-banner-dismissed";
+const ID_KEY = "jdx-banner-id";
+const HEIGHT_KEY = "jdx-banner-height";
 
 export function initBanner() {
   if (typeof window === "undefined") return;
   fetch(ENDPOINT)
     .then((r) => (r.ok ? r.json() : null))
     .then((b) => {
-      if (!b || !b.enabled) return;
-      if (isExpired(b.expires)) return;
-      if (localStorage.getItem(STORAGE_KEY) === b.id) return;
+      if (
+        !b ||
+        !b.enabled ||
+        isExpired(b.expires) ||
+        localStorage.getItem(STORAGE_KEY) === b.id
+      ) {
+        clearReserved();
+        return;
+      }
       render(b);
     })
-    .catch(() => {});
+    .catch(clearReserved);
+}
+
+function clearReserved() {
+  document.documentElement.style.removeProperty("--vp-layout-top-height");
+  try {
+    localStorage.removeItem(ID_KEY);
+    localStorage.removeItem(HEIGHT_KEY);
+  } catch {
+    // localStorage unavailable — nothing cached to clear.
+  }
 }
 
 function isExpired(expires) {
@@ -56,6 +74,12 @@ function render(b) {
       "--vp-layout-top-height",
       `${el.offsetHeight}px`,
     );
+    try {
+      localStorage.setItem(ID_KEY, b.id);
+      localStorage.setItem(HEIGHT_KEY, `${el.offsetHeight}px`);
+    } catch {
+      // localStorage unavailable — skip caching.
+    }
   };
 
   const observer =
@@ -71,7 +95,7 @@ function render(b) {
     localStorage.setItem(STORAGE_KEY, b.id);
     observer?.disconnect();
     el.remove();
-    document.documentElement.style.removeProperty("--vp-layout-top-height");
+    clearReserved();
   });
   el.appendChild(btn);
 


### PR DESCRIPTION
## Summary

- cache the active announcement id and rendered height
- reserve the cached height before hydration on repeat visits
- clear stale reservations when the banner is disabled, expired, dismissed, or unavailable
- increase the dismiss control to a 44px mobile touch target

## Why

The remotely loaded announcement moved the navbar after hydration on every page load. Reusing the measured height avoids that repeated layout shift without hard-coding a banner size.

## Validation

- `npm run docs:build`
- Chromium mobile audit at 320px
- verified a delayed warm reload preserves the 51px navbar offset
- verified the dismiss target renders at 44×44px

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only announcement UI and localStorage caching; no auth, APIs, or data handling beyond existing remote banner fetch.
> 
> **Overview**
> Reduces **layout shift** when the docs site loads a remote announcement banner by reserving navbar top space before hydration and reusing the last measured height on repeat visits.
> 
> A **head inline script** in VitePress config reads `jdx-banner-cache` from `localStorage`, validates cache age (~5 min), expiry, dismiss state, and viewport context (width, root font size, pixel ratio), then sets `--vp-layout-top-height` early when the cache still applies.
> 
> **`banner.js`** now caches measured height and banner payload after render, paints from cache when that CSS variable is already set, fetches `banner.json` with a 5s abort, and clears stale spacing when the banner is off, expired, dismissed, or the request fails. It tracks a single `activeBanner` (update in place, scheduled expiry, teardown on dismiss).
> 
> **`banner.css`** adds a minimum banner height, enlarges the dismiss control to a **44×44px** touch target, and adjusts mobile padding so the close button stays vertically centered.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f06c19970eca2b1dd7da44a30b0afd46e704b30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved banner layout stability when returning to a page.
  - Validated saved banner layouts against display settings and cache age.
  - Removed invalid saved banner data automatically.
  - Prevented stale banner spacing after dismissal, expiration, removal, or loading errors.
  - Improved handling of unavailable storage and failed banner loads.
  - Ensured restored banner spacing matches the current display size.
  - Improved close-button alignment and sizing, including on mobile devices.
  - Added a minimum banner height for more consistent display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->