### PR TITLE
test: handle unavailable secret providers

### DIFF
--- a/test/edit.bats
+++ b/test/edit.bats
@@ -287,9 +287,10 @@ EOF
 	# Setup: Create initial keychain secrets. A keychain CLI can be present in
 	# headless CI while its backing keychain is still unavailable.
 	run fnox set KC_EXISTING "kc-original" --provider keychain
-	if [ "$status" -ne 0 ]; then
+	if [ "$status" -ne 0 ] && [[ "$output" == *"User interaction is"* ]] && [[ "$output" == *"not allowed"* ]]; then
 		skip "Keychain not accessible in this environment"
 	fi
+	assert_success
 	echo "kc-to-delete" | fnox set KC_DELETE --provider keychain
 
 	# Verify setup

--- a/test/edit.bats
+++ b/test/edit.bats
@@ -284,8 +284,12 @@ service = "fnox-test"
 prefix = "test-$$/"
 EOF
 
-	# Setup: Create initial keychain secrets
-	echo "kc-original" | fnox set KC_EXISTING --provider keychain
+	# Setup: Create initial keychain secrets. A keychain CLI can be present in
+	# headless CI while its backing keychain is still unavailable.
+	run fnox set KC_EXISTING "kc-original" --provider keychain
+	if [ "$status" -ne 0 ]; then
+		skip "Keychain not accessible in this environment"
+	fi
 	echo "kc-to-delete" | fnox set KC_DELETE --provider keychain
 
 	# Verify setup

--- a/test/password_store.bats
+++ b/test/password_store.bats
@@ -202,7 +202,8 @@ EOF
 	# Try to get non-existent secret
 	run "$FNOX_BIN" get NONEXISTENT
 	assert_failure
-	assert_output --partial "password-store CLI command failed"
+	assert_output --partial "password-store: secret"
+	assert_output --partial "not found"
 }
 
 @test "fnox set with special characters" {


### PR DESCRIPTION
## Summary

- skip the edit keychain test when a visible keychain CLI has no writable backing keychain
- update the password-store missing-secret assertion to match the current structured error

## Validation

- `git diff --check`
- targeted Bats invocation reached setup but skipped locally because the fnox binary was not installed

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production code or security impact.
> 
> **Overview**
> Updates Bats tests so flaky or environment-specific secret backends don’t fail CI.
> 
> The **keychain edit** test now runs the initial `fnox set` under `run`, skips when the CLI reports user interaction is not allowed (typical headless CI with no writable keychain), and otherwise asserts success before continuing setup.
> 
> The **password-store** test for a missing secret now expects the structured provider error (`password-store: secret` … `not found`) instead of the older generic `password-store CLI command failed` message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2371605e7c6be07d0ec1660394d8f6c3259bc7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unavailable keychain services during credential-store validation.
  * Updated missing-secret validation to display the provider-specific “secret not found” error.

* **Tests**
  * Strengthened coverage for keychain write failures and password-store error reporting, helping ensure more accurate results across supported credential providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->