### PR TITLE
fix(daemon): resolve interactive cache misses in foreground

### DIFF
--- a/crates/fnox-core/src/secret_resolver.rs
+++ b/crates/fnox-core/src/secret_resolver.rs
@@ -731,13 +731,28 @@ pub async fn resolve_secrets_batch(
     profile: &[String],
     secrets: &IndexMap<String, SecretConfig>,
 ) -> Result<IndexMap<String, Option<String>>> {
+    resolve_secrets_batch_with_pre_resolved(config, profile, secrets, &IndexMap::new()).await
+}
+
+/// Resolves multiple secrets while treating previously resolved values as
+/// dependencies that are already available.
+pub async fn resolve_secrets_batch_with_pre_resolved(
+    config: &Config,
+    profile: &[String],
+    secrets: &IndexMap<String, SecretConfig>,
+    pre_resolved: &IndexMap<String, Option<String>>,
+) -> Result<IndexMap<String, Option<String>>> {
     // Classify each secret: provider-backed vs no-provider
     let mut secret_provider: HashMap<String, (String, String)> = HashMap::new(); // key -> (provider_name, provider_value)
     let mut no_provider = Vec::new();
 
     let providers = config.get_providers(profile);
     let all_keys: Vec<String> = secrets.keys().cloned().collect();
-    let secret_keys: HashSet<&str> = all_keys.iter().map(|k| k.as_str()).collect();
+    let secret_keys: HashSet<&str> = all_keys
+        .iter()
+        .map(|key| key.as_str())
+        .chain(pre_resolved.keys().map(|key| key.as_str()))
+        .collect();
     let mut default_deps: HashMap<String, Vec<String>> = HashMap::new();
     let mut hard_default_deps: HashMap<String, Vec<String>> = HashMap::new();
 
@@ -831,7 +846,13 @@ pub async fn resolve_secrets_batch(
     let (levels, cycle) = compute_resolution_levels(&all_keys, &deps_for_secret, &no_provider_set);
 
     // Resolve each level in order
-    let mut temp_results: HashMap<String, Option<String>> = HashMap::new();
+    let mut temp_results: HashMap<String, Option<String>> =
+        pre_resolved.clone().into_iter().collect();
+    for (key, value) in pre_resolved {
+        if let Some(value) = value {
+            env::set_var(key, value);
+        }
+    }
 
     for ready in &levels {
         let level_results = resolve_level(
@@ -1706,6 +1727,33 @@ mod tests {
                 .get("DATABASE_URL")
                 .and_then(|value| value.as_ref()),
             Some(&"postgres://app@localhost/fnox".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_interpolated_default_can_use_pre_resolved_reference() {
+        let config = Config::new();
+        let secrets = IndexMap::from([(
+            "DATABASE_URL".to_string(),
+            default_secret("postgres://${POSTGRES_USER}@localhost/fnox"),
+        )]);
+        let pre_resolved =
+            IndexMap::from([("POSTGRES_USER".to_string(), Some("cached-user".to_string()))]);
+
+        let resolved = resolve_secrets_batch_with_pre_resolved(
+            &config,
+            &profile("default"),
+            &secrets,
+            &pre_resolved,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            resolved
+                .get("DATABASE_URL")
+                .and_then(|value| value.as_ref()),
+            Some(&"postgres://cached-user@localhost/fnox".to_string())
         );
     }
 

--- a/docs/guide/daemon.md
+++ b/docs/guide/daemon.md
@@ -23,6 +23,12 @@ fnox daemon clear
 fnox daemon stop
 ```
 
+On a cache miss, an interactive fnox client resolves the requested secrets in
+the foreground and sends the results to the daemon for memory-only caching.
+This keeps terminal-dependent authentication, such as a FIDO2 PIN and hardware
+key touch, attached to the terminal that invoked fnox. Explicitly
+non-interactive clients resolve misses in the daemon and never prompt.
+
 Use `--no-daemon` for a single direct resolution:
 
 ```bash
@@ -84,7 +90,7 @@ vault = "Engineering"
 daemon_cache = false
 ```
 
-This disables cache reuse for those values. If daemon mode is enabled, fnox still talks to the daemon for supported read commands; the daemon resolves those entries directly instead of returning a cached value.
+This disables cache reuse for those values. If daemon mode is enabled, fnox still talks to the daemon for supported read commands, but those entries are resolved again for every request.
 
 ## Security Model
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -52,7 +52,7 @@ impl ResolveContext {
                 || settings
                     .as_ref()
                     .is_some_and(|settings| settings.no_defaults),
-            non_interactive: cli.non_interactive,
+            non_interactive: cli.non_interactive || crate::env::is_non_interactive(),
             no_daemon: cli.no_daemon,
         }
     }
@@ -94,6 +94,7 @@ impl Purpose {
 enum Request {
     ResolveBatch(ResolveBatchRequest),
     ResolveOne(ResolveOneRequest),
+    StoreResolved(StoreResolvedRequest),
     Status,
     Clear,
     Shutdown,
@@ -135,11 +136,21 @@ struct ResolveOneRequest {
     env: Vec<(String, String)>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct StoreResolvedRequest {
+    request: ResolveBatchRequest,
+    fingerprint: String,
+    values: IndexMap<String, Option<String>>,
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "status", rename_all = "snake_case")]
 enum Response {
     Resolved {
         values: IndexMap<String, Option<String>>,
+    },
+    ResolveInForeground {
+        fingerprint: String,
     },
     Status {
         pid: u32,
@@ -232,7 +243,7 @@ pub async fn resolve_batch_with_context(
     }
 
     let keys = secrets.keys().cloned().collect();
-    let request = Request::ResolveBatch(ResolveBatchRequest {
+    let batch_request = ResolveBatchRequest {
         cwd: std::env::current_dir()
             .map_err(|e| FnoxError::Config(format!("Failed to get current directory: {e}")))?,
         config: ctx.config.clone(),
@@ -245,10 +256,25 @@ pub async fn resolve_batch_with_context(
         keys,
         include_all_modes,
         env: std::env::vars().collect(),
-    });
+    };
 
-    match call_or_start(ctx, config, request).await? {
+    match call_or_start(ctx, config, Request::ResolveBatch(batch_request.clone())).await? {
         Response::Resolved { values } => Ok(values),
+        Response::ResolveInForeground { fingerprint } => {
+            let secrets = if include_all_modes {
+                secrets.clone()
+            } else {
+                secrets
+                    .iter()
+                    .filter(|(_, secret)| secret.env_mode().in_shell())
+                    .map(|(key, secret)| (key.clone(), secret.clone()))
+                    .collect()
+            };
+            let values = resolve_secrets_batch(config, profile, &secrets).await?;
+            store_foreground_values(ctx, config, batch_request, fingerprint, values.clone())
+                .await?;
+            Ok(values)
+        }
         Response::Error { message } => Err(FnoxError::Config(message)),
         _ => Err(FnoxError::Config(
             "Invalid daemon response for ResolveBatch".to_string(),
@@ -287,7 +313,7 @@ pub async fn resolve_one_with_context(
         return crate::secret_resolver::resolve_secret(config, profile, key, secret_config).await;
     }
 
-    let request = Request::ResolveOne(ResolveOneRequest {
+    let one_request = ResolveOneRequest {
         cwd: std::env::current_dir()
             .map_err(|e| FnoxError::Config(format!("Failed to get current directory: {e}")))?,
         config: ctx.config.clone(),
@@ -299,13 +325,59 @@ pub async fn resolve_one_with_context(
         purpose: purpose.as_str().to_string(),
         key: key.to_string(),
         env: std::env::vars().collect(),
-    });
+    };
 
-    match call_or_start(ctx, config, request).await? {
+    match call_or_start(ctx, config, Request::ResolveOne(one_request.clone())).await? {
         Response::Resolved { mut values } => Ok(values.swap_remove(key).flatten()),
+        Response::ResolveInForeground { fingerprint } => {
+            let value =
+                crate::secret_resolver::resolve_secret(config, profile, key, secret_config).await?;
+            let values = [(key.to_string(), value.clone())].into_iter().collect();
+            let batch_request = ResolveBatchRequest {
+                cwd: one_request.cwd,
+                config: one_request.config,
+                profile: one_request.profile,
+                age_key_file: one_request.age_key_file,
+                if_missing: one_request.if_missing,
+                no_defaults: one_request.no_defaults,
+                non_interactive: one_request.non_interactive,
+                purpose: one_request.purpose,
+                keys: vec![key.to_string()],
+                include_all_modes: true,
+                env: one_request.env,
+            };
+            store_foreground_values(ctx, config, batch_request, fingerprint, values).await?;
+            Ok(value)
+        }
         Response::Error { message } => Err(FnoxError::Config(message)),
         _ => Err(FnoxError::Config(
             "Invalid daemon response for ResolveOne".to_string(),
+        )),
+    }
+}
+
+async fn store_foreground_values(
+    ctx: &ResolveContext,
+    config: &Config,
+    request: ResolveBatchRequest,
+    fingerprint: String,
+    values: IndexMap<String, Option<String>>,
+) -> Result<()> {
+    match call_or_start(
+        ctx,
+        config,
+        Request::StoreResolved(StoreResolvedRequest {
+            request,
+            fingerprint,
+            values,
+        }),
+    )
+    .await?
+    {
+        Response::Ok => Ok(()),
+        Response::Error { message } => Err(FnoxError::Config(message)),
+        _ => Err(FnoxError::Config(
+            "Invalid daemon response for StoreResolved".to_string(),
         )),
     }
 }
@@ -769,6 +841,39 @@ async fn process_request(
             let _guard = request_lock.lock().await;
             Ok(Response::Ok)
         }
+        Request::StoreResolved(req) => {
+            let _guard = request_lock.lock().await;
+            let _env = EnvOverlay::apply(&req.request.env)?;
+            let _cwd = CwdGuard::change_to(&req.request.cwd)?;
+            apply_request_settings(
+                req.request.age_key_file.clone(),
+                req.request.profile.clone(),
+                req.request.if_missing.clone(),
+                req.request.no_defaults,
+                req.request.non_interactive,
+            );
+            let config = Config::load_smart(&req.request.config)?;
+            let all_secrets = config.get_secrets(&req.request.profile)?;
+            let requested = req.request.keys.iter().cloned().collect::<HashSet<_>>();
+            let secrets: IndexMap<String, SecretConfig> = all_secrets
+                .into_iter()
+                .filter(|(key, sc)| {
+                    requested.contains(key)
+                        && (req.request.include_all_modes || sc.env_mode().in_shell())
+                })
+                .collect();
+            store_resolved_values(
+                &config,
+                &req.request.profile,
+                &secrets,
+                &req.request,
+                &req.fingerprint,
+                req.values,
+                state,
+            )
+            .await?;
+            Ok(Response::Ok)
+        }
         Request::ResolveBatch(req) => {
             let _guard = request_lock.lock().await;
             let _env = EnvOverlay::apply(&req.env)?;
@@ -789,6 +894,12 @@ async fn process_request(
                     requested.contains(key) && (req.include_all_modes || sc.env_mode().in_shell())
                 })
                 .collect();
+            if let Some(fingerprint) =
+                foreground_fingerprint_if_needed(&config, &req.profile, &secrets, &req, &state)
+                    .await?
+            {
+                return Ok(Response::ResolveInForeground { fingerprint });
+            }
             let values = resolve_with_cache(&config, &req.profile, secrets, &req, state).await?;
             Ok(Response::Resolved { values })
         }
@@ -822,17 +933,90 @@ async fn process_request(
                 include_all_modes: true,
                 env: req.env,
             };
-            let values = resolve_with_cache(
+            let secrets = [(req.key, secret_config)].into_iter().collect();
+            if let Some(fingerprint) = foreground_fingerprint_if_needed(
                 &config,
                 &batch_req.profile,
-                [(req.key, secret_config)].into_iter().collect(),
+                &secrets,
                 &batch_req,
-                state,
+                &state,
             )
-            .await?;
+            .await?
+            {
+                return Ok(Response::ResolveInForeground { fingerprint });
+            }
+            let values =
+                resolve_with_cache(&config, &batch_req.profile, secrets, &batch_req, state).await?;
             Ok(Response::Resolved { values })
         }
     }
+}
+
+fn secret_is_cacheable(
+    providers: &IndexMap<String, ProviderConfig>,
+    default_provider: Option<&str>,
+    secret: &SecretConfig,
+    req: &ResolveBatchRequest,
+) -> bool {
+    req.purpose != Purpose::Check.as_str()
+        && secret.daemon_cache.unwrap_or(true)
+        && provider_daemon_cache_enabled(providers, default_provider, secret)
+}
+
+async fn foreground_fingerprint_if_needed(
+    config: &Config,
+    profile: &[String],
+    secrets: &IndexMap<String, SecretConfig>,
+    req: &ResolveBatchRequest,
+    state: &std::sync::Arc<Mutex<DaemonState>>,
+) -> Result<Option<String>> {
+    if req.non_interactive || secrets.is_empty() {
+        return Ok(None);
+    }
+
+    let fingerprint = config_fingerprint(config, &req.env)?;
+    let providers = config.get_providers(profile);
+    let default_provider = cache_policy_default_provider(config, profile, &providers);
+    let state = state.lock().await;
+    for (key, secret) in secrets {
+        if !secret_is_cacheable(&providers, default_provider, secret, req)
+            || !state
+                .cache
+                .contains_key(&cache_key(&fingerprint, profile, key, secret, req))
+        {
+            return Ok(Some(fingerprint));
+        }
+    }
+    Ok(None)
+}
+
+async fn store_resolved_values(
+    config: &Config,
+    profile: &[String],
+    secrets: &IndexMap<String, SecretConfig>,
+    req: &ResolveBatchRequest,
+    expected_fingerprint: &str,
+    mut values: IndexMap<String, Option<String>>,
+    state: std::sync::Arc<Mutex<DaemonState>>,
+) -> Result<()> {
+    let fingerprint = config_fingerprint(config, &req.env)?;
+    if fingerprint != expected_fingerprint {
+        tracing::debug!("config changed during foreground resolution; skipping daemon cache fill");
+        return Ok(());
+    }
+
+    let providers = config.get_providers(profile);
+    let default_provider = cache_policy_default_provider(config, profile, &providers);
+    let mut state = state.lock().await;
+    for (key, secret) in secrets {
+        if secret_is_cacheable(&providers, default_provider, secret, req)
+            && let Some(value) = values.swap_remove(key)
+        {
+            let cache_key = cache_key(&fingerprint, profile, key, secret, req);
+            state.cache.insert(cache_key, value);
+        }
+    }
+    Ok(())
 }
 
 fn apply_request_settings(
@@ -868,9 +1052,7 @@ async fn resolve_with_cache(
     {
         let state = state.lock().await;
         for (key, secret) in &secrets {
-            let cacheable = req.purpose != Purpose::Check.as_str()
-                && secret.daemon_cache.unwrap_or(true)
-                && provider_daemon_cache_enabled(&providers, default_provider, secret);
+            let cacheable = secret_is_cacheable(&providers, default_provider, secret, req);
             if cacheable {
                 let cache_key = cache_key(&fingerprint, profile, key, secret, req);
                 if let Some(value) = state.cache.get(&cache_key) {
@@ -1043,7 +1225,7 @@ fn socket_path(cli: &Cli) -> Result<PathBuf> {
 /// Wire-protocol version tag included in the socket path hash.
 /// Incrementing this ensures new clients don't connect to stale daemons
 /// running an incompatible wire format.
-const WIRE_VERSION: u8 = 2;
+const WIRE_VERSION: u8 = 3;
 
 fn socket_path_for_context(ctx: &ResolveContext) -> Result<PathBuf> {
     let mut hasher = blake3::Hasher::new();
@@ -1344,7 +1526,8 @@ pub fn parse_duration(value: &str) -> Result<Duration> {
 mod tests {
     use super::{
         CacheKey, DaemonState, Purpose, ResolveBatchRequest, cache_key, config_fingerprint,
-        parse_duration, resolve_with_cache,
+        foreground_fingerprint_if_needed, parse_duration, resolve_with_cache,
+        store_resolved_values,
     };
     use fnox_core::config::{Config, ProviderConfig, SecretConfig};
     use indexmap::IndexMap;
@@ -1498,6 +1681,70 @@ mod tests {
         assert_eq!(
             resolved.get("API_KEY").and_then(|value| value.as_deref()),
             Some("fresh")
+        );
+    }
+
+    #[tokio::test]
+    async fn foreground_client_resolves_cache_miss_and_populates_cache() {
+        let mut config = Config::new();
+        config
+            .providers
+            .insert("plain".to_string(), plain_provider_config(None));
+        let secret = plain_secret("fresh");
+        let secrets = IndexMap::from([("API_KEY".to_string(), secret.clone())]);
+        let mut req = test_batch_request();
+        req.non_interactive = false;
+        let state = Arc::new(Mutex::new(DaemonState::default()));
+
+        let fingerprint =
+            foreground_fingerprint_if_needed(&config, &req.profile, &secrets, &req, &state)
+                .await
+                .unwrap()
+                .expect("cache miss should be resolved by the foreground client");
+
+        store_resolved_values(
+            &config,
+            &req.profile,
+            &secrets,
+            &req,
+            &fingerprint,
+            IndexMap::from([("API_KEY".to_string(), Some("fresh".to_string()))]),
+            state.clone(),
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            foreground_fingerprint_if_needed(&config, &req.profile, &secrets, &req, &state,)
+                .await
+                .unwrap()
+                .is_none(),
+            "cached requests should stay in the daemon"
+        );
+        let resolved = resolve_with_cache(&config, &req.profile, secrets, &req, state)
+            .await
+            .unwrap();
+        assert_eq!(
+            resolved.get("API_KEY").and_then(|value| value.as_deref()),
+            Some("fresh")
+        );
+    }
+
+    #[tokio::test]
+    async fn non_interactive_client_leaves_cache_miss_for_daemon() {
+        let mut config = Config::new();
+        config
+            .providers
+            .insert("plain".to_string(), plain_provider_config(None));
+        let secrets = IndexMap::from([("API_KEY".to_string(), plain_secret("fresh"))]);
+        let req = test_batch_request();
+        let state = Arc::new(Mutex::new(DaemonState::default()));
+
+        assert!(
+            foreground_fingerprint_if_needed(&config, &req.profile, &secrets, &req, &state,)
+                .await
+                .unwrap()
+                .is_none()
         );
     }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1,7 +1,7 @@
 use crate::commands::Cli;
 use crate::config::{Config, ProviderConfig, SecretConfig};
 use crate::error::{FnoxError, Result};
-use crate::secret_resolver::resolve_secrets_batch;
+use crate::secret_resolver::{resolve_secrets_batch, resolve_secrets_batch_with_pre_resolved};
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
@@ -151,6 +151,8 @@ enum Response {
     },
     ResolveInForeground {
         fingerprint: String,
+        cached_values: IndexMap<String, Option<String>>,
+        keys: Vec<String>,
     },
     Status {
         pid: u32,
@@ -260,7 +262,11 @@ pub async fn resolve_batch_with_context(
 
     match call_or_start(ctx, config, Request::ResolveBatch(batch_request.clone())).await? {
         Response::Resolved { values } => Ok(values),
-        Response::ResolveInForeground { fingerprint } => {
+        Response::ResolveInForeground {
+            fingerprint,
+            mut cached_values,
+            keys,
+        } => {
             let secrets = if include_all_modes {
                 secrets.clone()
             } else {
@@ -270,9 +276,33 @@ pub async fn resolve_batch_with_context(
                     .map(|(key, secret)| (key.clone(), secret.clone()))
                     .collect()
             };
-            let values = resolve_secrets_batch(config, profile, &secrets).await?;
-            store_foreground_values(ctx, config, batch_request, fingerprint, values.clone())
-                .await?;
+            let foreground_keys = keys.into_iter().collect::<HashSet<_>>();
+            let foreground_secrets = secrets
+                .iter()
+                .filter(|(key, _)| foreground_keys.contains(*key))
+                .map(|(key, secret)| (key.clone(), secret.clone()))
+                .collect();
+            let mut foreground_values = resolve_secrets_batch_with_pre_resolved(
+                config,
+                profile,
+                &foreground_secrets,
+                &cached_values,
+            )
+            .await?;
+            let mut values = IndexMap::new();
+            for key in secrets.keys() {
+                if let Some(value) = cached_values.swap_remove(key) {
+                    values.insert(key.clone(), value);
+                } else if let Some(value) = foreground_values.swap_remove(key) {
+                    values.insert(key.clone(), value);
+                }
+            }
+            if let Err(error) =
+                store_foreground_values(ctx, config, batch_request, fingerprint, values.clone())
+                    .await
+            {
+                tracing::warn!("failed to fill daemon cache after foreground resolution: {error}");
+            }
             Ok(values)
         }
         Response::Error { message } => Err(FnoxError::Config(message)),
@@ -329,7 +359,7 @@ pub async fn resolve_one_with_context(
 
     match call_or_start(ctx, config, Request::ResolveOne(one_request.clone())).await? {
         Response::Resolved { mut values } => Ok(values.swap_remove(key).flatten()),
-        Response::ResolveInForeground { fingerprint } => {
+        Response::ResolveInForeground { fingerprint, .. } => {
             let value =
                 crate::secret_resolver::resolve_secret(config, profile, key, secret_config).await?;
             let values = [(key.to_string(), value.clone())].into_iter().collect();
@@ -346,7 +376,11 @@ pub async fn resolve_one_with_context(
                 include_all_modes: true,
                 env: one_request.env,
             };
-            store_foreground_values(ctx, config, batch_request, fingerprint, values).await?;
+            if let Err(error) =
+                store_foreground_values(ctx, config, batch_request, fingerprint, values).await
+            {
+                tracing::warn!("failed to fill daemon cache after foreground resolution: {error}");
+            }
             Ok(value)
         }
         Response::Error { message } => Err(FnoxError::Config(message)),
@@ -894,11 +928,15 @@ async fn process_request(
                     requested.contains(key) && (req.include_all_modes || sc.env_mode().in_shell())
                 })
                 .collect();
-            if let Some(fingerprint) =
-                foreground_fingerprint_if_needed(&config, &req.profile, &secrets, &req, &state)
+            if let Some(foreground) =
+                foreground_resolution_if_needed(&config, &req.profile, &secrets, &req, &state)
                     .await?
             {
-                return Ok(Response::ResolveInForeground { fingerprint });
+                return Ok(Response::ResolveInForeground {
+                    fingerprint: foreground.fingerprint,
+                    cached_values: foreground.cached_values,
+                    keys: foreground.keys,
+                });
             }
             let values = resolve_with_cache(&config, &req.profile, secrets, &req, state).await?;
             Ok(Response::Resolved { values })
@@ -934,7 +972,7 @@ async fn process_request(
                 env: req.env,
             };
             let secrets = [(req.key, secret_config)].into_iter().collect();
-            if let Some(fingerprint) = foreground_fingerprint_if_needed(
+            if let Some(foreground) = foreground_resolution_if_needed(
                 &config,
                 &batch_req.profile,
                 &secrets,
@@ -943,7 +981,11 @@ async fn process_request(
             )
             .await?
             {
-                return Ok(Response::ResolveInForeground { fingerprint });
+                return Ok(Response::ResolveInForeground {
+                    fingerprint: foreground.fingerprint,
+                    cached_values: foreground.cached_values,
+                    keys: foreground.keys,
+                });
             }
             let values =
                 resolve_with_cache(&config, &batch_req.profile, secrets, &batch_req, state).await?;
@@ -963,13 +1005,19 @@ fn secret_is_cacheable(
         && provider_daemon_cache_enabled(providers, default_provider, secret)
 }
 
-async fn foreground_fingerprint_if_needed(
+struct ForegroundResolution {
+    fingerprint: String,
+    cached_values: IndexMap<String, Option<String>>,
+    keys: Vec<String>,
+}
+
+async fn foreground_resolution_if_needed(
     config: &Config,
     profile: &[String],
     secrets: &IndexMap<String, SecretConfig>,
     req: &ResolveBatchRequest,
     state: &std::sync::Arc<Mutex<DaemonState>>,
-) -> Result<Option<String>> {
+) -> Result<Option<ForegroundResolution>> {
     if req.non_interactive || secrets.is_empty() {
         return Ok(None);
     }
@@ -978,16 +1026,29 @@ async fn foreground_fingerprint_if_needed(
     let providers = config.get_providers(profile);
     let default_provider = cache_policy_default_provider(config, profile, &providers);
     let state = state.lock().await;
+    let mut cached_values = IndexMap::new();
+    let mut keys = Vec::new();
     for (key, secret) in secrets {
-        if !secret_is_cacheable(&providers, default_provider, secret, req)
-            || !state
-                .cache
-                .contains_key(&cache_key(&fingerprint, profile, key, secret, req))
+        if secret_is_cacheable(&providers, default_provider, secret, req)
+            && let Some(value) =
+                state
+                    .cache
+                    .get(&cache_key(&fingerprint, profile, key, secret, req))
         {
-            return Ok(Some(fingerprint));
+            cached_values.insert(key.clone(), value.clone());
+        } else {
+            keys.push(key.clone());
         }
     }
-    Ok(None)
+    if keys.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(ForegroundResolution {
+            fingerprint,
+            cached_values,
+            keys,
+        }))
+    }
 }
 
 async fn store_resolved_values(
@@ -1526,8 +1587,7 @@ pub fn parse_duration(value: &str) -> Result<Duration> {
 mod tests {
     use super::{
         CacheKey, DaemonState, Purpose, ResolveBatchRequest, cache_key, config_fingerprint,
-        foreground_fingerprint_if_needed, parse_duration, resolve_with_cache,
-        store_resolved_values,
+        foreground_resolution_if_needed, parse_duration, resolve_with_cache, store_resolved_values,
     };
     use fnox_core::config::{Config, ProviderConfig, SecretConfig};
     use indexmap::IndexMap;
@@ -1696,37 +1756,57 @@ mod tests {
         req.non_interactive = false;
         let state = Arc::new(Mutex::new(DaemonState::default()));
 
-        let fingerprint =
-            foreground_fingerprint_if_needed(&config, &req.profile, &secrets, &req, &state)
+        let foreground =
+            foreground_resolution_if_needed(&config, &req.profile, &secrets, &req, &state)
                 .await
                 .unwrap()
                 .expect("cache miss should be resolved by the foreground client");
+        assert_eq!(foreground.keys, ["API_KEY"]);
+        assert!(foreground.cached_values.is_empty());
 
         store_resolved_values(
             &config,
             &req.profile,
             &secrets,
             &req,
-            &fingerprint,
-            IndexMap::from([("API_KEY".to_string(), Some("fresh".to_string()))]),
+            &foreground.fingerprint,
+            IndexMap::from([("API_KEY".to_string(), Some("from-foreground".to_string()))]),
             state.clone(),
         )
         .await
         .unwrap();
 
         assert!(
-            foreground_fingerprint_if_needed(&config, &req.profile, &secrets, &req, &state,)
+            foreground_resolution_if_needed(&config, &req.profile, &secrets, &req, &state,)
                 .await
                 .unwrap()
                 .is_none(),
             "cached requests should stay in the daemon"
         );
-        let resolved = resolve_with_cache(&config, &req.profile, secrets, &req, state)
+        let resolved = resolve_with_cache(&config, &req.profile, secrets, &req, state.clone())
             .await
             .unwrap();
         assert_eq!(
             resolved.get("API_KEY").and_then(|value| value.as_deref()),
-            Some("fresh")
+            Some("from-foreground")
+        );
+
+        let secrets = IndexMap::from([
+            ("API_KEY".to_string(), secret),
+            ("OTHER_KEY".to_string(), plain_secret("other")),
+        ]);
+        let foreground =
+            foreground_resolution_if_needed(&config, &req.profile, &secrets, &req, &state)
+                .await
+                .unwrap()
+                .expect("the uncached entry should require foreground resolution");
+        assert_eq!(foreground.keys, ["OTHER_KEY"]);
+        assert_eq!(
+            foreground
+                .cached_values
+                .get("API_KEY")
+                .and_then(|value| value.as_deref()),
+            Some("from-foreground")
         );
     }
 
@@ -1741,7 +1821,7 @@ mod tests {
         let state = Arc::new(Mutex::new(DaemonState::default()));
 
         assert!(
-            foreground_fingerprint_if_needed(&config, &req.profile, &secrets, &req, &state,)
+            foreground_resolution_if_needed(&config, &req.profile, &secrets, &req, &state,)
                 .await
                 .unwrap()
                 .is_none()

--- a/test/daemon.bats
+++ b/test/daemon.bats
@@ -45,6 +45,45 @@ EOF
 	assert_output --partial "cached_entries: 1"
 }
 
+@test "daemon resolves cache misses in the foreground client" {
+	mkdir -p "$TEST_TEMP_DIR/bin"
+	cat >"$TEST_TEMP_DIR/bin/pass" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$PPID" >>"$PASS_PPID_FILE"
+printf 'foreground-value\n'
+EOF
+	chmod +x "$TEST_TEMP_DIR/bin/pass"
+	export PATH="$TEST_TEMP_DIR/bin:$PATH"
+	export PASS_PPID_FILE="$TEST_TEMP_DIR/pass-pids"
+
+	cat >fnox.toml <<'EOF'
+root = true
+
+[daemon]
+enabled = true
+
+[providers.pass]
+type = "password-store"
+
+[secrets]
+FOO = { provider = "pass", value = "foo" }
+EOF
+
+	run "$FNOX_BIN" get FOO
+	assert_success
+	assert_output "foreground-value"
+
+	run "$FNOX_BIN" daemon status
+	assert_success
+	daemon_pid="$(printf '%s\n' "$output" | sed -n 's/^pid: //p')"
+	assert_not_equal "$(cat "$PASS_PPID_FILE")" "$daemon_pid"
+
+	run "$FNOX_BIN" get FOO
+	assert_success
+	assert_output "foreground-value"
+	assert_equal "$(wc -l <"$PASS_PPID_FILE" | tr -d ' ')" "1"
+}
+
 @test "daemon clear removes cached entries" {
 	daemon_config
 

--- a/test/daemon.bats
+++ b/test/daemon.bats
@@ -76,7 +76,7 @@ EOF
 	run "$FNOX_BIN" daemon status
 	assert_success
 	daemon_pid="$(printf '%s\n' "$output" | sed -n 's/^pid: //p')"
-	assert_not_equal "$(cat "$PASS_PPID_FILE")" "$daemon_pid"
+	[ "$(cat "$PASS_PPID_FILE")" != "$daemon_pid" ]
 
 	run "$FNOX_BIN" get FOO
 	assert_success


### PR DESCRIPTION
## Summary

- return daemon cache misses to interactive clients for foreground resolution, preserving PIN, touch, browser, and auth-command access to the invoking terminal
- send resolved values back to the daemon through a fingerprint-validated cache-fill request while keeping non-interactive callers daemon-side
- bump the daemon wire version and document the cache-miss behavior
- add unit coverage plus an end-to-end test proving the provider runs under the foreground client and is skipped after caching

Addresses the behavior reported in https://github.com/jdx/fnox/discussions/742.

## Testing

- `cargo test`
- `mise run lint`
- `mise run test:bats -- test/daemon.bats` (9 passed)
- `mise run test:bats` (723 passed/skipped; 3 unrelated failures because subprocesses resolved through a mise shim that rejected this checkout as untrusted)

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the daemon wire protocol and secret-resolution path (cache fill, env overlay, fingerprint checks). Incorrect handling could skip prompts, miss cache, or store stale values.
> 
> **Overview**
> Interactive daemon clients no longer resolve cache misses inside the daemon. On a miss, the daemon returns cached hits plus the remaining keys; the client resolves those in the foreground (PIN, FIDO2, browser, auth commands stay on the invoking TTY) and sends values back via a new `StoreResolved` request.
> 
> Non-interactive clients still resolve misses in the daemon and never prompt. Cache fill is skipped if the config fingerprint changed during foreground work. Batch resolution can treat already-cached values as interpolation/env dependencies.
> 
> The daemon wire version is bumped to 3 so old daemons are not reused. Docs and tests cover foreground vs daemon-side misses and cache reuse.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69717a8c6ddcb8587a9adc11df2473c79365404e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Interactive clients now resolve secrets in the foreground when the daemon cache misses, then reuse cached results on subsequent requests.
  * Non-interactive clients resolve missing secrets automatically without prompting.
  * Partially cached requests reuse available values while resolving only missing secrets, preserving request order.
  * Requests with caching disabled resolve affected values again on each supported read.

* **Documentation**
  * Clarified daemon cache-miss and cache-disabled behavior.

* **Tests**
  * Added coverage for foreground resolution and subsequent cache reuse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->