### PR TITLE
docs: document ${DEFAULT} syntax

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -416,9 +416,11 @@ BASE_URL = { default = "example.com" }
 matter. Referenced secrets must be defined in the config and can resolve from a
 provider, a default, or an environment variable. Profile overrides also apply.
 
-Interpolation only works in `default` values. Provider values take precedence
-over defaults. Undefined references and dependency cycles are errors. A
-reference allowed to be missing expands to an empty string.
+Interpolation only works in `default` values. Resolution order is provider
+values, interpolated defaults, literal defaults, then environment variables.
+Undefined references and dependency cycles in an evaluated default are errors.
+If a referenced secret is defined but resolves to no value under a non-error
+`if_missing` policy, the reference expands to an empty string.
 
 **Use for:**
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -404,6 +404,22 @@ Fallback value if secret cannot be resolved.
 DATABASE_URL = { provider = "age", value = "encrypted...", default = "postgresql://localhost/dev" }  # Fallback for local dev
 ```
 
+Use `${SECRET_NAME}` to include another secret in a default value:
+
+```toml
+[secrets]
+API_BASE_URL = { default = "https://api.${BASE_URL}" }
+BASE_URL = { default = "example.com" }
+```
+
+`API_BASE_URL` resolves to `https://api.example.com`. Declaration order does not
+matter. Referenced secrets must be defined in the config and can resolve from a
+provider, a default, or an environment variable. Profile overrides also apply.
+
+Interpolation only works in `default` values. Provider values take precedence
+over defaults. Undefined references and dependency cycles are errors. A
+reference allowed to be missing expands to an empty string.
+
 **Use for:**
 
 - Non-sensitive defaults


### PR DESCRIPTION
I was about to open an issue asking for this feature, to then, after reading the code, realize it was already implemented :)

btw, why are issues disabled in this repo? Maybe worth adding a readme note explaining why?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Documentation**
  - Documented secret interpolation in default values using `${SECRET_NAME}` references.
  - Explained resolution order across providers, interpolated defaults, literal defaults, and environment variables.
  - Clarified that profile overrides are supported regardless of declaration order.
  - Documented errors for undefined references and dependency cycles.
  - Explained how defined references with non-error missing-value policies expand to an empty string.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->