### PR TITLE
feat(config): add selective profile inheritance

### DIFF
--- a/crates/fnox-core/src/config.rs
+++ b/crates/fnox-core/src/config.rs
@@ -806,7 +806,7 @@ impl Config {
 
         // Find the nearest directory to cwd that contains a config file.
         // This is the project root used for scoping the lease ledger.
-        config.project_dir = Self::find_project_dir(&current_dir);
+        config.project_dir = Self::find_project_dir(&current_dir, &profiles);
         Ok(config)
     }
 
@@ -869,9 +869,8 @@ impl Config {
 
     /// Find the nearest directory to `start` that contains a config file.
     /// Walks upward from `start` and returns the first match.
-    fn find_project_dir(start: &Path) -> Option<PathBuf> {
-        let profiles = Self::get_profiles(&[]);
-        let filenames = all_config_filenames(&profiles);
+    fn find_project_dir(start: &Path, profiles: &[String]) -> Option<PathBuf> {
+        let filenames = all_config_filenames(profiles);
         let mut dir = Some(start);
         while let Some(d) = dir {
             for filename in &filenames {
@@ -1486,7 +1485,21 @@ impl Config {
             visited: &mut HashSet<String>,
             force: bool,
         ) -> Result<()> {
+            if !env::is_valid_profile_name(profile) {
+                return Err(FnoxError::Config(format!(
+                    "Invalid inherited profile name: '{profile}'"
+                )));
+            }
             if visited.contains(profile) && !force {
+                return Ok(());
+            }
+
+            // `default` is represented by the top-level config. A
+            // `[profiles.default]` table is ignored everywhere else and must not
+            // become an alternate inheritance entry point.
+            if profile == "default" {
+                visited.insert(profile.to_string());
+                resolved.push(profile.to_string());
                 return Ok(());
             }
             if let Some(start) = visiting.iter().position(|name| name == profile) {
@@ -1643,7 +1656,7 @@ impl Config {
     /// Mirrors the precedence used by [`Self::get_secrets`]: later profiles take
     /// precedence, falling back to top-level secrets unless `no_defaults` is set
     /// and at least one non-default profile is active.
-    pub fn get_secret(&self, profiles: &[String], key: &str) -> Option<&SecretConfig> {
+    pub fn get_secret(&self, profiles: &[String], key: &str) -> Result<Option<&SecretConfig>> {
         self.get_secret_with_no_defaults(profiles, key, Settings::get().no_defaults)
     }
 
@@ -1653,23 +1666,23 @@ impl Config {
         profiles: &[String],
         key: &str,
         no_defaults: bool,
-    ) -> Option<&SecretConfig> {
-        let profiles = self.resolve_profiles(profiles).ok()?;
+    ) -> Result<Option<&SecretConfig>> {
+        let profiles = self.resolve_profiles(profiles)?;
         let has_non_default = profiles.iter().any(|p| p != "default");
 
         for profile in profiles.iter().filter(|p| *p != "default").rev() {
             if let Some(profile_config) = self.profiles.get(profile)
                 && let Some(secret) = profile_config.secrets.get(key)
             {
-                return Some(secret);
+                return Ok(Some(secret));
             }
         }
 
         if has_non_default && no_defaults {
-            return None;
+            return Ok(None);
         }
 
-        self.secrets.get(key)
+        Ok(self.secrets.get(key))
     }
 
     /// Get effective secrets (mutable) for the write target profile.
@@ -1692,10 +1705,8 @@ impl Config {
     pub fn get_leases(
         &self,
         profiles: &[String],
-    ) -> IndexMap<String, crate::lease_backends::LeaseBackendConfig> {
-        let profiles = self
-            .resolve_profiles(profiles)
-            .unwrap_or_else(|_| profiles.to_vec());
+    ) -> Result<IndexMap<String, crate::lease_backends::LeaseBackendConfig>> {
+        let profiles = self.resolve_profiles(profiles)?;
         let mut leases = self.leases.clone();
 
         for profile in profiles.iter().filter(|p| *p != "default") {
@@ -1704,17 +1715,15 @@ impl Config {
             }
         }
 
-        leases
+        Ok(leases)
     }
 
     /// Get effective providers for the active profile stack.
     ///
     /// Top-level providers form the base. Profile-specific providers are overlaid
     /// in order, with later profiles taking precedence.
-    pub fn get_providers(&self, profiles: &[String]) -> IndexMap<String, ProviderConfig> {
-        let profiles = self
-            .resolve_profiles(profiles)
-            .unwrap_or_else(|_| profiles.to_vec());
+    pub fn get_providers(&self, profiles: &[String]) -> Result<IndexMap<String, ProviderConfig>> {
+        let profiles = self.resolve_profiles(profiles)?;
         let mut providers = self.providers.clone();
 
         for profile in profiles.iter().filter(|p| *p != "default") {
@@ -1723,7 +1732,7 @@ impl Config {
             }
         }
 
-        providers
+        Ok(providers)
     }
 
     /// Get the default provider for the active profile stack.
@@ -1733,7 +1742,7 @@ impl Config {
     /// is used when no profile overrides it.
     pub fn get_default_provider(&self, profiles: &[String]) -> Result<Option<String>> {
         let profiles = self.resolve_profiles(profiles)?;
-        let providers = self.get_providers(&profiles);
+        let providers = self.get_providers(&profiles)?;
 
         // If no providers configured and this is a root config, return None
         if providers.is_empty() && self.root {
@@ -1915,7 +1924,7 @@ impl Config {
     fn is_plain_provider(&self, secret_provider: Option<&str>, profile: &str) -> bool {
         // Get providers for this profile first (needed for auto-selection)
         let profiles = [profile.to_string()];
-        let providers = self.get_providers(&profiles);
+        let providers = self.get_providers(&profiles).unwrap_or_default();
 
         // Determine which provider name to use
         let provider_name = secret_provider
@@ -1998,7 +2007,7 @@ impl Config {
 
         // Validate each profile
         for (profile_name, profile_config) in &self.profiles {
-            let providers = self.get_providers(std::slice::from_ref(profile_name));
+            let providers = self.get_providers(std::slice::from_ref(profile_name))?;
 
             // Check for profile secrets with empty values (likely a mistake, but allowed for plain provider)
             for (key, secret) in &profile_config.secrets {
@@ -2718,7 +2727,7 @@ value = "prod"
         .unwrap();
 
         let profiles = vec!["aws".to_string(), "prod".to_string()];
-        let providers = config.get_providers(&profiles);
+        let providers = config.get_providers(&profiles).unwrap();
         assert!(providers.contains_key("base"));
         assert!(providers.contains_key("aws_plain"));
         assert!(providers.contains_key("prod_plain"));
@@ -2804,6 +2813,85 @@ inherits = ["a"]
             error,
             FnoxError::ProfileInheritanceCycle { cycle } if cycle == "a -> b -> c -> a"
         ));
+    }
+
+    #[test]
+    fn test_profile_inheritance_rejects_invalid_names() {
+        let config: Config = toml_edit::de::from_str(
+            r#"
+[profiles.app]
+inherits = ["x/../other"]
+"#,
+        )
+        .unwrap();
+
+        let error = config.resolve_profiles(&["app".to_string()]).unwrap_err();
+        assert!(matches!(
+            error,
+            FnoxError::Config(message)
+                if message == "Invalid inherited profile name: 'x/../other'"
+        ));
+    }
+
+    #[test]
+    fn test_default_profile_does_not_inherit_from_profile_table() {
+        let config: Config = toml_edit::de::from_str(
+            r#"
+[profiles.default]
+inherits = ["unexpected"]
+
+[profiles.app]
+inherits = ["default"]
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            config.resolve_profiles(&["app".to_string()]).unwrap(),
+            vec!["default", "app"]
+        );
+    }
+
+    #[test]
+    fn test_effective_config_getters_propagate_inheritance_cycles() {
+        let config: Config = toml_edit::de::from_str(
+            r#"
+[profiles.a]
+inherits = ["b"]
+
+[profiles.b]
+inherits = ["a"]
+"#,
+        )
+        .unwrap();
+        let profiles = ["a".to_string()];
+
+        assert!(matches!(
+            config.get_secret(&profiles, "KEY"),
+            Err(FnoxError::ProfileInheritanceCycle { .. })
+        ));
+        assert!(matches!(
+            config.get_providers(&profiles),
+            Err(FnoxError::ProfileInheritanceCycle { .. })
+        ));
+        assert!(matches!(
+            config.get_leases(&profiles),
+            Err(FnoxError::ProfileInheritanceCycle { .. })
+        ));
+    }
+
+    #[test]
+    fn test_find_project_dir_uses_inherited_profile_files() {
+        let root = tempfile::tempdir().unwrap();
+        let nested = root.path().join("nested");
+        std::fs::create_dir(&nested).unwrap();
+        std::fs::write(root.path().join("fnox.toml"), "").unwrap();
+        std::fs::write(nested.join("fnox.shared.toml"), "").unwrap();
+
+        assert_eq!(
+            Config::find_project_dir(&nested, &["shared".to_string()]),
+            Some(nested)
+        );
     }
 
     #[test]

--- a/crates/fnox-core/src/config.rs
+++ b/crates/fnox-core/src/config.rs
@@ -765,7 +765,7 @@ impl Config {
         })?;
 
         if let Some(profile) = profile_name_from_file(path) {
-            config.loaded_file_profiles.insert(profile);
+            config.scope_to_profile(profile);
         }
 
         // Set source paths for all secrets and providers
@@ -774,19 +774,49 @@ impl Config {
         Ok(config)
     }
 
+    /// Treat top-level provider, secret, lease, and default-provider entries
+    /// from `fnox.<profile>.toml` as entries in that named profile. The file is
+    /// loaded conditionally for the profile, so leaving these entries at the
+    /// config root would give them base precedence and let inherited profile
+    /// tables override the selected profile file.
+    fn scope_to_profile(&mut self, profile_name: String) {
+        self.loaded_file_profiles.insert(profile_name.clone());
+        self.scope_root_entries_to_profile(profile_name);
+    }
+
+    fn scope_root_entries_to_profile(&mut self, profile_name: String) {
+        let profile = self.profiles.entry(profile_name).or_default();
+        profile.leases.extend(std::mem::take(&mut self.leases));
+        profile
+            .providers
+            .extend(std::mem::take(&mut self.providers));
+        profile
+            .provider_sources
+            .extend(std::mem::take(&mut self.provider_sources));
+        profile.secrets.extend(std::mem::take(&mut self.secrets));
+        profile
+            .secret_sources
+            .extend(std::mem::take(&mut self.secret_sources));
+        if self.default_provider.is_some() {
+            profile.default_provider = self.default_provider.take();
+            profile.default_provider_source = self.default_provider_source.take();
+        }
+    }
+
     /// Load configuration with recursive directory search and merging
     fn load_with_recursion<P: AsRef<Path>>(_start_path: P) -> Result<Self> {
         // Start from current working directory and search upwards
         let current_dir = env::current_dir()
             .map_err(|e| FnoxError::Config(format!("Failed to get current directory: {}", e)))?;
 
-        let mut profiles = Self::get_profiles(&[]);
+        let requested_profiles = Self::get_profiles(&[]);
+        let mut profiles = requested_profiles.clone();
         let (mut config, mut found) = Self::load_recursive(&current_dir, false, &profiles)?;
 
         // Profile inheritance can select additional profile-specific files. Keep
         // loading until discovering those files no longer expands the stack.
         loop {
-            let expanded = config.resolve_profiles(&profiles)?;
+            let expanded = config.resolve_profiles_for_discovery(&profiles)?;
             if expanded == profiles {
                 break;
             }
@@ -803,6 +833,11 @@ impl Config {
                 help: "Run 'fnox init' to create a configuration file".to_string(),
             });
         }
+
+        // Discovery must be permissive long enough to look for an inherited
+        // profile file. Once the fixed point is reached, reject inherited
+        // profiles that were neither declared nor discovered.
+        config.resolve_profiles(&requested_profiles)?;
 
         // Find the nearest directory to cwd that contains a config file.
         // This is the project root used for scoping the lease ledger.
@@ -822,7 +857,14 @@ impl Config {
         for filename in &filenames {
             let path = dir.join(filename);
             if path.exists() {
-                let file_config = Self::load(&path)?;
+                let mut file_config = Self::load(&path)?;
+                if matches!(filename.as_str(), "fnox.local.toml" | ".fnox.local.toml") {
+                    let write_profile = Self::write_profile(profiles);
+                    if write_profile != "default" {
+                        file_config.scope_root_entries_to_profile(write_profile.to_string());
+                        file_config.set_source_paths(&path);
+                    }
+                }
                 config = Self::merge_configs(config, file_config)?;
                 found = true;
             }
@@ -1477,6 +1519,21 @@ impl Config {
     /// profile that names them. Profiles reached through multiple paths are
     /// applied once at their earliest dependency-valid position.
     pub fn resolve_profiles(&self, profiles: &[String]) -> Result<Vec<String>> {
+        self.resolve_profiles_inner(profiles, true)
+    }
+
+    /// Resolve profiles while discovering profile-specific files. Missing
+    /// inherited profiles are allowed here because their file may be what the
+    /// next fixed-point iteration discovers.
+    fn resolve_profiles_for_discovery(&self, profiles: &[String]) -> Result<Vec<String>> {
+        self.resolve_profiles_inner(profiles, false)
+    }
+
+    fn resolve_profiles_inner(
+        &self,
+        profiles: &[String],
+        validate_inherited: bool,
+    ) -> Result<Vec<String>> {
         fn visit(
             config: &Config,
             profile: &str,
@@ -1484,6 +1541,7 @@ impl Config {
             visiting: &mut Vec<String>,
             visited: &mut HashSet<String>,
             force: bool,
+            validate_inherited: bool,
         ) -> Result<()> {
             if !env::is_valid_profile_name(profile) {
                 return Err(FnoxError::Config(format!(
@@ -1502,6 +1560,16 @@ impl Config {
                 resolved.push(profile.to_string());
                 return Ok(());
             }
+            if validate_inherited
+                && !force
+                && !config.profiles.contains_key(profile)
+                && !config.loaded_file_profiles.contains(profile)
+            {
+                return Err(FnoxError::ProfileNotFound {
+                    profile: profile.to_string(),
+                    available_profiles: config.available_profiles(),
+                });
+            }
             if let Some(start) = visiting.iter().position(|name| name == profile) {
                 let mut cycle = visiting[start..].to_vec();
                 cycle.push(profile.to_string());
@@ -1513,7 +1581,15 @@ impl Config {
             visiting.push(profile.to_string());
             if let Some(profile_config) = config.profiles.get(profile) {
                 for inherited in profile_config.inherits() {
-                    visit(config, inherited, resolved, visiting, visited, false)?;
+                    visit(
+                        config,
+                        inherited,
+                        resolved,
+                        visiting,
+                        visited,
+                        false,
+                        validate_inherited,
+                    )?;
                 }
             }
             visiting.pop();
@@ -1536,6 +1612,7 @@ impl Config {
                 &mut visiting,
                 &mut visited,
                 true,
+                validate_inherited,
             )?;
         }
         Ok(resolved)
@@ -2831,6 +2908,62 @@ inherits = ["x/../other"]
             FnoxError::Config(message)
                 if message == "Invalid inherited profile name: 'x/../other'"
         ));
+    }
+
+    #[test]
+    fn test_effective_getters_reject_missing_inherited_profile() {
+        let config: Config = toml_edit::de::from_str(
+            r#"
+[profiles.app]
+inherits = ["missing"]
+"#,
+        )
+        .unwrap();
+
+        let error = config.get_secrets(&["app".to_string()]).unwrap_err();
+        assert!(matches!(
+            error,
+            FnoxError::ProfileNotFound { profile, .. } if profile == "missing"
+        ));
+    }
+
+    #[test]
+    fn test_profile_file_content_is_scoped_to_named_profile() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("fnox.app.toml");
+        std::fs::write(
+            &path,
+            r#"
+default_provider = "plain"
+
+[providers.plain]
+type = "plain"
+
+[leases.command]
+type = "command"
+create_command = "echo token"
+
+[secrets.KEY]
+default = "app"
+"#,
+        )
+        .unwrap();
+
+        let config = Config::load(&path).unwrap();
+        let profile = &config.profiles["app"];
+        assert!(config.secrets.is_empty());
+        assert!(config.providers.is_empty());
+        assert!(config.leases.is_empty());
+        assert_eq!(profile.default_provider(), Some("plain"));
+        assert!(profile.providers.contains_key("plain"));
+        assert!(profile.leases.contains_key("command"));
+        assert_eq!(profile.secrets["KEY"].default.as_deref(), Some("app"));
+        assert_eq!(profile.secret_sources["KEY"].as_path(), path.as_path());
+        assert_eq!(profile.provider_sources["plain"].as_path(), path.as_path());
+        assert_eq!(
+            profile.default_provider_source.as_deref(),
+            Some(path.as_path())
+        );
     }
 
     #[test]

--- a/crates/fnox-core/src/config.rs
+++ b/crates/fnox-core/src/config.rs
@@ -334,6 +334,10 @@ pub struct SecretConfig {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct ProfileConfig {
+    /// Profiles to apply before this profile, in order
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub inherits: Option<Vec<String>>,
+
     /// Lease backend configurations for this profile
     #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
     pub leases: IndexMap<String, crate::lease_backends::LeaseBackendConfig>,
@@ -776,33 +780,40 @@ impl Config {
         let current_dir = env::current_dir()
             .map_err(|e| FnoxError::Config(format!("Failed to get current directory: {}", e)))?;
 
-        match Self::load_recursive(&current_dir, false) {
-            Ok((_config, found)) if !found => {
-                // No config file was found anywhere in the directory tree
-                Err(FnoxError::ConfigNotFound {
-                    message: format!(
-                        "No configuration file found in {} or any parent directory",
-                        current_dir.display()
-                    ),
-                    help: "Run 'fnox init' to create a configuration file".to_string(),
-                })
+        let mut profiles = Self::get_profiles(&[]);
+        let (mut config, mut found) = Self::load_recursive(&current_dir, false, &profiles)?;
+
+        // Profile inheritance can select additional profile-specific files. Keep
+        // loading until discovering those files no longer expands the stack.
+        loop {
+            let expanded = config.resolve_profiles(&profiles)?;
+            if expanded == profiles {
+                break;
             }
-            Ok((mut config, _)) => {
-                // Find the nearest directory to cwd that contains a config file.
-                // This is the project root used for scoping the lease ledger.
-                config.project_dir = Self::find_project_dir(&current_dir);
-                Ok(config)
-            }
-            Err(e) => Err(e),
+            profiles = expanded;
+            (config, found) = Self::load_recursive(&current_dir, false, &profiles)?;
         }
+
+        if !found {
+            return Err(FnoxError::ConfigNotFound {
+                message: format!(
+                    "No configuration file found in {} or any parent directory",
+                    current_dir.display()
+                ),
+                help: "Run 'fnox init' to create a configuration file".to_string(),
+            });
+        }
+
+        // Find the nearest directory to cwd that contains a config file.
+        // This is the project root used for scoping the lease ledger.
+        config.project_dir = Self::find_project_dir(&current_dir);
+        Ok(config)
     }
 
     /// Recursively search for fnox.toml files and merge them
     /// Returns (config, found_any) where found_any indicates if any config file was found
-    fn load_recursive(dir: &Path, found_any: bool) -> Result<(Self, bool)> {
-        // Get active profiles from Settings (respects: CLI flag > Env var > Default)
-        let profiles = Self::get_profiles(&[]);
-        let filenames = all_config_filenames(&profiles);
+    fn load_recursive(dir: &Path, found_any: bool, profiles: &[String]) -> Result<(Self, bool)> {
+        let filenames = all_config_filenames(profiles);
 
         // Load all existing config files in order (later files override earlier ones)
         let mut config = Self::new();
@@ -841,7 +852,7 @@ impl Config {
 
         // If we have a parent directory, recurse up and merge
         if let Some(parent_dir) = dir.parent() {
-            let (parent_config, parent_found) = Self::load_recursive(parent_dir, found)?;
+            let (parent_config, parent_found) = Self::load_recursive(parent_dir, found, profiles)?;
             config = Self::merge_configs(parent_config, config)?;
             found = found || parent_found;
         } else {
@@ -1023,6 +1034,9 @@ impl Config {
         for (name, profile) in overlay.profiles {
             if let Some(existing_profile) = merged.profiles.get_mut(&name) {
                 // Merge existing profile
+                if profile.inherits.is_some() {
+                    existing_profile.inherits = profile.inherits;
+                }
                 for (lease_name, lease) in profile.leases {
                     existing_profile.leases.insert(lease_name, lease);
                 }
@@ -1443,8 +1457,11 @@ impl Config {
         profiles: &[String],
         allow_missing: Option<&str>,
     ) -> Result<()> {
-        for profile in profiles.iter().filter(|profile| *profile != "default") {
-            if Some(profile.as_str()) != allow_missing
+        let resolved = self.resolve_profiles(profiles)?;
+        for profile in resolved.iter().filter(|profile| *profile != "default") {
+            let is_allowed_missing = Some(profile.as_str()) == allow_missing
+                && profiles.iter().any(|requested| requested == profile);
+            if !is_allowed_missing
                 && !self.profiles.contains_key(profile)
                 && !self.loaded_file_profiles.contains(profile)
             {
@@ -1455,6 +1472,60 @@ impl Config {
             }
         }
         Ok(())
+    }
+
+    /// Expand an ordered profile stack, applying inherited profiles before the
+    /// profile that names them. Profiles reached through multiple paths are
+    /// applied once at their earliest dependency-valid position.
+    pub fn resolve_profiles(&self, profiles: &[String]) -> Result<Vec<String>> {
+        fn visit(
+            config: &Config,
+            profile: &str,
+            resolved: &mut Vec<String>,
+            visiting: &mut Vec<String>,
+            visited: &mut HashSet<String>,
+            force: bool,
+        ) -> Result<()> {
+            if visited.contains(profile) && !force {
+                return Ok(());
+            }
+            if let Some(start) = visiting.iter().position(|name| name == profile) {
+                let mut cycle = visiting[start..].to_vec();
+                cycle.push(profile.to_string());
+                return Err(FnoxError::ProfileInheritanceCycle {
+                    cycle: cycle.join(" -> "),
+                });
+            }
+
+            visiting.push(profile.to_string());
+            if let Some(profile_config) = config.profiles.get(profile) {
+                for inherited in profile_config.inherits() {
+                    visit(config, inherited, resolved, visiting, visited, false)?;
+                }
+            }
+            visiting.pop();
+
+            visited.insert(profile.to_string());
+            resolved.push(profile.to_string());
+            Ok(())
+        }
+
+        let mut resolved = Vec::new();
+        let mut visiting = Vec::new();
+        let mut visited = HashSet::new();
+        for profile in profiles {
+            // Preserve the existing behavior of explicitly repeated profiles,
+            // while deduplicating shared inherited ancestors.
+            visit(
+                self,
+                profile,
+                &mut resolved,
+                &mut visiting,
+                &mut visited,
+                true,
+            )?;
+        }
+        Ok(resolved)
     }
 
     /// Resolve the write-target profile.
@@ -1532,6 +1603,7 @@ impl Config {
         profiles: &[String],
         no_defaults: bool,
     ) -> Result<IndexMap<String, SecretConfig>> {
+        let profiles = self.resolve_profiles(profiles)?;
         let has_non_default = profiles.iter().any(|p| p != "default");
         let mut secrets = if !has_non_default || !no_defaults {
             self.secrets.clone()
@@ -1582,6 +1654,7 @@ impl Config {
         key: &str,
         no_defaults: bool,
     ) -> Option<&SecretConfig> {
+        let profiles = self.resolve_profiles(profiles).ok()?;
         let has_non_default = profiles.iter().any(|p| p != "default");
 
         for profile in profiles.iter().filter(|p| *p != "default").rev() {
@@ -1620,6 +1693,9 @@ impl Config {
         &self,
         profiles: &[String],
     ) -> IndexMap<String, crate::lease_backends::LeaseBackendConfig> {
+        let profiles = self
+            .resolve_profiles(profiles)
+            .unwrap_or_else(|_| profiles.to_vec());
         let mut leases = self.leases.clone();
 
         for profile in profiles.iter().filter(|p| *p != "default") {
@@ -1636,6 +1712,9 @@ impl Config {
     /// Top-level providers form the base. Profile-specific providers are overlaid
     /// in order, with later profiles taking precedence.
     pub fn get_providers(&self, profiles: &[String]) -> IndexMap<String, ProviderConfig> {
+        let profiles = self
+            .resolve_profiles(profiles)
+            .unwrap_or_else(|_| profiles.to_vec());
         let mut providers = self.providers.clone();
 
         for profile in profiles.iter().filter(|p| *p != "default") {
@@ -1653,7 +1732,8 @@ impl Config {
     /// or auto-selects if there's only one provider. Top-level default_provider
     /// is used when no profile overrides it.
     pub fn get_default_provider(&self, profiles: &[String]) -> Result<Option<String>> {
-        let providers = self.get_providers(profiles);
+        let profiles = self.resolve_profiles(profiles)?;
+        let providers = self.get_providers(&profiles);
 
         // If no providers configured and this is a root config, return None
         if providers.is_empty() && self.root {
@@ -1834,30 +1914,13 @@ impl Config {
     /// Returns true if the provider is "plain" type.
     fn is_plain_provider(&self, secret_provider: Option<&str>, profile: &str) -> bool {
         // Get providers for this profile first (needed for auto-selection)
-        let providers = self.get_providers(&[profile.to_string()]);
+        let profiles = [profile.to_string()];
+        let providers = self.get_providers(&profiles);
 
         // Determine which provider name to use
         let provider_name = secret_provider
             .map(String::from)
-            .or_else(|| {
-                // Try profile's default_provider first (only for non-default profiles)
-                if profile != "default" {
-                    self.profiles
-                        .get(profile)
-                        .and_then(|p| p.default_provider().map(|s| s.to_string()))
-                } else {
-                    None
-                }
-            })
-            .or_else(|| self.default_provider().map(|s| s.to_string()))
-            .or_else(|| {
-                // Auto-select if exactly one provider exists (matching get_default_provider behavior)
-                if providers.len() == 1 {
-                    providers.keys().next().cloned()
-                } else {
-                    None
-                }
-            });
+            .or_else(|| self.get_default_provider(&profiles).ok().flatten());
 
         let Some(provider_name) = provider_name else {
             return false;
@@ -2228,6 +2291,7 @@ impl ProfileConfig {
     /// Create a new profile config
     pub fn new() -> Self {
         Self {
+            inherits: None,
             leases: IndexMap::new(),
             providers: IndexMap::new(),
             default_provider: None,
@@ -2240,7 +2304,8 @@ impl ProfileConfig {
 
     /// Check if the profile is effectively empty (no serializable content)
     pub fn is_empty(&self) -> bool {
-        self.leases.is_empty()
+        self.inherits.is_none()
+            && self.leases.is_empty()
             && self.providers.is_empty()
             && self.secrets.is_empty()
             && self.default_provider().is_none()
@@ -2251,6 +2316,11 @@ impl ProfileConfig {
         self.default_provider
             .as_ref()
             .map(|s: &SpannedValue<String>| s.value().as_str())
+    }
+
+    /// Profiles inherited by this profile, in overlay order.
+    pub fn inherits(&self) -> &[String] {
+        self.inherits.as_deref().unwrap_or_default()
     }
 
     /// Get the default provider's source span (byte range in the config file).
@@ -2670,6 +2740,110 @@ value = "prod"
             secrets.get("PROD_ONLY").and_then(SecretConfig::value),
             Some("prod")
         );
+    }
+
+    #[test]
+    fn test_profile_inheritance_expands_dependencies_before_profile() {
+        let config: Config = toml_edit::de::from_str(
+            r#"
+[profiles.shared]
+
+[profiles.database]
+inherits = ["shared"]
+
+[profiles.app]
+inherits = ["shared", "database"]
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            config.resolve_profiles(&["app".to_string()]).unwrap(),
+            vec!["shared", "database", "app"]
+        );
+    }
+
+    #[test]
+    fn test_profile_inheritance_preserves_explicit_repetition() {
+        let config: Config = toml_edit::de::from_str(
+            r#"
+[profiles.a]
+
+[profiles.b]
+inherits = ["a"]
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            config
+                .resolve_profiles(&["a".to_string(), "b".to_string(), "a".to_string()])
+                .unwrap(),
+            vec!["a", "b", "a"]
+        );
+    }
+
+    #[test]
+    fn test_profile_inheritance_detects_cycles() {
+        let config: Config = toml_edit::de::from_str(
+            r#"
+[profiles.a]
+inherits = ["b"]
+
+[profiles.b]
+inherits = ["c"]
+
+[profiles.c]
+inherits = ["a"]
+"#,
+        )
+        .unwrap();
+
+        let error = config.resolve_profiles(&["a".to_string()]).unwrap_err();
+        assert!(matches!(
+            error,
+            FnoxError::ProfileInheritanceCycle { cycle } if cycle == "a -> b -> c -> a"
+        ));
+    }
+
+    #[test]
+    fn test_profile_inheritance_validates_inherited_profiles() {
+        let config: Config = toml_edit::de::from_str(
+            r#"
+[profiles.app]
+inherits = ["missing"]
+"#,
+        )
+        .unwrap();
+
+        let error = config
+            .validate_profiles(&["app".to_string()], None)
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            FnoxError::ProfileNotFound { profile, .. } if profile == "missing"
+        ));
+    }
+
+    #[test]
+    fn test_profile_inherits_can_be_cleared_by_overlay() {
+        let base: Config = toml_edit::de::from_str(
+            r#"
+[profiles.app]
+inherits = ["shared"]
+"#,
+        )
+        .unwrap();
+        let overlay: Config = toml_edit::de::from_str(
+            r#"
+[profiles.app]
+inherits = []
+"#,
+        )
+        .unwrap();
+
+        let merged = Config::merge_configs(base, overlay).unwrap();
+        assert!(merged.profiles["app"].inherits().is_empty());
     }
 
     #[test]

--- a/crates/fnox-core/src/error.rs
+++ b/crates/fnox-core/src/error.rs
@@ -133,6 +133,14 @@ pub enum FnoxError {
         available_profiles: Vec<String>,
     },
 
+    #[error("Profile inheritance cycle detected: {cycle}")]
+    #[diagnostic(
+        code(fnox::profile::inheritance_cycle),
+        help("Remove one of the inherits entries in the cycle"),
+        url("https://fnox.jdx.dev/guide/profiles")
+    )]
+    ProfileInheritanceCycle { cycle: String },
+
     // ========================================================================
     // Secret Errors
     // ========================================================================

--- a/crates/fnox-core/src/lease.rs
+++ b/crates/fnox-core/src/lease.rs
@@ -343,7 +343,10 @@ pub async fn find_encryption_provider(
         _ => return EncryptionProviderResult::NotConfigured,
     };
 
-    let providers_map = config.get_providers(profile);
+    let providers_map = match config.get_providers(profile) {
+        Ok(providers) => providers,
+        Err(error) => return EncryptionProviderResult::Unavailable(provider_name, error),
+    };
     let provider_config = match providers_map.get(&provider_name) {
         Some(c) => c,
         None => return EncryptionProviderResult::NotConfigured,

--- a/crates/fnox-core/src/library.rs
+++ b/crates/fnox-core/src/library.rs
@@ -169,7 +169,7 @@ impl Fnox {
         // whole IndexMap — preferred over get_secrets(profile)?.get(key).
         if let Some(secret_config) =
             self.config
-                .get_secret_with_no_defaults(&self.profiles, key, self.no_defaults)
+                .get_secret_with_no_defaults(&self.profiles, key, self.no_defaults)?
         {
             return crate::secret_resolver::resolve_secret(
                 &self.config,
@@ -349,6 +349,31 @@ LIB_TEST_DEFAULTS_KEY_UNIQUE_X = { default = "the-default-value" }
             }
             other => panic!("expected SecretNotFound, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn get_propagates_profile_inheritance_cycles() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join(CONFIG_FILENAME),
+            r#"
+[profiles.a]
+inherits = ["b"]
+
+[profiles.b]
+inherits = ["a"]
+"#,
+        )
+        .unwrap();
+
+        let fnox = Fnox::open(dir.path().join(CONFIG_FILENAME))
+            .unwrap()
+            .with_profile("a");
+        let error = fnox.get("UNDECLARED").await.unwrap_err();
+        assert!(matches!(
+            error,
+            FnoxError::ProfileInheritanceCycle { cycle } if cycle == "a -> b -> a"
+        ));
     }
 
     /// Given a fnox.toml that declares similarly-named keys,

--- a/crates/fnox-core/src/providers/mod.rs
+++ b/crates/fnox-core/src/providers/mod.rs
@@ -428,6 +428,9 @@ fn provider_source_path(
     profiles: &[String],
     provider_name: &str,
 ) -> Option<PathBuf> {
+    let profiles = config
+        .resolve_profiles(profiles)
+        .unwrap_or_else(|_| profiles.to_vec());
     for profile in profiles.iter().filter(|p| *p != "default").rev() {
         if let Some(profile_config) = config.profiles.get(profile)
             && profile_config.providers.contains_key(provider_name)

--- a/crates/fnox-core/src/providers/resolver.rs
+++ b/crates/fnox-core/src/providers/resolver.rs
@@ -248,7 +248,7 @@ fn resolve_secret_ref<'a>(
 ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<String>> + Send + 'a>> {
     Box::pin(async move {
         // First, try to find the secret in config
-        let secrets = config.get_secrets(profile).unwrap_or_default();
+        let secrets = config.get_secrets(profile)?;
 
         if let Some(secret_config) = secrets.get(secret_name) {
             // Secret found in config - resolve it
@@ -354,5 +354,34 @@ mod tests {
         ctx.push("c");
 
         assert_eq!(ctx.path_string(), "a -> b -> c");
+    }
+
+    #[tokio::test]
+    async fn secret_ref_propagates_profile_inheritance_errors() {
+        let config: Config = toml_edit::de::from_str(
+            r#"
+[profiles.a]
+inherits = ["b"]
+
+[profiles.b]
+inherits = ["a"]
+"#,
+        )
+        .unwrap();
+        let mut ctx = ResolutionContext::new();
+
+        let error = resolve_secret_ref(
+            &config,
+            &["a".to_string()],
+            "provider",
+            "FNOX_CYCLE_TEST_SECRET",
+            &mut ctx,
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(
+            error,
+            FnoxError::ProfileInheritanceCycle { cycle } if cycle == "a -> b -> a"
+        ));
     }
 }

--- a/crates/fnox-core/src/providers/resolver.rs
+++ b/crates/fnox-core/src/providers/resolver.rs
@@ -193,7 +193,7 @@ pub fn resolve_provider_ref_with_identity_cycle_guard<'a>(
             return Ok(None);
         };
 
-        let providers = config.get_providers(profile);
+        let providers = config.get_providers(profile)?;
         let Some(provider_config) = providers.get(&provider_ref.provider) else {
             let available_providers: Vec<_> = providers.keys().map(|s| s.as_str()).collect();
             let similar = find_similar(&provider_ref.provider, available_providers);
@@ -256,7 +256,7 @@ fn resolve_secret_ref<'a>(
                 && let Some(provider_value) = secret_config.value()
             {
                 // This secret uses a provider - need to resolve that provider first
-                let providers = config.get_providers(profile);
+                let providers = config.get_providers(profile)?;
                 if let Some(secret_provider_config) = providers.get(secret_provider_name) {
                     if env::is_non_interactive()
                         && secret_provider_config.requires_interactive_auth()

--- a/crates/fnox-core/src/secret_resolver.rs
+++ b/crates/fnox-core/src/secret_resolver.rs
@@ -267,7 +267,7 @@ fn create_provider_not_configured_error(
     config: &Config,
 ) -> FnoxError {
     // Find similar provider names for suggestion
-    let providers = config.get_providers(profile);
+    let providers = config.get_providers(profile).unwrap_or_default();
     let available_providers: Vec<_> = providers.keys().map(|s| s.as_str()).collect();
     let similar = find_similar(provider_name, available_providers);
     let suggestion = format_suggestions(&similar);
@@ -614,7 +614,7 @@ async fn try_resolve_from_provider(
     };
 
     // Get the provider config
-    let providers = config.get_providers(profile);
+    let providers = config.get_providers(profile)?;
     let provider_config = providers.get(&provider_name).ok_or_else(|| {
         create_provider_not_configured_error(&provider_name, profile, secret_config, config)
     })?;
@@ -763,7 +763,7 @@ pub async fn resolve_secrets_batch_with_pre_resolved(
     let mut secret_provider: HashMap<String, (String, String)> = HashMap::new(); // key -> (provider_name, provider_value)
     let mut no_provider = Vec::new();
 
-    let providers = config.get_providers(profile);
+    let providers = config.get_providers(profile)?;
     let all_keys: Vec<String> = secrets.keys().cloned().collect();
     let secret_keys: HashSet<&str> = all_keys
         .iter()
@@ -1116,7 +1116,7 @@ async fn resolve_provider_batch(
     );
 
     // Get the provider config
-    let providers = config.get_providers(profile);
+    let providers = config.get_providers(profile)?;
     let provider_config = match providers.get(provider_name) {
         Some(config) => config,
         None => {

--- a/docs/guide/profiles.md
+++ b/docs/guide/profiles.md
@@ -119,6 +119,39 @@ LOG_LEVEL = { default = "warn" }  # Overrides LOG_LEVEL
 # Still inherits API_TIMEOUT="30" from top level
 ```
 
+Named profiles can also inherit other profiles. Inherited profiles are applied
+in list order, followed by the profile itself, so later entries and direct
+profile settings take precedence:
+
+```toml
+[profiles.openai.secrets]
+OPENAI_API_KEY = { provider = "age", value = "encrypted-key..." }
+
+[profiles.database-local.secrets]
+DATABASE_PASSWORD = { provider = "age", value = "encrypted-password..." }
+
+[profiles.api-local]
+inherits = ["openai", "database-local"]
+
+[profiles.openai-john.secrets]
+OPENAI_API_KEY = { provider = "age-john", value = "encrypted-john-key..." }
+
+[profiles.api-local-john]
+inherits = ["api-local", "openai-john"]
+```
+
+The application can then select its complete secret set with one stable name:
+
+```bash
+fnox -P api-local exec -- ./api
+fnox -P api-local-john exec -- ./api
+```
+
+Inheritance includes secrets, providers, lease backends, and the default
+provider. Nested inheritance is supported; cycles and unknown inherited
+profiles are reported as configuration errors. `--no-defaults` still controls
+whether top-level secrets are included.
+
 This reduces duplication for secrets shared across environments.
 
 ## Profile-Specific Providers

--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -1300,6 +1300,13 @@
       "description": "Configuration for a profile",
       "type": "object",
       "properties": {
+        "inherits": {
+          "description": "Profiles to apply before this profile, in order",
+          "type": ["array", "null"],
+          "items": {
+            "type": "string"
+          }
+        },
         "leases": {
           "description": "Lease backend configurations for this profile",
           "type": "object",

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -568,6 +568,21 @@ fnox exec --profile production --no-defaults -- ./deploy.sh
 
 With `--no-defaults`, only `[profiles.<name>.secrets]` are used for the selected profile.
 
+Profiles can selectively inherit other named profiles as an ordered overlay:
+
+```toml
+[profiles.api-local]
+inherits = ["openai", "database-local", "no-log-upload"]
+
+[profiles.api-local-john]
+inherits = ["api-local", "openai-john"]
+```
+
+Inherited profiles are applied before the profile that declares `inherits`.
+Later inherited profiles override earlier ones, and declarations directly on
+the selected profile override all of them. Inheritance includes secrets,
+providers, lease backends, and `default_provider`.
+
 ## Complete Example
 
 ```toml

--- a/src/commands/check.rs
+++ b/src/commands/check.rs
@@ -52,7 +52,7 @@ impl CheckCommand {
 
                     // Check provider configuration
                     if let Some(provider) = secret_config.provider() {
-                        let providers = config.get_providers(&profile);
+                        let providers = config.get_providers(&profile)?;
                         if !providers.contains_key(provider) {
                             warnings.push(format!(
                                 "Secret '{}' references unknown provider '{}'",
@@ -140,7 +140,7 @@ impl CheckCommand {
         }
 
         // Check providers
-        let providers = config.get_providers(&profile);
+        let providers = config.get_providers(&profile)?;
         if providers.is_empty() {
             warnings.push("No providers configured".to_string());
         } else {

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -70,7 +70,7 @@ impl DoctorCommand {
 
         // Providers info
         println!("🔧 Providers:");
-        let providers = config.get_providers(&profile);
+        let providers = config.get_providers(&profile)?;
         println!("  Count: {}", providers.len());
 
         if !providers.is_empty() {

--- a/src/commands/edit.rs
+++ b/src/commands/edit.rs
@@ -208,7 +208,7 @@ impl EditCommand {
 
             let (is_read_only, resolved_provider_name) = if let Some(ref prov_name) = provider_name
             {
-                let providers = config.get_providers(&profile_stack);
+                let providers = config.get_providers(&profile_stack)?;
                 if let Some(provider_config) = providers.get(prov_name) {
                     let provider =
                         get_provider_resolved(config, &profile_stack, prov_name, provider_config)
@@ -478,7 +478,7 @@ impl EditCommand {
                     config.get_default_provider(&profile_stack)?
                 };
                 let encrypted_value = if let Some(provider_name) = provider_to_use {
-                    let providers = config.get_providers(&profile_stack);
+                    let providers = config.get_providers(&profile_stack)?;
                     if let Some(provider_config) = providers.get(&provider_name) {
                         let provider = get_provider_resolved(
                             config,
@@ -515,7 +515,7 @@ impl EditCommand {
                 };
 
                 // Encrypt with the provider from this secret's profile
-                let providers = config.get_providers(&profile_stack);
+                let providers = config.get_providers(&profile_stack)?;
                 let Some(provider_config) = providers.get(&provider_name) else {
                     return Err(FnoxError::Config(format!(
                         "Provider '{}' not found for new secret '{}'",

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -44,7 +44,7 @@ impl ExecCommand {
 
         // Get the profile secrets
         let profile_secrets = config.get_secrets(&profile)?;
-        let leases = config.get_leases(&profile);
+        let leases = config.get_leases(&profile)?;
 
         #[cfg(unix)]
         if self.replace {

--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -120,7 +120,7 @@ impl GetCommand {
         config: &Config,
         profile: &[String],
     ) -> Result<Option<(String, IndexMap<String, SecretConfig>)>> {
-        let leases = config.get_leases(profile);
+        let leases = config.get_leases(profile)?;
 
         // Fast path: check if any lease backend produces this key (pure config
         // lookup — no network calls or backend instantiation needed).
@@ -172,7 +172,7 @@ impl GetCommand {
         // (e.g. VAULT_TOKEN) would never be injected and encryption would fail
         // permanently, forcing a fresh API call on every invocation.
         if let Ok(Some(ref default_provider_name)) = config.get_default_provider(profile) {
-            let providers_map = config.get_providers(profile);
+            let providers_map = config.get_providers(profile)?;
             if let Some(provider_config) = providers_map.get(default_provider_name) {
                 for dep in provider_config.env_dependencies() {
                     consumed.insert(dep);

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -115,7 +115,7 @@ impl ImportCommand {
         }
 
         // Verify provider exists (use merged config to find providers from any source)
-        let providers = merged_config.get_providers(&profile);
+        let providers = merged_config.get_providers(&profile)?;
         let provider_config =
             providers
                 .get(&self.provider)

--- a/src/commands/lease.rs
+++ b/src/commands/lease.rs
@@ -112,7 +112,7 @@ impl LeaseCreateCommand {
         }
         let profile = Config::get_profiles(cli.profile.as_slice());
         let project_dir = lease::project_dir_from_config(&config, &cli.config);
-        let leases = config.get_leases(&profile);
+        let leases = config.get_leases(&profile)?;
 
         // Resolve secrets once upfront (shared across all backends)
         let profile_secrets = config.get_secrets(&profile)?;
@@ -441,7 +441,7 @@ impl LeaseRevokeCommand {
         let cached_credentials = record.cached_credentials.clone();
         let encryption_provider_name = record.encryption_provider.clone();
         let profile = Config::get_profiles(cli.profile.as_slice());
-        let leases = config.get_leases(&profile);
+        let leases = config.get_leases(&profile)?;
 
         // Decrypt cached credentials (if encrypted) so backends can use
         // credential values for revocation (e.g. GitHub App needs the token).
@@ -534,7 +534,7 @@ impl LeaseCleanupCommand {
         }
 
         let profile = Config::get_profiles(cli.profile.as_slice());
-        let leases = config.get_leases(&profile);
+        let leases = config.get_leases(&profile)?;
         let mut cleaned = 0;
 
         for record in &expired {

--- a/src/commands/mcp.rs
+++ b/src/commands/mcp.rs
@@ -28,7 +28,7 @@ impl McpCommand {
             }
             let allowed_set: std::collections::HashSet<&str> =
                 allowlist.iter().map(|s| s.as_str()).collect();
-            let providers = config.get_providers(&profile);
+            let providers = config.get_providers(&profile)?;
             for name in allowlist {
                 if !all_secrets.contains_key(name) {
                     tracing::warn!(

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -266,7 +266,12 @@ fn complete_provider(
     Box::pin(async move {
         let config = completion_config(&ctx);
         let profiles = Config::get_profiles(&completion_profiles(&ctx));
-        candidates(config.get_providers(&profiles).into_keys())
+        candidates(
+            config
+                .get_providers(&profiles)
+                .unwrap_or_default()
+                .into_keys(),
+        )
     })
 }
 

--- a/src/commands/provider/list.rs
+++ b/src/commands/provider/list.rs
@@ -14,7 +14,7 @@ impl ListCommand {
     pub async fn run(&self, cli: &Cli, config: Config) -> Result<()> {
         tracing::debug!("Listing providers");
         let profiles = Config::get_profiles(cli.profile.as_slice());
-        let providers = config.get_providers(&profiles);
+        let providers = config.get_providers(&profiles)?;
 
         if providers.is_empty() {
             return Ok(());

--- a/src/commands/provider/test.rs
+++ b/src/commands/provider/test.rs
@@ -37,7 +37,7 @@ impl TestCommand {
     ) -> Result<()> {
         tracing::debug!("Testing provider '{}'", provider_name);
 
-        let providers = config.get_providers(profile);
+        let providers = config.get_providers(profile)?;
         let provider_config = providers
             .get(provider_name)
             .ok_or_else(|| FnoxError::Config(format!("Provider '{}' not found", provider_name)))?;
@@ -66,7 +66,7 @@ impl TestCommand {
         config: &Config,
         profile: &[String],
     ) -> Result<()> {
-        let providers = config.get_providers(profile);
+        let providers = config.get_providers(profile)?;
 
         if providers.is_empty() {
             println!("No providers configured");

--- a/src/commands/proxy.rs
+++ b/src/commands/proxy.rs
@@ -172,7 +172,7 @@ fn collect_requested_secrets(
     proxy: &ProxyConfig,
     all_secrets: &IndexMap<String, SecretConfig>,
 ) -> Result<IndexMap<String, SecretConfig>> {
-    let providers = config.get_providers(profile);
+    let providers = config.get_providers(profile)?;
     let default_provider = config.get_default_provider(profile)?;
     let mut requested = IndexMap::new();
 
@@ -283,7 +283,7 @@ impl ProxyRunCommand {
         for key in AMBIENT_CREDENTIAL_ENV_VARS {
             command.env_remove(key);
         }
-        for provider in config.get_providers(&profile).values() {
+        for provider in config.get_providers(&profile)?.values() {
             for dependency in provider.env_dependencies() {
                 command.env_remove(dependency);
             }

--- a/src/commands/reencrypt.rs
+++ b/src/commands/reencrypt.rs
@@ -47,7 +47,7 @@ impl ReencryptCommand {
 
         let profile_display = Config::display_profiles(&profile);
 
-        let providers = merged_config.get_providers(&profile);
+        let providers = merged_config.get_providers(&profile)?;
         let all_secrets = merged_config.get_secrets(&profile)?;
 
         let filter_regex = if let Some(ref filter) = self.filter {

--- a/src/commands/remove.rs
+++ b/src/commands/remove.rs
@@ -52,12 +52,9 @@ impl RemoveCommand {
 
         let config = Config::load(&target_path)?;
 
-        // Check existence in the write-target profile. For profile-specific
-        // files (fnox.<profile>.toml), secrets are at top-level [secrets].
-        let has_profile_section =
-            write_profile != "default" && !crate::config::is_profile_file(&target_path);
-
-        let found = if has_profile_section {
+        // Config::load scopes top-level entries from fnox.<profile>.toml into
+        // that profile, so named-profile lookups always use the profile map.
+        let found = if write_profile != "default" {
             config
                 .profiles
                 .get(&write_profile)

--- a/src/commands/set.rs
+++ b/src/commands/set.rs
@@ -30,7 +30,7 @@ fn secret_belongs_to_target(
         return false;
     }
 
-    if write_profile == "default" || config::is_profile_file(target_path) {
+    if write_profile == "default" {
         !secret.source_is_profile
     } else {
         secret.source_profile.as_deref() == Some(write_profile)
@@ -276,8 +276,16 @@ impl SetCommand {
         // full stack, so the secret lands in the correct TOML section.
         let profile_secrets = config.get_secrets_mut(&write_profile_stack);
 
-        // Get or create the secret config
-        let secret_config = profile_secrets.entry(self.key.clone()).or_default();
+        // A metadata-only update to an inherited secret creates a local
+        // override. Seed it from the effective secret so the override retains
+        // the inherited value/provider instead of shadowing it with an empty
+        // entry.
+        let inherited_secret = (secret_value.is_none() && existing_secret.is_none())
+            .then(|| effective_secret.clone())
+            .flatten();
+        let secret_config = profile_secrets
+            .entry(self.key.clone())
+            .or_insert_with(|| inherited_secret.unwrap_or_default());
 
         // Update metadata
         if let Some(ref desc) = self.description {
@@ -456,6 +464,20 @@ mod tests {
             &existing,
             Path::new("/child/fnox.toml"),
             "default"
+        ));
+    }
+
+    #[test]
+    fn profile_file_secret_belongs_to_named_profile_target() {
+        let mut existing = secret("plain", "value");
+        existing.source_path = Some("/project/fnox.app.toml".into());
+        existing.source_is_profile = true;
+        existing.source_profile = Some("app".to_string());
+
+        assert!(secret_belongs_to_target(
+            &existing,
+            Path::new("/project/fnox.app.toml"),
+            "app"
         ));
     }
 }

--- a/src/commands/set.rs
+++ b/src/commands/set.rs
@@ -157,7 +157,7 @@ impl SetCommand {
             Some(value)
         };
 
-        let effective_secret = config.get_secret(&write_profile_stack, &self.key).cloned();
+        let effective_secret = config.get_secret(&write_profile_stack, &self.key)?.cloned();
         let existing_secret = effective_secret
             .as_ref()
             .filter(|secret| secret_belongs_to_target(secret, &target_path, &write_profile))
@@ -190,7 +190,7 @@ impl SetCommand {
         let (encrypted_value, remote_key_name) = if let Some(ref value) = secret_value {
             if let Some(ref provider_name) = provider_name_to_use {
                 // Get the provider config
-                let providers = config.get_providers(&write_profile_stack);
+                let providers = config.get_providers(&write_profile_stack)?;
                 if let Some(provider_config) = providers.get(provider_name) {
                     // Get the provider (resolving any secret refs) and check its capabilities
                     let provider = crate::providers::get_provider_resolved(

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -83,7 +83,7 @@ impl SyncCommand {
         };
 
         // Verify target provider exists and has Encryption capability
-        let providers = merged_config.get_providers(&profile);
+        let providers = merged_config.get_providers(&profile)?;
         let provider_config = providers.get(&target_provider_name).ok_or_else(|| {
             FnoxError::ProviderNotConfigured {
                 provider: target_provider_name.clone(),

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1151,6 +1151,9 @@ fn cache_policy_default_provider<'a>(
     profile: &[String],
     providers: &'a IndexMap<String, ProviderConfig>,
 ) -> Option<&'a str> {
+    let profile = config
+        .resolve_profiles(profile)
+        .unwrap_or_else(|_| profile.to_vec());
     for p in profile.iter().filter(|p| *p != "default").rev() {
         if let Some(profile_config) = config.profiles.get(p)
             && let Some(default_provider) = profile_config.default_provider()

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -953,7 +953,7 @@ async fn process_request(
                 req.non_interactive,
             );
             let config = Config::load_smart(&req.config)?;
-            let Some(secret_config) = config.get_secret(&req.profile, &req.key).cloned() else {
+            let Some(secret_config) = config.get_secret(&req.profile, &req.key)?.cloned() else {
                 return Ok(Response::Resolved {
                     values: [(req.key, None)].into_iter().collect(),
                 });
@@ -1023,7 +1023,7 @@ async fn foreground_resolution_if_needed(
     }
 
     let fingerprint = config_fingerprint(config, &req.env)?;
-    let providers = config.get_providers(profile);
+    let providers = config.get_providers(profile)?;
     let default_provider = cache_policy_default_provider(config, profile, &providers);
     let state = state.lock().await;
     let mut cached_values = IndexMap::new();
@@ -1066,7 +1066,7 @@ async fn store_resolved_values(
         return Ok(());
     }
 
-    let providers = config.get_providers(profile);
+    let providers = config.get_providers(profile)?;
     let default_provider = cache_policy_default_provider(config, profile, &providers);
     let mut state = state.lock().await;
     for (key, secret) in secrets {
@@ -1104,7 +1104,7 @@ async fn resolve_with_cache(
     state: std::sync::Arc<Mutex<DaemonState>>,
 ) -> Result<IndexMap<String, Option<String>>> {
     let fingerprint = config_fingerprint(config, &req.env)?;
-    let providers = config.get_providers(profile);
+    let providers = config.get_providers(profile)?;
     let default_provider = cache_policy_default_provider(config, profile, &providers);
     let mut results = IndexMap::new();
     let mut misses = IndexMap::new();

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1219,6 +1219,13 @@ fn config_fingerprint(config: &Config, env: &[(String, String)]) -> Result<Strin
     if let Some(path) = &config.default_provider_source {
         paths.insert(path.clone());
     }
+    for profile in config.profiles.values() {
+        paths.extend(profile.provider_sources.values().cloned());
+        paths.extend(profile.secret_sources.values().cloned());
+        if let Some(path) = &profile.default_provider_source {
+            paths.insert(path.clone());
+        }
+    }
     if let Some(project_dir) = &config.project_dir {
         for name in crate::config::all_config_filenames(&[]) {
             let path = project_dir.join(name);

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -155,7 +155,7 @@ impl App {
     ) -> Result<Self> {
         let profile = Config::display_profiles(&profile_stack);
         let providers: Vec<String> = config
-            .get_providers(&profile_stack)
+            .get_providers(&profile_stack)?
             .keys()
             .cloned()
             .collect();
@@ -810,24 +810,22 @@ impl App {
 
         // Try to load secrets first before committing to the change
         let profile_stack = vec![new_profile.clone()];
-        match self.config.get_secrets(&profile_stack) {
-            Ok(secrets) => {
+        match (
+            self.config.get_secrets(&profile_stack),
+            self.config.get_providers(&profile_stack),
+        ) {
+            (Ok(secrets), Ok(providers)) => {
                 // Success - now update all state
                 self.profile = new_profile;
                 self.profile_stack = profile_stack.clone();
-                self.providers = self
-                    .config
-                    .get_providers(&profile_stack)
-                    .keys()
-                    .cloned()
-                    .collect();
+                self.providers = providers.keys().cloned().collect();
                 self.provider_index = 0;
                 self.secrets = secrets;
                 self.secret_index = 0;
                 self.search_filter.clear();
                 self.refresh();
             }
-            Err(e) => {
+            (Err(e), _) | (_, Err(e)) => {
                 // Failed - don't change anything, just show error
                 self.error_message = Some(format!("Failed to load profile: {}", e));
             }

--- a/test/profile_inheritance.bats
+++ b/test/profile_inheritance.bats
@@ -120,6 +120,28 @@ EOF
 	assert_output 'from-app-file'
 }
 
+@test 'remove deletes a secret from a profile-specific file' {
+	cat >fnox.toml <<'EOF'
+root = true
+
+[profiles.app]
+EOF
+
+	cat >fnox.app.toml <<'EOF'
+[secrets]
+APP_ONLY = { default = "from-app-file" }
+EOF
+
+	run "$FNOX_BIN" -P app remove APP_ONLY
+	assert_success
+
+	run "$FNOX_BIN" -P app get APP_ONLY
+	assert_failure
+	assert_output --partial "Secret 'APP_ONLY' not found"
+
+	assert_file_not_contains fnox.app.toml 'APP_ONLY'
+}
+
 @test 'metadata-only update preserves inherited secret value' {
 	cat >fnox.toml <<'EOF'
 root = true

--- a/test/profile_inheritance.bats
+++ b/test/profile_inheritance.bats
@@ -99,6 +99,49 @@ EOF
 	assert_output 'from-profile-file'
 }
 
+@test 'selected profile file overrides inherited profile tables' {
+	cat >fnox.toml <<'EOF'
+root = true
+
+[profiles.shared.secrets]
+SHARED = { default = "from-inherited-profile" }
+
+[profiles.app]
+inherits = ["shared"]
+EOF
+
+	cat >fnox.app.toml <<'EOF'
+[secrets]
+SHARED = { default = "from-app-file" }
+EOF
+
+	run "$FNOX_BIN" -P app --no-defaults get SHARED
+	assert_success
+	assert_output 'from-app-file'
+}
+
+@test 'metadata-only update preserves inherited secret value' {
+	cat >fnox.toml <<'EOF'
+root = true
+
+[profiles.shared.secrets]
+INHERITED = { default = "inherited-value" }
+
+[profiles.app]
+inherits = ["shared"]
+EOF
+
+	run "$FNOX_BIN" -P app set --description 'local description' INHERITED
+	assert_success
+
+	run "$FNOX_BIN" -P app --no-defaults get INHERITED
+	assert_success
+	assert_output 'inherited-value'
+
+	assert_file_contains fnox.toml 'local description'
+	assert_file_contains fnox.toml 'inherited-value'
+}
+
 @test 'profile inheritance reports unknown profiles' {
 	cat >fnox.toml <<'EOF'
 root = true

--- a/test/profile_inheritance.bats
+++ b/test/profile_inheritance.bats
@@ -1,0 +1,129 @@
+#!/usr/bin/env bats
+
+setup() {
+	load 'test_helper/common_setup'
+	_common_setup
+}
+
+teardown() {
+	_common_teardown
+}
+
+@test 'profile inherits ordered secrets and providers' {
+	cat >fnox.toml <<'EOF'
+root = true
+
+[profiles.openai]
+default_provider = "plain"
+
+[profiles.openai.providers.plain]
+type = "plain"
+
+[profiles.openai.secrets]
+OPENAI_API_KEY = { provider = "plain", value = "shared-key" }
+SHARED = { default = "openai" }
+
+[profiles.database-local.secrets]
+DATABASE_PASSWORD = { default = "local-password" }
+INHERITED_DEFAULT_PROVIDER = { value = "plain-value" }
+SHARED = { default = "database" }
+
+[profiles.api-local]
+inherits = ["openai", "database-local"]
+
+[profiles.api-local.secrets]
+APP_ONLY = { default = "app" }
+SHARED = { default = "app" }
+EOF
+
+	run "$FNOX_BIN" -P api-local --no-defaults get OPENAI_API_KEY
+	assert_success
+	assert_output 'shared-key'
+
+	run "$FNOX_BIN" -P api-local --no-defaults get DATABASE_PASSWORD
+	assert_success
+	assert_output 'local-password'
+
+	run "$FNOX_BIN" -P api-local --no-defaults get INHERITED_DEFAULT_PROVIDER
+	assert_success
+	assert_output 'plain-value'
+
+	run "$FNOX_BIN" -P api-local --no-defaults get SHARED
+	assert_success
+	assert_output 'app'
+}
+
+@test 'profile inheritance is nested and later profiles override earlier profiles' {
+	cat >fnox.toml <<'EOF'
+root = true
+
+[profiles.openai.secrets]
+OPENAI_API_KEY = { default = "shared" }
+
+[profiles.database-local.secrets]
+DATABASE_PASSWORD = { default = "local" }
+
+[profiles.api-local]
+inherits = ["openai", "database-local"]
+
+[profiles.openai-john.secrets]
+OPENAI_API_KEY = { default = "john" }
+
+[profiles.api-local-john]
+inherits = ["api-local", "openai-john"]
+EOF
+
+	run "$FNOX_BIN" -P api-local-john --no-defaults export --format json
+	assert_success
+	assert_output --partial '"OPENAI_API_KEY": "john"'
+	assert_output --partial '"DATABASE_PASSWORD": "local"'
+}
+
+@test 'profile inheritance loads inherited profile-specific files' {
+	cat >fnox.toml <<'EOF'
+root = true
+
+[profiles.source]
+
+[profiles.app]
+inherits = ["source"]
+EOF
+
+	cat >fnox.source.toml <<'EOF'
+[secrets]
+SOURCE_ONLY = { default = "from-profile-file" }
+EOF
+
+	run "$FNOX_BIN" -P app get SOURCE_ONLY
+	assert_success
+	assert_output 'from-profile-file'
+}
+
+@test 'profile inheritance reports unknown profiles' {
+	cat >fnox.toml <<'EOF'
+root = true
+
+[profiles.app]
+inherits = ["missing"]
+EOF
+
+	run "$FNOX_BIN" -P app list
+	assert_failure
+	assert_output --partial "Profile 'missing' not found"
+}
+
+@test 'profile inheritance reports cycles' {
+	cat >fnox.toml <<'EOF'
+root = true
+
+[profiles.a]
+inherits = ["b"]
+
+[profiles.b]
+inherits = ["a"]
+EOF
+
+	run "$FNOX_BIN" -P a list
+	assert_failure
+	assert_output --partial 'Profile inheritance cycle detected: a -> b -> a'
+}


### PR DESCRIPTION
## Summary

- add ordered `inherits` lists to named profiles, including nested inheritance and aggregate-profile overrides
- detect unknown inherited profiles and inheritance cycles with actionable errors
- load inherited `fnox.<profile>.toml` files through fixed-point profile discovery
- apply inheritance consistently to secrets, providers, lease backends, default providers, daemon cache policy, and provider source paths
- document the feature and update the generated config schema

Closes discussion context from #769.

## Testing

- `cargo test`
- `cargo clippy -q -- -D warnings`
- `mise run lint`
- `mise run test:bats -- test/profile_inheritance.bats`
- targeted Bats coverage for file secrets, KeePass, GitHub App/OAuth leases, and exec replacement

The complete Bats run passed all applicable tests; the OS keychain group could not run because this Linux container has no `secret-tool`/Secret Service.

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core config merge and profile resolution used by every secret/provider lookup; mistakes could alter effective credentials or break existing multi-profile setups, though cycles and missing inherits are now explicit errors.
> 
> **Overview**
> Profiles can now declare an ordered **`inherits`** list so secrets, providers, lease backends, and **`default_provider`** are layered from ancestor profiles before the selected profile, with later entries winning on conflicts.
> 
> **Config loading** expands the active profile stack until inherited **`fnox.<profile>.toml`** files are discovered, then validates missing inherited names and **inheritance cycles** via **`ProfileInheritanceCycle`**. Top-level entries in profile-specific files are **scoped into that profile** (and local overrides follow the write profile) so precedence matches profile overlays instead of the default root.
> 
> **Effective config getters** (`get_secrets`, `get_providers`, `get_leases`, `get_secret`) now **resolve inheritance first** and return **`Result`** so cycles and missing profiles surface through CLI, daemon, and resolution paths instead of being ignored. **`set`** seeds metadata-only overrides from inherited secrets so values are not wiped; **`remove`**/`set` target logic aligns with scoped profile files.
> 
> Docs/schema and Bats tests cover ordering, nested inheritance, file discovery, and error cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e4cb36d3f5f2e46a710f0b3c56a2455ceb6ec63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added profile inheritance for secrets, providers, leases, and default providers.
  - Supports nested inheritance, ordered overrides, repeated profiles, and inherited configuration files.
  - Validates secret names as portable environment-variable identifiers.

- **Bug Fixes**
  - Configuration lookup errors now surface instead of being silently ignored.
  - Detects cycles and unknown profiles with clear configuration errors.
  - Preserves inherited values during metadata-only updates and refreshes profile-source change detection.

- **Documentation**
  - Added inheritance examples, behavior details, and schema updates.

- **Tests**
  - Added coverage for ordering, overrides, validation, errors, cycles, and file discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->