### PR TITLE
fix(sync): prompt once for age batch decryption

### DIFF
--- a/crates/fnox-core/src/providers/age.rs
+++ b/crates/fnox-core/src/providers/age.rs
@@ -2,9 +2,13 @@ use crate::env;
 use crate::error::{FnoxError, Result};
 use crate::providers::OptionProviderSecretRef;
 use async_trait::async_trait;
+use std::collections::HashMap;
 use std::io::Read;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
+
+const BATCH_VALUE_PREFIX: &str = "fnox-age-batch-v1:";
+const BATCH_KEY_CONTEXT: &[u8] = b"fnox-age-batch-v1";
 
 pub fn env_dependencies() -> &'static [&'static str] {
     &[]
@@ -86,6 +90,31 @@ impl AgeEncryptionProvider {
             identity_cycle_guard,
         )
         .await
+    }
+
+    fn parse_batch_value(value: &str) -> Option<(&str, &str)> {
+        let value = value.strip_prefix(BATCH_VALUE_PREFIX)?;
+        value.split_once(':')
+    }
+
+    async fn decrypt_batch_key(&self, wrapped_key: &str) -> Result<Vec<u8>> {
+        use base64::Engine;
+
+        let encoded_key = self.decrypt_age_value(wrapped_key).await?;
+        let key = base64::engine::general_purpose::STANDARD
+            .decode(encoded_key)
+            .map_err(|e| FnoxError::AgeDecryptionFailed {
+                details: format!("Failed to decode batch key: {e}"),
+            })?;
+        if key.len() != 32 {
+            return Err(FnoxError::AgeDecryptionFailed {
+                details: format!(
+                    "Invalid batch key length: expected 32 bytes, got {}",
+                    key.len()
+                ),
+            });
+        }
+        Ok(key)
     }
 }
 
@@ -249,7 +278,93 @@ impl crate::providers::Provider for AgeEncryptionProvider {
         Ok(encrypted_base64)
     }
 
+    async fn encrypt_secrets_batch(
+        &self,
+        secrets: &[(String, String)],
+    ) -> HashMap<String, Result<String>> {
+        use base64::Engine;
+
+        if secrets.is_empty() {
+            return HashMap::new();
+        }
+
+        let mut batch_key = [0u8; 32];
+        rand::fill(&mut batch_key);
+        let encoded_key = base64::engine::general_purpose::STANDARD.encode(batch_key);
+        let wrapped_key = match self.encrypt(&encoded_key).await {
+            Ok(value) => value,
+            Err(error) => {
+                let message = error.to_string();
+                return secrets
+                    .iter()
+                    .map(|(key, _)| {
+                        (
+                            key.clone(),
+                            Err(FnoxError::AgeEncryptionFailed {
+                                details: message.clone(),
+                            }),
+                        )
+                    })
+                    .collect();
+            }
+        };
+
+        secrets
+            .iter()
+            .map(|(key, plaintext)| {
+                let encrypted =
+                    super::hw_encrypt::encrypt(&batch_key, BATCH_KEY_CONTEXT, plaintext).map(
+                        |ciphertext| format!("{BATCH_VALUE_PREFIX}{wrapped_key}:{ciphertext}"),
+                    );
+                (key.clone(), encrypted)
+            })
+            .collect()
+    }
+
     async fn get_secret(&self, value: &str) -> Result<String> {
+        if let Some((wrapped_key, ciphertext)) = Self::parse_batch_value(value) {
+            let batch_key = self.decrypt_batch_key(wrapped_key).await?;
+            return super::hw_encrypt::decrypt(&batch_key, BATCH_KEY_CONTEXT, ciphertext);
+        }
+
+        self.decrypt_age_value(value).await
+    }
+
+    async fn get_secrets_batch(
+        &self,
+        secrets: &[(String, String)],
+    ) -> HashMap<String, Result<String>> {
+        let mut results = HashMap::with_capacity(secrets.len());
+        let mut batch_keys: HashMap<String, Result<Vec<u8>>> = HashMap::new();
+
+        for (key, value) in secrets {
+            let result = if let Some((wrapped_key, ciphertext)) = Self::parse_batch_value(value) {
+                if !batch_keys.contains_key(wrapped_key) {
+                    batch_keys.insert(
+                        wrapped_key.to_string(),
+                        self.decrypt_batch_key(wrapped_key).await,
+                    );
+                }
+                match batch_keys.get(wrapped_key).expect("batch key was inserted") {
+                    Ok(batch_key) => {
+                        super::hw_encrypt::decrypt(batch_key, BATCH_KEY_CONTEXT, ciphertext)
+                    }
+                    Err(error) => Err(FnoxError::AgeDecryptionFailed {
+                        details: error.to_string(),
+                    }),
+                }
+            } else {
+                self.decrypt_age_value(value).await
+            };
+            results.insert(key.clone(), result);
+        }
+
+        results
+    }
+}
+
+impl AgeEncryptionProvider {
+    async fn decrypt_age_value(&self, value: &str) -> Result<String> {
         // value contains the encrypted blob (might be base64 encoded or raw)
 
         // Try to decode as base64 first, if that fails, treat as raw bytes
@@ -371,6 +486,25 @@ impl crate::providers::Provider for AgeEncryptionProvider {
 mod tests {
     use super::*;
     use crate::providers::Provider;
+    use age::secrecy::ExposeSecret;
+
+    fn test_provider() -> (AgeEncryptionProvider, tempfile::TempPath) {
+        let identity = age::x25519::Identity::generate();
+        let key_file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(key_file.path(), identity.to_string().expose_secret()).unwrap();
+        let key_path = key_file.path().to_string_lossy().into_owned();
+        let key_file = key_file.into_temp_path();
+
+        (
+            AgeEncryptionProvider::new(
+                vec![identity.to_public().to_string()],
+                Some(key_path),
+                OptionProviderSecretRef::none(),
+            )
+            .unwrap(),
+            key_file,
+        )
+    }
 
     /// Regression test for the "incorrect HRP" failure on age plugin recipients
     /// (e.g. age-plugin-yubikey). A plugin recipient must now be recognized and
@@ -397,5 +531,30 @@ mod tests {
                 "plugin recipient should parse successfully: {message}"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn batch_encryption_wraps_one_shared_key_and_round_trips() {
+        let (provider, _key_file) = test_provider();
+        let plaintext = vec![
+            ("FIRST".to_string(), "one".to_string()),
+            ("SECOND".to_string(), "two".to_string()),
+        ];
+
+        let encrypted = provider.encrypt_secrets_batch(&plaintext).await;
+        let first = encrypted["FIRST"].as_ref().unwrap();
+        let second = encrypted["SECOND"].as_ref().unwrap();
+        let (first_wrapped_key, _) = AgeEncryptionProvider::parse_batch_value(first).unwrap();
+        let (second_wrapped_key, _) = AgeEncryptionProvider::parse_batch_value(second).unwrap();
+        assert_eq!(first_wrapped_key, second_wrapped_key);
+
+        let ciphertexts = encrypted
+            .into_iter()
+            .map(|(key, value)| (key, value.unwrap()))
+            .collect::<Vec<_>>();
+        let decrypted = provider.get_secrets_batch(&ciphertexts).await;
+
+        assert_eq!(decrypted["FIRST"].as_ref().unwrap(), "one");
+        assert_eq!(decrypted["SECOND"].as_ref().unwrap(), "two");
     }
 }

--- a/crates/fnox-core/src/providers/mod.rs
+++ b/crates/fnox-core/src/providers/mod.rs
@@ -200,6 +200,21 @@ pub trait Provider: Send + Sync {
         ))
     }
 
+    /// Encrypt multiple values in a batch.
+    ///
+    /// Providers that need user interaction can override this to perform that
+    /// interaction once for the entire batch.
+    async fn encrypt_secrets_batch(
+        &self,
+        secrets: &[(String, String)],
+    ) -> HashMap<String, Result<String>> {
+        let mut encrypted = HashMap::with_capacity(secrets.len());
+        for (key, value) in secrets {
+            encrypted.insert(key.clone(), self.encrypt(value).await);
+        }
+        encrypted
+    }
+
     /// Store a secret and return the value to save in config
     ///
     /// This is a unified method for both encryption and remote storage:

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -262,17 +262,33 @@ impl SyncCommand {
             })?;
         }
 
+        let plaintext_secrets: Vec<(String, String)> = resolved
+            .iter()
+            .filter_map(|(key, plaintext)| {
+                plaintext
+                    .as_ref()
+                    .map(|plaintext| (key.clone(), plaintext.clone()))
+            })
+            .collect();
+        let mut encrypted_secrets = target_provider
+            .encrypt_secrets_batch(&plaintext_secrets)
+            .await;
+
         for (key, plaintext) in &resolved {
-            let Some(plaintext) = plaintext else {
+            if plaintext.is_none() {
                 tracing::warn!("Skipping '{}': could not resolve value", key);
                 skipped_count += 1;
                 continue;
-            };
+            }
 
             let mut secret_config = secrets_to_sync[key].clone();
 
             // Encrypt with target provider
-            match target_provider.encrypt(plaintext).await {
+            match encrypted_secrets.remove(key).unwrap_or_else(|| {
+                Err(FnoxError::Provider(format!(
+                    "provider did not return an encrypted value for '{key}'"
+                )))
+            }) {
                 Ok(encrypted) => {
                     secret_config.sync = Some(SyncConfig {
                         provider: target_provider_name.clone(),


### PR DESCRIPTION
## Summary

- add a provider batch-encryption API and use it from `fnox sync`
- wrap one random key with age per sync batch, then encrypt each cached secret independently with AES-256-GCM
- unwrap shared batch keys once during batch resolution while preserving support for existing age ciphertext
- add an age batch round-trip regression test

Existing sync caches remain readable. Re-running `fnox sync` migrates them to the batched format.

## Verification

- `mise run build`
- `mise run lint`
- `cargo test -p fnox-core providers::age --lib`
- `git diff --check`

The Bats sync suite could not run locally because the `bats` executable is unavailable in the environment.

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the sync encryption path and introduces a new ciphertext format for batched age syncs, though reads stay backward compatible with existing age blobs.
> 
> **Overview**
> **`fnox sync`** now encrypts all resolved secrets in one **`encrypt_secrets_batch`** call instead of per-key **`encrypt`**, so age (and hardware plugins) only run once per sync batch.
> 
> The **`Provider`** trait adds **`encrypt_secrets_batch`** with a default that still encrypts one-by-one; the **age** provider overrides it to generate one random 32-byte key, wrap it with age a single time, then encrypt each plaintext with **`hw_encrypt`** under a shared context. Stored values use the **`fnox-age-batch-v1:`** prefix so **`get_secret`** / **`get_secrets_batch`** can unwrap each shared wrapped key once and decrypt the rest locally. **Plain age ciphertext remains supported** on read; re-sync migrates caches to the batched format.
> 
> A regression test verifies two secrets in one batch share the same wrapped key and round-trip through batch encrypt/decrypt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74bc3788005879f3455b994d6fed539637fe1f71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added batch encryption support for syncing multiple secrets.
  * Age-protected secrets can now use efficient shared-key batch encryption while retaining secure per-secret protection.
* **Bug Fixes**
  * Improved handling of partially resolved secret sets during synchronization.
  * Encryption failures are reported clearly, and missing encryption results are detected instead of silently ignored.
  * Existing standard age decryption remains supported for compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->