### PR TITLE
chore(deps): bump usage to 6.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7546,21 +7546,21 @@ checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "usage-argv"
-version = "6.2.0"
+version = "6.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "857c0a155957d220665b2257ac7c58e168476ff7de09286940055ff78f622fb0"
+checksum = "832f849be4b8046c843219bc92d067a6689530df53f56e3c0a52ff5ebbd2f89b"
 
 [[package]]
 name = "usage-config"
-version = "6.2.0"
+version = "6.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a03db6df00ecda2b8fbdd6819bb1f6d0ea82d593d0620e6030eb11e0c9aa3c"
+checksum = "26de7cdb0937b87c778ae50e733a6922eaf9994d79eede89af62e09edf7dbd9f"
 
 [[package]]
 name = "usage-derive"
-version = "6.2.0"
+version = "6.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9b6be9a69c5659c8002ac46be4262fd6e3ef57db53787df0f85b2d116c9e790"
+checksum = "5634bb965ae075c5cedfc27942f7e6110bf5e7e169cba04de86346f4aeee41e7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7569,9 +7569,9 @@ dependencies = [
 
 [[package]]
 name = "usage-rs"
-version = "6.2.0"
+version = "6.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "689ff9bfcf0c894d94a44171b27f6533db7d44a9615b17cef9b846590df13463"
+checksum = "12a8c2b63902582429527f21cd91d2da0065fb9222b8a2a5b87d8f77c7daf71e"
 dependencies = [
  "usage-argv",
  "usage-config",
@@ -7581,9 +7581,9 @@ dependencies = [
 
 [[package]]
 name = "usage-test"
-version = "6.2.0"
+version = "6.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f73ccbe6b9a1023436ffecd83a52d8a74b9e825ce593fc07641f0359d13f427f"
+checksum = "574ec714315c7acd46b892ae156d105e346cb1a27b53759eb6cc6b0a45256adb"
 dependencies = [
  "usage-argv",
 ]

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -2043,7 +2043,7 @@
         "flags": [
           {
             "name": "ignore",
-            "usage": "-i --ignore… <IGNORE>",
+            "usage": "-i --ignore <IGNORE>",
             "help": "Skip files matching this glob pattern (can be used multiple times)",
             "help_first_line": "Skip files matching this glob pattern (can be used multiple times)",
             "short": ["i"],
@@ -2637,7 +2637,7 @@
       },
       {
         "name": "profile",
-        "usage": "-P --profile… <PROFILE>",
+        "usage": "-P --profile <PROFILE>",
         "help": "Profile to use (default: default, or FNOX_PROFILE env var). Supports multiple profiles separated by commas or repeated flags; later profiles overlay earlier ones.",
         "help_first_line": "Profile to use (default: default, or FNOX_PROFILE env var). Supports multiple profiles separated by commas or repeated flags; later profiles overlay earlier ones.",
         "short": ["P"],

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -14,7 +14,7 @@
 
   **Default:** `fnox.toml`
 
-- **`-P --profile… <PROFILE>`** — Profile to use (default: default, or FNOX_PROFILE env var). Supports multiple profiles separated by commas or repeated flags; later profiles overlay earlier ones.
+- **`-P --profile <PROFILE>`** — Profile to use (default: default, or FNOX_PROFILE env var). Supports multiple profiles separated by commas or repeated flags; later profiles overlay earlier ones.
 - **`-v --verbose`** — Enable verbose logging
 - **`--if-missing <IF_MISSING>`** — What to do if a secret is missing (error, warn, ignore)
 - **`--no-color`** — Disable colored output

--- a/docs/cli/scan.md
+++ b/docs/cli/scan.md
@@ -14,7 +14,7 @@ Scan repository for potential secrets
 
 ## Flags
 
-- **`-i --ignore… <IGNORE>`** — Skip files matching this glob pattern (can be used multiple times)
+- **`-i --ignore <IGNORE>`** — Skip files matching this glob pattern (can be used multiple times)
 - **`--format <FORMAT>`** — Output format
 
   **Choices:** `human`, `json`

--- a/mise.lock
+++ b/mise.lock
@@ -669,43 +669,43 @@ url = "https://github.com/mvdan/sh/releases/download/v3.13.1/shfmt_v3.13.1_windo
 url_api = "https://api.github.com/repos/mvdan/sh/releases/assets/390322844"
 
 [[tools.usage]]
-version = "6.2.0"
+version = "6.4.0"
 backend = "aqua:jdx/usage"
 
 [tools.usage."platforms.linux-arm64"]
-checksum = "sha256:93502e6ec4c4efe5437a8ef0970b0d87cd88020e341bcdd6b0b78022ce316a4b"
-url = "https://github.com/jdx/usage/releases/download/v6.2.0/usage-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/usage/releases/assets/527050809"
+checksum = "sha256:96acfe9a312da8af144dd516b9347bd7de62391ca797dba722aed48abe5ec21d"
+url = "https://github.com/jdx/usage/releases/download/v6.4.0/usage-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/usage/releases/assets/528035595"
 
 [tools.usage."platforms.linux-arm64-musl"]
-checksum = "sha256:86d8273aee09adc471ac34e8e61ef8386fc26b2d06cc43985722b705a52c5a7e"
-url = "https://github.com/jdx/usage/releases/download/v6.2.0/usage-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/usage/releases/assets/527051257"
+checksum = "sha256:60ff89e6d87cabcbc6c20fc851911c78490c605d38553147a62e1dce30e6470a"
+url = "https://github.com/jdx/usage/releases/download/v6.4.0/usage-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/usage/releases/assets/528035659"
 
 [tools.usage."platforms.linux-x64"]
-checksum = "sha256:38df801e9ed2b4d23ea66793a25369f52d92c4aefd55ebacb6e343a2ab84528d"
-url = "https://github.com/jdx/usage/releases/download/v6.2.0/usage-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/usage/releases/assets/527050648"
+checksum = "sha256:04007997a0524aa5934458530cd025e1745e0b0803aac74559cc03a26b66c53b"
+url = "https://github.com/jdx/usage/releases/download/v6.4.0/usage-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/usage/releases/assets/528035518"
 
 [tools.usage."platforms.linux-x64-musl"]
-checksum = "sha256:ded7d1815254fe064b07a8f33251b8e112ec346c338e476ce0e9ee8d8babc0ed"
-url = "https://github.com/jdx/usage/releases/download/v6.2.0/usage-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/usage/releases/assets/527051701"
+checksum = "sha256:c416e18838f974810f8b67ac1eed6ef170cf9ff48e165469563885f24c548d90"
+url = "https://github.com/jdx/usage/releases/download/v6.4.0/usage-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/usage/releases/assets/528035933"
 
 [tools.usage."platforms.macos-arm64"]
-checksum = "sha256:6c2d37e3cba67d45fdfeb5edaff81962388bfde09667cc9ed35b0734b7c0a8c1"
-url = "https://github.com/jdx/usage/releases/download/v6.2.0/usage-universal-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/usage/releases/assets/527053103"
+checksum = "sha256:c02f4235446b06f917747e6bdaa6496ea3f63a66c74081a5c1450da2c734f6f1"
+url = "https://github.com/jdx/usage/releases/download/v6.4.0/usage-universal-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/usage/releases/assets/528044147"
 
 [tools.usage."platforms.macos-x64"]
-checksum = "sha256:6c2d37e3cba67d45fdfeb5edaff81962388bfde09667cc9ed35b0734b7c0a8c1"
-url = "https://github.com/jdx/usage/releases/download/v6.2.0/usage-universal-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/usage/releases/assets/527053103"
+checksum = "sha256:c02f4235446b06f917747e6bdaa6496ea3f63a66c74081a5c1450da2c734f6f1"
+url = "https://github.com/jdx/usage/releases/download/v6.4.0/usage-universal-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/usage/releases/assets/528044147"
 
 [tools.usage."platforms.windows-x64"]
-checksum = "sha256:c13234e43cee2b172376ade8d0cdd1ea26c8a2032275b283243b05de57256c3f"
-url = "https://github.com/jdx/usage/releases/download/v6.2.0/usage-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/usage/releases/assets/527054199"
+checksum = "sha256:6ffa5d4deb26c6728ea9ab5d9c7b76c3c4ca75cb6bf49acdace1045512fa7cd3"
+url = "https://github.com/jdx/usage/releases/download/v6.4.0/usage-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/usage/releases/assets/528039229"
 
 [[tools.vault]]
 version = "2.0.4"

--- a/mise.toml
+++ b/mise.toml
@@ -2,7 +2,7 @@
 _.path = ["target/debug", "test/bats/bin"]
 
 [tools]
-usage = "6.2.0"
+usage = "6.4.0"
 # Pinned rather than "latest" because tak is the measuring instrument: an
 # upgrade that changes how it samples would land in the series as a step change
 # in fnox's numbers, indistinguishable from a real regression. Bump deliberately.


### PR DESCRIPTION
## Summary
- bump usage-rs and the standalone usage renderer to 6.4.0
- refresh Cargo.lock and mise.lock
- regenerate CLI reference artifacts with usage 6.4.0

## Validation
- cargo check --locked
- mise run test:cargo
- mise run render
- mise --locked x usage -- usage --version
- mise lock usage --dry-run --json
- git diff --check
- upstream publish-cli run completed successfully: https://github.com/jdx/usage/actions/runs/32764359979

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and generated-docs-only change with no fnox runtime logic edits; minor CLI reference string formatting.
> 
> **Overview**
> Bumps the **usage** toolchain from **6.2.0** to **6.4.0**: `mise.toml` and `mise.lock` for the standalone `usage` CLI, and `Cargo.lock` for the `usage-*` / `usage-rs` crates used at build time.
> 
> Regenerated CLI reference output (`docs/cli/commands.json`, `index.md`, `scan.md`) reflects usage **6.4.0**’s formatting change for repeatable flags—usage strings for **`--profile`** and **`scan --ignore`** no longer show the `…` suffix (e.g. `-P --profile <PROFILE>` instead of `-P --profile… <PROFILE>`). Help text still notes that those flags can be repeated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ba04fa1ceaa81449d9589e1f2bcfb3a8bc8d2ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated CLI reference pages to display the complete `--profile` and `--ignore` option names without trailing ellipses.
  - Improved consistency and clarity across generated command usage documentation.

- **Chores**
  - Updated the usage tool to version 6.4.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->