### PR TITLE
security(env): harden secret injection boundaries

### DIFF
--- a/crates/fnox-core/src/config.rs
+++ b/crates/fnox-core/src/config.rs
@@ -16,6 +16,41 @@ use strum::{EnumString, VariantNames};
 /// Default config filename, used as the clap default for `--config`.
 pub const DEFAULT_CONFIG_FILENAME: &str = "fnox.toml";
 
+/// Return whether a secret name can be used as a shell environment variable.
+///
+/// Shell integration evaluates generated shell code, so accepting anything
+/// broader than a portable identifier would make the name itself part of the
+/// command grammar. Keep this deliberately ASCII-only and equivalent to
+/// `^[A-Za-z_][A-Za-z0-9_]*$`.
+pub fn is_valid_secret_name(name: &str) -> bool {
+    let mut bytes = name.bytes();
+    matches!(bytes.next(), Some(b'A'..=b'Z' | b'a'..=b'z' | b'_'))
+        && bytes.all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
+}
+
+fn invalid_secret_name_issue(name: &str, profile: Option<&str>) -> crate::error::ValidationIssue {
+    let location = profile
+        .filter(|profile| *profile != "default")
+        .map(|profile| format!(" in profile '{profile}'"))
+        .unwrap_or_default();
+    crate::error::ValidationIssue::with_help(
+        format!("Secret name '{name}'{location} is not a valid environment variable name"),
+        "Use only letters, digits, and underscores, starting with a letter or underscore",
+    )
+}
+
+/// Validate one secret name before it is persisted or used for environment
+/// injection.
+pub fn validate_secret_name(name: &str) -> Result<()> {
+    if is_valid_secret_name(name) {
+        Ok(())
+    } else {
+        Err(FnoxError::ConfigValidationFailed {
+            issues: vec![invalid_secret_name_issue(name, None)],
+        })
+    }
+}
+
 /// Returns all config filenames in load order (first = lowest priority, last = highest priority).
 ///
 /// Order: main configs → profile configs (in the order given) → local configs
@@ -1510,6 +1545,15 @@ impl Config {
             }
         }
 
+        let issues = secrets
+            .keys()
+            .filter(|name| !is_valid_secret_name(name))
+            .map(|name| invalid_secret_name_issue(name, None))
+            .collect::<Vec<_>>();
+        if !issues.is_empty() {
+            return Err(FnoxError::ConfigValidationFailed { issues });
+        }
+
         // Secrets that don't set `env` themselves inherit the top-level default
         if self.env.is_some() {
             for secret in secrets.values_mut() {
@@ -1843,6 +1887,9 @@ impl Config {
 
         // Check for secrets with empty values (likely a mistake, but allowed for plain provider)
         for (key, secret) in &self.secrets {
+            if !is_valid_secret_name(key) {
+                issues.push(invalid_secret_name_issue(key, None));
+            }
             if let Some(issue) = self.check_empty_value(key, secret, "default") {
                 issues.push(issue);
             }
@@ -1892,6 +1939,9 @@ impl Config {
 
             // Check for profile secrets with empty values (likely a mistake, but allowed for plain provider)
             for (key, secret) in &profile_config.secrets {
+                if !is_valid_secret_name(key) {
+                    issues.push(invalid_secret_name_issue(key, Some(profile_name)));
+                }
                 if let Some(issue) = self.check_empty_value(key, secret, profile_name) {
                     issues.push(issue);
                 }
@@ -2232,6 +2282,42 @@ fn is_false(value: &bool) -> bool {
 mod tests {
     use super::*;
     use std::path::Path;
+
+    #[test]
+    fn secret_names_are_portable_environment_identifiers() {
+        for valid in ["A", "_", "MY_SECRET", "secret_123"] {
+            assert!(
+                is_valid_secret_name(valid),
+                "expected {valid:?} to be valid"
+            );
+        }
+        for invalid in ["", "1SECRET", "BAD-NAME", "BAD NAME", "X; touch /tmp/pwn #"] {
+            assert!(
+                !is_valid_secret_name(invalid),
+                "expected {invalid:?} to be invalid"
+            );
+        }
+    }
+
+    #[test]
+    fn get_secrets_rejects_invalid_environment_names() {
+        let config: Config = toml_edit::de::from_str(
+            r#"
+root = true
+
+[secrets]
+"X; touch /tmp/pwn #" = { default = "harmless" }
+"ALSO-BAD" = { default = "harmless" }
+"#,
+        )
+        .unwrap();
+
+        let error = config
+            .get_secrets_with_no_defaults(&["default".to_string()], false)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("Configuration validation failed (2 issues)"));
+    }
 
     #[test]
     fn test_empty_import_not_serialized() {

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -488,8 +488,8 @@
           {
             "name": "replace",
             "usage": "--replace",
-            "help": "Run the command in fnox's process, keeping the same PID and receiving signals directly; supports environment-only secrets without leases and does not inherit ambient FNOX_AGE_KEY or FNOX_AGE_KEY_FILE values. Available on Linux, macOS, and other Unix-like systems",
-            "help_first_line": "Run the command in fnox's process, keeping the same PID and receiving signals directly; supports environment-only secrets without leases and does not inherit ambient FNOX_AGE_KEY or FNOX_AGE_KEY_FILE values. Available on Linux, macOS, and other Unix-like systems",
+            "help": "Run the command in fnox's process, keeping the same PID and receiving signals directly; supports environment-only secrets without leases. Available on Linux, macOS, and other Unix-like systems",
+            "help_first_line": "Run the command in fnox's process, keeping the same PID and receiving signals directly; supports environment-only secrets without leases. Available on Linux, macOS, and other Unix-like systems",
             "short": [],
             "long": ["replace"],
             "hide": false,

--- a/docs/cli/exec.md
+++ b/docs/cli/exec.md
@@ -13,5 +13,5 @@ Execute a command with secrets as environment variables
 
 ## Flags
 
-- **`--replace`** — Run the command in fnox's process, keeping the same PID and receiving signals directly; supports environment-only secrets without leases and does not inherit ambient FNOX_AGE_KEY or FNOX_AGE_KEY_FILE values. Available on Linux, macOS, and other Unix-like systems
+- **`--replace`** — Run the command in fnox's process, keeping the same PID and receiving signals directly; supports environment-only secrets without leases. Available on Linux, macOS, and other Unix-like systems
 - **`-h --help`** — Print help

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -95,6 +95,9 @@ SECRET_NAME = { provider = "PROVIDER_NAME", value = "...", default = "...", if_m
 # ... same structure as top-level ...
 ```
 
+Secret names are environment variable names and must match
+`^[A-Za-z_][A-Za-z0-9_]*$`.
+
 ## Top-Level Settings
 
 ### `if_missing`

--- a/fnox.usage.kdl
+++ b/fnox.usage.kdl
@@ -90,7 +90,7 @@ cmd edit help="Edit the configuration file" {
 cmd exec help="Execute a command with secrets as environment variables" {
     alias x
     alias run hide=#true
-    flag --replace help="Run the command in fnox's process, keeping the same PID and receiving signals directly; supports environment-only secrets without leases and does not inherit ambient FNOX_AGE_KEY or FNOX_AGE_KEY_FILE values. Available on Linux, macOS, and other Unix-like systems"
+    flag --replace help="Run the command in fnox's process, keeping the same PID and receiving signals directly; supports environment-only secrets without leases. Available on Linux, macOS, and other Unix-like systems"
     flag "-h --help" help="Print help" action=help builtin=#true
     arg "[COMMAND]..." help="Command to run" double_dash=automatic
     complete command type=command_args

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -72,6 +72,12 @@ impl ExecCommand {
 
         let mut cmd = Command::new(cmd_path);
 
+        // The target should not inherit the age identity that decrypts other
+        // values in the configuration. Explicit secrets and lease credentials
+        // with these names are intentionally applied after this ambient scrub.
+        cmd.env_remove("FNOX_AGE_KEY");
+        cmd.env_remove("FNOX_AGE_KEY_FILE");
+
         if self.command.len() > 1 {
             cmd.args(&self.command[1..]);
         }
@@ -152,12 +158,6 @@ impl ExecCommand {
                 }
             }
         }
-
-        // The target should receive resolved secrets, not the age identity that
-        // decrypts other values in the configuration. Explicitly configured
-        // secrets with these names are added back by the loop below.
-        cmd.env_remove("FNOX_AGE_KEY");
-        cmd.env_remove("FNOX_AGE_KEY_FILE");
 
         // Add resolved secrets as environment variables
         for (key, value) in resolved_secrets {

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -10,9 +10,8 @@ use tempfile::NamedTempFile;
 #[usage(alias = "x", alias_hidden = "run")]
 pub struct ExecCommand {
     /// Run the command in fnox's process, keeping the same PID and receiving signals
-    /// directly; supports environment-only secrets without leases and does not inherit
-    /// ambient FNOX_AGE_KEY or FNOX_AGE_KEY_FILE values. Available on Linux,
-    /// macOS, and other Unix-like systems
+    /// directly; supports environment-only secrets without leases. Available on
+    /// Linux, macOS, and other Unix-like systems
     #[cfg(unix)]
     #[usage(long)]
     pub replace: bool,
@@ -157,11 +156,8 @@ impl ExecCommand {
         // The target should receive resolved secrets, not the age identity that
         // decrypts other values in the configuration. Explicitly configured
         // secrets with these names are added back by the loop below.
-        #[cfg(unix)]
-        if self.replace {
-            cmd.env_remove("FNOX_AGE_KEY");
-            cmd.env_remove("FNOX_AGE_KEY_FILE");
-        }
+        cmd.env_remove("FNOX_AGE_KEY");
+        cmd.env_remove("FNOX_AGE_KEY_FILE");
 
         // Add resolved secrets as environment variables
         for (key, value) in resolved_secrets {

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -100,6 +100,15 @@ impl ImportCommand {
             secrets = prefixed_secrets;
         }
 
+        // Reject names after filtering and prefixing, before provider lookup or
+        // encryption can perform any side effects. Otherwise import could
+        // persist a config that fails as soon as secrets are resolved.
+        let mut secret_names = secrets.keys().collect::<Vec<_>>();
+        secret_names.sort_unstable();
+        for key in secret_names {
+            config::validate_secret_name(key)?;
+        }
+
         if secrets.is_empty() {
             println!("No secrets to import");
             return Ok(());

--- a/src/commands/set.rs
+++ b/src/commands/set.rs
@@ -95,6 +95,8 @@ pub struct SetCommand {
 
 impl SetCommand {
     pub async fn run(&self, cli: &Cli, mut config: Config) -> Result<()> {
+        config::validate_secret_name(&self.key)?;
+
         let profile = Config::get_profiles(cli.profile.as_slice());
         let write_profile = Config::resolve_write_profile(&profile, cli.write_profile.as_deref())?;
         tracing::debug!(

--- a/src/mcp_server.rs
+++ b/src/mcp_server.rs
@@ -25,6 +25,11 @@ const PER_STREAM_LIMIT: usize = (MAX_OUTPUT_BYTES / 2) + 1;
 /// Default execution timeout (5 minutes)
 const DEFAULT_EXEC_TIMEOUT_SECS: u64 = 300;
 
+fn scrub_age_identity(cmd: &mut tokio::process::Command) {
+    cmd.env_remove("FNOX_AGE_KEY");
+    cmd.env_remove("FNOX_AGE_KEY_FILE");
+}
+
 /// MCP tool parameter: request a secret by name
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct GetSecretParams {
@@ -353,6 +358,10 @@ impl FnoxMcpServer {
         let cmd_path = cmd_name;
 
         let mut cmd = tokio::process::Command::new(cmd_path);
+        // MCP subprocesses must receive resolved secrets, not the ambient age
+        // identity that can decrypt other values in the configuration.
+        // Explicitly configured secrets with these names are injected below.
+        scrub_age_identity(&mut cmd);
         if params.command.len() > 1 {
             cmd.args(&params.command[1..]);
         }
@@ -648,6 +657,20 @@ mod tests {
         let result = server.list_tools_result();
         assert_eq!(result.ttl_ms, Some(0));
         assert_eq!(result.cache_scope, Some(CacheScope::Private));
+    }
+
+    #[test]
+    fn mcp_exec_command_scrubs_ambient_age_identity() {
+        let mut cmd = tokio::process::Command::new("unused");
+        scrub_age_identity(&mut cmd);
+
+        let removed = cmd
+            .as_std()
+            .get_envs()
+            .filter_map(|(key, value)| value.is_none().then_some(key.to_string_lossy()))
+            .collect::<Vec<_>>();
+        assert!(removed.iter().any(|key| key == "FNOX_AGE_KEY"));
+        assert!(removed.iter().any(|key| key == "FNOX_AGE_KEY_FILE"));
     }
 
     #[test]

--- a/src/shell/bash.rs
+++ b/src/shell/bash.rs
@@ -81,11 +81,15 @@ PROMPT_COMMAND="${PROMPT_COMMAND//_fnox_hook/}"
     }
 
     fn set_env(&self, key: &str, value: &str) -> String {
-        format!("export {}={}\n", key, super::posix_quote(value))
+        format!(
+            "export {}={}\n",
+            super::posix_quote(key),
+            super::posix_quote(value)
+        )
     }
 
     fn unset_env(&self, key: &str) -> String {
-        format!("unset {}\n", key)
+        format!("unset {}\n", super::posix_quote(key))
     }
 }
 

--- a/src/shell/fish.rs
+++ b/src/shell/fish.rs
@@ -75,16 +75,24 @@ end
 
     fn set_env(&self, key: &str, value: &str) -> String {
         // Fish uses different quoting
+        let key = fish_escape(key);
         let value = value
             .replace('\\', "\\\\")
             .replace('"', "\\\"")
             .replace('$', "\\$");
-        format!("set -gx {} \"{}\"\n", key, value)
+        format!("set -gx \"{}\" \"{}\"\n", key, value)
     }
 
     fn unset_env(&self, key: &str) -> String {
-        format!("set -e {}\n", key)
+        format!("set -e \"{}\"\n", fish_escape(key))
     }
+}
+
+fn fish_escape(value: &str) -> String {
+    value
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('$', "\\$")
 }
 
 impl fmt::Display for Fish {

--- a/src/shell/pwsh.rs
+++ b/src/shell/pwsh.rs
@@ -144,8 +144,9 @@ Remove-Item -ErrorAction SilentlyContinue -LiteralPath 'Env:__FNOX_SESSION'
     }
 
     fn set_env(&self, key: &str, value: &str) -> String {
+        let k = powershell_escape(key.into());
         let v = powershell_escape(value.into());
-        format!("${{Env:{key}}}='{v}'\n")
+        format!("Set-Item -LiteralPath 'Env:{k}' -Value '{v}'\n")
     }
 
     fn unset_env(&self, key: &str) -> String {

--- a/src/shell/zsh.rs
+++ b/src/shell/zsh.rs
@@ -120,11 +120,15 @@ add-zsh-hook -d zshexit _fnox_cleanup 2>/dev/null
     }
 
     fn set_env(&self, key: &str, value: &str) -> String {
-        format!("export {}={}\n", key, super::posix_quote(value))
+        format!(
+            "export {}={}\n",
+            super::posix_quote(key),
+            super::posix_quote(value)
+        )
     }
 
     fn unset_env(&self, key: &str) -> String {
-        format!("unset {}\n", key)
+        format!("unset {}\n", super::posix_quote(key))
     }
 }
 

--- a/test/azure_secrets_manager.bats
+++ b/test/azure_secrets_manager.bats
@@ -340,12 +340,13 @@ EOF
 	# Note: Azure Key Vault secret names can only contain alphanumeric characters and hyphens
 	export TEST_SECRET_NAME="fnox-test-AZURE-SM-CREATE-TEST-${timestamp}"
 
-	# Create secret using fnox set (will create it in Azure Key Vault)
-	run "$FNOX_BIN" set "AZURE-SM-CREATE-TEST-${timestamp}" "$secret_value" --provider azure-sm
+	# Keep the local key portable while using Azure's hyphenated remote name.
+	run "$FNOX_BIN" set AZURE_SM_CREATE_TEST "$secret_value" \
+		--provider azure-sm --key-name "AZURE-SM-CREATE-TEST-${timestamp}"
 	assert_success
 
 	# Get secret back to verify it was created correctly
-	run "$FNOX_BIN" get "AZURE-SM-CREATE-TEST-${timestamp}"
+	run "$FNOX_BIN" get AZURE_SM_CREATE_TEST
 	assert_success
 	assert_output "$secret_value"
 

--- a/test/exec_replace.bats
+++ b/test/exec_replace.bats
@@ -127,6 +127,19 @@ SCRIPT
 	assert_output "replacement-ok"
 }
 
+@test "exec omits ambient age identities when spawning a child" {
+	cat >fnox.toml <<'TOML'
+root = true
+TOML
+
+	export FNOX_AGE_KEY="AGE-SECRET-KEY-TEST"
+	export FNOX_AGE_KEY_FILE="$TEST_TEMP_DIR/age-key.txt"
+
+	run "$FNOX_BIN" --no-daemon exec -- \
+		bash -c 'test -z "${FNOX_AGE_KEY+x}" && test -z "${FNOX_AGE_KEY_FILE+x}"'
+	assert_success
+}
+
 @test "exec --replace delivers signals directly to the replacement process" {
 	cat >fnox.toml <<'TOML'
 root = true
@@ -225,7 +238,7 @@ SCRIPT
 	TARGET_PID=""
 }
 
-@test "exec --replace allows explicit secrets to restore scrubbed variables" {
+@test "exec allows explicit secrets to restore scrubbed variables" {
 	cat >fnox.toml <<'TOML'
 root = true
 
@@ -245,6 +258,10 @@ TOML
 	export FNOX_AGE_KEY_FILE="ambient-file"
 
 	# Selected secrets are applied after ambient resolver credentials are removed.
+	run "$FNOX_BIN" --no-daemon exec -- \
+		bash -c 'test "$FNOX_AGE_KEY" = "selected-value" && test "$FNOX_AGE_KEY_FILE" = "selected-file"'
+	assert_success
+
 	run "$FNOX_BIN" --no-daemon exec --replace -- \
 		bash -c 'test "$FNOX_AGE_KEY" = "selected-value" && test "$FNOX_AGE_KEY_FILE" = "selected-file"'
 	assert_success

--- a/test/import.bats
+++ b/test/import.bats
@@ -213,6 +213,19 @@ EOF
 	assert_fnox_failure get API_KEY
 }
 
+@test "fnox import rejects invalid secret names after prefixing" {
+	setup_age_provider
+
+	cat >.env <<EOF
+API_KEY=secret-key-xyz
+EOF
+
+	assert_fnox_failure import -i .env --prefix "INVALID-" --provider age --force
+	assert_output --partial "Secret name 'INVALID-API_KEY'"
+	assert_output --partial "not a valid environment variable name"
+	assert_config_not_contains "INVALID-API_KEY"
+}
+
 @test "fnox import requires confirmation by default" {
 	setup_age_provider
 

--- a/test/lease_command.bats
+++ b/test/lease_command.bats
@@ -153,6 +153,21 @@ EOF
 	assert_output --partial "MY_SECRET=sec-xyz789"
 }
 
+@test "command backend: exec preserves leased age identity credentials" {
+	cat >"$TEST_TEMP_DIR/create-age-creds.sh" <<'SCRIPT'
+#!/usr/bin/env bash
+echo '{"credentials":{"FNOX_AGE_KEY":"leased-key","FNOX_AGE_KEY_FILE":"leased-file"},"lease_id":"cmd-age-lease"}'
+SCRIPT
+	chmod +x "$TEST_TEMP_DIR/create-age-creds.sh"
+	create_command_config "$TEST_TEMP_DIR/create-age-creds.sh"
+
+	export FNOX_AGE_KEY="ambient-key"
+	export FNOX_AGE_KEY_FILE="ambient-file"
+	run "$FNOX_BIN" exec -- bash -c \
+		'test "$FNOX_AGE_KEY" = "leased-key" && test "$FNOX_AGE_KEY_FILE" = "leased-file"'
+	assert_success
+}
+
 @test "command backend: passes FNOX_LEASE_DURATION and FNOX_LEASE_LABEL" {
 	create_cred_script_with_env
 	create_command_config "$TEST_TEMP_DIR/create-creds-env.sh"

--- a/test/shell-integration.bats
+++ b/test/shell-integration.bats
@@ -182,6 +182,23 @@ teardown() {
 	assert_output --partial 'export SECRET_THREE=value-three'
 }
 
+@test "fnox hook-env rejects command injection in secret names" {
+	cd "$TEST_TEMP_DIR"
+	marker="$TEST_TEMP_DIR/fnox-hook-injected"
+	cat >fnox.toml <<-EOF
+		root = true
+
+		[secrets]
+		"X; touch $marker #" = { default = "harmless" }
+	EOF
+
+	run bash -c 'eval "$("$1" hook-env -s bash)"' _ "$FNOX_BIN"
+
+	assert_success
+	assert_output --partial "Configuration validation failed"
+	assert_file_not_exists "$marker"
+}
+
 @test "fnox hook-env generates fish-compatible output" {
 	cd "$TEST_TEMP_DIR"
 	cat >fnox.toml <<-EOF
@@ -196,8 +213,8 @@ teardown() {
 	run "$FNOX_BIN" hook-env -s fish
 
 	assert_success
-	assert_output --partial 'set -gx FISH_SECRET "fish-value"'
-	assert_output --partial 'set -gx __FNOX_SESSION'
+	assert_output --partial 'set -gx "FISH_SECRET" "fish-value"'
+	assert_output --partial 'set -gx "__FNOX_SESSION"'
 }
 
 @test "fnox hook-env generates powershell-compatible output" {
@@ -214,8 +231,8 @@ teardown() {
 	run "$FNOX_BIN" hook-env -s pwsh
 
 	assert_success
-	assert_output --partial "\${Env:PWSH_SECRET}='pwsh-value'"
-	assert_output --partial '${Env:__FNOX_SESSION}='
+	assert_output --partial "Set-Item -LiteralPath 'Env:PWSH_SECRET' -Value 'pwsh-value'"
+	assert_output --partial "Set-Item -LiteralPath 'Env:__FNOX_SESSION' -Value"
 }
 
 @test "fnox hook-env escapes single quotes for powershell" {
@@ -232,7 +249,7 @@ teardown() {
 	run "$FNOX_BIN" hook-env -s pwsh
 
 	assert_success
-	assert_output --partial "\${Env:PWSH_QUOTE}='it''s a value'"
+	assert_output --partial "Set-Item -LiteralPath 'Env:PWSH_QUOTE' -Value 'it''s a value'"
 }
 
 @test "fnox hook-env finds config in parent directory" {


### PR DESCRIPTION
## Summary

- reject non-portable secret names before environment injection and defensively quote names in shell emitters
- strip ambient `FNOX_AGE_KEY` and `FNOX_AGE_KEY_FILE` in both exec modes while preserving explicitly configured values
- add regression coverage and document the portable secret-name requirement

The CI secret-isolation finding reported with these issues is now covered by #762 on `main`, so this branch keeps that newer trusted/untrusted workflow split instead of duplicating it.

## Testing

- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `mise run lint`
- `MISE_TRUSTED_CONFIG_PATHS=/ mise run test:bats -- test/shell-integration.bats test/exec_replace.bats`
- `cargo msrv verify`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication-adjacent env handling and shell code generation; mistakes could break exec/leases or leave injection paths open, but the direction reduces credential leakage and command injection risk.
> 
> **Overview**
> This PR tightens how secret **names** and **resolver credentials** reach shells and child processes.
> 
> Secret keys must look like portable environment identifiers (`^[A-Za-z_][A-Za-z0-9_]*$`). Validation runs when loading/merging secrets, validating `fnox.toml`, running **`set`**, and **`import`** (after prefixing), with profile-aware error messages. Shell **`hook-env`** emitters now quote or escape names in Bash, Zsh, Fish, and PowerShell so malicious keys cannot break out of generated `export`/`set`/`Set-Item` lines.
> 
> **`exec`** and MCP **`exec`** always strip ambient `FNOX_AGE_KEY` and `FNOX_AGE_KEY_FILE` before spawning the target; explicitly configured secrets (including lease-backed credentials) are still injected afterward. CLI help and docs no longer describe age scrubbing as **`--replace`**-only behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f70ac4fec6db5a90dc48a019cd483d9aef50e7a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Secret names must use valid shell-compatible environment variable identifiers.
  * Clear, profile-aware errors are shown for invalid names when configuring, setting, or importing secrets.
  * Environment variable handling is safer across Bash, Zsh, Fish, and PowerShell.

* **Bug Fixes**
  * Unsafe secret names are rejected before changes are made or commands run.
  * Ambient age credentials are removed before command execution and MCP subprocesses, while explicitly selected credentials remain available.

* **Documentation**
  * Updated CLI help and configuration guidance for secret naming and credential inheritance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->