### PR TITLE
docs(sync): call out the golden path and add hardware-backed decryption

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -61,14 +61,15 @@ export default defineConfig({
           { text: "What is fnox?", link: "/guide/what-is-fnox" },
           { text: "Installation", link: "/guide/installation" },
           { text: "Quick Start", link: "/guide/quick-start" },
-          { text: "Contributing", link: "/contributing" },
           { text: "How It Works", link: "/guide/how-it-works" },
+          { text: "Contributing", link: "/contributing" },
         ],
       },
       {
         text: "Features",
         items: [
           { text: "Shell Integration", link: "/guide/shell-integration" },
+          { text: "Syncing Secrets Locally", link: "/guide/sync" },
           { text: "Per-User Daemon", link: "/guide/daemon" },
           { text: "Credential Proxy", link: "/guide/proxy" },
           { text: "Mise Integration", link: "/guide/mise-integration" },
@@ -80,7 +81,6 @@ export default defineConfig({
             link: "/guide/missing-secrets",
           },
           { text: "Import/Export", link: "/guide/import-export" },
-          { text: "Syncing Secrets Locally", link: "/guide/sync" },
           { text: "Credential Leases", link: "/guide/leases" },
           { text: "MCP Server", link: "/guide/mcp" },
         ],
@@ -99,6 +99,7 @@ export default defineConfig({
       {
         text: "Examples",
         items: [
+          { text: "Golden Path Setup", link: "/guide/golden-path" },
           { text: "Real-World Setup", link: "/guide/real-world-example" },
         ],
       },

--- a/docs/guide/golden-path.md
+++ b/docs/guide/golden-path.md
@@ -1,0 +1,137 @@
+# Golden Path Setup
+
+A complete, zero-to-working walkthrough of [the golden path](/guide/what-is-fnox#the-golden-path): secrets live in 1Password, `fnox.toml` commits only references to them, and `fnox sync` caches everything locally under a personal age key so day-to-day loads are instant and offline.
+
+The same recipe works with any remote provider — swap 1Password for [AWS Secrets Manager](/providers/aws-sm), [Bitwarden](/providers/bitwarden), [Doppler](/providers/doppler), or any other [remote provider](/providers/overview).
+
+## Prerequisites
+
+- [fnox installed](/guide/installation)
+- The [1Password CLI](https://developer.1password.com/docs/cli/) installed and signed in (`op signin`)
+- `age` installed (`brew install age` / `apt install age`)
+
+## Step 1: One-Time Machine Setup
+
+Create a personal age key and a machine-wide `sync-age` provider. You do this once per machine, then reuse it in every project:
+
+```bash
+# Generate your personal age key
+mkdir -p ~/.config/fnox
+age-keygen -o ~/.config/fnox/age.txt
+
+# Add the machine-wide provider, then replace its age1... placeholder
+# with the "public key:" line from ~/.config/fnox/age.txt
+fnox provider add sync-age age --global
+"${EDITOR:-vi}" "${FNOX_CONFIG_DIR:-$HOME/.config/fnox}/config.toml"
+```
+
+Point the provider at your key file so decryption works without any environment setup:
+
+```toml
+# ~/.config/fnox/config.toml
+[providers.sync-age]
+type = "age"
+recipients = ["age1..."] # your public key
+key_file = "~/.config/fnox/age.txt"
+```
+
+::: tip Harden it with hardware
+Instead of a key file on disk, the age key can live in [Apple's Secure Enclave (Touch ID)](/guide/sync#apple-secure-enclave-touch-id), a [YubiKey](/guide/sync#yubikey), or a [TPM or FIDO2 token](/guide/sync#tpm-and-fido2). Only this step changes — everything below stays the same.
+:::
+
+## Step 2: Put Secrets in 1Password
+
+The vault is the single source of truth. Use existing items, or create them:
+
+```bash
+op item create --category=login --vault=Engineering --title=Database \
+  'url=postgresql://db.example.com/myapp'
+op item create --category=login --vault=Engineering --title=Stripe \
+  'secret-key=sk_live_...'
+```
+
+## Step 3: Commit References in fnox.toml
+
+In the project, reference the 1Password items — no secret material goes into git:
+
+```bash
+cd my-api
+fnox init
+```
+
+```toml
+# fnox.toml (committed)
+[providers.op]
+type = "1password"
+vault = "Engineering"
+
+[secrets]
+DATABASE_URL = { provider = "op", value = "Database/url" }
+STRIPE_KEY = { provider = "op", value = "Stripe/secret-key" }
+```
+
+Make sure the local cache never gets committed:
+
+```bash
+echo "fnox.local.toml" >> .gitignore
+git add fnox.toml .gitignore
+git commit -m "add fnox config"
+```
+
+## Step 4: Sync
+
+Pull every secret from 1Password once and cache it locally, re-encrypted to your personal age key:
+
+```bash
+fnox sync --provider sync-age --local-file
+```
+
+This writes the encrypted values into the gitignored `fnox.local.toml`. From now on fnox decrypts locally instead of calling 1Password — see [Syncing Secrets Locally](/guide/sync) for exactly what this looks like on disk.
+
+## Step 5: Enable Shell Integration
+
+```bash
+# Add to your shell profile
+eval "$(fnox activate zsh)"  # or bash, fish
+```
+
+Entering the project now loads secrets instantly, offline, with no 1Password calls:
+
+```bash
+~/projects $ cd my-api
+fnox: +2 DATABASE_URL, STRIPE_KEY
+~/projects/my-api $
+```
+
+## Day-to-Day
+
+**A secret changed in 1Password?** Re-sync:
+
+```bash
+fnox sync --provider sync-age --local-file --force
+```
+
+**A teammate joins?** They do Step 1 once on their machine, clone the repo, and run Step 4. Their cache is encrypted to their own key — nothing is shared except the vault.
+
+**A new secret?** Add the item to 1Password, add its reference to `fnox.toml`, commit, and everyone re-syncs.
+
+## What About CI?
+
+Don't sync in CI — the cache is a per-developer convenience, and a synced key sitting in CI defeats its purpose. Instead, let CI authenticate to the vault directly:
+
+```yaml
+# GitHub Actions
+- name: Run tests
+  env:
+    OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+  run: fnox exec -- npm test
+```
+
+The committed `fnox.toml` references resolve straight from 1Password using the [service account token](https://developer.1password.com/docs/service-accounts/). Alternatively, keep a separate set of [age-encrypted secrets in git](/providers/age) for CI.
+
+## Next Steps
+
+- [Syncing Secrets Locally](/guide/sync) - Everything `fnox sync` can do, including hardware-backed keys
+- [Real-World Setup](/guide/real-world-example) - An alternative workflow with encrypted secrets in git
+- [Profiles](/guide/profiles) - Different secrets for dev, staging, and production
+- [Credential Leases](/guide/leases) - Short-lived credentials from long-lived masters

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -82,7 +82,7 @@ recipients = ["age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"]
 EOF
 
 # 4. Set your decryption key
-export FNOX_AGE_KEY=$(cat ~/.config/fnox/age.txt | grep "AGE-SECRET-KEY")
+export FNOX_AGE_KEY=$(grep "AGE-SECRET-KEY" ~/.config/fnox/age.txt)
 
 # 5. Encrypt a secret
 fnox set DATABASE_URL "postgresql://prod.example.com/db" --provider age
@@ -90,9 +90,16 @@ fnox set DATABASE_URL "postgresql://prod.example.com/db" --provider age
 
 The secret is now encrypted in `fnox.toml` and safe to commit to git!
 
+::: tip Using a password manager or cloud vault?
+Encrypted-in-git is great for solo and open source projects. If your team keeps
+secrets in a vault like 1Password, follow [the golden path](/guide/golden-path)
+instead: commit references to the vault and cache secrets locally with
+[`fnox sync`](/guide/sync).
+:::
+
 ## Next Steps
 
-- [Syncing Secrets Locally](/guide/sync) - The golden path: keep secrets in a remote vault like 1Password and cache them locally with age
+- [Golden Path Setup](/guide/golden-path) - The recommended workflow: a remote vault plus a local encrypted cache
 - [How It Works](/guide/how-it-works) - Understand fnox's architecture
 - [Providers](/providers/overview) - Explore all available providers
 - [Shell Integration](/guide/shell-integration) - Deep dive into shell integration

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -92,6 +92,7 @@ The secret is now encrypted in `fnox.toml` and safe to commit to git!
 
 ## Next Steps
 
+- [Syncing Secrets Locally](/guide/sync) - The golden path: keep secrets in a remote vault like 1Password and cache them locally with age
 - [How It Works](/guide/how-it-works) - Understand fnox's architecture
 - [Providers](/providers/overview) - Explore all available providers
 - [Shell Integration](/guide/shell-integration) - Deep dive into shell integration

--- a/docs/guide/real-world-example.md
+++ b/docs/guide/real-world-example.md
@@ -2,6 +2,8 @@
 
 Let's build a complete setup for a typical web application with development, staging, and production environments.
 
+This example keeps dev/staging secrets encrypted in git with age. If your team keeps secrets in a vault like 1Password instead, see the [Golden Path Setup](/guide/golden-path).
+
 ## The Scenario
 
 You're building an API that needs:
@@ -55,7 +57,7 @@ Set decryption key:
 
 ```bash
 # Add to ~/.bashrc or ~/.zshrc
-export FNOX_AGE_KEY=$(cat ~/.config/fnox/age.txt | grep "AGE-SECRET-KEY")
+export FNOX_AGE_KEY=$(grep "AGE-SECRET-KEY" ~/.config/fnox/age.txt)
 ```
 
 ## Step 3: Add Development Secrets
@@ -306,7 +308,7 @@ jobs:
 2. Add `FNOX_AGE_KEY`:
    ```bash
    # Copy the CI age secret key (from the CI recipient's age.txt)
-   cat ~/.config/fnox/ci-age.txt | grep "AGE-SECRET-KEY"
+   grep "AGE-SECRET-KEY" ~/.config/fnox/ci-age.txt
    ```
 3. Add `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` for production
 
@@ -330,7 +332,7 @@ grep "public key:" ~/.config/fnox/age.txt
 # Send to team lead to add to fnox.toml recipients
 
 # 5. Set decryption key
-echo 'export FNOX_AGE_KEY=$(cat ~/.config/fnox/age.txt | grep "AGE-SECRET-KEY")' >> ~/.bashrc
+echo 'export FNOX_AGE_KEY=$(grep "AGE-SECRET-KEY" ~/.config/fnox/age.txt)' >> ~/.bashrc
 source ~/.bashrc
 
 # 6. Enable shell integration

--- a/docs/guide/sync.md
+++ b/docs/guide/sync.md
@@ -172,8 +172,8 @@ the portable token, and FIDO2-HMAC unwraps an age identity into host memory.
 
 On macOS, [age-plugin-se](https://github.com/remko/age-plugin-se) generates the
 age key inside Apple's Secure Enclave. The private key is non-exportable and
-never leaves the hardware, and each decryption can require Touch ID — so the
-local cache is unreadable without both your Mac and your fingerprint.
+never leaves the hardware. Decryption requires that Mac and enforces the access
+control policy chosen when the identity was created, which can require Touch ID.
 
 ```bash
 # 1. Install the plugin (must be on PATH)

--- a/docs/guide/sync.md
+++ b/docs/guide/sync.md
@@ -3,15 +3,13 @@
 `fnox sync` fetches secrets from remote providers (1Password, AWS Secrets Manager, etc.) and re-encrypts them with a local encryption provider (age, YubiKey via age plugin, AWS KMS, etc.). The encrypted values are stored in `fnox.local.toml` (gitignored) so that subsequent access is instant and offline — no remote calls needed.
 
 ::: tip The golden path
-This is the recommended way to use fnox: keep secrets in a remote vault like
-1Password as the single source of truth, commit only references to them in
-`fnox.toml`, and cache them locally with `fnox sync` behind a personal age key.
-You get centralized management and instant, offline secret loading. For the
-strongest setup, bind the local key to hardware —
+This is the recommended way to use fnox: secrets live in a remote vault like
+1Password, `fnox.toml` only holds references to them, and `fnox sync` caches
+them locally under a personal age key. The vault stays the single source of
+truth, but day-to-day loads are instant and work offline. To go further, keep
+the age key in hardware:
 [Apple's Secure Enclave (Touch ID)](#apple-secure-enclave-touch-id), a
-[YubiKey](#yubikey), or [TPM and FIDO2 hardware](#tpm-and-fido2). Secure Enclave
-and TPM keys are bound to one machine, while YubiKey and FIDO2 tokens are
-portable; each option's security properties are described below.
+[YubiKey](#yubikey), or a [TPM or FIDO2 token](#tpm-and-fido2).
 :::
 
 ## Why Sync?
@@ -161,19 +159,20 @@ name, so use a distinct name such as `sync-age` for the cache.
 
 ## Hardware-Backed Decryption
 
-The sync cache is only as secure as the age key that decrypts it. Instead of a
-plaintext key file on disk, you can bind decryption to hardware via an
-[age plugin](/providers/age#plugin-support) — the workflow stays exactly the
-same, only the provider's recipient (and identity) changes. The guarantees vary:
-Secure Enclave and TPM identities are machine-bound, YubiKey identities require
-the portable token, and FIDO2-HMAC unwraps an age identity into host memory.
+The sync cache is only as secure as the age key that decrypts it. Rather than
+keeping that key in a plaintext file on disk, you can hold it in hardware
+through an [age plugin](/providers/age#plugin-support). Syncing works the same
+either way; all that changes is the provider's recipient and identity. Secure
+Enclave and TPM keys never leave the machine they were created on, a YubiKey
+travels with you, and FIDO2-HMAC sits somewhere in between (the identity gets
+copied into host memory during decryption).
 
 ### Apple Secure Enclave (Touch ID)
 
 On macOS, [age-plugin-se](https://github.com/remko/age-plugin-se) generates the
-age key inside Apple's Secure Enclave. The private key is non-exportable and
-never leaves the hardware. Decryption requires that Mac and enforces the access
-control policy chosen when the identity was created, which can require Touch ID.
+age key inside Apple's Secure Enclave. The private key can't be exported, so
+decryption only works on that Mac — and, depending on the access control policy
+you pick at keygen time, only after a Touch ID prompt.
 
 ```bash
 # 1. Install the plugin (must be on PATH)
@@ -185,8 +184,9 @@ age-plugin-se keygen --access-control=any-biometry -o ~/.config/fnox/age-se.txt
 # Public key: age1se1...
 ```
 
-Configure the personal provider with the printed `age1se1...` recipient — in
-the global config so every project on this machine can reuse it:
+Put the printed `age1se1...` recipient in the provider config. The global
+config is a good home for it, since every project on the machine can then reuse
+the same key:
 
 ```toml
 # ~/.config/fnox/config.toml
@@ -202,17 +202,16 @@ Then sync as usual:
 fnox sync --provider sync-age --local-file
 ```
 
-From now on, `fnox get`, `fnox exec`, and shell integration decrypt the cache
-through the Secure Enclave, prompting for Touch ID according to the
-`--access-control` policy you chose (`any-biometry`, `any-biometry-or-passcode`,
-`none`, …).
+That's it — `fnox get`, `fnox exec`, and shell integration now decrypt the
+cache through the Secure Enclave. Whether you're prompted for Touch ID depends
+on the `--access-control` policy you chose (`any-biometry`,
+`any-biometry-or-passcode`, `none`, …).
 
 ::: warning
-`age-se.txt` is only a reference to the hardware key, not the key itself — but
-treat it like an identity file anyway. Unset `FNOX_AGE_KEY` if you have it
-exported, since it takes precedence over the provider's `key_file`. Secure
-Enclave identity generation and decryption require macOS 14 or later and a Mac
-with a Secure Enclave processor.
+`age-se.txt` doesn't contain the private key — it's a reference to the key in
+the Secure Enclave — but treat it like an identity file anyway. If you have
+`FNOX_AGE_KEY` exported, unset it: it takes precedence over the provider's
+`key_file`. Requires macOS 14+ and a Mac with a Secure Enclave.
 :::
 
 ### YubiKey
@@ -229,28 +228,28 @@ recipients = ["age1yubikey1q..."]  # YubiKey recipient
 fnox sync --provider sync-age --local-file
 ```
 
-Secrets are encrypted to your YubiKey's age identity. Decryption requires the
-YubiKey to be plugged in, adding hardware-based security to your local cache.
-The token is portable, so you can decrypt on another compatible machine that
-has the plugin and identity reference. See [Age Plugin
+Secrets are encrypted to your YubiKey's age identity, so decrypting the cache
+requires the key to be plugged in. Unlike a Secure Enclave or TPM key, the
+YubiKey isn't tied to one machine: plug it into any machine that has the plugin
+and the identity reference and you can decrypt there too. See [Age Plugin
 Support](/providers/age#plugin-support) for details and other plugins.
 
 ### TPM and FIDO2
 
-Machines without a Secure Enclave or YubiKey usually still have hardware key
-storage:
+No Secure Enclave or YubiKey? Most machines still have some form of hardware
+key storage:
 
-- [age-plugin-tpm](https://github.com/Foxboron/age-plugin-tpm) binds the age
-  key to the TPM 2.0 chip built into most modern laptops. The identity cannot be
-  used with another machine's TPM; current recipients start with `age1tag1...`.
+- [age-plugin-tpm](https://github.com/Foxboron/age-plugin-tpm) stores the age
+  key in the TPM 2.0 chip found in most modern laptops. Like the Secure
+  Enclave, the key is stuck to that machine. Current releases produce
+  recipients starting with `age1tag1...`.
 - [age-plugin-fido2-hmac](https://github.com/olastor/age-plugin-fido2-hmac)
-  works with FIDO2 security keys that support the `hmac-secret` extension;
-  documented recipients start with `age1zdy...`. The plugin is experimental and
-  unwraps the age identity into host memory during decryption. If that in-memory
-  identity is stolen, it can decrypt without the token.
+  works with FIDO2 security keys that support the `hmac-secret` extension
+  (recipients start with `age1zdy...`). It's still experimental, and during
+  decryption the age identity gets unwrapped into host memory — anyone who
+  steals it from there can decrypt without the token.
 
-Follow each plugin's installation instructions for your platform, then generate
-the identity and recipient with its documented command:
+Install the plugin for your platform, then generate an identity:
 
 ```bash
 # TPM
@@ -261,9 +260,9 @@ age-plugin-tpm -y ~/.config/fnox/age-tpm.txt
 age-plugin-fido2-hmac -g > ~/.config/fnox/age-fido2.txt
 ```
 
-Put the resulting recipient in the provider's `recipients`, point `key_file` at
-the identity file, and run `fnox sync` as usual. A YubiKey is preferable to
-FIDO2-HMAC when the decrypted identity must never enter host memory.
+Add the resulting recipient to the provider's `recipients`, point `key_file`
+at the identity file, and sync as usual. If the identity must never touch host
+memory, use a YubiKey rather than FIDO2-HMAC.
 
 ## Refreshing the Cache
 

--- a/docs/guide/sync.md
+++ b/docs/guide/sync.md
@@ -2,6 +2,17 @@
 
 `fnox sync` fetches secrets from remote providers (1Password, AWS Secrets Manager, etc.) and re-encrypts them with a local encryption provider (age, YubiKey via age plugin, AWS KMS, etc.). The encrypted values are stored in `fnox.local.toml` (gitignored) so that subsequent access is instant and offline — no remote calls needed.
 
+::: tip The golden path
+This is the recommended way to use fnox: keep secrets in a remote vault like
+1Password as the single source of truth, commit only references to them in
+`fnox.toml`, and cache them locally with `fnox sync` behind a personal age key.
+You get centralized management and instant, offline secret loading. For the
+strongest setup, bind the local key to hardware —
+[Apple's Secure Enclave (Touch ID)](#apple-secure-enclave-touch-id), a
+[YubiKey](#yubikey), or a [TPM / FIDO2 key](#tpm-and-fido2-linux-windows) — so
+the cache can only be decrypted on your machine.
+:::
+
 ## Why Sync?
 
 A typical team setup stores secrets in a shared provider like 1Password:
@@ -147,7 +158,60 @@ Provider definitions are replaced as a unit when configs are merged. A local
 name, so use a distinct name such as `sync-age` for the cache.
 :::
 
-## Using a YubiKey
+## Hardware-Backed Decryption
+
+The sync cache is only as secure as the age key that decrypts it. Instead of a
+plaintext key file on disk, you can bind decryption to hardware via an
+[age plugin](/providers/age#plugin-support) — the workflow stays exactly the
+same, only the provider's recipient (and identity) changes.
+
+### Apple Secure Enclave (Touch ID)
+
+On macOS, [age-plugin-se](https://github.com/remko/age-plugin-se) generates the
+age key inside Apple's Secure Enclave. The private key is non-exportable and
+never leaves the hardware, and each decryption can require Touch ID — so the
+local cache is unreadable without both your Mac and your fingerprint.
+
+```bash
+# 1. Install the plugin (must be on PATH)
+brew install age-plugin-se
+
+# 2. Generate a hardware-bound identity
+mkdir -p ~/.config/fnox
+age-plugin-se keygen --access-control=any-biometry -o ~/.config/fnox/age-se.txt
+# Public key: age1se1...
+```
+
+Configure the personal provider with the printed `age1se1...` recipient — in
+the global config so every project on this machine can reuse it:
+
+```toml
+# ~/.config/fnox/config.toml
+[providers.sync-age]
+type = "age"
+recipients = ["age1se1..."]
+key_file = "~/.config/fnox/age-se.txt"
+```
+
+Then sync as usual:
+
+```bash
+fnox sync --provider sync-age --local-file
+```
+
+From now on, `fnox get`, `fnox exec`, and shell integration decrypt the cache
+through the Secure Enclave, prompting for Touch ID according to the
+`--access-control` policy you chose (`any-biometry`, `any-biometry-or-passcode`,
+`none`, …).
+
+::: warning
+`age-se.txt` is only a reference to the hardware key, not the key itself — but
+treat it like an identity file anyway. Unset `FNOX_AGE_KEY` if you have it
+exported, since it takes precedence over the provider's `key_file`. Secure
+Enclave decryption requires macOS 14 or later.
+:::
+
+### YubiKey
 
 If you use a YubiKey with the [age-plugin-yubikey](https://github.com/str4d/age-plugin-yubikey), syncing works the same way. Your age provider just uses the YubiKey identity:
 
@@ -161,7 +225,22 @@ recipients = ["age1yubikey1q..."]  # YubiKey recipient
 fnox sync --provider sync-age --local-file
 ```
 
-Secrets are encrypted to your YubiKey's age identity. Decryption requires the YubiKey to be plugged in, adding hardware-based security to your local cache. See [Age Plugin Support](/providers/age#plugin-support) for details and other plugins (TPM, FIDO2, …).
+Secrets are encrypted to your YubiKey's age identity. Decryption requires the YubiKey to be plugged in, adding hardware-based security to your local cache. See [Age Plugin Support](/providers/age#plugin-support) for details and other plugins.
+
+### TPM and FIDO2 (Linux / Windows)
+
+Machines without a Secure Enclave or YubiKey usually still have hardware key
+storage:
+
+- [age-plugin-tpm](https://github.com/Foxboron/age-plugin-tpm) binds the age
+  key to the TPM 2.0 chip built into most modern laptops (recipients start with
+  `age1tpm1...`).
+- [age-plugin-fido2-hmac](https://github.com/olastor/age-plugin-fido2-hmac)
+  works with any FIDO2 security key (recipients start with `age1fido2-hmac1...`).
+
+The pattern is always the same: generate an identity with the plugin's keygen
+command, put the printed recipient in the provider's `recipients`, point
+`key_file` at the identity file, and run `fnox sync` as usual.
 
 ## Refreshing the Cache
 

--- a/docs/guide/sync.md
+++ b/docs/guide/sync.md
@@ -9,8 +9,9 @@ This is the recommended way to use fnox: keep secrets in a remote vault like
 You get centralized management and instant, offline secret loading. For the
 strongest setup, bind the local key to hardware —
 [Apple's Secure Enclave (Touch ID)](#apple-secure-enclave-touch-id), a
-[YubiKey](#yubikey), or a [TPM / FIDO2 key](#tpm-and-fido2-linux-windows) — so
-the cache can only be decrypted on your machine.
+[YubiKey](#yubikey), or [TPM and FIDO2 hardware](#tpm-and-fido2). Secure Enclave
+and TPM keys are bound to one machine, while YubiKey and FIDO2 tokens are
+portable; each option's security properties are described below.
 :::
 
 ## Why Sync?
@@ -163,7 +164,9 @@ name, so use a distinct name such as `sync-age` for the cache.
 The sync cache is only as secure as the age key that decrypts it. Instead of a
 plaintext key file on disk, you can bind decryption to hardware via an
 [age plugin](/providers/age#plugin-support) — the workflow stays exactly the
-same, only the provider's recipient (and identity) changes.
+same, only the provider's recipient (and identity) changes. The guarantees vary:
+Secure Enclave and TPM identities are machine-bound, YubiKey identities require
+the portable token, and FIDO2-HMAC unwraps an age identity into host memory.
 
 ### Apple Secure Enclave (Touch ID)
 
@@ -208,7 +211,8 @@ through the Secure Enclave, prompting for Touch ID according to the
 `age-se.txt` is only a reference to the hardware key, not the key itself — but
 treat it like an identity file anyway. Unset `FNOX_AGE_KEY` if you have it
 exported, since it takes precedence over the provider's `key_file`. Secure
-Enclave decryption requires macOS 14 or later.
+Enclave identity generation and decryption require macOS 14 or later and a Mac
+with a Secure Enclave processor.
 :::
 
 ### YubiKey
@@ -225,22 +229,41 @@ recipients = ["age1yubikey1q..."]  # YubiKey recipient
 fnox sync --provider sync-age --local-file
 ```
 
-Secrets are encrypted to your YubiKey's age identity. Decryption requires the YubiKey to be plugged in, adding hardware-based security to your local cache. See [Age Plugin Support](/providers/age#plugin-support) for details and other plugins.
+Secrets are encrypted to your YubiKey's age identity. Decryption requires the
+YubiKey to be plugged in, adding hardware-based security to your local cache.
+The token is portable, so you can decrypt on another compatible machine that
+has the plugin and identity reference. See [Age Plugin
+Support](/providers/age#plugin-support) for details and other plugins.
 
-### TPM and FIDO2 (Linux / Windows)
+### TPM and FIDO2
 
 Machines without a Secure Enclave or YubiKey usually still have hardware key
 storage:
 
 - [age-plugin-tpm](https://github.com/Foxboron/age-plugin-tpm) binds the age
-  key to the TPM 2.0 chip built into most modern laptops (recipients start with
-  `age1tpm1...`).
+  key to the TPM 2.0 chip built into most modern laptops. The identity cannot be
+  used with another machine's TPM; current recipients start with `age1tag1...`.
 - [age-plugin-fido2-hmac](https://github.com/olastor/age-plugin-fido2-hmac)
-  works with any FIDO2 security key (recipients start with `age1fido2-hmac1...`).
+  works with FIDO2 security keys that support the `hmac-secret` extension;
+  documented recipients start with `age1zdy...`. The plugin is experimental and
+  unwraps the age identity into host memory during decryption. If that in-memory
+  identity is stolen, it can decrypt without the token.
 
-The pattern is always the same: generate an identity with the plugin's keygen
-command, put the printed recipient in the provider's `recipients`, point
-`key_file` at the identity file, and run `fnox sync` as usual.
+Follow each plugin's installation instructions for your platform, then generate
+the identity and recipient with its documented command:
+
+```bash
+# TPM
+age-plugin-tpm --generate -o ~/.config/fnox/age-tpm.txt
+age-plugin-tpm -y ~/.config/fnox/age-tpm.txt
+
+# FIDO2-HMAC; writes the identity and prints its public key in a comment
+age-plugin-fido2-hmac -g > ~/.config/fnox/age-fido2.txt
+```
+
+Put the resulting recipient in the provider's `recipients`, point `key_file` at
+the identity file, and run `fnox sync` as usual. A YubiKey is preferable to
+FIDO2-HMAC when the decrypted identity must never enter host memory.
 
 ## Refreshing the Cache
 

--- a/docs/guide/sync.md
+++ b/docs/guide/sync.md
@@ -10,6 +10,9 @@ truth, but day-to-day loads are instant and work offline. To go further, keep
 the age key in hardware:
 [Apple's Secure Enclave (Touch ID)](#apple-secure-enclave-touch-id), a
 [YubiKey](#yubikey), or a [TPM or FIDO2 token](#tpm-and-fido2).
+
+For a zero-to-working walkthrough of the whole setup, see
+[Golden Path Setup](/guide/golden-path).
 :::
 
 ## Why Sync?
@@ -264,6 +267,29 @@ Add the resulting recipient to the provider's `recipients`, point `key_file`
 at the identity file, and sync as usual. If the identity must never touch host
 memory, use a YubiKey rather than FIDO2-HMAC.
 
+### Age Plugins vs. Native Hardware Providers
+
+fnox also ships native [`yubikey`](/providers/yubikey) and
+[`fido2`](/providers/fido2) providers that skip age entirely: they derive a
+symmetric AES-256-GCM key from the hardware token and can be used as sync
+targets the same way (`fnox sync --provider secure --local-file`). The
+trade-offs:
+
+- **Native providers** need no plugin binary — fnox talks to the token
+  directly — and the config is fully portable: move `fnox.local.toml` to
+  another machine, plug in the same token, and it decrypts. But the encryption
+  is symmetric, so the token must be present (and touched) for `fnox sync`
+  itself, not just for decryption, and only that one token can ever decrypt
+  the cache.
+- **Age plugins** encrypt to a public recipient, so syncing never touches the
+  hardware — only decryption does — and a provider can list several recipients
+  (e.g. a YubiKey plus a backup key). In exchange, the plugin binary must be
+  installed wherever you decrypt.
+
+For a personal sync cache either works well; pick the native providers if you
+don't want to install age plugins, and the age route if you want backup
+recipients or hardware-free syncing.
+
 ## Refreshing the Cache
 
 When secrets change in the remote provider, re-run sync to update the local cache:
@@ -273,6 +299,15 @@ fnox sync --provider sync-age --local-file --force
 ```
 
 The `--force` flag skips the confirmation prompt. fnox re-fetches from the original provider and re-encrypts.
+
+## What About CI?
+
+The sync cache is a per-developer convenience — don't sync in CI. Let CI
+authenticate to the remote provider directly (e.g. a 1Password
+[service account token](https://developer.1password.com/docs/service-accounts/)
+or an AWS role), or give it [age-encrypted secrets committed to
+git](/providers/age#ci-cd-setup) with its own key. The committed `fnox.toml`
+references resolve the same way in both cases.
 
 ## Full Workflow Example
 
@@ -315,6 +350,7 @@ cd .. && cd my-api
 
 ## Next Steps
 
+- [Golden Path Setup](/guide/golden-path) - Zero-to-working walkthrough of this workflow
 - [Per-User Daemon](/guide/daemon) - Cache resolved secrets in memory for a session
 - [Import/Export](/guide/import-export) - Migrate secrets between formats
 - [Shell Integration](/guide/shell-integration) - Auto-load secrets on `cd`

--- a/docs/guide/what-is-fnox.md
+++ b/docs/guide/what-is-fnox.md
@@ -17,13 +17,13 @@ fnox's config file, `fnox.toml`, will either contain the encrypted secrets, or a
 
 ## The Golden Path
 
-fnox supports many provider combinations, but the recommended workflow — the golden path — combines a remote vault with a local encrypted cache:
+fnox supports a lot of provider combinations, but there's one workflow we recommend — the golden path:
 
-1. **Keep secrets in a remote vault** like [1Password](/providers/1password), and commit only references to them in `fnox.toml`. The vault is the single source of truth, and nothing sensitive ever lands in git.
-2. **Cache them locally with [`fnox sync`](/guide/sync)**, which re-encrypts every secret to your personal [age](/providers/age) key in the gitignored `fnox.local.toml`.
-3. **Load them instantly** via [shell integration](/guide/shell-integration) or `fnox exec` — decryption happens locally and offline, with no network calls to the vault.
+1. **Keep secrets in a remote vault** like [1Password](/providers/1password) and commit only references to them in `fnox.toml`. The vault stays the single source of truth and nothing sensitive goes into git.
+2. **Cache them locally with [`fnox sync`](/guide/sync)**, which re-encrypts each secret to your personal [age](/providers/age) key in the gitignored `fnox.local.toml`.
+3. **Load them from the cache** via [shell integration](/guide/shell-integration) or `fnox exec`. Decryption is local, so it's instant and works offline.
 
-For the strongest setup, protect the local age key with hardware — [Apple's Secure Enclave (Touch ID)](/guide/sync#apple-secure-enclave-touch-id), a [YubiKey](/guide/sync#yubikey), or [TPM and FIDO2 hardware](/guide/sync#tpm-and-fido2). Secure Enclave and TPM keys are machine-bound; YubiKey and FIDO2 tokens are portable and have different security properties. See [Syncing Secrets Locally](/guide/sync) for the full walkthrough.
+You can also keep the age key in hardware — [Apple's Secure Enclave (Touch ID)](/guide/sync#apple-secure-enclave-touch-id), a [YubiKey](/guide/sync#yubikey), or a [TPM or FIDO2 token](/guide/sync#tpm-and-fido2) — so the cache can't be decrypted without the machine or the token. See [Syncing Secrets Locally](/guide/sync) for the full walkthrough.
 
 ## Why Choose fnox?
 

--- a/docs/guide/what-is-fnox.md
+++ b/docs/guide/what-is-fnox.md
@@ -23,7 +23,7 @@ fnox supports many provider combinations, but the recommended workflow — the g
 2. **Cache them locally with [`fnox sync`](/guide/sync)**, which re-encrypts every secret to your personal [age](/providers/age) key in the gitignored `fnox.local.toml`.
 3. **Load them instantly** via [shell integration](/guide/shell-integration) or `fnox exec` — decryption happens locally and offline, with no network calls to the vault.
 
-For the strongest setup, back the local age key with hardware — [Apple's Secure Enclave (Touch ID)](/guide/sync#apple-secure-enclave-touch-id), a [YubiKey](/guide/sync#yubikey), or a [TPM / FIDO2 key](/guide/sync#tpm-and-fido2-linux-windows) on Linux and Windows — so the cache can only be decrypted on your machine. See [Syncing Secrets Locally](/guide/sync) for the full walkthrough.
+For the strongest setup, protect the local age key with hardware — [Apple's Secure Enclave (Touch ID)](/guide/sync#apple-secure-enclave-touch-id), a [YubiKey](/guide/sync#yubikey), or [TPM and FIDO2 hardware](/guide/sync#tpm-and-fido2). Secure Enclave and TPM keys are machine-bound; YubiKey and FIDO2 tokens are portable and have different security properties. See [Syncing Secrets Locally](/guide/sync) for the full walkthrough.
 
 ## Why Choose fnox?
 

--- a/docs/guide/what-is-fnox.md
+++ b/docs/guide/what-is-fnox.md
@@ -23,7 +23,7 @@ fnox supports a lot of provider combinations, but there's one workflow we recomm
 2. **Cache them locally with [`fnox sync`](/guide/sync)**, which re-encrypts each secret to your personal [age](/providers/age) key in the gitignored `fnox.local.toml`.
 3. **Load them from the cache** via [shell integration](/guide/shell-integration) or `fnox exec`. Decryption is local, so it's instant and works offline.
 
-You can also keep the age key in hardware: [Apple's Secure Enclave (Touch ID)](/guide/sync#apple-secure-enclave-touch-id), a [YubiKey](/guide/sync#yubikey), or a [TPM or FIDO2 token](/guide/sync#tpm-and-fido2). A Secure Enclave or TPM key only decrypts on the machine that created it, while a YubiKey travels with you. See [Syncing Secrets Locally](/guide/sync) for the walkthroughs and what each option actually protects against.
+You can also keep the age key in hardware: [Apple's Secure Enclave (Touch ID)](/guide/sync#apple-secure-enclave-touch-id), a [YubiKey](/guide/sync#yubikey), or a [TPM or FIDO2 token](/guide/sync#tpm-and-fido2). A Secure Enclave or TPM key only decrypts on the machine that created it, while a YubiKey travels with you. See [Syncing Secrets Locally](/guide/sync) for the walkthroughs and what each option actually protects against, or follow the complete [Golden Path Setup](/guide/golden-path) example from start to finish.
 
 ## Why Choose fnox?
 

--- a/docs/guide/what-is-fnox.md
+++ b/docs/guide/what-is-fnox.md
@@ -23,7 +23,7 @@ fnox supports a lot of provider combinations, but there's one workflow we recomm
 2. **Cache them locally with [`fnox sync`](/guide/sync)**, which re-encrypts each secret to your personal [age](/providers/age) key in the gitignored `fnox.local.toml`.
 3. **Load them from the cache** via [shell integration](/guide/shell-integration) or `fnox exec`. Decryption is local, so it's instant and works offline.
 
-You can also keep the age key in hardware — [Apple's Secure Enclave (Touch ID)](/guide/sync#apple-secure-enclave-touch-id), a [YubiKey](/guide/sync#yubikey), or a [TPM or FIDO2 token](/guide/sync#tpm-and-fido2) — so the cache can't be decrypted without the machine or the token. See [Syncing Secrets Locally](/guide/sync) for the full walkthrough.
+You can also keep the age key in hardware: [Apple's Secure Enclave (Touch ID)](/guide/sync#apple-secure-enclave-touch-id), a [YubiKey](/guide/sync#yubikey), or a [TPM or FIDO2 token](/guide/sync#tpm-and-fido2). A Secure Enclave or TPM key only decrypts on the machine that created it, while a YubiKey travels with you. See [Syncing Secrets Locally](/guide/sync) for the walkthroughs and what each option actually protects against.
 
 ## Why Choose fnox?
 

--- a/docs/guide/what-is-fnox.md
+++ b/docs/guide/what-is-fnox.md
@@ -15,6 +15,16 @@ fnox works with either—or both! They've got their pros and cons. Either way, f
 
 fnox's config file, `fnox.toml`, will either contain the encrypted secrets, or a reference to a secret in a cloud provider. You can either use `fnox exec -- <command>` to run a command with the secrets, or you can use the [shell integration](/guide/shell-integration) to automatically load the secrets into your shell environment when you `cd` into a directory with a `fnox.toml` file.
 
+## The Golden Path
+
+fnox supports many provider combinations, but the recommended workflow — the golden path — combines a remote vault with a local encrypted cache:
+
+1. **Keep secrets in a remote vault** like [1Password](/providers/1password), and commit only references to them in `fnox.toml`. The vault is the single source of truth, and nothing sensitive ever lands in git.
+2. **Cache them locally with [`fnox sync`](/guide/sync)**, which re-encrypts every secret to your personal [age](/providers/age) key in the gitignored `fnox.local.toml`.
+3. **Load them instantly** via [shell integration](/guide/shell-integration) or `fnox exec` — decryption happens locally and offline, with no network calls to the vault.
+
+For the strongest setup, back the local age key with hardware — [Apple's Secure Enclave (Touch ID)](/guide/sync#apple-secure-enclave-touch-id), a [YubiKey](/guide/sync#yubikey), or a [TPM / FIDO2 key](/guide/sync#tpm-and-fido2-linux-windows) on Linux and Windows — so the cache can only be decrypted on your machine. See [Syncing Secrets Locally](/guide/sync) for the full walkthrough.
+
 ## Why Choose fnox?
 
 ### Works with Your Existing Infrastructure

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,13 +61,13 @@ eval "$(fnox activate bash)"  # or zsh, fish — see docs for Nushell
 
 ## The Golden Path
 
-The recommended workflow combines a remote vault with a local encrypted cache: keep secrets in a vault like 1Password (committing only references in `fnox.toml`), then cache them locally with [`fnox sync`](/guide/sync) behind a personal age key — optionally hardware-backed by [Apple's Secure Enclave, a YubiKey, or a TPM](/guide/sync#hardware-backed-decryption).
+The recommended setup: keep secrets in a vault like 1Password, commit only references to them in `fnox.toml`, and cache them locally with [`fnox sync`](/guide/sync) under a personal age key — which can even live in [hardware like a Secure Enclave, YubiKey, or TPM](/guide/sync#hardware-backed-decryption).
 
 ```bash
 fnox sync --provider sync-age --local-file
 ```
 
-You get centralized secret management and instant, offline loads on every `cd`. See [The Golden Path](/guide/what-is-fnox#the-golden-path) for details.
+The vault stays the source of truth, but secrets load instantly and offline on every `cd`. See [The Golden Path](/guide/what-is-fnox#the-golden-path) for details.
 
 ## How It Works
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,6 +59,16 @@ fnox exec -- npm start
 eval "$(fnox activate bash)"  # or zsh, fish — see docs for Nushell
 ```
 
+## The Golden Path
+
+The recommended workflow combines a remote vault with a local encrypted cache: keep secrets in a vault like 1Password (committing only references in `fnox.toml`), then cache them locally with [`fnox sync`](/guide/sync) behind a personal age key — optionally hardware-backed by [Apple's Secure Enclave, a YubiKey, or a TPM](/guide/sync#hardware-backed-decryption).
+
+```bash
+fnox sync --provider sync-age --local-file
+```
+
+You get centralized secret management and instant, offline loads on every `cd`. See [The Golden Path](/guide/what-is-fnox#the-golden-path) for details.
+
 ## How It Works
 
 fnox uses a simple TOML config file (`fnox.toml`) that you check into git. Secrets are either:

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,7 +67,7 @@ The recommended setup: keep secrets in a vault like 1Password, commit only refer
 fnox sync --provider sync-age --local-file
 ```
 
-The vault stays the source of truth, but secrets load instantly and offline on every `cd`. See [The Golden Path](/guide/what-is-fnox#the-golden-path) for details.
+The vault stays the source of truth, but secrets load instantly and offline on every `cd`. See [The Golden Path](/guide/what-is-fnox#the-golden-path) for details, or jump straight to the [setup walkthrough](/guide/golden-path).
 
 ## How It Works
 
@@ -90,34 +90,11 @@ API_KEY = { default = "dev-key-12345" }  # ← plain default value for local dev
 
 ## Supported Providers
 
-### 🔐 Encryption (secrets in git, encrypted)
+fnox works with over 20 providers across four categories:
 
-- **age** - Modern encryption (works with SSH keys!)
-- **aws-kms** - AWS Key Management Service
-- **azure-kms** - Azure Key Vault encryption
-- **gcp-kms** - Google Cloud KMS
+- **🔐 Encryption (secrets in git)** — age (with SSH keys and hardware plugins), FIDO2, YubiKey, AWS/Azure/GCP KMS
+- **☁️ Cloud secret storage** — AWS Secrets Manager & Parameter Store, Azure Key Vault, GCP Secret Manager, HashiCorp Vault, Doppler, and more
+- **🔑 Password managers** — 1Password, Bitwarden, Proton Pass, Infisical
+- **💻 Local storage** — OS keychain, KeePass, password-store
 
-### ☁️ Cloud Secret Storage (remote, centralized)
-
-- **aws-ps** - AWS Parameter Store
-- **aws-sm** - AWS Secrets Manager
-- **azure-ac** - Azure App Configuration
-- **azure-sm** - Azure Key Vault Secrets
-- **gcp-sm** - Google Cloud Secret Manager
-- **bitwarden-sm** - Bitwarden Secrets Manager
-- **doppler** - Doppler secrets manager
-- **foks** - FOKS (Federated Open Key Service)
-- **keeper-sm** - Keeper Secrets Manager
-- **vault** - HashiCorp Vault
-
-### 🔑 Password Managers & Secret Services
-
-- **1password** - 1Password CLI
-- **bitwarden** - Bitwarden/Vaultwarden
-- **infisical** - Infisical secrets management
-
-### 💻 Local Storage
-
-- **keychain** - OS Keychain (macOS/Windows/Linux)
-- **password-store** - GPG-encrypted password store (Unix pass)
-- **plain** - Plain text (for defaults only!)
+See the [Providers Overview](/providers/overview) for the full list and a comparison of trade-offs.

--- a/docs/providers/age.md
+++ b/docs/providers/age.md
@@ -19,7 +19,7 @@ age = { type = "age", recipients = ["age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8z
 EOF
 
 # 4. Set private key
-export FNOX_AGE_KEY=$(cat ~/.config/fnox/age.txt | grep "AGE-SECRET-KEY")
+export FNOX_AGE_KEY=$(grep "AGE-SECRET-KEY" ~/.config/fnox/age.txt)
 
 # 5. Encrypt a secret
 fnox set DATABASE_URL "postgresql://localhost/mydb" --provider age
@@ -64,12 +64,7 @@ AGE-SECRET-KEY-1ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEFGHIJKLMNOPQRS
 
 ### Option 2: Use SSH Key
 
-Age has first-class SSH key support! Use your existing SSH keys:
-
-```bash
-# No key generation needed!
-# Just use your SSH public key as the recipient
-```
+Age has first-class SSH key support — no key generation needed. Your existing SSH public key becomes the recipient and your private key decrypts; see [SSH Key Support](#ssh-key-support) below.
 
 ## Configuration
 
@@ -110,10 +105,10 @@ age = { type = "age", recipients = ["age1..."], identity = { provider = "keychai
 
 ```bash
 # Export the secret key
-export FNOX_AGE_KEY=$(cat ~/.config/fnox/age.txt | grep "AGE-SECRET-KEY")
+export FNOX_AGE_KEY=$(grep "AGE-SECRET-KEY" ~/.config/fnox/age.txt)
 
 # Add to shell profile
-echo 'export FNOX_AGE_KEY=$(cat ~/.config/fnox/age.txt | grep "AGE-SECRET-KEY")' >> ~/.bashrc
+echo 'export FNOX_AGE_KEY=$(grep "AGE-SECRET-KEY" ~/.config/fnox/age.txt)' >> ~/.bashrc
 ```
 
 #### Using SSH Key
@@ -369,7 +364,7 @@ jobs:
 3. Copy the secret key:
 
    ```bash
-   cat ci-age.txt | grep "AGE-SECRET-KEY"
+   grep "AGE-SECRET-KEY" ci-age.txt
    ```
 
 4. Add to GitHub Secrets as `FNOX_AGE_KEY`
@@ -404,7 +399,7 @@ cat ~/.config/fnox/age.txt  # Check public key
 cat ~/.ssh/id_ed25519.pub   # Check SSH public key
 
 # Compare with fnox.toml recipients
-cat fnox.toml | grep recipients
+grep recipients fnox.toml
 ```
 
 ### "failed to decrypt"

--- a/docs/providers/age.md
+++ b/docs/providers/age.md
@@ -198,9 +198,9 @@ cat ~/.ssh/id_rsa.pub
 
 Age plugins extend age with hardware-backed and alternative keys. fnox supports any [age plugin](https://github.com/FiloSottile/awesome-age#plugins), for example [age-plugin-yubikey](https://github.com/str4d/age-plugin-yubikey) (YubiKey / PIV) or [age-plugin-se](https://github.com/remko/age-plugin-se) (Apple's Secure Enclave).
 
-A plugin recipient can carry the plugin name in its prefix, such as
-`age1yubikey1...`. Some plugins instead produce `age1tag1...` recipients; for
-example, current age-plugin-tpm releases use that format.
+Plugin recipients usually carry the plugin name in their prefix
+(`age1yubikey1...`), though not always — current age-plugin-tpm releases
+produce `age1tag1...` recipients, for example.
 
 ```toml
 [providers.age]
@@ -208,11 +208,9 @@ type = "age"
 recipients = ["age1yubikey1qwla8v7cu3mx6mp79asgrh5ad2h52flwln7c66ydcyy50lg5uh0gxh4kmaz"]
 ```
 
-Please refer to the respective plugin docs for detailed setup instructions.
-For end-to-end walkthroughs of hardware-backed decryption (Secure Enclave,
-YubiKey, TPM, FIDO2) see
-[Hardware-Backed Decryption](/guide/sync#hardware-backed-decryption) in the
-sync guide.
+Refer to each plugin's docs for setup instructions. The sync guide also has
+full [hardware-backed decryption](/guide/sync#hardware-backed-decryption)
+walkthroughs for Secure Enclave, YubiKey, TPM, and FIDO2.
 
 ## Team Workflow
 

--- a/docs/providers/age.md
+++ b/docs/providers/age.md
@@ -198,8 +198,9 @@ cat ~/.ssh/id_rsa.pub
 
 Age plugins extend age with hardware-backed and alternative keys. fnox supports any [age plugin](https://github.com/FiloSottile/awesome-age#plugins), for example [age-plugin-yubikey](https://github.com/str4d/age-plugin-yubikey) (YubiKey / PIV) or [age-plugin-se](https://github.com/remko/age-plugin-se) (Apple's Secure Enclave).
 
-A plugin recipient looks like a native age recipient but carries the plugin name
-in its prefix (`age1yubikey1...`, `age1tpm1...`, …):
+A plugin recipient can carry the plugin name in its prefix, such as
+`age1yubikey1...`. Some plugins instead produce `age1tag1...` recipients; for
+example, current age-plugin-tpm releases use that format.
 
 ```toml
 [providers.age]

--- a/docs/providers/age.md
+++ b/docs/providers/age.md
@@ -208,6 +208,10 @@ recipients = ["age1yubikey1qwla8v7cu3mx6mp79asgrh5ad2h52flwln7c66ydcyy50lg5uh0gx
 ```
 
 Please refer to the respective plugin docs for detailed setup instructions.
+For end-to-end walkthroughs of hardware-backed decryption (Secure Enclave,
+YubiKey, TPM, FIDO2) see
+[Hardware-Backed Decryption](/guide/sync#hardware-backed-decryption) in the
+sync guide.
 
 ## Team Workflow
 

--- a/docs/providers/aws-ps.md
+++ b/docs/providers/aws-ps.md
@@ -414,7 +414,7 @@ Parameter doesn't exist. Check:
 aws ssm get-parameters-by-path --path "/myapp/prod/" --recursive
 
 # Check if prefix is correct in fnox.toml
-cat fnox.toml | grep prefix
+grep prefix fnox.toml
 ```
 
 ### "Invalid Region"
@@ -423,7 +423,7 @@ Verify region matches:
 
 ```bash
 # Check fnox.toml region
-cat fnox.toml | grep region
+grep region fnox.toml
 
 # Check AWS credentials region
 echo $AWS_REGION

--- a/docs/providers/aws-sm.md
+++ b/docs/providers/aws-sm.md
@@ -449,7 +449,7 @@ Secret doesn't exist. Check:
 aws secretsmanager list-secrets
 
 # Check if prefix is correct in fnox.toml
-cat fnox.toml | grep prefix
+grep prefix fnox.toml
 ```
 
 ### "Invalid Region"
@@ -458,7 +458,7 @@ Verify region matches:
 
 ```bash
 # Check fnox.toml region
-cat fnox.toml | grep region
+grep region fnox.toml
 
 # Check AWS credentials region
 echo $AWS_REGION

--- a/docs/providers/overview.md
+++ b/docs/providers/overview.md
@@ -2,6 +2,8 @@
 
 fnox supports multiple secret storage and encryption providers. Choose the ones that fit your workflow.
 
+Not sure where to start? [The golden path](/guide/what-is-fnox#the-golden-path) combines a remote vault (source of truth) with a local age cache via [`fnox sync`](/guide/sync) — see the [Golden Path Setup](/guide/golden-path) walkthrough.
+
 ## Provider Categories
 
 ### 🔐 Encryption (secrets in git, encrypted)
@@ -11,6 +13,8 @@ Store encrypted secrets in your `fnox.toml` file. The encrypted ciphertext is sa
 | Provider                          | Description                              | Best For                                  |
 | --------------------------------- | ---------------------------------------- | ----------------------------------------- |
 | [age](/providers/age)             | Modern encryption (works with SSH keys!) | Development secrets, open source projects |
+| [FIDO2](/providers/fido2)         | Symmetric key from a FIDO2 security key  | Secrets bound to a hardware token         |
+| [YubiKey](/providers/yubikey)     | YubiKey HMAC challenge-response          | Secrets bound to a specific YubiKey       |
 | [AWS KMS](/providers/aws-kms)     | AWS Key Management Service               | AWS-based projects requiring IAM control  |
 | [Azure KMS](/providers/azure-kms) | Azure Key Vault encryption               | Azure-based projects                      |
 | [GCP KMS](/providers/gcp-kms)     | Google Cloud KMS                         | GCP-based projects                        |
@@ -77,7 +81,7 @@ DATABASE_URL = { provider = "aws", value = "database-url" }
 
 | Feature        | age    | AWS KMS | AWS SM | 1Password | Vault |
 | -------------- | ------ | ------- | ------ | --------- | ----- |
-| Offline        | ✅     | ❌      | ❌     | ❌        | ❌    |
+| Offline†       | ✅     | ❌      | ❌     | ❌        | ❌    |
 | In Git         | ✅     | ✅      | ❌     | ❌        | ❌    |
 | Free           | ✅     | 💰      | 💰     | 💰        | ✅\*  |
 | Audit Logs     | ❌     | ✅      | ✅     | ✅        | ✅    |
@@ -86,6 +90,8 @@ DATABASE_URL = { provider = "aws", value = "database-url" }
 | Team-Friendly  | ✅     | ✅      | ✅     | ✅        | ✅    |
 
 \*Self-hosted Vault is free, HCP Vault is paid
+
+†Any remote provider becomes offline-capable by caching secrets locally with [`fnox sync`](/guide/sync)
 
 ## Next Steps
 

--- a/docs/reference/environment.md
+++ b/docs/reference/environment.md
@@ -73,7 +73,7 @@ export FNOX_AGE_KEY="AGE-SECRET-KEY-1..."
 
 ```bash
 # Set age key from file
-export FNOX_AGE_KEY=$(cat ~/.config/fnox/age.txt | grep "AGE-SECRET-KEY")
+export FNOX_AGE_KEY=$(grep "AGE-SECRET-KEY" ~/.config/fnox/age.txt)
 
 # Or set directly
 export FNOX_AGE_KEY="AGE-SECRET-KEY-1ABCDEFGHIJKLMNOPQRSTUVWXYZ..."


### PR DESCRIPTION
## Summary

Positions the **remote vault → `fnox sync` → local age cache** workflow as the recommended "golden path" and builds out the docs around it.

### Golden path callouts
- **Homepage**, **What is fnox?**, and **Quick Start** all introduce the golden path early and link to the walkthroughs.
- **New end-to-end example**: `docs/guide/golden-path.md` — zero-to-working walkthrough (1Password → committed references → global `sync-age` provider → sync → shell integration), plus day-to-day operations and a "what about CI?" section (authenticate to the vault directly in CI; don't sync).
- **Sidebar**: the example leads the Examples group, "Syncing Secrets Locally" moves up next to Shell Integration, and Contributing moves below How It Works.

### Hardware-backed decryption
- **Sync guide**: new **Hardware-Backed Decryption** section with an end-to-end **Apple Secure Enclave (Touch ID)** walkthrough via `age-plugin-se` (access-control policies, `FNOX_AGE_KEY` precedence caveat, macOS 14+), the existing **YubiKey** content, and a **TPM / FIDO2** subsection for other platforms.
- New comparison of **age plugins vs. the native `yubikey`/`fido2` providers** as sync targets (symmetric vs. recipient-based trade-offs).
- **Providers overview**: native FIDO2/YubiKey providers added to the encryption table; footnote that `fnox sync` makes any remote provider offline-capable.

### Cleanups
- Homepage's hand-maintained provider list (already missing several providers) replaced with category highlights linking to the overview.
- Age docs: empty "Use SSH Key" setup block replaced with prose; `cat | grep` pipelines fixed across the docs.

## Testing

- `mise run lint` passes.
- `aube run docs:build` (VitePress, dead-link checking) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*AI-assisted — Tool: Claude Code; model: anthropic/claude-fable-5; version: unavailable.*