### PR TITLE
chore: generate release notes before publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,4 +189,4 @@ jobs:
           else
             TAG_NAME="${GITHUB_REF_NAME}"
           fi
-          gh release edit "$TAG_NAME" --draft=false
+          gh release edit "$TAG_NAME" --repo "${{ github.repository }}" --draft=false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,6 +112,7 @@ jobs:
           gh release create "$TAG_NAME" \
             --title "$TAG_NAME" \
             --notes-file release-notes.md \
+            --draft \
             release-assets/*
         env:
           INPUTS_VERSION: ${{ inputs.version }}
@@ -171,3 +172,21 @@ jobs:
           If fnox is handling secrets or config for you or your team, please consider [sponsoring at jdx.dev](https://jdx.dev/sponsors.html). Sponsorships are what let fnox stay independent and the project keep moving.
           EOF
           gh release edit "$TAG_NAME" --notes-file /tmp/release-notes.md
+
+  publish-release:
+    needs: [enhance-release]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Publish GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.FNOX_GH_TOKEN }}
+          INPUTS_VERSION: ${{ inputs.version }}
+        run: |
+          if [[ -n "${INPUTS_VERSION}" ]]; then
+            TAG_NAME="v${INPUTS_VERSION}"
+          else
+            TAG_NAME="${GITHUB_REF_NAME}"
+          fi
+          gh release edit "$TAG_NAME" --draft=false


### PR DESCRIPTION
## Summary

- create the GitHub release as a draft
- run Communiqué and sponsor normalization before publication
- add a final publish job that only runs after enhancement succeeds

## Validation

- actionlint with ShellCheck enabled
- git diff --check
- verified a failed enhancement leaves the release as a draft

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the GitHub release publication path: a failed or skipped publish job can leave a draft, or a token/repo mismatch could fail to go live. Not auth or product-data handling.
> 
> **Overview**
> GitHub releases are now created as **drafts** so Communiqué notes and the sponsor blurb can finish before anything is public.
> 
> A new `publish-release` job runs after `enhance-release` and undrafts the tag. If enhancement fails, the release stays unpublished.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a56720b7344ef6ddd8be8042cbb797911f7c0e6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Process**
  - Releases are now created as drafts before publication.
  - Releases are automatically published after release notes are enhanced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
