### PR TITLE
chore(ci): adopt mbx for Rust builds

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -7,7 +7,7 @@ runs:
     - uses: jdx/mr-boxington-action@2bbb8f141e40e388b509cc68fe0bfbe7bc4b6818 # v1
       with:
         version: 0.4.0
-        backend: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'github' || 'server' }}
+        backend: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'github' || 'server' }}
         server-url: https://cache.mise.jdx.dev
         namespace: jdx/fnox
         oidc-audience: https://cache.mise.jdx.dev

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -6,7 +6,7 @@ runs:
   steps:
     - uses: jdx/mr-boxington-action@2bbb8f141e40e388b509cc68fe0bfbe7bc4b6818 # v1
       with:
-        version: 0.3.0
+        version: 0.4.0
         backend: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'github' || 'server' }}
         server-url: https://cache.mise.jdx.dev
         namespace: jdx/fnox

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -7,7 +7,7 @@ runs:
     - uses: jdx/mr-boxington-action@2bbb8f141e40e388b509cc68fe0bfbe7bc4b6818 # v1
       with:
         version: 0.4.0
-        backend: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'github' || 'server' }}
+        backend: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'github' || 'server' }}
         server-url: https://cache.mise.jdx.dev
         namespace: jdx/fnox
         oidc-audience: https://cache.mise.jdx.dev

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -1,0 +1,13 @@
+name: Set up mbx
+description: Select the trusted jdx server or fork-safe GitHub cache backend
+
+runs:
+  using: composite
+  steps:
+    - uses: jdx/mr-boxington-action@2bbb8f141e40e388b509cc68fe0bfbe7bc4b6818 # v1
+      with:
+        version: 0.3.0
+        backend: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'github' || 'server' }}
+        server-url: https://cache.mise.jdx.dev
+        namespace: jdx/fnox
+        oidc-audience: https://cache.mise.jdx.dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,10 +341,10 @@ jobs:
         with:
           submodules: recursive
           persist-credentials: false
-      - uses: ./.github/actions/mbx
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
         with:
           cache: false
+      - uses: ./.github/actions/mbx
       - name: Install system dependencies
         run: |
           if [ -f /etc/apt/apt-mirrors.txt ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
             runner: namespace-profile-endev-macos-arm64
           - os: ubuntu-latest
             runner: namespace-profile-endev-linux-amd64
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && matrix.os || matrix.runner }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && matrix.os || matrix.runner }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -78,7 +78,7 @@ jobs:
           - os: ubuntu-latest
             runner: namespace-profile-endev-linux-amd64
             tranche: 1
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && matrix.os || matrix.runner }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && matrix.os || matrix.runner }}
     timeout-minutes: 20
     steps:
       - run: brew install parallel hashicorp/tap/vault
@@ -99,7 +99,7 @@ jobs:
           chmod +x target/debug/fnox
           echo "$GITHUB_WORKSPACE/target/debug" >> "$GITHUB_PATH"
       - name: Setup age key for fnox
-        if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]')
+        if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'jdx')
         run: mkdir -p ~/.config/fnox && echo "${{ secrets.AGE_SECRET }}" > ~/.config/fnox/age.txt
       - name: Setup services (Ubuntu)
         if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -258,7 +258,7 @@ jobs:
             runner: namespace-profile-endev-macos-arm64
           - os: ubuntu-latest
             runner: namespace-profile-endev-linux-amd64
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && matrix.os || matrix.runner }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && matrix.os || matrix.runner }}
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -299,10 +299,10 @@ jobs:
           chmod +x target/debug/fnox
           echo "$GITHUB_WORKSPACE/target/debug" >> "$GITHUB_PATH"
       - name: Setup age key for fnox
-        if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]')
+        if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'jdx')
         run: mkdir -p ~/.config/fnox && echo "${{ secrets.AGE_SECRET }}" > ~/.config/fnox/age.txt
       - name: Redact secrets in CI output
-        if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]')
+        if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'jdx')
         run: |
           fnox ci-redact
           # shellcheck disable=SC2016
@@ -331,7 +331,7 @@ jobs:
         run: mbx clippy --workspace --all-targets -- -D warnings
 
   msrv:
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     timeout-minutes: 10
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
           chmod +x target/debug/fnox
           echo "$GITHUB_WORKSPACE/target/debug" >> "$GITHUB_PATH"
       - name: Setup age key for fnox
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]')
         run: mkdir -p ~/.config/fnox && echo "${{ secrets.AGE_SECRET }}" > ~/.config/fnox/age.txt
       - name: Setup services (Ubuntu)
         if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -299,10 +299,10 @@ jobs:
           chmod +x target/debug/fnox
           echo "$GITHUB_WORKSPACE/target/debug" >> "$GITHUB_PATH"
       - name: Setup age key for fnox
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]')
         run: mkdir -p ~/.config/fnox && echo "${{ secrets.AGE_SECRET }}" > ~/.config/fnox/age.txt
       - name: Redact secrets in CI output
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]')
         run: |
           fnox ci-redact
           # shellcheck disable=SC2016

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,13 +21,16 @@ jobs:
   build:
     permissions:
       contents: read
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - macos-latest
-          - ubuntu-latest
-    runs-on: ${{ matrix.os }}
+        include:
+          - os: macos-latest
+            runner: namespace-profile-endev-macos-arm64
+          - os: ubuntu-latest
+            runner: namespace-profile-endev-linux-amd64
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && matrix.os || matrix.runner }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -37,11 +40,7 @@ jobs:
       - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
         with:
           cache: false
-      # save-if: false — this job never saves to cache, only restores from main's cache.
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2 # zizmor: ignore[cache-poisoning]
-        with:
-          shared-key: debug-${{ matrix.os }}
-          save-if: false
+      - uses: ./.github/actions/mbx
       - name: Install system dependencies (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
         run: |
@@ -53,7 +52,7 @@ jobs:
       - name: Install Rust components
         run: rustup component add rustfmt clippy
       - name: Build
-        run: cargo build
+        run: mbx build build
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: fnox-${{ matrix.os }}
@@ -66,11 +65,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - macos-latest
-          - ubuntu-latest
-        tranche: [0, 1]
-    runs-on: ${{ matrix.os }}
+        include:
+          - os: macos-latest
+            runner: namespace-profile-endev-macos-arm64
+            tranche: 0
+          - os: macos-latest
+            runner: namespace-profile-endev-macos-arm64
+            tranche: 1
+          - os: ubuntu-latest
+            runner: namespace-profile-endev-linux-amd64
+            tranche: 0
+          - os: ubuntu-latest
+            runner: namespace-profile-endev-linux-amd64
+            tranche: 1
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && matrix.os || matrix.runner }}
     timeout-minutes: 20
     steps:
       - run: brew install parallel hashicorp/tap/vault
@@ -223,6 +231,7 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -232,25 +241,24 @@ jobs:
         with:
           cache: false
           fetch_from_github: false
-      # save-if: only saves on main pushes, so PRs cannot poison the cache.
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2 # zizmor: ignore[cache-poisoning]
-        with:
-          shared-key: check-windows
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - uses: ./.github/actions/mbx
       - name: Check Windows build
-        run: cargo check --workspace
+        run: mbx build check --workspace
 
   ci-other:
     needs: build
     permissions:
       contents: read
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - macos-latest
-          - ubuntu-latest
-    runs-on: ${{ matrix.os }}
+        include:
+          - os: macos-latest
+            runner: namespace-profile-endev-macos-arm64
+          - os: ubuntu-latest
+            runner: namespace-profile-endev-linux-amd64
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && matrix.os || matrix.runner }}
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -260,11 +268,7 @@ jobs:
       - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
         with:
           cache: false
-      # save-if: only saves on main pushes, so PRs cannot poison the cache.
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2 # zizmor: ignore[cache-poisoning]
-        with:
-          shared-key: debug-${{ matrix.os }}
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - uses: ./.github/actions/mbx
       - name: Install system dependencies (Ubuntu)
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
@@ -306,7 +310,7 @@ jobs:
       - name: Clean cached Rust build artifacts
         run: cargo clean
       - name: Run tests
-        run: cargo test --workspace
+        run: mbx build test --workspace
       - name: mise run render
         run: mise run render
       - name: assert render produces no diff
@@ -324,23 +328,20 @@ jobs:
           max_attempts: 3
           command: mise run lint
       - name: Run clippy
-        run: cargo clippy --workspace --all-targets -- -D warnings
+        run: mbx build clippy --workspace --all-targets -- -D warnings
 
   msrv:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     timeout-minutes: 10
     permissions:
       contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
           persist-credentials: false
-      # save-if: only saves on main pushes, so PRs cannot poison the cache.
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2 # zizmor: ignore[cache-poisoning]
-        with:
-          shared-key: msrv
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - uses: ./.github/actions/mbx
       - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
         with:
           cache: false
@@ -353,7 +354,7 @@ jobs:
           sudo apt-get install -y libudev-dev
       # cargo-msrv doesn't accept --workspace; verifying the binary's MSRV
       # transitively covers fnox-core because the binary depends on it.
-      - run: cargo msrv verify
+      - run: mbx build msrv verify
 
   final:
     permissions: {}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
             runner: namespace-profile-endev-macos-arm64
           - os: ubuntu-latest
             runner: namespace-profile-endev-linux-amd64
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && matrix.os || matrix.runner }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && matrix.os || matrix.runner }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -78,7 +78,7 @@ jobs:
           - os: ubuntu-latest
             runner: namespace-profile-endev-linux-amd64
             tranche: 1
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && matrix.os || matrix.runner }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && matrix.os || matrix.runner }}
     timeout-minutes: 20
     steps:
       - run: brew install parallel hashicorp/tap/vault
@@ -258,7 +258,7 @@ jobs:
             runner: namespace-profile-endev-macos-arm64
           - os: ubuntu-latest
             runner: namespace-profile-endev-linux-amd64
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && matrix.os || matrix.runner }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && matrix.os || matrix.runner }}
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -331,7 +331,7 @@ jobs:
         run: mbx clippy --workspace --all-targets -- -D warnings
 
   msrv:
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     timeout-minutes: 10
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Install Rust components
         run: rustup component add rustfmt clippy
       - name: Build
-        run: mbx build build
+        run: mbx build
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: fnox-${{ matrix.os }}
@@ -243,7 +243,7 @@ jobs:
           fetch_from_github: false
       - uses: ./.github/actions/mbx
       - name: Check Windows build
-        run: mbx build check --workspace
+        run: mbx check --workspace
 
   ci-other:
     needs: build
@@ -310,7 +310,7 @@ jobs:
       - name: Clean cached Rust build artifacts
         run: cargo clean
       - name: Run tests
-        run: mbx build test --workspace
+        run: mbx test --workspace
       - name: mise run render
         run: mise run render
       - name: assert render produces no diff
@@ -328,7 +328,7 @@ jobs:
           max_attempts: 3
           command: mise run lint
       - name: Run clippy
-        run: mbx build clippy --workspace --all-targets -- -D warnings
+        run: mbx clippy --workspace --all-targets -- -D warnings
 
   msrv:
     runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
@@ -354,7 +354,7 @@ jobs:
           sudo apt-get install -y libudev-dev
       # cargo-msrv doesn't accept --workspace; verifying the binary's MSRV
       # transitively covers fnox-core because the binary depends on it.
-      - run: mbx build msrv verify
+      - run: mbx msrv verify
 
   final:
     permissions: {}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,16 @@
 # Fnox Development Guide
 
+## mbx build cache
+
+Compilation-heavy mise tasks and hk checks use `mbx`. If an mbx command fails
+or creates a development papercut, rerun the exact equivalent `cargo` command
+from `CONTRIBUTING.md`; this unblocks work without weakening the check. If Cargo
+succeeds, surface the mismatch and recommend a
+[mr-boxington Discussion](https://github.com/jdx/mr-boxington/discussions) with
+the repository and commit, OS, `mbx --version`, both commands and outputs, the
+cache summary, and `MBX_BYPASS_LOG` details when relevant. Do not silently make
+Cargo the permanent path, and do not post externally without user authorization.
+
 ## Conventional Commits
 
 Format: `<type>(<scope>): <description>` (lowercase, imperative mood)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,9 @@ unblock yourself without skipping or weakening the check:
 ```sh
 cargo build
 cargo test
+cargo check --workspace
 cargo clippy -q -- -D warnings
+cargo msrv verify
 ```
 
 If Cargo succeeds where mbx fails, or mbx introduces a papercut, please start a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,8 @@ cargo build
 cargo test
 cargo check --workspace
 cargo clippy -q -- -D warnings
+# CI also runs this broader clippy check:
+cargo clippy --workspace --all-targets -- -D warnings
 cargo msrv verify
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,22 @@
 # Contributing
 
 See the [contributing guide](https://fnox.jdx.dev/contributing).
+
+## mbx build cache
+
+The normal `mise run build`, `mise run test:cargo`, and `mise run lint`
+workflows use [mbx](https://mr-boxington.jdx.dev) for compilation-heavy Cargo
+work. If mbx appears to be the problem, use the equivalent Cargo commands to
+unblock yourself without skipping or weakening the check:
+
+```sh
+cargo build
+cargo test
+cargo clippy -q -- -D warnings
+```
+
+If Cargo succeeds where mbx fails, or mbx introduces a papercut, please start a
+[mr-boxington Discussion](https://github.com/jdx/mr-boxington/discussions).
+Include the repository and commit, operating system, `mbx --version`, both
+commands and their output, the mbx cache summary, and an `MBX_BYPASS_LOG` when
+relevant (for example, `MBX_BYPASS_LOG=mbx-bypasses.log mise run build`).

--- a/hk.pkl
+++ b/hk.pkl
@@ -8,7 +8,7 @@ local linters = new Mapping<String, Step> {
     }
     ["cargo-fmt"] = Builtins.cargo_fmt
     ["cargo-clippy"] = (Builtins.cargo_clippy) {
-        check = "mbx build clippy -q -- -D warnings"
+        check = "mbx clippy -q -- -D warnings"
     }
     ["shfmt"] = (Builtins.shfmt) {
         glob = List("**/*.bats", "**/*.sh", "**/*.bash")

--- a/hk.pkl
+++ b/hk.pkl
@@ -8,7 +8,7 @@ local linters = new Mapping<String, Step> {
     }
     ["cargo-fmt"] = Builtins.cargo_fmt
     ["cargo-clippy"] = (Builtins.cargo_clippy) {
-        check = "cargo clippy -q -- -D warnings"
+        check = "mbx build clippy -q -- -D warnings"
     }
     ["shfmt"] = (Builtins.shfmt) {
         glob = List("**/*.bats", "**/*.sh", "**/*.bash")

--- a/mise.lock
+++ b/mise.lock
@@ -441,43 +441,43 @@ url = "https://github.com/foresterre/cargo-msrv/releases/download/v0.19.3/cargo-
 url_api = "https://api.github.com/repos/foresterre/cargo-msrv/releases/assets/380851496"
 
 [[tools."github:jdx/mr-boxington"]]
-version = "0.3.0"
+version = "0.4.0"
 backend = "github:jdx/mr-boxington"
 
 [tools."github:jdx/mr-boxington"."platforms.linux-arm64"]
-checksum = "sha256:4be02935fb0c1892b659c8146e07fe092fb12f6c4e86c6ebbc3b63449d5dcb25"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704880"
+checksum = "sha256:ed81dab87775bcc8764c7257d8bea0dd8b7f811d6263b71bc7cd83a879661593"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.4.0/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/529719396"
 
 [tools."github:jdx/mr-boxington"."platforms.linux-arm64-musl"]
-checksum = "sha256:4be02935fb0c1892b659c8146e07fe092fb12f6c4e86c6ebbc3b63449d5dcb25"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704880"
+checksum = "sha256:ed81dab87775bcc8764c7257d8bea0dd8b7f811d6263b71bc7cd83a879661593"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.4.0/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/529719396"
 
 [tools."github:jdx/mr-boxington"."platforms.linux-x64"]
-checksum = "sha256:65ef46c20761ffd1d930638c3ff2d237535a98f28968929f04f195bfdd258e77"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704890"
+checksum = "sha256:b288265404b8fa4620ea1d082ba9b33a0a1695212d88a385e76aa07a743da250"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.4.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/529719409"
 
 [tools."github:jdx/mr-boxington"."platforms.linux-x64-musl"]
-checksum = "sha256:65ef46c20761ffd1d930638c3ff2d237535a98f28968929f04f195bfdd258e77"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704890"
+checksum = "sha256:b288265404b8fa4620ea1d082ba9b33a0a1695212d88a385e76aa07a743da250"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.4.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/529719409"
 
 [tools."github:jdx/mr-boxington"."platforms.macos-arm64"]
-checksum = "sha256:1803cec79be0b753fc3af23044edc46fd81ffdf9d66fcb7b6637cfb22cc6db4a"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704881"
+checksum = "sha256:416cab92e23c4652183e4a794af3fdcbc50b56296d8c09f8b6548e7577416307"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.4.0/mbx-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/529719398"
 
 [tools."github:jdx/mr-boxington"."platforms.macos-x64"]
-checksum = "sha256:72a98d019b83859e465d30a91422e7b2eb72cf53fb42e116a277865310392c0c"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-x86_64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704883"
+checksum = "sha256:9f1016b0592ffd3b4b4000640223e10a2100cc6136d722fac5c4829cb89fc7ed"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.4.0/mbx-x86_64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/529719400"
 
 [tools."github:jdx/mr-boxington"."platforms.windows-x64"]
-checksum = "sha256:9d99f1f57789e88f4870ac61fd6c4e2ceec5ed532f4c9c8e9be4f32663a1fd16"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704879"
+checksum = "sha256:f841b1907cf86c54db4d3d2d1e88f87303ccc8f720efff90b6331d7d5592bf4e"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.4.0/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/529719397"
 
 [[tools."github:jdx/tak"]]
 version = "0.0.5"

--- a/mise.lock
+++ b/mise.lock
@@ -440,6 +440,45 @@ checksum = "sha256:e437443331865218763d44089680f4d36547353e8c3c8b394c24859203e6c
 url = "https://github.com/foresterre/cargo-msrv/releases/download/v0.19.3/cargo-msrv-x86_64-pc-windows-msvc-v0.19.3.zip"
 url_api = "https://api.github.com/repos/foresterre/cargo-msrv/releases/assets/380851496"
 
+[[tools."github:jdx/mr-boxington"]]
+version = "0.3.0"
+backend = "github:jdx/mr-boxington"
+
+[tools."github:jdx/mr-boxington"."platforms.linux-arm64"]
+checksum = "sha256:4be02935fb0c1892b659c8146e07fe092fb12f6c4e86c6ebbc3b63449d5dcb25"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704880"
+
+[tools."github:jdx/mr-boxington"."platforms.linux-arm64-musl"]
+checksum = "sha256:4be02935fb0c1892b659c8146e07fe092fb12f6c4e86c6ebbc3b63449d5dcb25"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704880"
+
+[tools."github:jdx/mr-boxington"."platforms.linux-x64"]
+checksum = "sha256:65ef46c20761ffd1d930638c3ff2d237535a98f28968929f04f195bfdd258e77"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704890"
+
+[tools."github:jdx/mr-boxington"."platforms.linux-x64-musl"]
+checksum = "sha256:65ef46c20761ffd1d930638c3ff2d237535a98f28968929f04f195bfdd258e77"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704890"
+
+[tools."github:jdx/mr-boxington"."platforms.macos-arm64"]
+checksum = "sha256:1803cec79be0b753fc3af23044edc46fd81ffdf9d66fcb7b6637cfb22cc6db4a"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704881"
+
+[tools."github:jdx/mr-boxington"."platforms.macos-x64"]
+checksum = "sha256:72a98d019b83859e465d30a91422e7b2eb72cf53fb42e116a277865310392c0c"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-x86_64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704883"
+
+[tools."github:jdx/mr-boxington"."platforms.windows-x64"]
+checksum = "sha256:9d99f1f57789e88f4870ac61fd6c4e2ceec5ed532f4c9c8e9be4f32663a1fd16"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704879"
+
 [[tools."github:jdx/tak"]]
 version = "0.0.5"
 backend = "github:jdx/tak"

--- a/mise.toml
+++ b/mise.toml
@@ -2,6 +2,7 @@
 _.path = ["target/debug", "test/bats/bin"]
 
 [tools]
+"github:jdx/mr-boxington" = "latest"
 usage = "6.4.0"
 # Pinned rather than "latest" because tak is the measuring instrument: an
 # upgrade that changes how it samples would land in the series as a step change
@@ -33,7 +34,7 @@ depends = ["test:cargo", "test:bats"]
 
 [tasks."test:cargo"]
 description = "Run cargo tests only"
-run = "cargo test"
+run = "mbx build test"
 
 [tasks."test:bats"]
 description = "Run bats tests only"
@@ -57,7 +58,7 @@ run = "fnox exec -- bats --jobs 16 {{arg(name='test', var=true, default='test')}
 
 [tasks.cargo-test]
 description = "Run cargo tests only"
-run = "cargo test"
+run = "mbx build test"
 
 [tasks.lint]
 run = "hk check --all --slow"
@@ -67,7 +68,7 @@ run = "hk fix --all --slow"
 
 [tasks.build]
 description = "Build the project"
-run = "cargo build"
+run = "mbx build build"
 
 [tasks.ci]
 description = "Run full CI check (build, test, lint)"

--- a/mise.toml
+++ b/mise.toml
@@ -34,7 +34,7 @@ depends = ["test:cargo", "test:bats"]
 
 [tasks."test:cargo"]
 description = "Run cargo tests only"
-run = "mbx build test"
+run = "mbx test"
 
 [tasks."test:bats"]
 description = "Run bats tests only"
@@ -58,7 +58,7 @@ run = "fnox exec -- bats --jobs 16 {{arg(name='test', var=true, default='test')}
 
 [tasks.cargo-test]
 description = "Run cargo tests only"
-run = "mbx build test"
+run = "mbx test"
 
 [tasks.lint]
 run = "hk check --all --slow"
@@ -68,7 +68,7 @@ run = "hk fix --all --slow"
 
 [tasks.build]
 description = "Build the project"
-run = "mbx build build"
+run = "mbx build"
 
 [tasks.ci]
 description = "Run full CI check (build, test, lint)"


### PR DESCRIPTION
## Summary

- route compilation-heavy local mise tasks and hk checks through mbx
- configure trusted Namespace jobs for the jdx server cache and fork-safe GitHub-hosted cache restores
- document exact Cargo fallbacks and the mr-boxington Discussions escalation path
- use the direct Cargo-subcommand syntax released in mbx 0.4.0
- pin local and CI setup to mbx 0.4.0

## Validation

- resolved the committed mise lock to mbx 0.4.0
- installed the locked tool and confirmed `mbx 0.4.0`
- evaluated the mise configuration and task list
- confirmed `mbx build` direct syntax
- ran actionlint and the repository-specific configuration checks for the original integration


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cached workflows for Rust builds, tests, linting, workspace checks, and compatibility verification.
  * CI now selects appropriate runners and cache backends based on pull request context.

* **Documentation**
  * Added guidance for bypassing cached workflows with equivalent Cargo commands.
  * Documented diagnostic information for reporting cache-related issues.

* **Developer Experience**
  * Simplified cached build and test commands.
  * Updated development tooling to the latest supported version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI runner selection, OIDC permissions, and fork/trust gating for caches and secrets change how untrusted PRs execute; a logic mistake could expose secrets or use the wrong cache backend.
> 
> **Overview**
> Replaces **Swatinem/rust-cache** with **mbx** (mr-boxington 0.4.0) for compilation-heavy Rust work in CI, local **mise** tasks, and **hk** clippy checks. A new composite action **`.github/actions/mbx`** wires the cache backend: trusted in-repo **`jdx`** PRs use the jdx server cache (OIDC); fork or non-**`jdx`** PRs use a GitHub-hosted backend only.
> 
> CI jobs that compile or test now run **`mbx build`**, **`mbx test`**, **`mbx check`**, **`mbx clippy`**, and **`mbx msrv verify`** instead of direct **`cargo`** invocations. Several jobs gain **`id-token: write`** for cache auth. Linux/macOS matrices pick **Namespace** runners for trusted runs and fall back to **`matrix.os`** GitHub runners for untrusted PRs.
> 
> **AGE** secret setup, redaction, and related steps are tightened so they run on PRs only when the head repo is upstream **and** the PR author is **`jdx`**. **AGENTS.md** and **CONTRIBUTING.md** document equivalent **`cargo`** fallbacks and how to report mbx issues.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cac5c854c652da2678b1b923290591805ba5ea78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->