### PR TITLE
fix(config): silence intentional default fallbacks

### DIFF
--- a/crates/fnox-core/src/secret_resolver.rs
+++ b/crates/fnox-core/src/secret_resolver.rs
@@ -377,11 +377,14 @@ pub fn handle_provider_error(
     }
 }
 
-fn log_provider_default_fallback(key: &str, error: &FnoxError) {
-    if matches!(
-        error,
-        FnoxError::ProviderNotConfigured { .. } | FnoxError::ProviderNotConfiguredWithSource { .. }
-    ) {
+fn log_provider_default_fallback(key: &str, error: &FnoxError, if_missing: IfMissing) {
+    if if_missing == IfMissing::Ignore
+        || matches!(
+            error,
+            FnoxError::ProviderNotConfigured { .. }
+                | FnoxError::ProviderNotConfiguredWithSource { .. }
+        )
+    {
         tracing::debug!(
             "Falling back to default value for secret '{}' after provider resolution failed: {}",
             key,
@@ -504,11 +507,11 @@ async fn resolve_interpolated_default_value(
         return Ok(None);
     }
 
-    let subset = collect_interpolation_closure(config, profile, key, &secrets)?;
-    let mut resolved = resolve_secrets_batch(config, profile, &subset).await?;
-    if let Some(Some(value)) = resolved.shift_remove(key) {
-        return Ok(Some(value));
-    }
+    let mut dependencies = collect_interpolation_closure(config, profile, key, &secrets)?;
+    // The caller has already attempted the root secret's provider. Resolve only
+    // the secrets referenced by its default so the provider is not retried.
+    dependencies.shift_remove(key);
+    let resolved = resolve_secrets_batch(config, profile, &dependencies).await?;
     let resolved_context: HashMap<String, Option<String>> = resolved.into_iter().collect();
     let default = render_default_template(key, default, &resolved_context)?;
     Ok(Some(apply_post_processing(default, secret_config)?))
@@ -524,7 +527,11 @@ async fn resolve_secret_raw(
     let provider_value = match try_resolve_from_provider(config, profile, secret_config).await {
         Ok(value) => value,
         Err(error) if secret_config.default.is_some() => {
-            log_provider_default_fallback(key, &error);
+            log_provider_default_fallback(
+                key,
+                &error,
+                resolve_if_missing_behavior(secret_config, config),
+            );
             None
         }
         Err(error) => return Err(error),
@@ -1117,6 +1124,7 @@ async fn resolve_provider_batch(
                 resolve_default_fallbacks(&fallback_keys, secrets, resolved_so_far, &mut results)?;
             for (key, _) in &provider_secrets {
                 if fallback_resolved.contains(key) {
+                    let secret_config = &secrets[key];
                     log_provider_default_fallback(
                         key,
                         &FnoxError::ProviderNotConfigured {
@@ -1125,6 +1133,7 @@ async fn resolve_provider_batch(
                             config_path: None,
                             suggestion: suggestion.clone(),
                         },
+                        resolve_if_missing_behavior(secret_config, config),
                     );
                     continue;
                 }
@@ -1159,12 +1168,14 @@ async fn resolve_provider_batch(
             resolve_default_fallbacks(&fallback_keys, secrets, resolved_so_far, &mut results)?;
         for (key, _) in &provider_secrets {
             if fallback_resolved.contains(key) {
+                let secret_config = &secrets[key];
                 log_provider_default_fallback(
                     key,
                     &FnoxError::Provider(format!(
                         "Provider '{}' requires interactive authentication and cannot be used in non-interactive mode. Use 'fnox exec' instead.",
                         provider_name
                     )),
+                    resolve_if_missing_behavior(secret_config, config),
                 );
                 continue;
             }
@@ -1313,7 +1324,12 @@ fn handle_batch_error(
         resolve_default_fallbacks(&fallback_keys, secrets, resolved_so_far, results)?;
     for (key, _) in provider_secrets {
         if fallback_resolved.contains(key) {
-            log_provider_default_fallback(key, error);
+            let secret_config = &secrets[key];
+            log_provider_default_fallback(
+                key,
+                error,
+                resolve_if_missing_behavior(secret_config, config),
+            );
             continue;
         }
 
@@ -1404,7 +1420,12 @@ fn process_batch_results(
 
     for (key, e) in failed {
         if fallback_resolved.contains(&key) {
-            log_provider_default_fallback(&key, &e);
+            let secret_config = &secrets[&key];
+            log_provider_default_fallback(
+                &key,
+                &e,
+                resolve_if_missing_behavior(secret_config, config),
+            );
             continue;
         }
 

--- a/crates/fnox-core/src/secret_resolver.rs
+++ b/crates/fnox-core/src/secret_resolver.rs
@@ -507,11 +507,21 @@ async fn resolve_interpolated_default_value(
         return Ok(None);
     }
 
-    let mut dependencies = collect_interpolation_closure(config, profile, key, &secrets)?;
-    // The caller has already attempted the root secret's provider. Resolve only
-    // the secrets referenced by its default so the provider is not retried.
-    dependencies.shift_remove(key);
-    let resolved = resolve_secrets_batch(config, profile, &dependencies).await?;
+    let mut subset = collect_interpolation_closure(config, profile, key, &secrets)?;
+    // The caller has already attempted the root secret's provider. Keep the
+    // root in the dependency graph for cycle detection, but remove the source
+    // that would cause the provider to be retried.
+    let root = subset
+        .get_mut(key)
+        .expect("interpolation closure contains its root");
+    root.set_provider(None);
+    root.set_value(None);
+    root.sync = None;
+
+    let mut resolved = resolve_secrets_batch(config, profile, &subset).await?;
+    if let Some(Some(value)) = resolved.shift_remove(key) {
+        return Ok(Some(value));
+    }
     let resolved_context: HashMap<String, Option<String>> = resolved.into_iter().collect();
     let default = render_default_template(key, default, &resolved_context)?;
     Ok(Some(apply_post_processing(default, secret_config)?))
@@ -2066,6 +2076,54 @@ mod tests {
             .unwrap();
 
         assert_eq!(resolved, Some("postgres://localhost/fnox".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_resolve_secret_preserves_cycle_through_root_fallback() {
+        use crate::providers::OptionStringOrSecretRef;
+
+        let mut config = Config::new();
+        config.providers.insert(
+            "onepassword".to_string(),
+            ProviderConfig::OnePassword {
+                vault: OptionStringOrSecretRef::none(),
+                account: OptionStringOrSecretRef::none(),
+                token: OptionStringOrSecretRef::none(),
+                auth_command: None,
+                daemon_cache: None,
+            },
+        );
+
+        let mut root = default_secret("${DEPENDENT_SECRET}");
+        root.set_provider(Some("missing-provider".to_string()));
+        root.set_value(Some("encrypted-root".to_string()));
+        root.if_missing = Some(IfMissing::Ignore);
+        config
+            .secrets
+            .insert("OP_SERVICE_ACCOUNT_TOKEN".to_string(), root);
+
+        let mut dependent = SecretConfig::new();
+        dependent.set_provider(Some("onepassword".to_string()));
+        dependent.set_value(Some("op://vault/item/field".to_string()));
+        config
+            .secrets
+            .insert("DEPENDENT_SECRET".to_string(), dependent);
+
+        let root_config = &config.secrets["OP_SERVICE_ACCOUNT_TOKEN"];
+        let err = resolve_secret(
+            &config,
+            &profile("default"),
+            "OP_SERVICE_ACCOUNT_TOKEN",
+            root_config,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("Interpolation dependency cycle among secrets"),
+            "unexpected error: {err}"
+        );
     }
 
     #[tokio::test]

--- a/test/age.bats
+++ b/test/age.bats
@@ -9,6 +9,52 @@ teardown() {
 	_common_teardown
 }
 
+@test "quiet interpolated fallback tries the unavailable age secret once" {
+	if ! command -v age-keygen >/dev/null 2>&1; then
+		skip "age-keygen not installed"
+	fi
+
+	local readwrite_keygen_output readonly_keygen_output
+	readwrite_keygen_output=$(age-keygen -o readwrite-key.txt 2>&1)
+	readonly_keygen_output=$(age-keygen -o readonly-key.txt 2>&1)
+	local readwrite_public readonly_public readwrite_private readonly_private
+	readwrite_public=$(echo "$readwrite_keygen_output" | grep "^Public key:" | cut -d' ' -f3)
+	readonly_public=$(echo "$readonly_keygen_output" | grep "^Public key:" | cut -d' ' -f3)
+	readwrite_private=$(grep "^AGE-SECRET-KEY" readwrite-key.txt)
+	readonly_private=$(grep "^AGE-SECRET-KEY" readonly-key.txt)
+
+	cat >fnox.toml <<EOF
+root = true
+
+[providers.readwrite]
+type = "age"
+recipients = ["$readwrite_public"]
+
+[providers.readonly]
+type = "age"
+recipients = ["$readonly_public"]
+
+[secrets]
+EOF
+
+	export FNOX_AGE_KEY=$readwrite_private
+	run "$FNOX_BIN" set AZURE_STORAGE_SAS_TOKEN readwrite --provider readwrite \
+		--default '${DVC_READONLY_SAS_TOKEN}' --if-missing ignore
+	assert_success
+
+	export FNOX_AGE_KEY=$readonly_private
+	run "$FNOX_BIN" set DVC_READONLY_SAS_TOKEN readonly --provider readonly
+	assert_success
+
+	run env FNOX_DAEMON=off "$FNOX_BIN" get AZURE_STORAGE_SAS_TOKEN
+	assert_success
+	assert_output "readonly"
+
+	run env FNOX_DAEMON=off RUST_LOG=debug "$FNOX_BIN" get AZURE_STORAGE_SAS_TOKEN
+	assert_success
+	[[ $(grep -c "Falling back to default value for secret 'AZURE_STORAGE_SAS_TOKEN'" <<<"$output") -eq 1 ]]
+}
+
 @test "decrypts using FNOX_AGE_KEY environment variable" {
 	# Skip if age not installed
 	if ! command -v age-keygen >/dev/null 2>&1; then

--- a/test/age.bats
+++ b/test/age.bats
@@ -29,10 +29,12 @@ root = true
 [providers.readwrite]
 type = "age"
 recipients = ["$readwrite_public"]
+key_file = "missing-readwrite-key.txt"
 
 [providers.readonly]
 type = "age"
 recipients = ["$readonly_public"]
+key_file = "readonly-key.txt"
 
 [secrets]
 EOF
@@ -45,6 +47,7 @@ EOF
 	export FNOX_AGE_KEY=$readonly_private
 	run "$FNOX_BIN" set DVC_READONLY_SAS_TOKEN readonly --provider readonly
 	assert_success
+	unset FNOX_AGE_KEY
 
 	run env FNOX_DAEMON=off "$FNOX_BIN" get AZURE_STORAGE_SAS_TOKEN
 	assert_success


### PR DESCRIPTION
## Summary

- downgrade successful provider-to-default fallback logging to debug when the effective `if_missing` policy is `ignore`
- resolve only interpolated-default dependencies after the requested provider has already failed, avoiding a duplicate provider attempt
- add an Age regression reproducing the permission-scoped read/write-to-read-only fallback from Discussion #768

This is a focused fix for the workaround described in #768, not an implementation of the proposed ordered `sources` schema.

The affected behavior originated across #549 (interpolated defaults) and #572 (fallback after provider errors). The open profile-inheritance work in #770 touches nearby provider lookup APIs but does not overlap these resolver hunks semantically.

## Testing

- `mise run build`
- `cargo build`
- `mise run test:cargo`
- `mise run test:cargo --package fnox-core secret_resolver`
- `cargo test --package fnox-core secret_resolver`
- `mise run test:bats -- test/age.bats`
- `mise run lint`

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core secret resolver fallback and interpolated-default paths; behavior is well-covered by new unit and bats tests but mistakes could affect resolution order, cycle detection, or error vs ignore semantics.
> 
> **Overview**
> When a secret uses **`if_missing: ignore`** and falls back from a failed provider to a default (including interpolated defaults), **fallback logging is downgraded to `debug`** instead of `warn`, so intentional quiet paths do not spam logs.
> 
> **Interpolated default resolution** no longer re-runs the root secret’s provider after the caller already failed it: the root stays in the dependency closure for **cycle detection**, but its provider, value, and sync are cleared before batch resolution so only dependent secrets are fetched. A new unit test asserts that a cyclic default chain still surfaces an interpolation cycle error instead of masking it via a duplicate provider attempt.
> 
> An **Age bats regression** covers read/write → read-only interpolated fallback (`if-missing ignore`): the unavailable secret is tried once, the interpolated default resolves, and the fallback message appears exactly once at debug.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2f40689f6d54a0ec05d7504582c69c068663cc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary log messages and provider retries when missing secrets are configured to be ignored.
  * Fixed interpolated default values to resolve correctly without retrying the root secret provider.
  * Improved detection and reporting of dependency cycles involving fallback values.

* **Tests**
  * Added coverage for quiet fallback behavior, correct value resolution, and logging.
  * Added validation for dependency cycles involving fallback values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->