### PR TITLE
chore(sponsors): replace 37signals with omacom foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Manage secrets with encryption or cloud providers—or both! fnox gives you a un
 
 ## Sponsors
 
-fnox is sponsored by [entire.io](https://entire.io) and [37signals](https://37signals.com).
+fnox is sponsored by [entire.io](https://entire.io) and [Omacom Foundation](https://omarchy.org/patrons/).
 
 [View all sponsors](https://jdx.dev/sponsors.html).
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,24 @@ Manage secrets with encryption or cloud providers—or both! fnox gives you a un
 
 ## Sponsors
 
-fnox is sponsored by [entire.io](https://entire.io) and [Omacom Foundation](https://omarchy.org/patrons/).
-
-[View all sponsors](https://jdx.dev/sponsors.html).
+<p align="center">
+  Sponsored by<br><br>
+  <a href="https://entire.io">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://jdx.dev/sponsors/entire-lockup.svg">
+      <img src="https://jdx.dev/sponsors/entire-lockup-on-light.svg" alt="Entire" height="36">
+    </picture>
+  </a>
+  &nbsp;&nbsp;&nbsp;
+  <a href="https://omarchy.org/patrons/">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://jdx.dev/sponsors/omacom-foundation.svg">
+      <img src="https://jdx.dev/sponsors/omacom-foundation-on-light.svg" alt="Omacom Foundation" height="36">
+    </picture>
+  </a>
+  <br><br>
+  <a href="https://jdx.dev/sponsors.html">View all sponsors</a>
+</p>
 
 ## Quick Start
 

--- a/src/commands/sponsors.rs
+++ b/src/commands/sponsors.rs
@@ -7,7 +7,7 @@ pub struct SponsorsCommand;
 impl SponsorsCommand {
     pub async fn run(&self, _cli: &Cli) -> Result<()> {
         println!(
-            "fnox and the jdx.dev open source tools are sponsored by:\n\n  entire.io - https://entire.io\n  37signals - https://37signals.com\n\nView all sponsors: https://jdx.dev/sponsors.html"
+            "fnox and the jdx.dev open source tools are sponsored by:\n\n  entire.io - https://entire.io\n  Omacom Foundation - https://omarchy.org/patrons/\n\nView all sponsors: https://jdx.dev/sponsors.html"
         );
         Ok(())
     }


### PR DESCRIPTION
## Summary
- replace 37signals with the Omacom Foundation in the README and `fnox sponsors` output
- add linked, theme-aware Entire and Omarchy wordmarks to the README

## Verification
- `cargo fmt --all --check`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*