### PR TITLE
fix(config): encode html in generated documentation

### DIFF
--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -11,7 +11,7 @@
 
 Path to a file containing the age encryption key.
 
-This can be set via: - CLI flag: --age-key-file <path> - Environment variable: FNOX_AGE_KEY_FILE
+This can be set via: - CLI flag: --age-key-file &lt;path> - Environment variable: FNOX_AGE_KEY_FILE
 
 Priority (highest to lowest): CLI > Environment > Default
 
@@ -93,7 +93,7 @@ export FNOX_IF_MISSING_DEFAULT=ignore  # Lenient by default
 - **since**: 1.12.0
 - **set with**: `--no-defaults`, `FNOX_NO_DEFAULTS`
 
-When a non-default profile is selected, do not merge top-level [secrets] into the profile. Only [profiles.<name>.secrets] will be used.
+When a non-default profile is selected, do not merge top-level [secrets] into the profile. Only [profiles.&lt;name>.secrets] will be used.
 
 Priority (highest to lowest): CLI > Environment > Default
 

--- a/mise.toml
+++ b/mise.toml
@@ -91,7 +91,7 @@ depends = ["build"]
 run = [
   "fnox usage > fnox.usage.kdl",
   "rm -rf docs/cli && mkdir -p docs/cli",
-  "usage g markdown -mf fnox.usage.kdl --out-dir docs/cli --url-prefix /cli",
+  "usage g markdown -mf fnox.usage.kdl --out-dir docs/cli --url-prefix /cli --html-encode",
   "perl -pi -e 'if (/^```$/) { s/$/sh/ unless $in_fence; $in_fence = !$in_fence }' docs/cli/configuration.md",
   "usage g json -f fnox.usage.kdl > docs/cli/commands.json",
   "prettier --write docs/cli",


### PR DESCRIPTION
## Summary

- enable usage-cli HTML encoding for generated Markdown
- regenerate configuration documentation with angle brackets escaped
- prevent VitePress from interpreting placeholders such as `<path>` as Vue elements

## Testing

- `mise run render:usage`
- `aube run docs:build`

*AI-assisted — Tool: Codex; model: unavailable/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-generation flag and regenerated markdown only; no runtime or security impact.
> 
> **Overview**
> Enables `--html-encode` on `usage g markdown` in `render:usage` so generated CLI docs escape angle brackets.
> 
> Regenerated `configuration.md` now uses `&lt;path>` and `&lt;name>` instead of raw `<...>` placeholders, which VitePress was treating as Vue tags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66a090f1d7c3b243e6d4b3898ebde7efaf924345. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved CLI configuration examples for safe rendering in HTML-based documentation.
  * Updated generated Markdown CLI documentation to encode special characters correctly.
  * Refreshed CLI documentation generation to use a consistent, managed tool version and improved HTML encoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->