### PR TITLE
fix(export): preserve dollar signs in dotenv output

### DIFF
--- a/src/commands/export.rs
+++ b/src/commands/export.rs
@@ -232,8 +232,13 @@ fn dotenv_quote(value: &str) -> String {
         return value.to_string();
     }
 
-    // Dotenv parsers treat `$` and backticks literally; use `--format shell`
-    // for sourceable shell output.
+    // Docker Compose interpolates `$` in unquoted and double-quoted dotenv
+    // values. Single quotes keep secret values literal.
+    if value.contains('$') {
+        return format!("'{}'", value.replace('\'', "\\'"));
+    }
+
+    // Use `--format shell` for sourceable shell output.
     let mut quoted = String::with_capacity(value.len() + 2);
     quoted.push('"');
     for c in value.chars() {
@@ -267,6 +272,15 @@ mod tests {
     fn dotenv_quote_escapes_special_values() {
         assert_eq!(dotenv_quote("value with spaces"), "\"value with spaces\"");
         assert_eq!(dotenv_quote("it's \"fine\""), "\"it's \\\"fine\\\"\"");
-        assert_eq!(dotenv_quote("a\nb\t$c`d"), "\"a\\nb\\t$c`d\"");
+        assert_eq!(dotenv_quote("a\nb\tc`d"), "\"a\\nb\\tc`d\"");
+    }
+
+    #[test]
+    fn dotenv_quote_single_quotes_dollar_values() {
+        assert_eq!(dotenv_quote("secret$value"), "'secret$value'");
+        assert_eq!(dotenv_quote("${TOKEN:-fallback}"), "'${TOKEN:-fallback}'");
+        assert_eq!(dotenv_quote("$$test"), "'$$test'");
+        assert_eq!(dotenv_quote("it's $5"), "'it\\'s $5'");
+        assert_eq!(dotenv_quote("a\n$b"), "'a\n$b'");
     }
 }

--- a/src/commands/export.rs
+++ b/src/commands/export.rs
@@ -264,7 +264,7 @@ fn dotenv_double_quote(value: &str, escape_dollars: bool) -> String {
             '\n' => quoted.push_str("\\n"),
             '\r' => quoted.push_str("\\r"),
             '\t' => quoted.push_str("\\t"),
-            '$' if escape_dollars => quoted.push_str("$$"),
+            '$' if escape_dollars => quoted.push_str("\\$"),
             _ => quoted.push(c),
         }
     }
@@ -299,11 +299,11 @@ mod tests {
         assert_eq!(dotenv_quote("$$test"), "'$$test'");
         assert_eq!(dotenv_quote("it's $5"), "'it\\'s $5'");
         assert_eq!(dotenv_quote("a\n$b"), "'a\n$b'");
-        assert_eq!(dotenv_quote("secret$value\\"), "\"secret$$value\\\\\"");
-        assert_eq!(dotenv_quote("a\\'b $5"), "\"a\\\\'b $$5\"");
+        assert_eq!(dotenv_quote("secret$value\\"), "\"secret\\$value\\\\\"");
+        assert_eq!(dotenv_quote("a\\'b $5"), "\"a\\\\'b \\$5\"");
         assert_eq!(
             dotenv_quote("prefix\\'$value\ncontinuation"),
-            "\"prefix\\\\'$$value\\ncontinuation\""
+            "\"prefix\\\\'\\$value\\ncontinuation\""
         );
     }
 }

--- a/src/commands/export.rs
+++ b/src/commands/export.rs
@@ -234,11 +234,27 @@ fn dotenv_quote(value: &str) -> String {
 
     // Docker Compose interpolates `$` in unquoted and double-quoted dotenv
     // values. Single quotes keep secret values literal.
-    if value.contains('$') {
+    if value.contains('$') && is_single_quote_safe(value) {
         return format!("'{}'", value.replace('\'', "\\'"));
     }
 
     // Use `--format shell` for sourceable shell output.
+    dotenv_double_quote(value, value.contains('$'))
+}
+
+fn is_single_quote_safe(value: &str) -> bool {
+    let mut backslashes = 0;
+    for c in value.chars() {
+        match c {
+            '\\' => backslashes += 1,
+            '\'' if backslashes % 2 == 1 => return false,
+            _ => backslashes = 0,
+        }
+    }
+    backslashes % 2 == 0
+}
+
+fn dotenv_double_quote(value: &str, escape_dollars: bool) -> String {
     let mut quoted = String::with_capacity(value.len() + 2);
     quoted.push('"');
     for c in value.chars() {
@@ -248,6 +264,7 @@ fn dotenv_quote(value: &str) -> String {
             '\n' => quoted.push_str("\\n"),
             '\r' => quoted.push_str("\\r"),
             '\t' => quoted.push_str("\\t"),
+            '$' if escape_dollars => quoted.push_str("$$"),
             _ => quoted.push(c),
         }
     }
@@ -282,5 +299,7 @@ mod tests {
         assert_eq!(dotenv_quote("$$test"), "'$$test'");
         assert_eq!(dotenv_quote("it's $5"), "'it\\'s $5'");
         assert_eq!(dotenv_quote("a\n$b"), "'a\n$b'");
+        assert_eq!(dotenv_quote("secret$value\\"), "\"secret$$value\\\\\"");
+        assert_eq!(dotenv_quote("a\\'b $5"), "\"a\\\\'b $$5\"");
     }
 }

--- a/src/commands/export.rs
+++ b/src/commands/export.rs
@@ -301,5 +301,9 @@ mod tests {
         assert_eq!(dotenv_quote("a\n$b"), "'a\n$b'");
         assert_eq!(dotenv_quote("secret$value\\"), "\"secret$$value\\\\\"");
         assert_eq!(dotenv_quote("a\\'b $5"), "\"a\\\\'b $$5\"");
+        assert_eq!(
+            dotenv_quote("prefix\\'$value\ncontinuation"),
+            "\"prefix\\\\'$$value\\ncontinuation\""
+        );
     }
 }

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -304,7 +304,7 @@ impl ImportCommand {
         let mut lines = input.lines();
 
         while let Some(line) = lines.next() {
-            let mut line = line.trim().to_string();
+            let mut line = line.trim_start().to_string();
 
             // Skip empty lines and comments
             if line.is_empty() || line.starts_with('#') {
@@ -546,9 +546,22 @@ fn unescape_single_quoted_env_value(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        has_unclosed_single_quoted_value, unescape_double_quoted_env_value,
-        unescape_single_quoted_env_value,
+        ImportCommand, ImportFormat, has_unclosed_single_quoted_value,
+        unescape_double_quoted_env_value, unescape_single_quoted_env_value,
     };
+
+    fn import_command() -> ImportCommand {
+        ImportCommand {
+            format: ImportFormat::Env,
+            force: true,
+            global: false,
+            input: None,
+            dry_run: false,
+            provider: String::new(),
+            filter: None,
+            prefix: None,
+        }
+    }
 
     #[test]
     fn detects_multiline_single_quoted_values() {
@@ -556,6 +569,16 @@ mod tests {
         assert!(has_unclosed_single_quoted_value("VALUE='it\\'s first"));
         assert!(!has_unclosed_single_quoted_value("VALUE='first'"));
         assert!(!has_unclosed_single_quoted_value("VALUE=first"));
+    }
+
+    #[test]
+    fn parse_env_preserves_multiline_spaces_and_double_quoted_fallbacks() {
+        let secrets = import_command()
+            .parse_env("SPACES='first  \nsecond'\nFALLBACK=\"prefix\\\\'$$value\\ncontinuation\"")
+            .unwrap();
+
+        assert_eq!(secrets["SPACES"], "first  \nsecond");
+        assert_eq!(secrets["FALLBACK"], "prefix\\'$value\ncontinuation");
     }
 
     #[test]

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -512,6 +512,11 @@ fn unescape_double_quoted_env_value(value: &str) -> String {
     let mut chars = value.chars();
 
     while let Some(c) = chars.next() {
+        if c == '$' && chars.as_str().starts_with('$') {
+            chars.next();
+            unescaped.push('$');
+            continue;
+        }
         if c != '\\' {
             unescaped.push(c);
             continue;
@@ -558,6 +563,10 @@ mod tests {
         assert_eq!(
             unescape_double_quoted_env_value(r#"line1\nline2\t\"quoted\"\\path"#),
             "line1\nline2\t\"quoted\"\\path"
+        );
+        assert_eq!(
+            unescape_double_quoted_env_value(r"secret$$value\\"),
+            "secret$value\\"
         );
     }
 

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -301,20 +301,31 @@ impl ImportCommand {
 
     fn parse_env(&self, input: &str) -> Result<HashMap<String, String>> {
         let mut secrets = HashMap::new();
+        let mut lines = input.lines();
 
-        for line in input.lines() {
-            let line = line.trim();
+        while let Some(line) = lines.next() {
+            let mut line = line.trim().to_string();
 
             // Skip empty lines and comments
             if line.is_empty() || line.starts_with('#') {
                 continue;
             }
 
+            // Docker Compose permits literal newlines inside single-quoted
+            // dotenv values. Reassemble them before parsing the assignment.
+            while has_unclosed_single_quoted_value(&line) {
+                let Some(next_line) = lines.next() else {
+                    break;
+                };
+                line.push('\n');
+                line.push_str(next_line);
+            }
+
             // Parse export statements and simple KEY=VALUE
             if let Some(export_key_value) = line.strip_prefix("export ") {
                 self.parse_key_value(export_key_value, &mut secrets)?;
             } else {
-                self.parse_key_value(line, &mut secrets)?;
+                self.parse_key_value(&line, &mut secrets)?;
             }
         }
 
@@ -332,7 +343,7 @@ impl ImportCommand {
                 unescape_double_quoted_env_value(inner)
             } else if let Some(inner) = value.strip_prefix('\'').and_then(|v| v.strip_suffix('\''))
             {
-                inner.to_string()
+                unescape_single_quoted_env_value(inner)
             } else {
                 value.to_string()
             };
@@ -477,6 +488,25 @@ impl ImportCommand {
     }
 }
 
+fn has_unclosed_single_quoted_value(line: &str) -> bool {
+    let line = line.strip_prefix("export ").unwrap_or(line);
+    let Some((_, value)) = line.split_once('=') else {
+        return false;
+    };
+    let Some(value) = value.trim_start().strip_prefix('\'') else {
+        return false;
+    };
+
+    let mut escaped = false;
+    for c in value.chars() {
+        if c == '\'' && !escaped {
+            return false;
+        }
+        escaped = c == '\\' && !escaped;
+    }
+    true
+}
+
 fn unescape_double_quoted_env_value(value: &str) -> String {
     let mut unescaped = String::with_capacity(value.len());
     let mut chars = value.chars();
@@ -504,9 +534,24 @@ fn unescape_double_quoted_env_value(value: &str) -> String {
     unescaped
 }
 
+fn unescape_single_quoted_env_value(value: &str) -> String {
+    value.replace("\\'", "'")
+}
+
 #[cfg(test)]
 mod tests {
-    use super::unescape_double_quoted_env_value;
+    use super::{
+        has_unclosed_single_quoted_value, unescape_double_quoted_env_value,
+        unescape_single_quoted_env_value,
+    };
+
+    #[test]
+    fn detects_multiline_single_quoted_values() {
+        assert!(has_unclosed_single_quoted_value("VALUE='first"));
+        assert!(has_unclosed_single_quoted_value("VALUE='it\\'s first"));
+        assert!(!has_unclosed_single_quoted_value("VALUE='first'"));
+        assert!(!has_unclosed_single_quoted_value("VALUE=first"));
+    }
 
     #[test]
     fn unescape_double_quoted_env_value_handles_export_escapes() {
@@ -522,5 +567,10 @@ mod tests {
             unescape_double_quoted_env_value(r#"secret\$value\`tick"#),
             r#"secret\$value\`tick"#
         );
+    }
+
+    #[test]
+    fn unescape_single_quoted_env_value_handles_apostrophes() {
+        assert_eq!(unescape_single_quoted_env_value(r"it\'s $5"), "it's $5");
     }
 }

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -315,7 +315,9 @@ impl ImportCommand {
             // dotenv values. Reassemble them before parsing the assignment.
             while has_unclosed_single_quoted_value(&line) {
                 let Some(next_line) = lines.next() else {
-                    break;
+                    return Err(FnoxError::Config(
+                        "Unterminated single-quoted ENV value".to_string(),
+                    ));
                 };
                 line.push('\n');
                 line.push_str(next_line);
@@ -575,6 +577,16 @@ mod tests {
 
         assert_eq!(secrets["SPACES"], "first  \nsecond");
         assert_eq!(secrets["FALLBACK"], "prefix\\'$value\ncontinuation");
+    }
+
+    #[test]
+    fn parse_env_rejects_unterminated_single_quoted_values() {
+        let error = import_command().parse_env("KEY='secret").unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "Configuration error: Unterminated single-quoted ENV value"
+        );
     }
 
     #[test]

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -512,11 +512,6 @@ fn unescape_double_quoted_env_value(value: &str) -> String {
     let mut chars = value.chars();
 
     while let Some(c) = chars.next() {
-        if c == '$' && chars.as_str().starts_with('$') {
-            chars.next();
-            unescaped.push('$');
-            continue;
-        }
         if c != '\\' {
             unescaped.push(c);
             continue;
@@ -525,6 +520,7 @@ fn unescape_double_quoted_env_value(value: &str) -> String {
         match chars.next() {
             Some('\\') => unescaped.push('\\'),
             Some('"') => unescaped.push('"'),
+            Some('$') => unescaped.push('$'),
             Some('n') => unescaped.push('\n'),
             Some('r') => unescaped.push('\r'),
             Some('t') => unescaped.push('\t'),
@@ -574,7 +570,7 @@ mod tests {
     #[test]
     fn parse_env_preserves_multiline_spaces_and_double_quoted_fallbacks() {
         let secrets = import_command()
-            .parse_env("SPACES='first  \nsecond'\nFALLBACK=\"prefix\\\\'$$value\\ncontinuation\"")
+            .parse_env("SPACES='first  \nsecond'\nFALLBACK=\"prefix\\\\'\\$value\\ncontinuation\"")
             .unwrap();
 
         assert_eq!(secrets["SPACES"], "first  \nsecond");
@@ -588,8 +584,12 @@ mod tests {
             "line1\nline2\t\"quoted\"\\path"
         );
         assert_eq!(
-            unescape_double_quoted_env_value(r"secret$$value\\"),
+            unescape_double_quoted_env_value(r"secret\$value\\"),
             "secret$value\\"
+        );
+        assert_eq!(
+            unescape_double_quoted_env_value("secret$$value"),
+            "secret$$value"
         );
     }
 
@@ -597,7 +597,7 @@ mod tests {
     fn unescape_double_quoted_env_value_preserves_unknown_escapes() {
         assert_eq!(
             unescape_double_quoted_env_value(r#"secret\$value\`tick"#),
-            r#"secret\$value\`tick"#
+            r#"secret$value\`tick"#
         );
     }
 

--- a/test/file_secrets.bats
+++ b/test/file_secrets.bats
@@ -597,7 +597,7 @@ EOF
 	assert_success
 	assert_output --partial "SPECIAL_SECRET='secret\$value\`tick\`'"
 	assert_output --partial 'QUOTED_SECRET="quoted \"value\" with \\ backslash"'
-	assert_output --partial 'TRAILING_BACKSLASH="secret$$value\\"'
+	assert_output --partial 'TRAILING_BACKSLASH="secret\$value\\"'
 }
 
 @test "export env format can include metadata header" {

--- a/test/file_secrets.bats
+++ b/test/file_secrets.bats
@@ -594,7 +594,7 @@ EOF
 
 	run "$FNOX_BIN" export --format env
 	assert_success
-	assert_output --partial 'SPECIAL_SECRET="secret$value`tick`"'
+	assert_output --partial "SPECIAL_SECRET='secret\$value\`tick\`'"
 	assert_output --partial 'QUOTED_SECRET="quoted \"value\" with \\ backslash"'
 }
 

--- a/test/file_secrets.bats
+++ b/test/file_secrets.bats
@@ -590,12 +590,14 @@ type = "plain"
 [secrets]
 SPECIAL_SECRET = { provider = "plain", value = "secret$value`tick`" }
 QUOTED_SECRET = { provider = "plain", value = "quoted \"value\" with \\ backslash" }
+TRAILING_BACKSLASH = { provider = "plain", value = 'secret$value\' }
 EOF
 
 	run "$FNOX_BIN" export --format env
 	assert_success
 	assert_output --partial "SPECIAL_SECRET='secret\$value\`tick\`'"
 	assert_output --partial 'QUOTED_SECRET="quoted \"value\" with \\ backslash"'
+	assert_output --partial 'TRAILING_BACKSLASH="secret$$value\\"'
 }
 
 @test "export env format can include metadata header" {

--- a/test/import.bats
+++ b/test/import.bats
@@ -86,7 +86,7 @@ SINGLE_QUOTED_MULTILINE='first line
 $second line'
 DOUBLE_QUOTED="another value with spaces"
 DOUBLE_QUOTED_ESCAPES="quoted \"value\" with \\ backslash and \n newline"
-DOUBLE_QUOTED_DOLLAR_ESCAPE="secret$$value\\"
+DOUBLE_QUOTED_DOLLAR_ESCAPE="secret\$value\\"
 DOLLAR_AND_BACKTICK="secret$value`tick`"
 UNQUOTED=no_spaces
 EOF

--- a/test/import.bats
+++ b/test/import.bats
@@ -81,6 +81,9 @@ EOF
 	# Create a .env file with quoted values
 	cat >.env <<'EOF'
 SINGLE_QUOTED='value with spaces'
+SINGLE_QUOTED_APOSTROPHE='it\'s $5'
+SINGLE_QUOTED_MULTILINE='first line
+$second line'
 DOUBLE_QUOTED="another value with spaces"
 DOUBLE_QUOTED_ESCAPES="quoted \"value\" with \\ backslash and \n newline"
 DOLLAR_AND_BACKTICK="secret$value`tick`"
@@ -91,6 +94,12 @@ EOF
 
 	assert_fnox_success get SINGLE_QUOTED --age-key-file key.txt
 	assert_output "value with spaces"
+
+	assert_fnox_success get SINGLE_QUOTED_APOSTROPHE --age-key-file key.txt
+	assert_output 'it'\''s $5'
+
+	assert_fnox_success get SINGLE_QUOTED_MULTILINE --age-key-file key.txt
+	assert_output $'first line\n$second line'
 
 	assert_fnox_success get DOUBLE_QUOTED --age-key-file key.txt
 	assert_output "another value with spaces"

--- a/test/import.bats
+++ b/test/import.bats
@@ -86,6 +86,7 @@ SINGLE_QUOTED_MULTILINE='first line
 $second line'
 DOUBLE_QUOTED="another value with spaces"
 DOUBLE_QUOTED_ESCAPES="quoted \"value\" with \\ backslash and \n newline"
+DOUBLE_QUOTED_DOLLAR_ESCAPE="secret$$value\\"
 DOLLAR_AND_BACKTICK="secret$value`tick`"
 UNQUOTED=no_spaces
 EOF
@@ -106,6 +107,9 @@ EOF
 
 	assert_fnox_success get DOUBLE_QUOTED_ESCAPES --age-key-file key.txt
 	assert_output $'quoted "value" with \\ backslash and \n newline'
+
+	assert_fnox_success get DOUBLE_QUOTED_DOLLAR_ESCAPE --age-key-file key.txt
+	assert_output "secret\$value\\"
 
 	assert_fnox_success get DOLLAR_AND_BACKTICK --age-key-file key.txt
 	assert_output 'secret$value`tick`'


### PR DESCRIPTION
## Summary

- emit single-quoted dotenv values when secrets contain `$` so Docker Compose does not interpolate them
- preserve apostrophes and multiline single-quoted values when importing dotenv files
- add export and import regressions for literal dollar signs

Addresses https://github.com/jdx/fnox/discussions/284.

## Test plan

- `mise run lint`
- `mise run test:cargo`
- `mise run test:bats -- test/import.bats`
- `test/bats/bin/bats --filter "export env format preserves dotenv literal dollar and backtick values" test/file_secrets.bats`
- verified generated output with Docker Compose v5.1.3 via `docker compose config --environment`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how secrets are quoted on export and parsed on import; incorrect quoting could leak or corrupt values in Docker Compose and `.env` workflows, though the change is targeted at fixing literal `$` handling.
> 
> **Overview**
> **Dotenv export** now avoids Docker Compose interpolating secrets that contain `$`. Values with dollar signs are emitted in **single quotes** when apostrophe/backslash escaping is safe; otherwise they use **double quotes** with `\$` escaping. Simple unquoted values are unchanged.
> 
> **Dotenv import** is aligned with that behavior: it **reassembles multiline single-quoted** assignments (Compose-style), **unescapes `\'`** in single quotes, and treats **`\$`** in double quotes as a literal dollar. Unterminated single-quoted values return a clear configuration error.
> 
> Unit and Bats tests cover dollar signs, backticks, trailing backslashes, multiline values, and round-trip cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18eaefd036997af111ecff387caf9979d9690cfd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved dollar signs and trailing backslashes when exporting environment values.
  * Improved import handling for multiline single-quoted values, including whitespace and escaped apostrophes.
  * Correctly restored escaped dollar signs and backslashes in double-quoted values.
  * Improved handling of quoted environment values containing special characters.

* **Tests**
  * Added coverage for multiline values, whitespace, apostrophes, dollar signs, backslashes, and quote handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->