### PR TITLE
fix(config): reject unknown profiles

### DIFF
--- a/crates/fnox-core/src/config.rs
+++ b/crates/fnox-core/src/config.rs
@@ -118,6 +118,17 @@ pub fn is_profile_file(path: &Path) -> bool {
         })
 }
 
+/// Extract the profile declared by a profile-specific config filename.
+/// `default` is excluded because `fnox.default.toml` is not a supported
+/// profile overlay.
+fn profile_name_from_file(path: &Path) -> Option<String> {
+    let name = path.file_name()?.to_str()?;
+    let name = name.strip_prefix('.').unwrap_or(name);
+    let profile = name.strip_prefix("fnox.")?.strip_suffix(".toml")?;
+    (profile != "default" && profile != "local" && env::is_valid_profile_name(profile))
+        .then(|| profile.to_string())
+}
+
 // Re-export ProviderConfig from providers module
 pub use crate::providers::ProviderConfig;
 
@@ -714,6 +725,10 @@ impl Config {
             }
         })?;
 
+        if let Some(profile) = profile_name_from_file(path) {
+            config.loaded_file_profiles.insert(profile);
+        }
+
         // Set source paths for all secrets and providers
         config.set_source_paths(path);
 
@@ -761,14 +776,7 @@ impl Config {
         for filename in &filenames {
             let path = dir.join(filename);
             if path.exists() {
-                let mut file_config = Self::load(&path)?;
-                for profile in profiles.iter().filter(|profile| *profile != "default") {
-                    if filename == &format!("fnox.{profile}.toml")
-                        || filename == &format!(".fnox.{profile}.toml")
-                    {
-                        file_config.loaded_file_profiles.insert(profile.clone());
-                    }
-                }
+                let file_config = Self::load(&path)?;
                 config = Self::merge_configs(config, file_config)?;
                 found = true;
             }

--- a/crates/fnox-core/src/config.rs
+++ b/crates/fnox-core/src/config.rs
@@ -6,7 +6,7 @@ use crate::spanned::SpannedValue;
 use indexmap::IndexMap;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::ops::Range;
 use std::path::{Path, PathBuf};
@@ -194,6 +194,10 @@ pub struct Config {
     /// Track which config file the default_provider came from (not serialized)
     #[serde(skip)]
     pub default_provider_source: Option<PathBuf>,
+
+    /// Profile names whose profile-specific config file was loaded.
+    #[serde(skip)]
+    loaded_file_profiles: HashSet<String>,
 
     /// The project root directory — the nearest directory to cwd that contains
     /// a config file. Used for scoping the lease ledger per-project.
@@ -757,7 +761,14 @@ impl Config {
         for filename in &filenames {
             let path = dir.join(filename);
             if path.exists() {
-                let file_config = Self::load(&path)?;
+                let mut file_config = Self::load(&path)?;
+                for profile in profiles.iter().filter(|profile| *profile != "default") {
+                    if filename == &format!("fnox.{profile}.toml")
+                        || filename == &format!(".fnox.{profile}.toml")
+                    {
+                        file_config.loaded_file_profiles.insert(profile.clone());
+                    }
+                }
                 config = Self::merge_configs(config, file_config)?;
                 found = true;
             }
@@ -960,6 +971,10 @@ impl Config {
         for (name, source) in overlay.secret_sources {
             merged.secret_sources.insert(name, source);
         }
+
+        merged
+            .loaded_file_profiles
+            .extend(overlay.loaded_file_profiles);
 
         // Merge profiles (overlay takes precedence)
         for (name, profile) in overlay.profiles {
@@ -1324,6 +1339,7 @@ impl Config {
             provider_sources: HashMap::new(),
             secret_sources: HashMap::new(),
             default_provider_source: None,
+            loaded_file_profiles: HashSet::new(),
             project_dir: None,
         }
     }
@@ -1363,6 +1379,39 @@ impl Config {
         } else {
             profiles.join(",")
         }
+    }
+
+    /// Return all profile names declared by a profile table or by a loaded
+    /// profile-specific config file.
+    pub fn available_profiles(&self) -> Vec<String> {
+        let mut profiles = vec!["default".to_string()];
+        profiles.extend(self.profiles.keys().cloned());
+        profiles.extend(self.loaded_file_profiles.iter().cloned());
+        profiles.sort();
+        profiles.dedup();
+        profiles
+    }
+
+    /// Ensure every active profile is backed by either a `[profiles.<name>]`
+    /// table or a profile-specific config file. `allow_missing` is the profile
+    /// a write command is about to create.
+    pub fn validate_profiles(
+        &self,
+        profiles: &[String],
+        allow_missing: Option<&str>,
+    ) -> Result<()> {
+        for profile in profiles.iter().filter(|profile| *profile != "default") {
+            if Some(profile.as_str()) != allow_missing
+                && !self.profiles.contains_key(profile)
+                && !self.loaded_file_profiles.contains(profile)
+            {
+                return Err(FnoxError::ProfileNotFound {
+                    profile: profile.clone(),
+                    available_profiles: self.available_profiles(),
+                });
+            }
+        }
+        Ok(())
     }
 
     /// Resolve the write-target profile.

--- a/crates/fnox-core/src/error.rs
+++ b/crates/fnox-core/src/error.rs
@@ -122,6 +122,16 @@ pub enum FnoxError {
     // ========================================================================
     // Profile Errors
     // ========================================================================
+    #[error("Profile '{profile}' not found")]
+    #[diagnostic(
+        code(fnox::profile::not_found),
+        help("Available profiles: {}", available_profiles.join(", ")),
+        url("https://fnox.jdx.dev/guide/profiles")
+    )]
+    ProfileNotFound {
+        profile: String,
+        available_profiles: Vec<String>,
+    },
 
     // ========================================================================
     // Secret Errors

--- a/src/commands/hook_env.rs
+++ b/src/commands/hook_env.rs
@@ -262,6 +262,9 @@ async fn load_secrets_from_config(cli: &Cli) -> Result<LoadedSecrets> {
 
     // Get the active profile (settings was already loaded above)
     let profile_name = &settings.profile;
+    config
+        .validate_profiles(profile_name, None)
+        .map_err(|e| anyhow::anyhow!(e))?;
 
     // Get secrets for the profile using the Config method (inherits top-level secrets)
     let profile_secrets = config

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -317,6 +317,11 @@ impl Commands {
             Commands::List(cmd) => cmd.run(cli, self.load_config(cli)?).await,
             Commands::Mcp(cmd) => cmd.run(cli, self.load_config(cli)?).await,
             Commands::Profiles(cmd) => cmd.run(cli, self.load_config(cli)?).await,
+            Commands::Provider(cmd)
+                if matches!(&cmd.action, Some(provider::ProviderAction::Add(_))) =>
+            {
+                cmd.run(cli, Config::new()).await
+            }
             Commands::Provider(cmd) => cmd.run(cli, self.load_config(cli)?).await,
             Commands::Proxy(cmd) => cmd.run(cli, self.load_config(cli)?).await,
             Commands::Reencrypt(cmd) => cmd.run(cli, self.load_config(cli)?).await,
@@ -338,14 +343,6 @@ impl Commands {
                 &profiles,
                 cli.write_profile.as_deref(),
             )?),
-            // Provider add intentionally ignores FNOX_PROFILE and uses only
-            // explicit CLI profiles. It also loads and updates its target
-            // config independently, so there is nothing to validate here.
-            Commands::Provider(cmd)
-                if matches!(&cmd.action, Some(provider::ProviderAction::Add(_))) =>
-            {
-                return Ok(config);
-            }
             Commands::Profiles(_) => return Ok(config),
             _ => {
                 config.validate_profiles(&profiles, None)?;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -329,6 +329,7 @@ impl Commands {
         }
     }
 
+    /// Load configuration and validate the active profiles for this command.
     fn load_config(&self, cli: &Cli) -> Result<Config> {
         let config = Config::load_smart(&cli.config)?;
         let profiles = Config::get_profiles(&cli.profile);
@@ -337,13 +338,13 @@ impl Commands {
                 &profiles,
                 cli.write_profile.as_deref(),
             )?),
+            // Provider add intentionally ignores FNOX_PROFILE and uses only
+            // explicit CLI profiles. It also loads and updates its target
+            // config independently, so there is nothing to validate here.
             Commands::Provider(cmd)
                 if matches!(&cmd.action, Some(provider::ProviderAction::Add(_))) =>
             {
-                Some(Config::resolve_write_profile(
-                    &profiles,
-                    cli.write_profile.as_deref(),
-                )?)
+                return Ok(config);
             }
             Commands::Profiles(_) => return Ok(config),
             _ => {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -330,7 +330,29 @@ impl Commands {
     }
 
     fn load_config(&self, cli: &Cli) -> Result<Config> {
-        Config::load_smart(&cli.config)
+        let config = Config::load_smart(&cli.config)?;
+        let profiles = Config::get_profiles(&cli.profile);
+        let allow_missing = match self {
+            Commands::Set(_) | Commands::Import(_) => Some(Config::resolve_write_profile(
+                &profiles,
+                cli.write_profile.as_deref(),
+            )?),
+            Commands::Provider(cmd)
+                if matches!(&cmd.action, Some(provider::ProviderAction::Add(_))) =>
+            {
+                Some(Config::resolve_write_profile(
+                    &profiles,
+                    cli.write_profile.as_deref(),
+                )?)
+            }
+            Commands::Profiles(_) => return Ok(config),
+            _ => {
+                config.validate_profiles(&profiles, None)?;
+                return Ok(config);
+            }
+        };
+        config.validate_profiles(&profiles, allow_missing.as_deref())?;
+        Ok(config)
     }
 }
 

--- a/src/commands/profiles.rs
+++ b/src/commands/profiles.rs
@@ -12,10 +12,7 @@ pub struct ProfilesCommand {
 
 impl ProfilesCommand {
     pub async fn run(&self, _cli: &Cli, config: Config) -> Result<()> {
-        let mut profile_names = vec!["default".to_string()];
-        profile_names.extend(config.profiles.keys().cloned());
-        profile_names.sort();
-        profile_names.dedup();
+        let profile_names = config.available_profiles();
 
         if self.complete {
             // Output for completion

--- a/test/check.bats
+++ b/test/check.bats
@@ -47,13 +47,10 @@ EOF
 	assert_fnox_success check --profile test
 }
 
-@test "fnox check works with unknown profile (profile-specific config file support)" {
+@test "fnox check fails with unknown profile" {
 	create_test_config
-	# With fnox.$FNOX_PROFILE.toml support, unknown profiles are allowed
-	# They just use top-level secrets (same as default profile)
-	assert_fnox_success check --profile unknown
-	# Should show it's checking the profile
-	assert_output --partial "unknown"
+	assert_fnox_failure check --profile unknown
+	assert_output --partial "Profile 'unknown' not found"
 }
 
 @test "fnox check warns about unknown provider" {

--- a/test/config_hierarchy_set.bats
+++ b/test/config_hierarchy_set.bats
@@ -259,6 +259,9 @@ EOF
 [secrets]
 STAGING_EXISTING = { default = "staging" }
 EOF
+	cat >fnox.extra.toml <<EOF
+# Empty profile used to exercise a composed write target.
+EOF
 
 	# Multiple profiles without --write-profile should error
 	run "$FNOX_BIN" -P staging -P extra set NEW_SECRET "new-value"

--- a/test/profile_config.bats
+++ b/test/profile_config.bats
@@ -313,6 +313,8 @@ recipients = ["age1test"]
 
 [secrets]
 MAIN_SECRET = { description = "Main secret", default = "main-value" }
+
+[profiles.production]
 EOF
 
 	# Create production profile config
@@ -430,6 +432,52 @@ EOF
 	run "$FNOX_BIN" -P extra get S1
 	assert_success
 	assert_output --partial "v1"
+}
+
+@test 'unknown profile fails instead of exporting top-level secrets' {
+	cat >fnox.toml <<'EOF'
+root = true
+
+[secrets]
+SHARED = { default = "top-level-value" }
+EOF
+
+	run "$FNOX_BIN" export --profile typo --format json
+	assert_failure
+	assert_output --partial "Profile 'typo' not found"
+	refute_output --partial 'top-level-value'
+}
+
+@test 'profile-specific config file declares a valid profile' {
+	cat >fnox.toml <<'EOF'
+root = true
+
+[secrets]
+SHARED = { default = "top-level-value" }
+EOF
+	cat >fnox.staging.toml <<'EOF'
+[secrets]
+SHARED = { default = "staging-value" }
+EOF
+
+	run "$FNOX_BIN" export --profile staging --format json
+	assert_success
+	assert_output --partial 'staging-value'
+	assert_output --partial '"profile": "staging"'
+}
+
+@test 'set can create an unknown write profile' {
+	cat >fnox.toml <<'EOF'
+root = true
+
+[providers.plain]
+type = "plain"
+EOF
+
+	run "$FNOX_BIN" set --profile new NEW_SECRET 'new-value'
+	assert_success
+	assert_file_contains fnox.toml '\[profiles.new.secrets\]'
+	assert_file_contains fnox.toml 'NEW_SECRET.*new-value'
 }
 
 @test 'fnox.$FNOX_PROFILE.toml can override default_provider' {

--- a/test/profile_config.bats
+++ b/test/profile_config.bats
@@ -466,6 +466,20 @@ EOF
 	assert_output --partial '"profile": "staging"'
 }
 
+@test 'explicit profile-specific config file declares a valid profile' {
+	cat >fnox.staging.toml <<'EOF'
+root = true
+
+[secrets]
+SHARED = { default = "staging-value" }
+EOF
+
+	run "$FNOX_BIN" --config ./fnox.staging.toml --profile staging export --format json
+	assert_success
+	assert_output --partial 'staging-value'
+	assert_output --partial '"profile": "staging"'
+}
+
 @test 'set can create an unknown write profile' {
 	cat >fnox.toml <<'EOF'
 root = true

--- a/test/provider_add.bats
+++ b/test/provider_add.bats
@@ -92,6 +92,21 @@ vault|vault|vault"
 	assert_output --partial "[providers.myage]"
 }
 
+@test "fnox provider add ignores FNOX_PROFILE" {
+	unset FNOX_PROFILE
+	run "$FNOX_BIN" init --skip-wizard
+	assert_success
+
+	run env FNOX_PROFILE=missing,other "$FNOX_BIN" provider add myage age
+	assert_success
+
+	run cat "$FNOX_CONFIG_FILE"
+	assert_success
+	assert_output --partial "[providers.myage]"
+	refute_output --partial "[profiles.missing"
+	refute_output --partial "[profiles.other"
+}
+
 @test "fnox provider add with --profile writes to profile section" {
 	run "$FNOX_BIN" init --skip-wizard
 	assert_success

--- a/test/provider_add.bats
+++ b/test/provider_add.bats
@@ -96,15 +96,17 @@ vault|vault|vault"
 	unset FNOX_PROFILE
 	run "$FNOX_BIN" init --skip-wizard
 	assert_success
+	cat >fnox.missing.toml <<'EOF'
+this is not valid toml
+EOF
 
-	run env FNOX_PROFILE=missing,other "$FNOX_BIN" provider add myage age
+	run env FNOX_PROFILE=missing "$FNOX_BIN" provider add myage age
 	assert_success
 
 	run cat "$FNOX_CONFIG_FILE"
 	assert_success
 	assert_output --partial "[providers.myage]"
 	refute_output --partial "[profiles.missing"
-	refute_output --partial "[profiles.other"
 }
 
 @test "fnox provider add with --profile writes to profile section" {

--- a/test/shell-integration.bats
+++ b/test/shell-integration.bats
@@ -502,6 +502,24 @@ teardown() {
 	assert_output --partial 'export DEFAULT_SECRET=default-value'
 }
 
+@test "fnox hook-env does not load defaults for an unknown profile" {
+	cd "$TEST_TEMP_DIR"
+	cat >fnox.toml <<-EOF
+		[providers.plain]
+		type = "plain"
+
+		[secrets.DEFAULT_SECRET]
+		provider = "plain"
+		value = "default-value"
+	EOF
+
+	export FNOX_PROFILE="typo"
+	run "$FNOX_BIN" hook-env -s bash
+
+	assert_success
+	refute_output --partial 'DEFAULT_SECRET'
+}
+
 # ============================================================================
 # Error handling tests
 # ============================================================================


### PR DESCRIPTION
## Summary

- reject active profiles that have neither a `[profiles.<name>]` table nor a loaded profile-specific config file
- preserve creation of new profiles through `set`, `import`, and `provider add`
- prevent shell integration from loading top-level secrets for an unknown profile
- add regressions for profile files, explicit configs, composed profiles, and write targets

Addresses https://github.com/jdx/fnox/discussions/740

## Tests

- `mise run lint`
- `cargo test`
- `mise run test:bats -- test/config_hierarchy_set.bats test/profile_config.bats test/check.bats test/shell-integration.bats`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes profile selection and secret export behavior (including shell hooks). Unknown profiles now fail instead of falling back to top-level secrets, which is a breaking UX change but reduces accidental secret leakage.
> 
> **Overview**
> Unknown `--profile` / `FNOX_PROFILE` values now error unless they exist as a `[profiles.<name>]` table or a loaded `fnox.<name>.toml` overlay. Previously they fell through to top-level secrets, which could leak defaults on typos.
> 
> `set` and `import` may still create the write-target profile. `provider add` skips config load so a bogus `FNOX_PROFILE` does not block adding a top-level provider. `hook-env` also refuses unknown profiles so shell integration does not export defaults.
> 
> Profile listing includes file-declared overlays. Errors report available profiles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca5e7c0239e19ea0b0fc64b939f1551bfba28050. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Profile listings now include profiles declared in configuration files.
  - Write operations can create a new profile when explicitly targeted.
  - Profile validation now provides clearer errors and lists available profiles.

- **Bug Fixes**
  - Unknown profiles fail clearly without falling back to default secrets.
  - Profile-specific configuration files are recognized consistently across loading methods.
  - Provider creation ignores inherited profile selection and writes to the top-level configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->