### PR TITLE
perf(env): skip redundant secret reloads

### DIFF
--- a/src/hook_env.rs
+++ b/src/hook_env.rs
@@ -154,12 +154,6 @@ pub fn hash_secret_value_with_session(session: &HookEnvSession, key: &str, value
 /// Check if we should exit early (optimization)
 /// Returns true if nothing changed and we can skip work
 pub fn should_exit_early() -> bool {
-    // Check if directory changed
-    if has_directory_changed() {
-        tracing::debug!("directory changed, must run hook-env");
-        return false;
-    }
-
     // Check if fnox.toml was modified
     if has_config_been_modified() {
         tracing::debug!("fnox.toml modified, must run hook-env");
@@ -174,12 +168,6 @@ pub fn should_exit_early() -> bool {
 
     tracing::debug!("no changes detected, exiting early");
     true
-}
-
-/// Check if current directory is different from previous session
-fn has_directory_changed() -> bool {
-    let current_dir = std::env::current_dir().ok();
-    PREV_SESSION.dir != current_dir
 }
 
 /// Check if any config files in the hierarchy have been modified since last run

--- a/test/shell-integration.bats
+++ b/test/shell-integration.bats
@@ -286,6 +286,33 @@ teardown() {
 	assert_output ""
 }
 
+@test "fnox hook-env exits early when moving within the same config hierarchy" {
+	project_dir="$TEST_TEMP_DIR/project"
+	mkdir -p "$project_dir/inner"
+	cd "$project_dir"
+	cat >fnox.toml <<-EOF
+		[providers.plain]
+		type = "plain"
+
+		[secrets.CACHED_SECRET]
+		provider = "plain"
+		value = "cached-value"
+	EOF
+
+	# First run from the project root loads the secret and creates the session
+	output1=$("$FNOX_BIN" hook-env -s bash)
+	echo "$output1" | grep -q 'export CACHED_SECRET=cached-value'
+	session=$(echo "$output1" | grep '__FNOX_SESSION=' | sed -E "s/^export __FNOX_SESSION=//; s/^'(.*)'\$/\\1/")
+
+	# Moving into an empty child keeps the same effective config hierarchy
+	export __FNOX_SESSION="$session"
+	cd inner
+	run "$FNOX_BIN" hook-env -s bash
+
+	assert_success
+	assert_output ""
+}
+
 @test "fnox hook-env reloads when config is modified" {
 	cd "$TEST_TEMP_DIR"
 	cat >fnox.toml <<-EOF
@@ -396,7 +423,7 @@ teardown() {
 	assert_output --partial 'unset TEMPORARY_SECRET'
 }
 
-@test "fnox hook-env reloads when directory changes" {
+@test "fnox hook-env reloads when moving to a different config hierarchy" {
 	# Create first directory with config
 	dir1="$TEST_TEMP_DIR/dir1"
 	mkdir -p "$dir1"
@@ -428,7 +455,7 @@ teardown() {
 		value = "dir2-value"
 	EOF
 
-	# Second run in dir2 with session from dir1 - should detect directory change
+	# Second run in dir2 with session from dir1 - should detect the config change
 	export __FNOX_SESSION="$session"
 	run "$FNOX_BIN" hook-env -s bash
 


### PR DESCRIPTION
## Summary

- stop treating every working-directory change as a reason to reload secrets
- use the existing effective config hierarchy fingerprint to decide whether `hook-env` must run
- add regression coverage for navigation into an empty child directory
- retain reload coverage when moving between different config hierarchies

Closes the behavior reported in #765.

## Testing

- `mise run build`
- `mise run test:bats -- test/shell-integration.bats` (37 tests, 0 failures, 1 expected skip)
- `mise run lint`

This still needs human review; although the focused tests pass, I am not certain the change covers every real-world shell/provider interaction.

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when shell hooks refresh secrets on `cd`; incorrect early exit could leave stale env vars if hierarchy detection misses an edge case, though config mtime/path hashing is intended to cover hierarchy moves.
> 
> **Overview**
> **`hook-env` no longer forces a full reload on every working-directory change.** Early exit now depends only on whether the effective config hierarchy fingerprint (`config_files_hash` / `has_config_been_modified`) or `FNOX_*` environment variables changed; the `has_directory_changed()` check and `PREV_SESSION.dir` comparison were removed.
> 
> Shell integration tests were updated to match: a new case asserts **no output** when `cd` into an empty child under the same `fnox.toml` tree, and the cross-directory test was renamed to document reload when moving to a **different** config hierarchy (still driven by config hash, not cwd alone).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1005dcb16af29a5db3a045dcb1ada16ee7c2e2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `fnox hook-env` now preserves sessions when moving between directories within the same configuration hierarchy.
  * Sessions are refreshed only when configuration files or relevant environment variables change.

* **Tests**
  * Added coverage confirming that child-directory navigation produces no unnecessary output.
  * Updated test descriptions to reflect configuration-hierarchy behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->