### PR TITLE
ci: notarize the macOS release binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,8 @@ jobs:
           token: ${{ secrets.FNOX_GH_TOKEN }}
           codesign: "Developer ID Application: Jeffrey Dickey (4993Y37DX6)"
           codesign_prefix: dev.jdx.
+          # Apple will not notarize a binary without the hardened runtime.
+          codesign_options: runtime
           dry-run: true # Always dry-run to just build without uploading
       # Signing settles who built the binary; notarization is what Gatekeeper
       # demands once an archive carries the quarantine bit, which is to say
@@ -109,6 +111,21 @@ jobs:
           for binary in $BINARIES; do
             cp "$binary" "$work/stage/"
           done
+          # Apple rejects a binary without the hardened runtime or a secure
+          # timestamp. Naming a missing one here turns an opaque Invalid verdict
+          # into a diagnosis; Apple stays the authority on whether to accept.
+          for binary in $BINARIES; do
+            details="$(codesign --display --verbose=4 "$binary" 2>&1 || true)"
+            case "$details" in
+              *runtime*) ;;
+              *) echo "::warning title=No hardened runtime::$binary is signed without --options runtime, which Apple requires; expect an Invalid verdict below." ;;
+            esac
+            case "$details" in
+              *Timestamp=*) ;;
+              *) echo "::warning title=No secure timestamp::$binary carries no secure timestamp, which Apple requires; expect an Invalid verdict below." ;;
+            esac
+          done
+
           ditto -c -k --norsrc --noextattr "$work/stage" "$work/submission.zip"
 
           # `--wait` is not a gate on its own: it can return zero on an Invalid

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,71 @@ jobs:
           codesign: "Developer ID Application: Jeffrey Dickey (4993Y37DX6)"
           codesign_prefix: dev.jdx.
           dry-run: true # Always dry-run to just build without uploading
+      # Signing settles who built the binary; notarization is what Gatekeeper
+      # demands once an archive carries the quarantine bit, which is to say
+      # whenever someone downloads it in a browser rather than with curl.
+      # Without a ticket it is blocked behind a "cannot be verified" dialog that
+      # only a deliberate override gets past.
+      #
+      # The ticket lives on Apple's side and is keyed to the binary's cdhash, so
+      # nothing here rewrites what was already built or uploaded -- stapling
+      # would, but `stapler` only writes into bundles, disk images, and
+      # installer packages, and this is a bare Mach-O in an archive. Gatekeeper
+      # resolves the ticket online instead.
+      - name: Notarize macOS binary
+        if: matrix.os == 'macos-latest'
+        shell: bash
+        env:
+          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
+          BINARIES: target/${{ matrix.target }}/release/fnox
+        run: |
+          set -euo pipefail
+
+          if [ -z "$APPLE_API_KEY_P8" ] || [ -z "$APPLE_API_KEY_ID" ] || [ -z "$APPLE_API_ISSUER_ID" ]; then
+            echo "::warning title=Not notarized::App Store Connect credentials are unset, so this release ships signed but un-notarized macOS binaries. Gatekeeper will block them for anyone who downloads an archive through a browser."
+            exit 0
+          fi
+
+          # Outside the workspace, so no later step can sweep the key into an
+          # artifact, and removed even when notarization fails.
+          work="$(mktemp -d)"
+          trap 'rm -rf "$work"' EXIT
+          printf '%s' "$APPLE_API_KEY_P8" | base64 --decode > "$work/key.p8"
+
+          # notarytool takes a container, never a bare executable. Copies are
+          # fine: a Mach-O carries its signature inline, so the cdhash the
+          # ticket is keyed to is the one already shipped.
+          mkdir "$work/stage"
+          for binary in $BINARIES; do
+            cp "$binary" "$work/stage/"
+          done
+          ditto -c -k --norsrc --noextattr "$work/stage" "$work/submission.zip"
+
+          # `--wait` is not a gate on its own: it can return zero on an Invalid
+          # submission, so the reported status is what decides. plutil reads
+          # JSON and ships with macOS, which keeps this off jq.
+          result="$(xcrun notarytool submit "$work/submission.zip" \
+            --key "$work/key.p8" \
+            --key-id "$APPLE_API_KEY_ID" \
+            --issuer "$APPLE_API_ISSUER_ID" \
+            --output-format json \
+            --timeout 30m \
+            --wait)"
+          echo "$result"
+
+          status="$(printf '%s' "$result" | plutil -extract status raw -o - -)"
+          id="$(printf '%s' "$result" | plutil -extract id raw -o - -)"
+          if [ "$status" != "Accepted" ]; then
+            echo "::error::notarization returned $status for submission $id"
+            xcrun notarytool log "$id" \
+              --key "$work/key.p8" \
+              --key-id "$APPLE_API_KEY_ID" \
+              --issuer "$APPLE_API_ISSUER_ID" || true
+            exit 1
+          fi
+          echo "notarized: submission $id"
       - name: Upload binary artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:


### PR DESCRIPTION
The macOS binary is signed but never submitted to Apple's notary service. Signing settles *who* built it; notarization is what Gatekeeper demands once an archive carries the quarantine bit — which is to say whenever someone downloads it in a browser rather than with `curl`. Without a ticket it is blocked behind a "cannot be verified" dialog that only a deliberate override gets past.

`upload-rust-binary-action` signs in place and archives from those same bytes, so this step submits exactly what users download. Notable choices, all commented in place:

- **Nothing is stapled**, and nothing rewrites the artifact. The ticket lives on Apple's side keyed to the binary's cdhash; `stapler` only writes into bundles, disk images, and installer packages, and this is a bare Mach-O in an archive. Gatekeeper resolves the ticket online.
- **The status is parsed, not inferred from the exit code.** `notarytool submit --wait` can return zero on an `Invalid` submission, so the JSON `status` decides. A rejection prints `notarytool log` before failing.
- **`plutil` parses the JSON**, not `jq`, so this assumes nothing about the runner image.
- **No secrets plumbing is needed** here: `release.yml` triggers directly on a tag push rather than through `workflow_call`, so the three secrets resolve from repository scope.
- **The credentials are optional.** Absent them the release still ships a signed binary and emits a `Not notarized` warning, rather than failing a release on a secret that is not configured yet.

## Verification

I cannot notarize for real from here, so the step was exercised against a stubbed `xcrun`:

- **Accepted** — base64 → key file, `ditto -c -k --norsrc --noextattr` produced a clean zip of the staged binaries, every flag reached `notarytool` intact, status parsed as `Accepted`, exit 0.
- **Invalid** — the stub deliberately exits **0** while reporting `Invalid`; the step still failed and fetched the notary log, confirming the status check and not the exit code is the gate.
- **No credentials** — warned and exited 0.
- The `trap` left no key or temp directory behind in any case.
- `bash -n` and `shellcheck` clean; the workflow parses and the step is ordered after signing and before the upload.

## What you need to do

Nothing in this PR works until three repository secrets exist: `APPLE_API_KEY_P8` (base64 of an App Store Connect **team** API key `.p8` with the Developer role), `APPLE_API_KEY_ID`, and `APPLE_API_ISSUER_ID`. It must be a team key — `notarytool` takes an issuer only for those. Until then, releases ship signed but un-notarized and annotate a warning.

This is one of several sibling PRs applying the same step across the jdx.dev CLIs. They each carry their own copy; if you would rather consolidate, a composite action would collapse all seven into one — happy to do that instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release pipeline and Gatekeeper behavior for distributed macOS binaries; misconfigured credentials or notarization failures can block releases or ship un-notarized artifacts.
> 
> **Overview**
> macOS release builds now enable **hardened runtime** signing (`codesign_options: runtime`) and add a **notarize** job step between signing and artifact upload.
> 
> When App Store Connect API secrets are present, the workflow zips the signed `fnox` binary, submits it with `xcrun notarytool`, and **fails the release** unless the JSON status is `Accepted` (not merely a zero exit from `--wait`). Rejections pull `notarytool log`; missing credentials emit a warning and ship signed-but-un-notarized binaries. API keys are decoded in a temp directory removed on exit; `codesign` is pre-checked for runtime and secure timestamp; JSON is parsed with `plutil`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 964b92965c0f6bb9f4eb98e457767a8a7bc80e92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release Process**
  * Added macOS hardened-runtime signing to improve application security.
  * Releases now verify required security metadata before notarization submission.
  * Notarization submissions include secure timestamps for improved verification.
  * Releases validate notarization credentials and report rejected submissions.
  * Notarization is skipped with a warning when credentials are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->