### PR TITLE
fix(check): prompt once for age batch decryption

### DIFF
--- a/crates/fnox-core/build/generate_providers.rs
+++ b/crates/fnox-core/build/generate_providers.rs
@@ -363,6 +363,8 @@ fn generate_provider_methods(
     let mut auth_command_arms = Vec::new();
     let mut daemon_cache_arms = Vec::new();
     let mut env_deps_arms = Vec::new();
+    let mut config_secret_deps_arms = Vec::new();
+    let mut nested_provider_deps_arms = Vec::new();
     let mut interactive_auth_arms = Vec::new();
 
     for (_name, provider) in providers {
@@ -410,6 +412,54 @@ fn generate_provider_methods(
         env_deps_arms.push(quote! {
             Self::#variant { .. } => #module::env_dependencies()
         });
+        let config_secret_fields: Vec<_> = provider
+            .fields
+            .iter()
+            .filter(|(_, field)| matches!(field.typ.as_str(), "required" | "optional"))
+            .map(|(name, _)| {
+                let field_name = Ident::new(name, Span::call_site());
+                quote! { #field_name.secret_name() }
+            })
+            .collect();
+        let config_secret_patterns: Vec<_> = provider
+            .fields
+            .iter()
+            .filter(|(_, field)| matches!(field.typ.as_str(), "required" | "optional"))
+            .map(|(name, _)| Ident::new(name, Span::call_site()))
+            .collect();
+        config_secret_deps_arms.push(if config_secret_patterns.is_empty() {
+            quote! { Self::#variant { .. } => Vec::new() }
+        } else {
+            quote! {
+                Self::#variant { #(#config_secret_patterns),*, .. } => {
+                    [#(#config_secret_fields),*].into_iter().flatten().collect()
+                }
+            }
+        });
+        let provider_ref_fields: Vec<_> = provider
+            .fields
+            .iter()
+            .filter(|(_, field)| field.typ == "provider_ref")
+            .map(|(name, _)| {
+                let field_name = Ident::new(name, Span::call_site());
+                quote! { #field_name.as_ref().map(|reference| reference.provider.as_str()) }
+            })
+            .collect();
+        let provider_ref_patterns: Vec<_> = provider
+            .fields
+            .iter()
+            .filter(|(_, field)| field.typ == "provider_ref")
+            .map(|(name, _)| Ident::new(name, Span::call_site()))
+            .collect();
+        nested_provider_deps_arms.push(if provider_ref_patterns.is_empty() {
+            quote! { Self::#variant { .. } => Vec::new() }
+        } else {
+            quote! {
+                Self::#variant { #(#provider_ref_patterns),*, .. } => {
+                    [#(#provider_ref_fields),*].into_iter().flatten().collect()
+                }
+            }
+        });
         let interactive = provider.requires_interactive_auth;
         interactive_auth_arms.push(quote! {
             Self::#variant { .. } => #interactive
@@ -445,6 +495,18 @@ fn generate_provider_methods(
             pub fn env_dependencies(&self) -> &'static [&'static str] {
                 match self {
                     #(#env_deps_arms),*
+                }
+            }
+
+            pub(crate) fn config_secret_dependencies(&self) -> Vec<&str> {
+                match self {
+                    #(#config_secret_deps_arms),*
+                }
+            }
+
+            pub(crate) fn nested_provider_dependencies(&self) -> Vec<&str> {
+                match self {
+                    #(#nested_provider_deps_arms),*
                 }
             }
 

--- a/crates/fnox-core/src/auth_prompt.rs
+++ b/crates/fnox-core/src/auth_prompt.rs
@@ -20,16 +20,31 @@ pub fn prompt_and_run_auth(
     provider_name: &str,
     error: &FnoxError,
 ) -> Result<bool> {
-    if !error.is_auth_error() {
+    let Some(auth_command) =
+        prompt_for_auth_command(config, provider_config, provider_name, error)?
+    else {
         return Ok(false);
+    };
+
+    run_confirmed_auth_command(auth_command)
+}
+
+pub(crate) fn prompt_for_auth_command<'a>(
+    config: &Config,
+    provider_config: &'a ProviderConfig,
+    provider_name: &str,
+    error: &FnoxError,
+) -> Result<Option<&'a str>> {
+    if !error.is_auth_error() {
+        return Ok(None);
     }
 
     if !config.should_prompt_auth() {
-        return Ok(false);
+        return Ok(None);
     }
 
     let Some(auth_command) = provider_config.default_auth_command() else {
-        return Ok(false);
+        return Ok(None);
     };
 
     // Show the error and prompt
@@ -45,13 +60,16 @@ pub fn prompt_and_run_auth(
         .map_err(|e| FnoxError::Provider(format!("Failed to show prompt: {}", e)))?;
 
     if !user_confirmed {
-        return Ok(false);
+        return Ok(None);
     }
 
-    // Run the auth command
+    Ok(Some(auth_command))
+}
+
+pub(crate) fn run_confirmed_auth_command(auth_command: &str) -> Result<bool> {
     eprintln!("Running: {}", auth_command);
 
-    let status = run_auth_command(auth_command);
+    let status = execute_auth_command(auth_command);
 
     match status {
         Ok(exit_status) if exit_status.success() => {
@@ -69,7 +87,7 @@ pub fn prompt_and_run_auth(
     }
 }
 
-fn run_auth_command(auth_command: &str) -> std::io::Result<std::process::ExitStatus> {
+fn execute_auth_command(auth_command: &str) -> std::io::Result<std::process::ExitStatus> {
     if cfg!(target_os = "windows") {
         Command::new("cmd")
             .args(["/C", auth_command])
@@ -133,7 +151,7 @@ mod tests {
         const MARKER: &str = "auth-command-output-marker";
 
         if std::env::var(CHILD_ENV).ok().as_deref() == Some("1") {
-            run_auth_command(&format!("echo {MARKER}")).unwrap();
+            execute_auth_command(&format!("echo {MARKER}")).unwrap();
             return;
         }
 

--- a/crates/fnox-core/src/env.rs
+++ b/crates/fnox-core/src/env.rs
@@ -1,5 +1,6 @@
+use std::collections::HashMap;
 pub use std::env::*;
-use std::ffi::OsStr;
+use std::ffi::{OsStr, OsString};
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::{path::PathBuf, sync::LazyLock};
@@ -18,6 +19,50 @@ pub fn is_non_interactive() -> bool {
 
 /// Mutex to serialize access to std::env::set_var, which is unsafe in Rust 2024 edition.
 static ENV_MUTEX: Mutex<()> = Mutex::new(());
+
+pub(crate) static PROVIDER_ENV_ACCESS: LazyLock<tokio::sync::RwLock<()>> =
+    LazyLock::new(|| tokio::sync::RwLock::new(()));
+
+pub(crate) struct ProviderEnvOverlay {
+    previous: Vec<(String, Option<OsString>)>,
+}
+
+impl ProviderEnvOverlay {
+    pub(crate) fn resolved_values(
+        dependencies: &[&str],
+        resolved: &HashMap<String, Option<String>>,
+    ) -> Vec<(String, String)> {
+        dependencies
+            .iter()
+            .filter_map(|dependency| {
+                resolved
+                    .get(*dependency)
+                    .and_then(|value| value.as_ref())
+                    .map(|value| ((*dependency).to_string(), value.clone()))
+            })
+            .collect()
+    }
+
+    pub(crate) fn apply(values: &[(String, String)]) -> Self {
+        let mut previous = Vec::new();
+        for (key, value) in values {
+            previous.push((key.clone(), var_os(key)));
+            set_var(key, value);
+        }
+        Self { previous }
+    }
+}
+
+impl Drop for ProviderEnvOverlay {
+    fn drop(&mut self) {
+        for (key, value) in self.previous.drain(..).rev() {
+            match value {
+                Some(value) => set_var(key, value),
+                None => remove_var(key),
+            }
+        }
+    }
+}
 
 /// Set an environment variable, serializing access via ENV_MUTEX.
 ///

--- a/crates/fnox-core/src/env.rs
+++ b/crates/fnox-core/src/env.rs
@@ -53,6 +53,23 @@ impl ProviderEnvOverlay {
     }
 }
 
+/// Run provider work while isolating its declared process-environment values.
+/// Resolve nested provider dependencies first because this guard is not reentrant.
+pub(crate) async fn with_provider_env<T, F, Fut>(values: &[(String, String)], run: F) -> T
+where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = T>,
+{
+    if values.is_empty() {
+        let _access = PROVIDER_ENV_ACCESS.read().await;
+        run().await
+    } else {
+        let _access = PROVIDER_ENV_ACCESS.write().await;
+        let _env = ProviderEnvOverlay::apply(values);
+        run().await
+    }
+}
+
 impl Drop for ProviderEnvOverlay {
     fn drop(&mut self) {
         for (key, value) in self.previous.drain(..).rev() {

--- a/crates/fnox-core/src/providers/age.rs
+++ b/crates/fnox-core/src/providers/age.rs
@@ -17,11 +17,15 @@ pub fn env_dependencies() -> &'static [&'static str] {
 pub struct AgeEncryptionProvider {
     recipients: Vec<String>,
     key_file: Option<PathBuf>,
-    identity: OptionProviderSecretRef,
+    identity: AgeIdentity,
     config: Option<Arc<crate::config::Config>>,
     profile: Vec<String>,
     provider_name: String,
-    identity_cycle_guard: Option<AgeIdentityCycleGuard>,
+}
+
+enum AgeIdentity {
+    Reference(OptionProviderSecretRef),
+    Resolved(Option<String>),
 }
 
 impl AgeEncryptionProvider {
@@ -33,11 +37,10 @@ impl AgeEncryptionProvider {
         Ok(Self {
             recipients,
             key_file: key_file.map(|k| crate::config_path::resolve_relative_to_file(&k, None)),
-            identity,
+            identity: AgeIdentity::Reference(identity),
             config: None,
             profile: vec!["default".to_string()],
             provider_name: "age".to_string(),
-            identity_cycle_guard: None,
         })
     }
 
@@ -48,22 +51,41 @@ impl AgeEncryptionProvider {
         config: Arc<crate::config::Config>,
         profile: Vec<String>,
         provider_name: String,
-        identity_cycle_guard: Option<AgeIdentityCycleGuard>,
     ) -> Result<Self> {
         Ok(Self {
             recipients,
             key_file: key_file.map(|k| crate::config_path::resolve_relative_to_file(&k, None)),
-            identity,
+            identity: AgeIdentity::Reference(identity),
             config: Some(config),
             profile,
             provider_name,
-            identity_cycle_guard,
+        })
+    }
+
+    pub(crate) fn new_with_resolved_identity(
+        recipients: Vec<String>,
+        key_file: Option<String>,
+        identity: Option<String>,
+    ) -> Result<Self> {
+        Ok(Self {
+            recipients,
+            key_file: key_file.map(|k| crate::config_path::resolve_relative_to_file(&k, None)),
+            identity: AgeIdentity::Resolved(identity),
+            config: None,
+            profile: vec!["default".to_string()],
+            provider_name: "age".to_string(),
         })
     }
 
     async fn resolve_provider_identity(&self) -> Result<Option<String>> {
-        let Some(identity) = self.identity.as_ref() else {
-            return Ok(None);
+        let identity = match &self.identity {
+            AgeIdentity::Resolved(identity) => return Ok(identity.clone()),
+            AgeIdentity::Reference(identity) => {
+                let Some(identity) = identity.as_ref() else {
+                    return Ok(None);
+                };
+                identity
+            }
         };
 
         if identity.provider == self.provider_name {
@@ -79,15 +101,16 @@ impl AgeEncryptionProvider {
             ));
         };
 
-        let identity_cycle_guard = self.identity_cycle_guard.clone().unwrap_or_default();
+        let identity_cycle_guard = AgeIdentityCycleGuard::default();
         let _guard = identity_cycle_guard.enter(&self.provider_name)?;
-        let mut ctx = crate::providers::resolver::ResolutionContext::new();
-        crate::providers::resolver::resolve_provider_ref_with_identity_cycle_guard(
+        let mut ctx = crate::providers::resolver::ResolutionContext::with_identity_cycle_guard(
+            identity_cycle_guard,
+        );
+        crate::providers::resolver::resolve_provider_ref(
             config,
             &self.profile,
-            &self.identity,
+            &OptionProviderSecretRef(Some(identity.clone())),
             &mut ctx,
-            identity_cycle_guard,
         )
         .await
     }
@@ -124,7 +147,7 @@ pub struct AgeIdentityCycleGuard {
 }
 
 impl AgeIdentityCycleGuard {
-    fn enter(&self, provider_name: &str) -> Result<AgeIdentityCycleEntry> {
+    pub(crate) fn enter(&self, provider_name: &str) -> Result<AgeIdentityCycleEntry> {
         let mut resolving = self
             .resolving
             .lock()
@@ -148,7 +171,39 @@ impl AgeIdentityCycleGuard {
     }
 }
 
-struct AgeIdentityCycleEntry {
+pub(crate) async fn resolve_identity_for_read(
+    config: &crate::config::Config,
+    profile: &[String],
+    provider_name: &str,
+    identity: &OptionProviderSecretRef,
+    ctx: &mut crate::providers::resolver::ResolutionContext,
+) -> Result<Option<String>> {
+    if env::FNOX_AGE_KEY.is_some() {
+        return Ok(None);
+    }
+
+    let Some(identity) = identity.as_ref() else {
+        return Ok(None);
+    };
+    if identity.provider == provider_name {
+        return Err(FnoxError::ProviderConfigCycle {
+            provider: provider_name.to_string(),
+            cycle: format!("{provider_name} -> {provider_name}"),
+        });
+    }
+
+    let identity_cycle_guard = ctx.age_identity_cycle_guard();
+    let _guard = identity_cycle_guard.enter(provider_name)?;
+    crate::providers::resolver::resolve_provider_ref(
+        config,
+        profile,
+        &OptionProviderSecretRef(Some(identity.clone())),
+        ctx,
+    )
+    .await
+}
+
+pub(crate) struct AgeIdentityCycleEntry {
     provider_name: String,
     resolving: Arc<Mutex<Vec<String>>>,
 }
@@ -486,6 +541,7 @@ impl AgeEncryptionProvider {
 mod tests {
     use super::*;
     use crate::providers::Provider;
+    use crate::providers::secret_ref::ProviderSecretRef;
     use age::secrecy::ExposeSecret;
 
     fn test_provider() -> (AgeEncryptionProvider, tempfile::TempPath) {
@@ -556,5 +612,50 @@ mod tests {
 
         assert_eq!(decrypted["FIRST"].as_ref().unwrap(), "one");
         assert_eq!(decrypted["SECOND"].as_ref().unwrap(), "two");
+    }
+
+    #[tokio::test]
+    async fn concurrent_identity_reads_have_independent_cycle_guards() {
+        let config: crate::config::Config = toml_edit::de::from_str(
+            r#"
+[providers.identity]
+type = "plain"
+"#,
+        )
+        .unwrap();
+        let provider = Arc::new(
+            AgeEncryptionProvider::new_with_config(
+                Vec::new(),
+                None,
+                OptionProviderSecretRef(Some(ProviderSecretRef {
+                    provider: "identity".to_string(),
+                    value: "identity-value".to_string(),
+                })),
+                Arc::new(config),
+                vec!["default".to_string()],
+                "age".to_string(),
+            )
+            .unwrap(),
+        );
+
+        let access = crate::env::PROVIDER_ENV_ACCESS.write().await;
+        let first = {
+            let provider = provider.clone();
+            tokio::spawn(async move { provider.resolve_provider_identity().await })
+        };
+        let second = {
+            let provider = provider.clone();
+            tokio::spawn(async move { provider.resolve_provider_identity().await })
+        };
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        drop(access);
+
+        let (first, second) = tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            tokio::join!(first, second)
+        })
+        .await
+        .unwrap();
+        assert_eq!(first.unwrap().unwrap().as_deref(), Some("identity-value"));
+        assert_eq!(second.unwrap().unwrap().as_deref(), Some("identity-value"));
     }
 }

--- a/crates/fnox-core/src/providers/mod.rs
+++ b/crates/fnox-core/src/providers/mod.rs
@@ -1,6 +1,7 @@
 use crate::error::Result;
 use async_trait::async_trait;
-use std::collections::HashMap;
+use indexmap::IndexMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
 // Provider implementation modules
@@ -290,6 +291,45 @@ impl ProviderConfig {
             .filter(|info| info.category == category)
             .collect()
     }
+
+    pub(crate) fn resolution_dependencies(
+        &self,
+        providers: &IndexMap<String, ProviderConfig>,
+    ) -> Vec<String> {
+        fn collect(
+            provider: &ProviderConfig,
+            providers: &IndexMap<String, ProviderConfig>,
+            visited: &mut HashSet<String>,
+            dependencies: &mut Vec<String>,
+        ) {
+            for dependency in provider
+                .env_dependencies()
+                .iter()
+                .copied()
+                .chain(provider.config_secret_dependencies())
+            {
+                if !dependencies.iter().any(|existing| existing == dependency) {
+                    dependencies.push(dependency.to_string());
+                }
+            }
+
+            if !matches!(provider, ProviderConfig::AgeEncryption { .. })
+                || crate::env::FNOX_AGE_KEY.is_none()
+            {
+                for provider_name in provider.nested_provider_dependencies() {
+                    if visited.insert(provider_name.to_string())
+                        && let Some(nested) = providers.get(provider_name)
+                    {
+                        collect(nested, providers, visited, dependencies);
+                    }
+                }
+            }
+        }
+
+        let mut dependencies = Vec::new();
+        collect(self, providers, &mut HashSet::new(), &mut dependencies);
+        dependencies
+    }
 }
 
 /// Create a provider from an unresolved provider configuration.
@@ -309,27 +349,77 @@ pub async fn get_provider_resolved(
     get_provider_from_resolved_with_context(config, profile, provider_name, &resolved)
 }
 
+pub(crate) enum PreparedProviderRead {
+    Standard(ResolvedProviderConfig),
+    Age {
+        recipients: Vec<String>,
+        key_file: Option<String>,
+        identity: Option<String>,
+    },
+}
+
+impl PreparedProviderRead {
+    pub(crate) fn instantiate(
+        self,
+        config: &crate::config::Config,
+        profile: &[String],
+        provider_name: &str,
+    ) -> Result<Box<dyn Provider>> {
+        match self {
+            Self::Standard(resolved) => {
+                get_provider_from_resolved_with_context(config, profile, provider_name, &resolved)
+            }
+            Self::Age {
+                recipients,
+                key_file,
+                identity,
+            } => {
+                let provider_source = provider_source_path(config, profile, provider_name);
+                Ok(Box::new(
+                    age::AgeEncryptionProvider::new_with_resolved_identity(
+                        recipients,
+                        crate::config_path::resolve_optional_string_relative_to_file(
+                            key_file,
+                            provider_source.as_deref(),
+                        ),
+                        identity,
+                    )?,
+                ))
+            }
+        }
+    }
+}
+
+pub(crate) async fn prepare_provider_read(
+    config: &crate::config::Config,
+    profile: &[String],
+    provider_name: &str,
+    resolved: ResolvedProviderConfig,
+    ctx: &mut resolver::ResolutionContext,
+) -> Result<PreparedProviderRead> {
+    if let ResolvedProviderConfig::AgeEncryption {
+        recipients,
+        key_file,
+        identity,
+    } = resolved
+    {
+        let identity =
+            age::resolve_identity_for_read(config, profile, provider_name, &identity, ctx).await?;
+        return Ok(PreparedProviderRead::Age {
+            recipients,
+            key_file,
+            identity,
+        });
+    }
+
+    Ok(PreparedProviderRead::Standard(resolved))
+}
+
 pub(crate) fn get_provider_from_resolved_with_context(
     config: &crate::config::Config,
     profile: &[String],
     provider_name: &str,
     resolved: &ResolvedProviderConfig,
-) -> Result<Box<dyn Provider>> {
-    get_provider_from_resolved_with_context_and_identity_cycle_guard(
-        config,
-        profile,
-        provider_name,
-        resolved,
-        None,
-    )
-}
-
-pub(crate) fn get_provider_from_resolved_with_context_and_identity_cycle_guard(
-    config: &crate::config::Config,
-    profile: &[String],
-    provider_name: &str,
-    resolved: &ResolvedProviderConfig,
-    identity_cycle_guard: Option<age::AgeIdentityCycleGuard>,
 ) -> Result<Box<dyn Provider>> {
     if let ResolvedProviderConfig::AgeEncryption {
         recipients,
@@ -348,7 +438,6 @@ pub(crate) fn get_provider_from_resolved_with_context_and_identity_cycle_guard(
             std::sync::Arc::new(config.clone()),
             profile.to_vec(),
             provider_name.to_string(),
-            identity_cycle_guard,
         )?));
     }
     if let ResolvedProviderConfig::KeePass {

--- a/crates/fnox-core/src/providers/resolver.rs
+++ b/crates/fnox-core/src/providers/resolver.rs
@@ -7,10 +7,10 @@
 //! can reference a secret from another provider) and detects circular dependencies.
 
 use crate::config::Config;
-use crate::env;
+use crate::env::{self, PROVIDER_ENV_ACCESS, ProviderEnvOverlay};
 use crate::error::{FnoxError, Result};
 use crate::suggest::{find_similar, format_suggestions};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use super::secret_ref::{OptionProviderSecretRef, OptionStringOrSecretRef, StringOrSecretRef};
 use super::{ProviderConfig, ResolvedProviderConfig};
@@ -22,6 +22,8 @@ pub struct ResolutionContext {
     provider_stack: HashSet<String>,
     /// Stack path for error messages
     resolution_path: Vec<String>,
+    pre_resolved: HashMap<String, Option<String>>,
+    age_identity_cycle_guard: super::age::AgeIdentityCycleGuard,
 }
 
 impl ResolutionContext {
@@ -30,7 +32,33 @@ impl ResolutionContext {
         Self {
             provider_stack: HashSet::new(),
             resolution_path: Vec::new(),
+            pre_resolved: HashMap::new(),
+            age_identity_cycle_guard: super::age::AgeIdentityCycleGuard::default(),
         }
+    }
+
+    pub(crate) fn with_pre_resolved(pre_resolved: &HashMap<String, Option<String>>) -> Self {
+        Self {
+            provider_stack: HashSet::new(),
+            resolution_path: Vec::new(),
+            pre_resolved: pre_resolved.clone(),
+            age_identity_cycle_guard: super::age::AgeIdentityCycleGuard::default(),
+        }
+    }
+
+    pub(crate) fn with_identity_cycle_guard(
+        age_identity_cycle_guard: super::age::AgeIdentityCycleGuard,
+    ) -> Self {
+        Self {
+            provider_stack: HashSet::new(),
+            resolution_path: Vec::new(),
+            pre_resolved: HashMap::new(),
+            age_identity_cycle_guard,
+        }
+    }
+
+    pub(crate) fn age_identity_cycle_guard(&self) -> super::age::AgeIdentityCycleGuard {
+        self.age_identity_cycle_guard.clone()
     }
 
     /// Check if we're already resolving this provider (cycle detection)
@@ -172,22 +200,6 @@ pub fn resolve_provider_ref<'a>(
     value: &'a OptionProviderSecretRef,
     ctx: &'a mut ResolutionContext,
 ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Option<String>>> + Send + 'a>> {
-    resolve_provider_ref_with_identity_cycle_guard(
-        config,
-        profile,
-        value,
-        ctx,
-        super::age::AgeIdentityCycleGuard::default(),
-    )
-}
-
-pub fn resolve_provider_ref_with_identity_cycle_guard<'a>(
-    config: &'a Config,
-    profile: &'a [String],
-    value: &'a OptionProviderSecretRef,
-    ctx: &'a mut ResolutionContext,
-    identity_cycle_guard: super::age::AgeIdentityCycleGuard,
-) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Option<String>>> + Send + 'a>> {
     Box::pin(async move {
         let Some(provider_ref) = value.as_ref() else {
             return Ok(None);
@@ -222,15 +234,32 @@ pub fn resolve_provider_ref_with_identity_cycle_guard<'a>(
             ctx,
         )
         .await?;
-        let provider = super::get_provider_from_resolved_with_context_and_identity_cycle_guard(
+        let prepared_provider = super::prepare_provider_read(
             config,
             profile,
             &provider_ref.provider,
-            &resolved_provider,
-            Some(identity_cycle_guard),
-        )?;
+            resolved_provider,
+            ctx,
+        )
+        .await?;
+        let values = ProviderEnvOverlay::resolved_values(
+            provider_config.env_dependencies(),
+            &ctx.pre_resolved,
+        );
+        let value = if values.is_empty() {
+            let _access = PROVIDER_ENV_ACCESS.read().await;
+            let provider =
+                prepared_provider.instantiate(config, profile, &provider_ref.provider)?;
+            provider.get_secret(&provider_ref.value).await?
+        } else {
+            let _access = PROVIDER_ENV_ACCESS.write().await;
+            let _env = ProviderEnvOverlay::apply(&values);
+            let provider =
+                prepared_provider.instantiate(config, profile, &provider_ref.provider)?;
+            provider.get_secret(&provider_ref.value).await?
+        };
 
-        provider.get_secret(&provider_ref.value).await.map(Some)
+        Ok(Some(value))
     })
 }
 
@@ -247,6 +276,16 @@ fn resolve_secret_ref<'a>(
     ctx: &'a mut ResolutionContext,
 ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<String>> + Send + 'a>> {
     Box::pin(async move {
+        if let Some(value) = ctx.pre_resolved.get(secret_name) {
+            return value
+                .clone()
+                .ok_or_else(|| FnoxError::ProviderConfigResolutionFailed {
+                    provider: provider_name.to_string(),
+                    secret: secret_name.to_string(),
+                    details: format!("Secret '{secret_name}' did not resolve"),
+                });
+        }
+
         // First, try to find the secret in config
         let secrets = config.get_secrets(profile)?;
 
@@ -276,14 +315,30 @@ fn resolve_secret_ref<'a>(
                         ctx,
                     )
                     .await?;
-
-                    // Create the provider and get the secret
-                    let provider = super::get_provider_from_resolved_with_context(
+                    let prepared_provider = super::prepare_provider_read(
                         config,
                         profile,
                         secret_provider_name,
-                        &resolved_provider,
-                    )?;
+                        resolved_provider,
+                        ctx,
+                    )
+                    .await?;
+
+                    let values = ProviderEnvOverlay::resolved_values(
+                        secret_provider_config.env_dependencies(),
+                        &ctx.pre_resolved,
+                    );
+                    if values.is_empty() {
+                        let _access = PROVIDER_ENV_ACCESS.read().await;
+                        let provider =
+                            prepared_provider.instantiate(config, profile, secret_provider_name)?;
+                        return provider.get_secret(provider_value).await;
+                    }
+
+                    let _access = PROVIDER_ENV_ACCESS.write().await;
+                    let _env = ProviderEnvOverlay::apply(&values);
+                    let provider =
+                        prepared_provider.instantiate(config, profile, secret_provider_name)?;
                     return provider.get_secret(provider_value).await;
                 } else {
                     // Find similar provider names for suggestion
@@ -308,6 +363,7 @@ fn resolve_secret_ref<'a>(
         }
 
         // Fall back to environment variable
+        let _access = PROVIDER_ENV_ACCESS.read().await;
         env::var(secret_name).map_err(|_| FnoxError::ProviderConfigResolutionFailed {
             provider: provider_name.to_string(),
             secret: secret_name.to_string(),
@@ -382,6 +438,49 @@ inherits = ["a"]
         assert!(matches!(
             error,
             FnoxError::ProfileInheritanceCycle { cycle } if cycle == "a -> b -> a"
+        ));
+    }
+
+    #[tokio::test]
+    async fn secret_ref_uses_pre_resolved_value() {
+        let config = Config::new();
+        let mut ctx = ResolutionContext::with_pre_resolved(&HashMap::from([(
+            "TOKEN".to_string(),
+            Some("resolved-token".to_string()),
+        )]));
+
+        let value = resolve_secret_ref(
+            &config,
+            &["default".to_string()],
+            "provider",
+            "TOKEN",
+            &mut ctx,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(value, "resolved-token");
+    }
+
+    #[tokio::test]
+    async fn secret_ref_does_not_retry_pre_resolved_missing_value() {
+        let config = Config::new();
+        let mut ctx =
+            ResolutionContext::with_pre_resolved(&HashMap::from([("TOKEN".to_string(), None)]));
+
+        let error = resolve_secret_ref(
+            &config,
+            &["default".to_string()],
+            "provider",
+            "TOKEN",
+            &mut ctx,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            FnoxError::ProviderConfigResolutionFailed { secret, .. } if secret == "TOKEN"
         ));
     }
 }

--- a/crates/fnox-core/src/providers/resolver.rs
+++ b/crates/fnox-core/src/providers/resolver.rs
@@ -246,18 +246,12 @@ pub fn resolve_provider_ref<'a>(
             provider_config.env_dependencies(),
             &ctx.pre_resolved,
         );
-        let value = if values.is_empty() {
-            let _access = PROVIDER_ENV_ACCESS.read().await;
+        let value = env::with_provider_env(&values, || async {
             let provider =
                 prepared_provider.instantiate(config, profile, &provider_ref.provider)?;
-            provider.get_secret(&provider_ref.value).await?
-        } else {
-            let _access = PROVIDER_ENV_ACCESS.write().await;
-            let _env = ProviderEnvOverlay::apply(&values);
-            let provider =
-                prepared_provider.instantiate(config, profile, &provider_ref.provider)?;
-            provider.get_secret(&provider_ref.value).await?
-        };
+            provider.get_secret(&provider_ref.value).await
+        })
+        .await?;
 
         Ok(Some(value))
     })
@@ -328,18 +322,12 @@ fn resolve_secret_ref<'a>(
                         secret_provider_config.env_dependencies(),
                         &ctx.pre_resolved,
                     );
-                    if values.is_empty() {
-                        let _access = PROVIDER_ENV_ACCESS.read().await;
+                    return env::with_provider_env(&values, || async {
                         let provider =
                             prepared_provider.instantiate(config, profile, secret_provider_name)?;
-                        return provider.get_secret(provider_value).await;
-                    }
-
-                    let _access = PROVIDER_ENV_ACCESS.write().await;
-                    let _env = ProviderEnvOverlay::apply(&values);
-                    let provider =
-                        prepared_provider.instantiate(config, profile, secret_provider_name)?;
-                    return provider.get_secret(provider_value).await;
+                        provider.get_secret(provider_value).await
+                    })
+                    .await;
                 } else {
                     // Find similar provider names for suggestion
                     let available_providers: Vec<_> =

--- a/crates/fnox-core/src/providers/secret_ref.rs
+++ b/crates/fnox-core/src/providers/secret_ref.rs
@@ -66,8 +66,7 @@ impl StringOrSecretRef {
     }
 
     /// Returns the secret name if this is a secret reference
-    #[cfg(test)]
-    pub fn secret_name(&self) -> Option<&str> {
+    pub(crate) fn secret_name(&self) -> Option<&str> {
         match self {
             Self::SecretRef { secret } => Some(secret),
             Self::Literal(_) => None,
@@ -175,8 +174,7 @@ impl OptionStringOrSecretRef {
     }
 
     /// Returns the secret name if this is a secret reference
-    #[cfg(test)]
-    pub fn secret_name(&self) -> Option<&str> {
+    pub(crate) fn secret_name(&self) -> Option<&str> {
         match &self.0 {
             Some(StringOrSecretRef::SecretRef { secret }) => Some(secret),
             _ => None,

--- a/crates/fnox-core/src/secret_resolver.rs
+++ b/crates/fnox-core/src/secret_resolver.rs
@@ -1,4 +1,4 @@
-use crate::auth_prompt::prompt_and_run_auth;
+use crate::auth_prompt::{prompt_for_auth_command, run_confirmed_auth_command};
 use crate::config::{Config, IfMissing, SecretConfig};
 use crate::env::{self, PROVIDER_ENV_ACCESS, ProviderEnvOverlay};
 use crate::error::{FnoxError, Result};
@@ -684,8 +684,13 @@ async fn prompt_and_run_auth_guarded(
     provider_name: &str,
     error: &FnoxError,
 ) -> Result<bool> {
-    let _access = PROVIDER_ENV_ACCESS.read().await;
-    prompt_and_run_auth(config, provider_config, provider_name, error)
+    let Some(auth_command) =
+        prompt_for_auth_command(config, provider_config, provider_name, error)?
+    else {
+        return Ok(false);
+    };
+
+    env::with_provider_env(&[], || async { run_confirmed_auth_command(auth_command) }).await
 }
 
 /// Helper to get a single secret from a provider without auth retry logic.
@@ -1581,18 +1586,20 @@ async fn prompt_and_run_batch_auth(
     ctx: &ProviderBatchContext<'_>,
     error: &FnoxError,
 ) -> Result<bool> {
+    let Some(auth_command) =
+        prompt_for_auth_command(ctx.config, ctx.provider_config, ctx.provider_name, error)?
+    else {
+        return Ok(false);
+    };
+
     let values = ProviderEnvOverlay::resolved_values(
         ctx.provider_config.env_dependencies(),
         ctx.resolved_so_far,
     );
-    if values.is_empty() {
-        let _access = PROVIDER_ENV_ACCESS.read().await;
-        prompt_and_run_auth(ctx.config, ctx.provider_config, ctx.provider_name, error)
-    } else {
-        let _access = PROVIDER_ENV_ACCESS.write().await;
-        let _env = ProviderEnvOverlay::apply(&values);
-        prompt_and_run_auth(ctx.config, ctx.provider_config, ctx.provider_name, error)
-    }
+    env::with_provider_env(&values, || async {
+        run_confirmed_auth_command(auth_command)
+    })
+    .await
 }
 
 /// Helper to get multiple secrets in batch from a provider without auth retry logic.
@@ -1625,16 +1632,11 @@ async fn try_get_secrets_batch(
         ctx.resolved_so_far,
     );
 
-    if values.is_empty() {
-        let _access = PROVIDER_ENV_ACCESS.read().await;
+    env::with_provider_env(&values, || async {
         let provider = prepared_provider.instantiate(ctx.config, ctx.profile, ctx.provider_name)?;
         Ok(provider.get_secrets_batch(provider_secrets).await)
-    } else {
-        let _access = PROVIDER_ENV_ACCESS.write().await;
-        let _env = ProviderEnvOverlay::apply(&values);
-        let provider = prepared_provider.instantiate(ctx.config, ctx.profile, ctx.provider_name)?;
-        Ok(provider.get_secrets_batch(provider_secrets).await)
-    }
+    })
+    .await
 }
 
 /// Process batch results and populate the results map
@@ -2278,8 +2280,8 @@ mod tests {
         assert!(errors.is_empty());
     }
 
-    #[test]
-    fn test_scoped_provider_env_restores_declared_dependencies() {
+    #[tokio::test]
+    async fn test_scoped_provider_env_restores_declared_dependencies() {
         const EXISTING: &str = "FNOX_TEST_SCOPED_PROVIDER_EXISTING";
         const ABSENT: &str = "FNOX_TEST_SCOPED_PROVIDER_ABSENT";
         const UNRELATED: &str = "FNOX_TEST_SCOPED_PROVIDER_UNRELATED";
@@ -2297,17 +2299,60 @@ mod tests {
         assert_eq!(values.len(), 2);
         assert!(values.iter().all(|(key, _)| key != UNRELATED));
 
-        {
-            let _guard = ProviderEnvOverlay::apply(&values);
+        env::with_provider_env(&values, || async {
             assert_eq!(env::var(EXISTING).as_deref(), Ok("replacement"));
             assert_eq!(env::var(ABSENT).as_deref(), Ok("temporary"));
             assert!(env::var_os(UNRELATED).is_none());
-        }
+        })
+        .await;
 
         assert_eq!(env::var(EXISTING).as_deref(), Ok("original"));
         assert!(env::var_os(ABSENT).is_none());
         assert!(env::var_os(UNRELATED).is_none());
         env::remove_var(EXISTING);
+    }
+
+    #[tokio::test]
+    async fn test_batch_auth_prompt_checks_before_acquiring_provider_env_access() {
+        let config = Config::new();
+        let provider_config = ProviderConfig::OnePassword {
+            vault: crate::providers::OptionStringOrSecretRef::literal("default"),
+            account: crate::providers::OptionStringOrSecretRef::none(),
+            token: crate::providers::OptionStringOrSecretRef::none(),
+            auth_command: None,
+            daemon_cache: None,
+        };
+        let secrets = IndexMap::new();
+        let profile = profile("default");
+        let resolved = HashMap::from([(
+            "OP_SERVICE_ACCOUNT_TOKEN".to_string(),
+            Some("token".to_string()),
+        )]);
+        let ctx = ProviderBatchContext {
+            config: &config,
+            profile: &profile,
+            secrets: &secrets,
+            provider_name: "1password",
+            provider_config: &provider_config,
+            resolved_so_far: &resolved,
+            failure_mode: BatchFailureMode::FailFast,
+        };
+        let error = provider_secret_not_found("TEST");
+        assert!(
+            !ProviderEnvOverlay::resolved_values(provider_config.env_dependencies(), &resolved)
+                .is_empty()
+        );
+
+        let _access = PROVIDER_ENV_ACCESS.write().await;
+        let prompted = tokio::time::timeout(
+            std::time::Duration::from_millis(20),
+            prompt_and_run_batch_auth(&ctx, &error),
+        )
+        .await
+        .expect("auth validation should not wait for provider environment access")
+        .unwrap();
+
+        assert!(!prompted);
     }
 
     #[tokio::test]

--- a/crates/fnox-core/src/secret_resolver.rs
+++ b/crates/fnox-core/src/secret_resolver.rs
@@ -1,8 +1,11 @@
 use crate::auth_prompt::prompt_and_run_auth;
 use crate::config::{Config, IfMissing, SecretConfig};
-use crate::env;
+use crate::env::{self, PROVIDER_ENV_ACCESS, ProviderEnvOverlay};
 use crate::error::{FnoxError, Result};
-use crate::providers::{ProviderConfig, get_provider_resolved};
+use crate::providers::{
+    ProviderConfig, prepare_provider_read,
+    resolver::{ResolutionContext, resolve_provider_config_with_context},
+};
 use crate::settings::Settings;
 use crate::source_registry;
 use crate::suggest::{find_similar, format_suggestions};
@@ -568,11 +571,14 @@ async fn resolve_secret_raw(
     }
 
     // Priority 3: Environment variable
-    let value_to_process = if let Ok(env_value) = env::var(key) {
-        tracing::debug!("Found secret '{}' in current environment", key);
-        Some(env_value)
-    } else {
-        None
+    let value_to_process = {
+        let _access = PROVIDER_ENV_ACCESS.read().await;
+        if let Ok(env_value) = env::var(key) {
+            tracing::debug!("Found secret '{}' in current environment", key);
+            Some(env_value)
+        } else {
+            None
+        }
     };
 
     // Apply post-processing to whatever value we found (e.g., JSON path extraction)
@@ -653,7 +659,7 @@ async fn try_resolve_with_auth_retry(
         Ok(value) => Ok(Some(value)),
         Err(error) => {
             // Try auth prompt and retry
-            if prompt_and_run_auth(config, provider_config, provider_name, &error)? {
+            if prompt_and_run_auth_guarded(config, provider_config, provider_name, &error).await? {
                 // Auth command ran successfully, retry
                 try_get_secret(
                     config,
@@ -672,6 +678,16 @@ async fn try_resolve_with_auth_retry(
     }
 }
 
+async fn prompt_and_run_auth_guarded(
+    config: &Config,
+    provider_config: &ProviderConfig,
+    provider_name: &str,
+    error: &FnoxError,
+) -> Result<bool> {
+    let _access = PROVIDER_ENV_ACCESS.read().await;
+    prompt_and_run_auth(config, provider_config, provider_name, error)
+}
+
 /// Helper to get a single secret from a provider without auth retry logic.
 /// Creates the provider instance and calls `get_secret`.
 async fn try_get_secret(
@@ -688,7 +704,19 @@ async fn try_get_secret(
         )));
     }
 
-    let provider = get_provider_resolved(config, profile, provider_name, provider_config).await?;
+    let mut ctx = ResolutionContext::new();
+    let resolved_provider = resolve_provider_config_with_context(
+        config,
+        profile,
+        provider_name,
+        provider_config,
+        &mut ctx,
+    )
+    .await?;
+    let prepared_provider =
+        prepare_provider_read(config, profile, provider_name, resolved_provider, &mut ctx).await?;
+    let _access = PROVIDER_ENV_ACCESS.read().await;
+    let provider = prepared_provider.instantiate(config, profile, provider_name)?;
     provider.get_secret(provider_value).await
 }
 
@@ -735,12 +763,11 @@ fn resolve_default_value(
 
 /// Resolves multiple secrets efficiently using batch operations when possible.
 ///
-/// Secrets are resolved in dependency order using Kahn's algorithm. If a provider
-/// declares env var dependencies (e.g., 1Password needs `OP_SERVICE_ACCOUNT_TOKEN`),
-/// and another secret provides that env var (e.g., an age-encrypted secret named
-/// `OP_SERVICE_ACCOUNT_TOKEN`), the dependency is resolved first. Between resolution
-/// levels, resolved values are set as environment variables so subsequent providers
-/// can read them.
+/// Secrets are resolved in dependency order using Kahn's algorithm. Provider environment
+/// dependencies, provider configuration secret references, nested provider dependencies,
+/// and interpolated defaults are resolved before the secrets that consume them. Between
+/// resolution levels, resolved values are set as environment variables so subsequent
+/// providers can read them.
 ///
 /// Returns an error immediately if any secret with `if_missing = "error"` fails to resolve.
 pub async fn resolve_secrets_batch(
@@ -748,14 +775,15 @@ pub async fn resolve_secrets_batch(
     profile: &[String],
     secrets: &IndexMap<String, SecretConfig>,
 ) -> Result<IndexMap<String, Option<String>>> {
-    resolve_secrets_batch_inner(
+    Ok(resolve_secrets_batch_inner(
         config,
         profile,
         secrets,
         &IndexMap::new(),
         BatchFailureMode::FailFast,
     )
-    .await
+    .await?
+    .values)
 }
 
 /// Adds provider and interpolated-default dependencies required to resolve a set of secrets.
@@ -787,11 +815,11 @@ pub fn include_resolution_dependencies(
                 });
 
             if let Some(provider) = provider_name.and_then(|name| providers.get(name)) {
-                for dependency in provider.env_dependencies() {
-                    if !requested.contains_key(*dependency)
-                        && let Some(secret) = all_secrets.get(*dependency)
+                for dependency in provider.resolution_dependencies(&providers) {
+                    if !requested.contains_key(&dependency)
+                        && let Some(secret) = all_secrets.get(&dependency)
                     {
-                        requested.insert((*dependency).to_string(), secret.clone());
+                        requested.insert(dependency, secret.clone());
                         added = true;
                     }
                 }
@@ -816,13 +844,21 @@ pub fn include_resolution_dependencies(
     Ok(requested)
 }
 
-/// Resolves multiple secrets while retaining successful values when provider-backed
-/// siblings fail. Structural configuration and post-processing errors still fail the batch.
+/// Values and provider diagnostics collected by best-effort batch resolution.
+#[derive(Debug, Default)]
+pub struct BestEffortBatchResolution {
+    pub values: IndexMap<String, Option<String>>,
+    pub errors: IndexMap<String, String>,
+}
+
+/// Resolves multiple secrets while retaining successful values and per-secret diagnostics
+/// when provider-backed siblings fail. Structural configuration and post-processing errors
+/// still fail the batch.
 pub async fn resolve_secrets_batch_best_effort(
     config: &Config,
     profile: &[String],
     secrets: &IndexMap<String, SecretConfig>,
-) -> Result<IndexMap<String, Option<String>>> {
+) -> Result<BestEffortBatchResolution> {
     resolve_secrets_batch_inner(
         config,
         profile,
@@ -841,14 +877,15 @@ pub async fn resolve_secrets_batch_with_pre_resolved(
     secrets: &IndexMap<String, SecretConfig>,
     pre_resolved: &IndexMap<String, Option<String>>,
 ) -> Result<IndexMap<String, Option<String>>> {
-    resolve_secrets_batch_inner(
+    Ok(resolve_secrets_batch_inner(
         config,
         profile,
         secrets,
         pre_resolved,
         BatchFailureMode::FailFast,
     )
-    .await
+    .await?
+    .values)
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -863,7 +900,7 @@ async fn resolve_secrets_batch_inner(
     secrets: &IndexMap<String, SecretConfig>,
     pre_resolved: &IndexMap<String, Option<String>>,
     failure_mode: BatchFailureMode,
-) -> Result<IndexMap<String, Option<String>>> {
+) -> Result<BestEffortBatchResolution> {
     // Classify each secret: provider-backed vs no-provider
     let mut secret_provider: HashMap<String, (String, String)> = HashMap::new(); // key -> (provider_name, provider_value)
     let mut no_provider = Vec::new();
@@ -942,12 +979,9 @@ async fn resolve_secrets_batch_inner(
     for (key, (provider_name, _)) in &secret_provider {
         let deps = providers
             .get(provider_name)
-            .map(|pc| pc.env_dependencies())
-            .unwrap_or(&[]);
-        deps_for_secret.insert(
-            key.clone(),
-            deps.iter().map(|dep| dep.to_string()).collect(),
-        );
+            .map(|provider| provider.resolution_dependencies(&providers))
+            .unwrap_or_default();
+        deps_for_secret.insert(key.clone(), deps);
     }
     for (key, refs) in &default_deps {
         match deps_for_secret.entry(key.clone()) {
@@ -970,9 +1004,13 @@ async fn resolve_secrets_batch_inner(
     // Resolve each level in order
     let mut temp_results: HashMap<String, Option<String>> =
         pre_resolved.clone().into_iter().collect();
-    for (key, value) in pre_resolved {
-        if let Some(value) = value {
-            env::set_var(key, value);
+    let mut temp_errors = HashMap::new();
+    if failure_mode == BatchFailureMode::FailFast {
+        let _access = PROVIDER_ENV_ACCESS.write().await;
+        for (key, value) in pre_resolved {
+            if let Some(value) = value {
+                env::set_var(key, value);
+            }
         }
     }
 
@@ -988,14 +1026,19 @@ async fn resolve_secrets_batch_inner(
         )
         .await?;
 
-        // Set resolved env vars so next level's providers can see them
-        for (key, value) in &level_results {
-            if let Some(val) = value {
-                env::set_var(key, val);
+        // Normal resolution exports every value for subsequent levels and callers.
+        // Check resolution scopes only declared dependencies around each provider.
+        if failure_mode == BatchFailureMode::FailFast {
+            let _access = PROVIDER_ENV_ACCESS.write().await;
+            for (key, value) in &level_results.values {
+                if let Some(val) = value {
+                    env::set_var(key, val);
+                }
             }
         }
 
-        temp_results.extend(level_results);
+        temp_results.extend(level_results.values);
+        temp_errors.extend(level_results.errors);
     }
 
     // Handle any remaining secrets (cycles) - resolve best-effort
@@ -1030,18 +1073,26 @@ async fn resolve_secrets_batch_inner(
             failure_mode,
         )
         .await?;
-        temp_results.extend(level_results);
+        temp_results.extend(level_results.values);
+        temp_errors.extend(level_results.errors);
     }
 
     // Build final results in the original order from the input secrets IndexMap
     let mut results = IndexMap::new();
+    let mut errors = IndexMap::new();
     for (key, _secret_config) in secrets {
         if let Some(value) = temp_results.remove(key) {
             results.insert(key.clone(), value);
         }
+        if let Some(error) = temp_errors.remove(key) {
+            errors.insert(key.clone(), error);
+        }
     }
 
-    Ok(results)
+    Ok(BestEffortBatchResolution {
+        values: results,
+        errors,
+    })
 }
 
 /// Build a dependency graph and compute resolution levels using Kahn's algorithm.
@@ -1119,6 +1170,12 @@ fn compute_resolution_levels(
 }
 
 /// Resolve a single level of secrets (all can be resolved in parallel).
+#[derive(Default)]
+struct LevelResolution {
+    values: HashMap<String, Option<String>>,
+    errors: HashMap<String, String>,
+}
+
 async fn resolve_level(
     config: &Config,
     profile: &[String],
@@ -1127,7 +1184,7 @@ async fn resolve_level(
     ready: &[String],
     resolved_so_far: &HashMap<String, Option<String>>,
     failure_mode: BatchFailureMode,
-) -> Result<HashMap<String, Option<String>>> {
+) -> Result<LevelResolution> {
     use futures::stream::{self, StreamExt};
 
     // Split ready keys into provider-backed and no-provider
@@ -1145,9 +1202,8 @@ async fn resolve_level(
         }
     }
 
-    let mut temp_results = HashMap::new();
+    let mut level_resolution = LevelResolution::default();
 
-    // Resolve provider-backed secrets in parallel by provider
     let provider_results: Vec<_> = stream::iter(by_provider)
         .map(|(provider_name, provider_secrets)| async move {
             resolve_provider_batch(
@@ -1166,7 +1222,9 @@ async fn resolve_level(
         .await;
 
     for provider_result in provider_results {
-        temp_results.extend(provider_result?);
+        let provider_resolution = provider_result?;
+        level_resolution.values.extend(provider_resolution.values);
+        level_resolution.errors.extend(provider_resolution.errors);
     }
 
     // Resolve no-provider secrets in parallel
@@ -1184,10 +1242,10 @@ async fn resolve_level(
 
     for result in no_provider_results {
         let (key, value) = result?;
-        temp_results.insert(key, value);
+        level_resolution.values.insert(key, value);
     }
 
-    Ok(temp_results)
+    Ok(level_resolution)
 }
 
 async fn resolve_no_provider_secret(
@@ -1213,8 +1271,8 @@ async fn resolve_provider_batch(
     provider_secrets: Vec<(String, String)>,
     resolved_so_far: &HashMap<String, Option<String>>,
     failure_mode: BatchFailureMode,
-) -> Result<HashMap<String, Option<String>>> {
-    let mut results = HashMap::new();
+) -> Result<LevelResolution> {
+    let mut resolution = LevelResolution::default();
 
     tracing::debug!(
         "Resolving {} secrets from provider '{}' using batch",
@@ -1237,8 +1295,12 @@ async fn resolve_provider_batch(
                 .iter()
                 .map(|(key, _)| key.clone())
                 .collect();
-            let fallback_resolved =
-                resolve_default_fallbacks(&fallback_keys, secrets, resolved_so_far, &mut results)?;
+            let fallback_resolved = resolve_default_fallbacks(
+                &fallback_keys,
+                secrets,
+                resolved_so_far,
+                &mut resolution.values,
+            )?;
             for (key, _) in &provider_secrets {
                 if fallback_resolved.contains(key) {
                     let secret_config = &secrets[key];
@@ -1263,13 +1325,18 @@ async fn resolve_provider_batch(
                     config_path: config.provider_sources.get(provider_name).cloned(),
                     suggestion: suggestion.clone(),
                 };
+                if failure_mode == BatchFailureMode::BestEffort {
+                    resolution.errors.insert(key.clone(), error.to_string());
+                    resolution.values.insert(key.clone(), None);
+                    continue;
+                }
                 if let Some(error) = handle_provider_error(key, error, if_missing, true) {
                     // Fail fast if if_missing is error
                     return Err(error);
                 }
-                results.insert(key.clone(), None);
+                resolution.values.insert(key.clone(), None);
             }
-            return Ok(results);
+            return Ok(resolution);
         }
     };
 
@@ -1281,8 +1348,12 @@ async fn resolve_provider_batch(
             .iter()
             .map(|(key, _)| key.clone())
             .collect();
-        let fallback_resolved =
-            resolve_default_fallbacks(&fallback_keys, secrets, resolved_so_far, &mut results)?;
+        let fallback_resolved = resolve_default_fallbacks(
+            &fallback_keys,
+            secrets,
+            resolved_so_far,
+            &mut resolution.values,
+        )?;
         for (key, _) in &provider_secrets {
             if fallback_resolved.contains(key) {
                 let secret_config = &secrets[key];
@@ -1303,12 +1374,17 @@ async fn resolve_provider_batch(
                 "Provider '{}' requires interactive authentication and cannot be used in non-interactive mode. Use 'fnox exec' instead.",
                 provider_name
             ));
+            if failure_mode == BatchFailureMode::BestEffort {
+                resolution.errors.insert(key.clone(), error.to_string());
+                resolution.values.insert(key.clone(), None);
+                continue;
+            }
             if let Some(error) = handle_provider_error(key, error, if_missing, true) {
                 return Err(error);
             }
-            results.insert(key.clone(), None);
+            resolution.values.insert(key.clone(), None);
         }
-        return Ok(results);
+        return Ok(resolution);
     }
 
     let ctx = ProviderBatchContext {
@@ -1322,7 +1398,7 @@ async fn resolve_provider_batch(
     };
 
     // Try to get secrets with auth retry on failure
-    try_batch_with_auth_retry(&ctx, &provider_secrets, &mut results).await
+    try_batch_with_auth_retry(&ctx, &provider_secrets, &mut resolution).await
 }
 
 struct ProviderBatchContext<'a> {
@@ -1341,19 +1417,14 @@ struct ProviderBatchContext<'a> {
 async fn try_batch_with_auth_retry(
     ctx: &ProviderBatchContext<'_>,
     provider_secrets: &[(String, String)],
-    results: &mut HashMap<String, Option<String>>,
-) -> Result<HashMap<String, Option<String>>> {
+    resolution: &mut LevelResolution,
+) -> Result<LevelResolution> {
     // Initial batch secret retrieval attempt before any authentication retry logic
     match try_get_secrets_batch(ctx, provider_secrets).await {
         Ok(batch_results) => {
             let auth_error = extract_auth_error_from_batch(&batch_results);
             if let Some(ref auth_err) = auth_error
-                && prompt_and_run_auth(
-                    ctx.config,
-                    ctx.provider_config,
-                    ctx.provider_name,
-                    auth_err,
-                )?
+                && prompt_and_run_batch_auth(ctx, auth_err).await?
             {
                 // Auth prompt successful, retry the batch operation.
                 return match try_get_secrets_batch(ctx, provider_secrets).await {
@@ -1363,10 +1434,11 @@ async fn try_batch_with_auth_retry(
                             ctx.config,
                             retry_results,
                             ctx.resolved_so_far,
-                            results,
+                            &mut resolution.values,
+                            &mut resolution.errors,
                             ctx.failure_mode,
                         )?;
-                        Ok(std::mem::take(results))
+                        Ok(std::mem::take(resolution))
                     }
                     Err(retry_error) => handle_batch_error(
                         ctx.secrets,
@@ -1374,7 +1446,7 @@ async fn try_batch_with_auth_retry(
                         provider_secrets,
                         &retry_error,
                         ctx.resolved_so_far,
-                        results,
+                        resolution,
                         ctx.failure_mode,
                     ),
                 };
@@ -1385,14 +1457,15 @@ async fn try_batch_with_auth_retry(
                 ctx.config,
                 batch_results,
                 ctx.resolved_so_far,
-                results,
+                &mut resolution.values,
+                &mut resolution.errors,
                 ctx.failure_mode,
             )?;
-            Ok(std::mem::take(results))
+            Ok(std::mem::take(resolution))
         }
         Err(error) => {
             // Try auth prompt and retry
-            if prompt_and_run_auth(ctx.config, ctx.provider_config, ctx.provider_name, &error)? {
+            if prompt_and_run_batch_auth(ctx, &error).await? {
                 // Auth command ran successfully, retry
                 match try_get_secrets_batch(ctx, provider_secrets).await {
                     Ok(batch_results) => {
@@ -1401,10 +1474,11 @@ async fn try_batch_with_auth_retry(
                             ctx.config,
                             batch_results,
                             ctx.resolved_so_far,
-                            results,
+                            &mut resolution.values,
+                            &mut resolution.errors,
                             ctx.failure_mode,
                         )?;
-                        Ok(std::mem::take(results))
+                        Ok(std::mem::take(resolution))
                     }
                     Err(retry_error) => handle_batch_error(
                         ctx.secrets,
@@ -1412,7 +1486,7 @@ async fn try_batch_with_auth_retry(
                         provider_secrets,
                         &retry_error,
                         ctx.resolved_so_far,
-                        results,
+                        resolution,
                         ctx.failure_mode,
                     ),
                 }
@@ -1424,7 +1498,7 @@ async fn try_batch_with_auth_retry(
                     provider_secrets,
                     &error,
                     ctx.resolved_so_far,
-                    results,
+                    resolution,
                     ctx.failure_mode,
                 )
             }
@@ -1439,15 +1513,19 @@ fn handle_batch_error(
     provider_secrets: &[(String, String)],
     error: &FnoxError,
     resolved_so_far: &HashMap<String, Option<String>>,
-    results: &mut HashMap<String, Option<String>>,
+    resolution: &mut LevelResolution,
     failure_mode: BatchFailureMode,
-) -> Result<HashMap<String, Option<String>>> {
+) -> Result<LevelResolution> {
     let fallback_keys: Vec<String> = provider_secrets
         .iter()
         .map(|(key, _)| key.clone())
         .collect();
-    let fallback_resolved =
-        resolve_default_fallbacks(&fallback_keys, secrets, resolved_so_far, results)?;
+    let fallback_resolved = resolve_default_fallbacks(
+        &fallback_keys,
+        secrets,
+        resolved_so_far,
+        &mut resolution.values,
+    )?;
     for (key, _) in provider_secrets {
         if fallback_resolved.contains(key) {
             let secret_config = &secrets[key];
@@ -1462,13 +1540,20 @@ fn handle_batch_error(
         let secret_config = &secrets[key];
         let if_missing = batch_if_missing_behavior(secret_config, config, failure_mode);
         let provider_error = FnoxError::Provider(error.to_string());
+        if failure_mode == BatchFailureMode::BestEffort {
+            resolution
+                .errors
+                .insert(key.clone(), provider_error.to_string());
+            resolution.values.insert(key.clone(), None);
+            continue;
+        }
         if let Some(err) = handle_provider_error(key, provider_error, if_missing, true) {
             // Fail fast if if_missing is error
             return Err(err);
         }
-        results.insert(key.clone(), None);
+        resolution.values.insert(key.clone(), None);
     }
-    Ok(std::mem::take(results))
+    Ok(std::mem::take(resolution))
 }
 
 /// Extract the first auth error from batch results, if any.
@@ -1492,20 +1577,64 @@ fn extract_auth_error_from_batch(
     })
 }
 
+async fn prompt_and_run_batch_auth(
+    ctx: &ProviderBatchContext<'_>,
+    error: &FnoxError,
+) -> Result<bool> {
+    let values = ProviderEnvOverlay::resolved_values(
+        ctx.provider_config.env_dependencies(),
+        ctx.resolved_so_far,
+    );
+    if values.is_empty() {
+        let _access = PROVIDER_ENV_ACCESS.read().await;
+        prompt_and_run_auth(ctx.config, ctx.provider_config, ctx.provider_name, error)
+    } else {
+        let _access = PROVIDER_ENV_ACCESS.write().await;
+        let _env = ProviderEnvOverlay::apply(&values);
+        prompt_and_run_auth(ctx.config, ctx.provider_config, ctx.provider_name, error)
+    }
+}
+
 /// Helper to get multiple secrets in batch from a provider without auth retry logic.
 /// Creates the provider instance and calls `get_secrets_batch` on it.
 async fn try_get_secrets_batch(
     ctx: &ProviderBatchContext<'_>,
     provider_secrets: &[(String, String)],
 ) -> Result<HashMap<String, Result<String>>> {
-    let provider = get_provider_resolved(
+    // Nested providers use the same pre-resolved dependency context while each
+    // provider command receives only its own declared environment values.
+    let mut resolution_ctx = ResolutionContext::with_pre_resolved(ctx.resolved_so_far);
+    let resolved_provider = resolve_provider_config_with_context(
         ctx.config,
         ctx.profile,
         ctx.provider_name,
         ctx.provider_config,
+        &mut resolution_ctx,
     )
     .await?;
-    Ok(provider.get_secrets_batch(provider_secrets).await)
+    let prepared_provider = prepare_provider_read(
+        ctx.config,
+        ctx.profile,
+        ctx.provider_name,
+        resolved_provider,
+        &mut resolution_ctx,
+    )
+    .await?;
+    let values = ProviderEnvOverlay::resolved_values(
+        ctx.provider_config.env_dependencies(),
+        ctx.resolved_so_far,
+    );
+
+    if values.is_empty() {
+        let _access = PROVIDER_ENV_ACCESS.read().await;
+        let provider = prepared_provider.instantiate(ctx.config, ctx.profile, ctx.provider_name)?;
+        Ok(provider.get_secrets_batch(provider_secrets).await)
+    } else {
+        let _access = PROVIDER_ENV_ACCESS.write().await;
+        let _env = ProviderEnvOverlay::apply(&values);
+        let provider = prepared_provider.instantiate(ctx.config, ctx.profile, ctx.provider_name)?;
+        Ok(provider.get_secrets_batch(provider_secrets).await)
+    }
 }
 
 /// Process batch results and populate the results map
@@ -1515,6 +1644,7 @@ fn process_batch_results(
     batch_results: HashMap<String, Result<String>>,
     resolved_so_far: &HashMap<String, Option<String>>,
     results: &mut HashMap<String, Option<String>>,
+    errors: &mut HashMap<String, String>,
     failure_mode: BatchFailureMode,
 ) -> Result<()> {
     let mut failed = Vec::new();
@@ -1558,6 +1688,11 @@ fn process_batch_results(
 
         let secret_config = &secrets[&key];
         let if_missing = batch_if_missing_behavior(secret_config, config, failure_mode);
+        if failure_mode == BatchFailureMode::BestEffort {
+            errors.insert(key.clone(), e.to_string());
+            results.insert(key, None);
+            continue;
+        }
         if let Some(error) = handle_provider_error(&key, e, if_missing, true) {
             // Fail fast if if_missing is error
             return Err(error);
@@ -1985,12 +2120,14 @@ mod tests {
 
         let resolved_so_far = HashMap::new();
         let mut results = HashMap::new();
+        let mut errors = HashMap::new();
         process_batch_results(
             &secrets,
             &config,
             batch_results,
             &resolved_so_far,
             &mut results,
+            &mut errors,
             BatchFailureMode::FailFast,
         )
         .unwrap();
@@ -2024,12 +2161,14 @@ mod tests {
 
         let resolved_so_far = HashMap::new();
         let mut results = HashMap::new();
+        let mut errors = HashMap::new();
         process_batch_results(
             &secrets,
             &config,
             batch_results,
             &resolved_so_far,
             &mut results,
+            &mut errors,
             BatchFailureMode::FailFast,
         )
         .unwrap();
@@ -2051,12 +2190,14 @@ mod tests {
 
         let resolved_so_far = HashMap::new();
         let mut results = HashMap::new();
+        let mut errors = HashMap::new();
         let err = process_batch_results(
             &secrets,
             &config,
             batch_results,
             &resolved_so_far,
             &mut results,
+            &mut errors,
             BatchFailureMode::FailFast,
         )
         .unwrap_err();
@@ -2086,6 +2227,7 @@ mod tests {
         .into_iter()
         .collect();
         let mut results = HashMap::new();
+        let mut errors = HashMap::new();
 
         process_batch_results(
             &secrets,
@@ -2093,12 +2235,178 @@ mod tests {
             batch_results,
             &HashMap::new(),
             &mut results,
+            &mut errors,
             BatchFailureMode::BestEffort,
         )
         .unwrap();
 
         assert_eq!(results.get("GOOD"), Some(&Some("value".to_string())));
         assert_eq!(results.get("BAD"), Some(&None));
+        assert!(errors["BAD"].contains("secret 'BAD' not found"));
+    }
+
+    #[test]
+    fn test_best_effort_batch_omits_recovered_errors() {
+        let config = Config::new();
+        let mut secret = default_secret("fallback");
+        secret.if_missing = Some(IfMissing::Error);
+        let secrets = [("RECOVERED".to_string(), secret)].into_iter().collect();
+        let batch_results = [(
+            "RECOVERED".to_string(),
+            Err(provider_secret_not_found("RECOVERED")),
+        )]
+        .into_iter()
+        .collect();
+        let mut results = HashMap::new();
+        let mut errors = HashMap::new();
+
+        process_batch_results(
+            &secrets,
+            &config,
+            batch_results,
+            &HashMap::new(),
+            &mut results,
+            &mut errors,
+            BatchFailureMode::BestEffort,
+        )
+        .unwrap();
+
+        assert_eq!(
+            results.get("RECOVERED"),
+            Some(&Some("fallback".to_string()))
+        );
+        assert!(errors.is_empty());
+    }
+
+    #[test]
+    fn test_scoped_provider_env_restores_declared_dependencies() {
+        const EXISTING: &str = "FNOX_TEST_SCOPED_PROVIDER_EXISTING";
+        const ABSENT: &str = "FNOX_TEST_SCOPED_PROVIDER_ABSENT";
+        const UNRELATED: &str = "FNOX_TEST_SCOPED_PROVIDER_UNRELATED";
+
+        env::set_var(EXISTING, "original");
+        env::remove_var(ABSENT);
+        env::remove_var(UNRELATED);
+        let resolved = HashMap::from([
+            (EXISTING.to_string(), Some("replacement".to_string())),
+            (ABSENT.to_string(), Some("temporary".to_string())),
+            (UNRELATED.to_string(), Some("secret".to_string())),
+        ]);
+
+        let values = ProviderEnvOverlay::resolved_values(&[EXISTING, ABSENT], &resolved);
+        assert_eq!(values.len(), 2);
+        assert!(values.iter().all(|(key, _)| key != UNRELATED));
+
+        {
+            let _guard = ProviderEnvOverlay::apply(&values);
+            assert_eq!(env::var(EXISTING).as_deref(), Ok("replacement"));
+            assert_eq!(env::var(ABSENT).as_deref(), Ok("temporary"));
+            assert!(env::var_os(UNRELATED).is_none());
+        }
+
+        assert_eq!(env::var(EXISTING).as_deref(), Ok("original"));
+        assert!(env::var_os(ABSENT).is_none());
+        assert!(env::var_os(UNRELATED).is_none());
+        env::remove_var(EXISTING);
+    }
+
+    #[tokio::test]
+    async fn test_provider_env_access_serializes_overlays() {
+        const KEY: &str = "FNOX_TEST_SERIALIZED_PROVIDER_ENV";
+
+        env::remove_var(KEY);
+        let first_started = std::sync::Arc::new(tokio::sync::Barrier::new(2));
+        let release_first = std::sync::Arc::new(tokio::sync::Notify::new());
+        let second_started = std::sync::Arc::new(tokio::sync::Notify::new());
+
+        let first = {
+            let first_started = first_started.clone();
+            let release_first = release_first.clone();
+            tokio::spawn(async move {
+                let _access = PROVIDER_ENV_ACCESS.write().await;
+                let _env = ProviderEnvOverlay::apply(&[(KEY.to_string(), "first".to_string())]);
+                first_started.wait().await;
+                release_first.notified().await;
+                assert_eq!(env::var(KEY).as_deref(), Ok("first"));
+            })
+        };
+
+        first_started.wait().await;
+        let second = {
+            let second_started = second_started.clone();
+            tokio::spawn(async move {
+                let _access = PROVIDER_ENV_ACCESS.write().await;
+                let _env = ProviderEnvOverlay::apply(&[(KEY.to_string(), "second".to_string())]);
+                second_started.notify_one();
+                assert_eq!(env::var(KEY).as_deref(), Ok("second"));
+            })
+        };
+
+        assert!(
+            tokio::time::timeout(
+                std::time::Duration::from_millis(20),
+                second_started.notified()
+            )
+            .await
+            .is_err()
+        );
+        release_first.notify_one();
+        first.await.unwrap();
+        second_started.notified().await;
+        second.await.unwrap();
+        assert!(env::var_os(KEY).is_none());
+    }
+
+    #[tokio::test]
+    async fn test_environment_fallback_waits_for_provider_overlay_restoration() {
+        const KEY: &str = "FNOX_TEST_PROVIDER_ENV_FALLBACK";
+
+        env::remove_var(KEY);
+        let overlay_started = std::sync::Arc::new(tokio::sync::Barrier::new(2));
+        let release_overlay = std::sync::Arc::new(tokio::sync::Notify::new());
+        let read_started = std::sync::Arc::new(tokio::sync::Barrier::new(2));
+        let read_finished = std::sync::Arc::new(tokio::sync::Notify::new());
+
+        let overlay = {
+            let overlay_started = overlay_started.clone();
+            let release_overlay = release_overlay.clone();
+            tokio::spawn(async move {
+                let _access = PROVIDER_ENV_ACCESS.write().await;
+                let _env = ProviderEnvOverlay::apply(&[(KEY.to_string(), "temporary".to_string())]);
+                overlay_started.wait().await;
+                release_overlay.notified().await;
+            })
+        };
+
+        overlay_started.wait().await;
+        let reader = {
+            let read_started = read_started.clone();
+            let read_finished = read_finished.clone();
+            tokio::spawn(async move {
+                let config = Config::new();
+                let mut secret = SecretConfig::new();
+                secret.if_missing = Some(IfMissing::Ignore);
+                read_started.wait().await;
+                let result =
+                    resolve_secret_raw(&config, &["default".to_string()], KEY, &secret).await;
+                read_finished.notify_one();
+                result
+            })
+        };
+
+        read_started.wait().await;
+        assert!(
+            tokio::time::timeout(
+                std::time::Duration::from_millis(20),
+                read_finished.notified()
+            )
+            .await
+            .is_err()
+        );
+        release_overlay.notify_one();
+        overlay.await.unwrap();
+        assert_eq!(reader.await.unwrap().unwrap(), None);
+        assert!(env::var_os(KEY).is_none());
     }
 
     #[tokio::test]

--- a/crates/fnox-core/src/secret_resolver.rs
+++ b/crates/fnox-core/src/secret_resolver.rs
@@ -536,6 +536,20 @@ async fn resolve_secret_raw(
     key: &str,
     secret_config: &SecretConfig,
 ) -> Result<Option<String>> {
+    let value = resolve_secret_raw_value(config, profile, key, secret_config).await?;
+    if value.is_some() {
+        return Ok(value);
+    }
+
+    handle_missing_secret(key, secret_config, config)
+}
+
+async fn resolve_secret_raw_value(
+    config: &Config,
+    profile: &[String],
+    key: &str,
+    secret_config: &SecretConfig,
+) -> Result<Option<String>> {
     // Priority 1: Provider (if specified and has a value)
     let provider_value = match try_resolve_from_provider(config, profile, secret_config).await {
         Ok(value) => value,
@@ -587,8 +601,7 @@ async fn resolve_secret_raw(
         return Ok(Some(processed));
     }
 
-    // No value found - handle based on if_missing with priority chain
-    handle_missing_secret(key, secret_config, config)
+    Ok(None)
 }
 
 async fn try_resolve_from_provider(
@@ -733,10 +746,7 @@ fn handle_missing_secret(
     let if_missing = resolve_if_missing_behavior(secret_config, config);
 
     match if_missing {
-        IfMissing::Error => Err(FnoxError::Config(format!(
-            "Secret '{}' not found and no default provided",
-            key
-        ))),
+        IfMissing::Error => Err(missing_secret_error(key)),
         IfMissing::Warn => {
             eprintln!(
                 "Warning: Secret '{}' not found and no default provided",
@@ -746,6 +756,13 @@ fn handle_missing_secret(
         }
         IfMissing::Ignore => Ok(None),
     }
+}
+
+fn missing_secret_error(key: &str) -> FnoxError {
+    FnoxError::Config(format!(
+        "Secret '{}' not found and no default provided",
+        key
+    ))
 }
 
 fn resolve_default_value(
@@ -849,7 +866,7 @@ pub fn include_resolution_dependencies(
     Ok(requested)
 }
 
-/// Values and provider diagnostics collected by best-effort batch resolution.
+/// Values and diagnostics collected by best-effort batch resolution.
 #[derive(Debug, Default)]
 pub struct BestEffortBatchResolution {
     pub values: IndexMap<String, Option<String>>,
@@ -857,7 +874,7 @@ pub struct BestEffortBatchResolution {
 }
 
 /// Resolves multiple secrets while retaining successful values and per-secret diagnostics
-/// when provider-backed siblings fail. Structural configuration and post-processing errors
+/// when recoverable secret lookups fail. Structural configuration and post-processing errors
 /// still fail the batch.
 pub async fn resolve_secrets_batch_best_effort(
     config: &Config,
@@ -1236,17 +1253,26 @@ async fn resolve_level(
     let no_provider_results: Vec<Result<_>> = stream::iter(level_no_provider)
         .map(|key| async move {
             let secret_config = &secrets[&key];
-            let value =
-                resolve_no_provider_secret(config, profile, &key, secret_config, resolved_so_far)
-                    .await?;
-            Ok((key, value))
+            let (value, error) = resolve_no_provider_secret(
+                config,
+                profile,
+                &key,
+                secret_config,
+                resolved_so_far,
+                failure_mode,
+            )
+            .await?;
+            Ok((key, value, error))
         })
         .buffer_unordered(10)
         .collect()
         .await;
 
     for result in no_provider_results {
-        let (key, value) = result?;
+        let (key, value, error) = result?;
+        if let Some(error) = error {
+            level_resolution.errors.insert(key.clone(), error);
+        }
         level_resolution.values.insert(key, value);
     }
 
@@ -1259,12 +1285,24 @@ async fn resolve_no_provider_secret(
     key: &str,
     secret_config: &SecretConfig,
     resolved_so_far: &HashMap<String, Option<String>>,
-) -> Result<Option<String>> {
+    failure_mode: BatchFailureMode,
+) -> Result<(Option<String>, Option<String>)> {
     if let Some(value) = resolve_default_value(key, secret_config, resolved_so_far)? {
-        return Ok(Some(value));
+        return Ok((Some(value), None));
     }
 
-    resolve_secret_raw(config, profile, key, secret_config).await
+    let value = resolve_secret_raw_value(config, profile, key, secret_config).await?;
+    if value.is_some() {
+        return Ok((value, None));
+    }
+
+    if failure_mode == BatchFailureMode::BestEffort
+        && resolve_if_missing_behavior(secret_config, config) == IfMissing::Error
+    {
+        return Ok((None, Some(missing_secret_error(key).to_string())));
+    }
+
+    Ok((handle_missing_secret(key, secret_config, config)?, None))
 }
 
 /// Resolve all secrets for a single provider using batch operations
@@ -2278,6 +2316,46 @@ mod tests {
             Some(&Some("fallback".to_string()))
         );
         assert!(errors.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_best_effort_batch_retains_missing_no_provider_diagnostic() {
+        const MISSING: &str = "FNOX_TEST_BEST_EFFORT_MISSING";
+
+        env::remove_var(MISSING);
+        let config = Config::new();
+        let mut missing = SecretConfig::new();
+        missing.if_missing = Some(IfMissing::Error);
+        let secrets = IndexMap::from([
+            (MISSING.to_string(), missing),
+            (
+                "DEPENDENT".to_string(),
+                default_secret("after-${FNOX_TEST_BEST_EFFORT_MISSING}"),
+            ),
+        ]);
+
+        let resolution = resolve_secrets_batch_best_effort(&config, &profile("default"), &secrets)
+            .await
+            .unwrap();
+
+        assert_eq!(resolution.values.get(MISSING), Some(&None));
+        assert!(resolution.errors[MISSING].contains("not found and no default provided"));
+        assert_eq!(
+            resolution
+                .values
+                .get("DEPENDENT")
+                .and_then(|value| value.as_deref()),
+            Some("after-")
+        );
+
+        let error = resolve_secrets_batch(&config, &profile("default"), &secrets)
+            .await
+            .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("not found and no default provided")
+        );
     }
 
     #[tokio::test]

--- a/crates/fnox-core/src/secret_resolver.rs
+++ b/crates/fnox-core/src/secret_resolver.rs
@@ -748,7 +748,89 @@ pub async fn resolve_secrets_batch(
     profile: &[String],
     secrets: &IndexMap<String, SecretConfig>,
 ) -> Result<IndexMap<String, Option<String>>> {
-    resolve_secrets_batch_with_pre_resolved(config, profile, secrets, &IndexMap::new()).await
+    resolve_secrets_batch_inner(
+        config,
+        profile,
+        secrets,
+        &IndexMap::new(),
+        BatchFailureMode::FailFast,
+    )
+    .await
+}
+
+/// Adds provider and interpolated-default dependencies required to resolve a set of secrets.
+pub fn include_resolution_dependencies(
+    config: &Config,
+    profile: &[String],
+    all_secrets: &IndexMap<String, SecretConfig>,
+    roots: &IndexMap<String, SecretConfig>,
+) -> Result<IndexMap<String, SecretConfig>> {
+    let providers = config.get_providers(profile)?;
+    let default_provider = config.get_default_provider(profile)?;
+    let mut requested = roots.clone();
+
+    loop {
+        let mut added = false;
+        let keys: Vec<_> = requested.keys().cloned().collect();
+        for key in keys {
+            let secret = requested[&key].clone();
+            let provider_name = secret
+                .sync
+                .as_ref()
+                .map(|sync| sync.provider.as_str())
+                .or_else(|| {
+                    secret
+                        .value()
+                        .is_some()
+                        .then(|| secret.provider().or(default_provider.as_deref()))
+                        .flatten()
+                });
+
+            if let Some(provider) = provider_name.and_then(|name| providers.get(name)) {
+                for dependency in provider.env_dependencies() {
+                    if !requested.contains_key(*dependency)
+                        && let Some(secret) = all_secrets.get(*dependency)
+                    {
+                        requested.insert((*dependency).to_string(), secret.clone());
+                        added = true;
+                    }
+                }
+            }
+
+            if let Some(default) = &secret.default {
+                for dependency in extract_default_references(default) {
+                    if !requested.contains_key(&dependency)
+                        && let Some(secret) = all_secrets.get(&dependency)
+                    {
+                        requested.insert(dependency, secret.clone());
+                        added = true;
+                    }
+                }
+            }
+        }
+        if !added {
+            break;
+        }
+    }
+
+    Ok(requested)
+}
+
+/// Resolves multiple secrets while retaining successful values when provider-backed
+/// siblings fail. Structural configuration and post-processing errors still fail the batch.
+pub async fn resolve_secrets_batch_best_effort(
+    config: &Config,
+    profile: &[String],
+    secrets: &IndexMap<String, SecretConfig>,
+) -> Result<IndexMap<String, Option<String>>> {
+    resolve_secrets_batch_inner(
+        config,
+        profile,
+        secrets,
+        &IndexMap::new(),
+        BatchFailureMode::BestEffort,
+    )
+    .await
 }
 
 /// Resolves multiple secrets while treating previously resolved values as
@@ -758,6 +840,29 @@ pub async fn resolve_secrets_batch_with_pre_resolved(
     profile: &[String],
     secrets: &IndexMap<String, SecretConfig>,
     pre_resolved: &IndexMap<String, Option<String>>,
+) -> Result<IndexMap<String, Option<String>>> {
+    resolve_secrets_batch_inner(
+        config,
+        profile,
+        secrets,
+        pre_resolved,
+        BatchFailureMode::FailFast,
+    )
+    .await
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum BatchFailureMode {
+    FailFast,
+    BestEffort,
+}
+
+async fn resolve_secrets_batch_inner(
+    config: &Config,
+    profile: &[String],
+    secrets: &IndexMap<String, SecretConfig>,
+    pre_resolved: &IndexMap<String, Option<String>>,
+    failure_mode: BatchFailureMode,
 ) -> Result<IndexMap<String, Option<String>>> {
     // Classify each secret: provider-backed vs no-provider
     let mut secret_provider: HashMap<String, (String, String)> = HashMap::new(); // key -> (provider_name, provider_value)
@@ -877,9 +982,9 @@ pub async fn resolve_secrets_batch_with_pre_resolved(
             profile,
             secrets,
             &secret_provider,
-            &no_provider,
             ready,
             &temp_results,
+            failure_mode,
         )
         .await?;
 
@@ -920,9 +1025,9 @@ pub async fn resolve_secrets_batch_with_pre_resolved(
             profile,
             secrets,
             &secret_provider,
-            &no_provider,
             &cycle,
             &temp_results,
+            failure_mode,
         )
         .await?;
         temp_results.extend(level_results);
@@ -1019,9 +1124,9 @@ async fn resolve_level(
     profile: &[String],
     secrets: &IndexMap<String, SecretConfig>,
     secret_provider: &HashMap<String, (String, String)>,
-    no_provider: &[String],
     ready: &[String],
     resolved_so_far: &HashMap<String, Option<String>>,
+    failure_mode: BatchFailureMode,
 ) -> Result<HashMap<String, Option<String>>> {
     use futures::stream::{self, StreamExt};
 
@@ -1035,7 +1140,7 @@ async fn resolve_level(
                 .entry(provider_name.clone())
                 .or_default()
                 .push((key.clone(), provider_value.clone()));
-        } else if no_provider.contains(key) {
+        } else {
             level_no_provider.push(key.clone());
         }
     }
@@ -1052,6 +1157,7 @@ async fn resolve_level(
                 &provider_name,
                 provider_secrets,
                 resolved_so_far,
+                failure_mode,
             )
             .await
         })
@@ -1106,6 +1212,7 @@ async fn resolve_provider_batch(
     provider_name: &str,
     provider_secrets: Vec<(String, String)>,
     resolved_so_far: &HashMap<String, Option<String>>,
+    failure_mode: BatchFailureMode,
 ) -> Result<HashMap<String, Option<String>>> {
     let mut results = HashMap::new();
 
@@ -1149,7 +1256,7 @@ async fn resolve_provider_batch(
                 }
 
                 let secret_config = &secrets[key];
-                let if_missing = resolve_if_missing_behavior(secret_config, config);
+                let if_missing = batch_if_missing_behavior(secret_config, config, failure_mode);
                 let error = FnoxError::ProviderNotConfigured {
                     provider: provider_name.to_string(),
                     profile: profile.join(","),
@@ -1191,7 +1298,7 @@ async fn resolve_provider_batch(
             }
 
             let secret_config = &secrets[key];
-            let if_missing = resolve_if_missing_behavior(secret_config, config);
+            let if_missing = batch_if_missing_behavior(secret_config, config, failure_mode);
             let error = FnoxError::Provider(format!(
                 "Provider '{}' requires interactive authentication and cannot be used in non-interactive mode. Use 'fnox exec' instead.",
                 provider_name
@@ -1211,6 +1318,7 @@ async fn resolve_provider_batch(
         provider_name,
         provider_config,
         resolved_so_far,
+        failure_mode,
     };
 
     // Try to get secrets with auth retry on failure
@@ -1224,6 +1332,7 @@ struct ProviderBatchContext<'a> {
     provider_name: &'a str,
     provider_config: &'a ProviderConfig,
     resolved_so_far: &'a HashMap<String, Option<String>>,
+    failure_mode: BatchFailureMode,
 }
 
 /// Attempts to resolve secrets in batch with optional auth retry.
@@ -1255,6 +1364,7 @@ async fn try_batch_with_auth_retry(
                             retry_results,
                             ctx.resolved_so_far,
                             results,
+                            ctx.failure_mode,
                         )?;
                         Ok(std::mem::take(results))
                     }
@@ -1265,6 +1375,7 @@ async fn try_batch_with_auth_retry(
                         &retry_error,
                         ctx.resolved_so_far,
                         results,
+                        ctx.failure_mode,
                     ),
                 };
             }
@@ -1275,6 +1386,7 @@ async fn try_batch_with_auth_retry(
                 batch_results,
                 ctx.resolved_so_far,
                 results,
+                ctx.failure_mode,
             )?;
             Ok(std::mem::take(results))
         }
@@ -1290,6 +1402,7 @@ async fn try_batch_with_auth_retry(
                             batch_results,
                             ctx.resolved_so_far,
                             results,
+                            ctx.failure_mode,
                         )?;
                         Ok(std::mem::take(results))
                     }
@@ -1300,6 +1413,7 @@ async fn try_batch_with_auth_retry(
                         &retry_error,
                         ctx.resolved_so_far,
                         results,
+                        ctx.failure_mode,
                     ),
                 }
             } else {
@@ -1311,6 +1425,7 @@ async fn try_batch_with_auth_retry(
                     &error,
                     ctx.resolved_so_far,
                     results,
+                    ctx.failure_mode,
                 )
             }
         }
@@ -1325,6 +1440,7 @@ fn handle_batch_error(
     error: &FnoxError,
     resolved_so_far: &HashMap<String, Option<String>>,
     results: &mut HashMap<String, Option<String>>,
+    failure_mode: BatchFailureMode,
 ) -> Result<HashMap<String, Option<String>>> {
     let fallback_keys: Vec<String> = provider_secrets
         .iter()
@@ -1344,7 +1460,7 @@ fn handle_batch_error(
         }
 
         let secret_config = &secrets[key];
-        let if_missing = resolve_if_missing_behavior(secret_config, config);
+        let if_missing = batch_if_missing_behavior(secret_config, config, failure_mode);
         let provider_error = FnoxError::Provider(error.to_string());
         if let Some(err) = handle_provider_error(key, provider_error, if_missing, true) {
             // Fail fast if if_missing is error
@@ -1399,6 +1515,7 @@ fn process_batch_results(
     batch_results: HashMap<String, Result<String>>,
     resolved_so_far: &HashMap<String, Option<String>>,
     results: &mut HashMap<String, Option<String>>,
+    failure_mode: BatchFailureMode,
 ) -> Result<()> {
     let mut failed = Vec::new();
 
@@ -1440,7 +1557,7 @@ fn process_batch_results(
         }
 
         let secret_config = &secrets[&key];
-        let if_missing = resolve_if_missing_behavior(secret_config, config);
+        let if_missing = batch_if_missing_behavior(secret_config, config, failure_mode);
         if let Some(error) = handle_provider_error(&key, e, if_missing, true) {
             // Fail fast if if_missing is error
             return Err(error);
@@ -1449,6 +1566,17 @@ fn process_batch_results(
     }
 
     Ok(())
+}
+
+fn batch_if_missing_behavior(
+    secret_config: &SecretConfig,
+    config: &Config,
+    failure_mode: BatchFailureMode,
+) -> IfMissing {
+    match failure_mode {
+        BatchFailureMode::FailFast => resolve_if_missing_behavior(secret_config, config),
+        BatchFailureMode::BestEffort => IfMissing::Ignore,
+    }
 }
 
 #[cfg(test)]
@@ -1863,6 +1991,7 @@ mod tests {
             batch_results,
             &resolved_so_far,
             &mut results,
+            BatchFailureMode::FailFast,
         )
         .unwrap();
 
@@ -1901,6 +2030,7 @@ mod tests {
             batch_results,
             &resolved_so_far,
             &mut results,
+            BatchFailureMode::FailFast,
         )
         .unwrap();
 
@@ -1927,6 +2057,7 @@ mod tests {
             batch_results,
             &resolved_so_far,
             &mut results,
+            BatchFailureMode::FailFast,
         )
         .unwrap_err();
         let msg = format!("{err}");
@@ -1935,6 +2066,39 @@ mod tests {
             msg.contains("Interpolation dependency cycle among fallback defaults"),
             "unexpected error: {msg}"
         );
+    }
+
+    #[test]
+    fn test_best_effort_batch_keeps_successful_siblings() {
+        let config = Config::new();
+        let mut required = SecretConfig::new();
+        required.if_missing = Some(IfMissing::Error);
+        let secrets = [
+            ("GOOD".to_string(), required.clone()),
+            ("BAD".to_string(), required),
+        ]
+        .into_iter()
+        .collect();
+        let batch_results = [
+            ("GOOD".to_string(), Ok("value".to_string())),
+            ("BAD".to_string(), Err(provider_secret_not_found("BAD"))),
+        ]
+        .into_iter()
+        .collect();
+        let mut results = HashMap::new();
+
+        process_batch_results(
+            &secrets,
+            &config,
+            batch_results,
+            &HashMap::new(),
+            &mut results,
+            BatchFailureMode::BestEffort,
+        )
+        .unwrap();
+
+        assert_eq!(results.get("GOOD"), Some(&Some("value".to_string())));
+        assert_eq!(results.get("BAD"), Some(&None));
     }
 
     #[tokio::test]

--- a/src/commands/check.rs
+++ b/src/commands/check.rs
@@ -1,6 +1,7 @@
-use crate::config::Config;
+use crate::config::{Config, SecretConfig};
 use crate::error::Result;
 use crate::secret_resolver;
+use indexmap::IndexMap;
 
 use crate::commands::Cli;
 
@@ -23,6 +24,8 @@ impl CheckCommand {
 
         let mut issues = Vec::new();
         let mut warnings = Vec::new();
+        let mut secrets_to_check = IndexMap::new();
+        let mut batches: IndexMap<String, IndexMap<String, SecretConfig>> = IndexMap::new();
 
         // Check secrets
         if let Ok(secrets) = config.get_secrets(&profile) {
@@ -76,62 +79,85 @@ impl CheckCommand {
                                 continue;
                             }
 
-                            // Try to actually resolve the secret from the provider
-                            match crate::daemon::resolve_one(
-                                cli,
-                                &config,
-                                &profile,
-                                &name,
-                                &secret_config,
-                                crate::daemon::Purpose::Check,
-                            )
-                            .await
-                            {
-                                Ok(Some(_)) => {
-                                    // Secret resolved successfully
-                                }
-                                Ok(None) => {
-                                    // No value found, but that might be OK depending on if_missing
-                                    match if_missing {
-                                        crate::config::IfMissing::Error => {
-                                            issues.push(format!(
-                                                "Secret '{}' could not be resolved from provider '{}'",
-                                                name, provider
-                                            ));
-                                        }
-                                        crate::config::IfMissing::Warn => {
-                                            warnings.push(format!(
-                                                "Secret '{}' could not be resolved from provider '{}'",
-                                                name, provider
-                                            ));
-                                        }
-                                        crate::config::IfMissing::Ignore => {
-                                            // Silently ignore
-                                        }
-                                    }
-                                }
-                                Err(err) => {
-                                    // Error resolving secret
-                                    match if_missing {
-                                        crate::config::IfMissing::Error => {
-                                            issues.push(format!(
-                                                "Secret '{}' failed to resolve: {}",
-                                                name, err
-                                            ));
-                                        }
-                                        crate::config::IfMissing::Warn => {
-                                            warnings.push(format!(
-                                                "Secret '{}' failed to resolve: {}",
-                                                name, err
-                                            ));
-                                        }
-                                        crate::config::IfMissing::Ignore => {
-                                            // Silently ignore
-                                        }
-                                    }
-                                }
-                            }
+                            let resolution_provider = secret_config
+                                .sync
+                                .as_ref()
+                                .map(|sync| sync.provider.clone())
+                                .unwrap_or_else(|| provider.to_string());
+                            batches
+                                .entry(resolution_provider)
+                                .or_default()
+                                .insert(name.clone(), secret_config.clone());
+                            secrets_to_check.insert(name, secret_config);
                         }
+                    }
+                }
+
+                let mut batch_values = IndexMap::new();
+                for (_, batch) in batches {
+                    if let Ok(values) = crate::daemon::resolve_batch(
+                        cli,
+                        &config,
+                        &profile,
+                        &batch,
+                        crate::daemon::Purpose::Check,
+                        true,
+                    )
+                    .await
+                    {
+                        batch_values.extend(values);
+                    }
+                }
+
+                for (name, secret_config) in secrets_to_check {
+                    if batch_values.shift_remove(&name).flatten().is_some() {
+                        continue;
+                    }
+
+                    let provider = secret_config
+                        .provider()
+                        .expect("checked secrets have an explicit provider");
+                    let if_missing =
+                        secret_resolver::resolve_if_missing_behavior(&secret_config, &config);
+
+                    // Fall back to single resolution to retain the detailed error for this secret.
+                    match crate::daemon::resolve_one(
+                        cli,
+                        &config,
+                        &profile,
+                        &name,
+                        &secret_config,
+                        crate::daemon::Purpose::Check,
+                    )
+                    .await
+                    {
+                        Ok(Some(_)) => {}
+                        Ok(None) => match if_missing {
+                            crate::config::IfMissing::Error => {
+                                issues.push(format!(
+                                    "Secret '{}' could not be resolved from provider '{}'",
+                                    name, provider
+                                ));
+                            }
+                            crate::config::IfMissing::Warn => {
+                                warnings.push(format!(
+                                    "Secret '{}' could not be resolved from provider '{}'",
+                                    name, provider
+                                ));
+                            }
+                            crate::config::IfMissing::Ignore => {}
+                        },
+                        Err(err) => match if_missing {
+                            crate::config::IfMissing::Error => {
+                                issues
+                                    .push(format!("Secret '{}' failed to resolve: {}", name, err));
+                            }
+                            crate::config::IfMissing::Warn => {
+                                warnings
+                                    .push(format!("Secret '{}' failed to resolve: {}", name, err));
+                            }
+                            crate::config::IfMissing::Ignore => {}
+                        },
                     }
                 }
             }

--- a/src/commands/check.rs
+++ b/src/commands/check.rs
@@ -89,27 +89,22 @@ impl CheckCommand {
                     &secrets,
                     &secrets_to_check,
                 )?;
-                let mut batch_values = crate::daemon::resolve_batch(
+                let mut batch_resolution = crate::daemon::resolve_batch_for_check(
                     cli,
                     &config,
                     &profile,
                     &secrets_to_resolve,
-                    crate::daemon::Purpose::Check,
                     true,
                 )
-                .await
-                .unwrap_or_default();
-
-                // Preserve dependency context when a daemon-backed batch is followed by
-                // foreground per-secret retries for detailed diagnostics.
-                for (name, value) in &batch_values {
-                    if let Some(value) = value {
-                        crate::env::set_var(name, value);
-                    }
-                }
+                .await?;
 
                 for (name, secret_config) in secrets_to_check {
-                    if batch_values.shift_remove(&name).flatten().is_some() {
+                    if batch_resolution
+                        .values
+                        .shift_remove(&name)
+                        .flatten()
+                        .is_some()
+                    {
                         continue;
                     }
 
@@ -118,20 +113,25 @@ impl CheckCommand {
                         .expect("checked secrets have an explicit provider");
                     let if_missing =
                         secret_resolver::resolve_if_missing_behavior(&secret_config, &config);
+                    let error = batch_resolution.errors.shift_remove(&name);
 
-                    // Fall back to single resolution to retain the detailed error for this secret.
-                    match crate::daemon::resolve_one(
-                        cli,
-                        &config,
-                        &profile,
-                        &name,
-                        &secret_config,
-                        crate::daemon::Purpose::Check,
-                    )
-                    .await
-                    {
-                        Ok(Some(_)) => {}
-                        Ok(None) => match if_missing {
+                    match error {
+                        Some(error) => match if_missing {
+                            crate::config::IfMissing::Error => {
+                                issues.push(format!(
+                                    "Secret '{}' failed to resolve: {}",
+                                    name, error
+                                ));
+                            }
+                            crate::config::IfMissing::Warn => {
+                                warnings.push(format!(
+                                    "Secret '{}' failed to resolve: {}",
+                                    name, error
+                                ));
+                            }
+                            crate::config::IfMissing::Ignore => {}
+                        },
+                        None => match if_missing {
                             crate::config::IfMissing::Error => {
                                 issues.push(format!(
                                     "Secret '{}' could not be resolved from provider '{}'",
@@ -143,17 +143,6 @@ impl CheckCommand {
                                     "Secret '{}' could not be resolved from provider '{}'",
                                     name, provider
                                 ));
-                            }
-                            crate::config::IfMissing::Ignore => {}
-                        },
-                        Err(err) => match if_missing {
-                            crate::config::IfMissing::Error => {
-                                issues
-                                    .push(format!("Secret '{}' failed to resolve: {}", name, err));
-                            }
-                            crate::config::IfMissing::Warn => {
-                                warnings
-                                    .push(format!("Secret '{}' failed to resolve: {}", name, err));
                             }
                             crate::config::IfMissing::Ignore => {}
                         },

--- a/src/commands/check.rs
+++ b/src/commands/check.rs
@@ -1,4 +1,4 @@
-use crate::config::{Config, SecretConfig};
+use crate::config::Config;
 use crate::error::Result;
 use crate::secret_resolver;
 use indexmap::IndexMap;
@@ -25,7 +25,6 @@ impl CheckCommand {
         let mut issues = Vec::new();
         let mut warnings = Vec::new();
         let mut secrets_to_check = IndexMap::new();
-        let mut batches: IndexMap<String, IndexMap<String, SecretConfig>> = IndexMap::new();
 
         // Check secrets
         if let Ok(secrets) = config.get_secrets(&profile) {
@@ -34,7 +33,7 @@ impl CheckCommand {
             } else {
                 println!("Found {} secret(s) in profile(s)", secrets.len());
 
-                for (name, secret_config) in secrets {
+                for (name, secret_config) in &secrets {
                     // Check if secret has a value source
                     if !secret_config.has_value() {
                         match secret_config.if_missing {
@@ -64,7 +63,7 @@ impl CheckCommand {
                         } else {
                             // Determine if we should check this secret
                             let if_missing = secret_resolver::resolve_if_missing_behavior(
-                                &secret_config,
+                                secret_config,
                                 &config,
                             );
 
@@ -79,33 +78,33 @@ impl CheckCommand {
                                 continue;
                             }
 
-                            let resolution_provider = secret_config
-                                .sync
-                                .as_ref()
-                                .map(|sync| sync.provider.clone())
-                                .unwrap_or_else(|| provider.to_string());
-                            batches
-                                .entry(resolution_provider)
-                                .or_default()
-                                .insert(name.clone(), secret_config.clone());
-                            secrets_to_check.insert(name, secret_config);
+                            secrets_to_check.insert(name.clone(), secret_config.clone());
                         }
                     }
                 }
 
-                let mut batch_values = IndexMap::new();
-                for (_, batch) in batches {
-                    if let Ok(values) = crate::daemon::resolve_batch(
-                        cli,
-                        &config,
-                        &profile,
-                        &batch,
-                        crate::daemon::Purpose::Check,
-                        true,
-                    )
-                    .await
-                    {
-                        batch_values.extend(values);
+                let secrets_to_resolve = secret_resolver::include_resolution_dependencies(
+                    &config,
+                    &profile,
+                    &secrets,
+                    &secrets_to_check,
+                )?;
+                let mut batch_values = crate::daemon::resolve_batch(
+                    cli,
+                    &config,
+                    &profile,
+                    &secrets_to_resolve,
+                    crate::daemon::Purpose::Check,
+                    true,
+                )
+                .await
+                .unwrap_or_default();
+
+                // Preserve dependency context when a daemon-backed batch is followed by
+                // foreground per-secret retries for detailed diagnostics.
+                for (name, value) in &batch_values {
+                    if let Some(value) = value {
+                        crate::env::set_var(name, value);
                     }
                 }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1,7 +1,10 @@
 use crate::commands::Cli;
 use crate::config::{Config, ProviderConfig, SecretConfig};
 use crate::error::{FnoxError, Result};
-use crate::secret_resolver::{resolve_secrets_batch, resolve_secrets_batch_with_pre_resolved};
+use crate::secret_resolver::{
+    resolve_secrets_batch, resolve_secrets_batch_best_effort,
+    resolve_secrets_batch_with_pre_resolved,
+};
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
@@ -241,7 +244,11 @@ pub async fn resolve_batch_with_context(
                 .map(|(key, secret)| (key.clone(), secret.clone()))
                 .collect()
         };
-        return resolve_secrets_batch(config, profile, &secrets).await;
+        return if purpose == Purpose::Check {
+            resolve_secrets_batch_best_effort(config, profile, &secrets).await
+        } else {
+            resolve_secrets_batch(config, profile, &secrets).await
+        };
     }
 
     let keys = secrets.keys().cloned().collect();
@@ -282,13 +289,17 @@ pub async fn resolve_batch_with_context(
                 .filter(|(key, _)| foreground_keys.contains(*key))
                 .map(|(key, secret)| (key.clone(), secret.clone()))
                 .collect();
-            let mut foreground_values = resolve_secrets_batch_with_pre_resolved(
-                config,
-                profile,
-                &foreground_secrets,
-                &cached_values,
-            )
-            .await?;
+            let mut foreground_values = if purpose == Purpose::Check {
+                resolve_secrets_batch_best_effort(config, profile, &foreground_secrets).await?
+            } else {
+                resolve_secrets_batch_with_pre_resolved(
+                    config,
+                    profile,
+                    &foreground_secrets,
+                    &cached_values,
+                )
+                .await?
+            };
             let mut values = IndexMap::new();
             for key in secrets.keys() {
                 if let Some(value) = cached_values.swap_remove(key) {
@@ -938,7 +949,10 @@ async fn process_request(
                     keys: foreground.keys,
                 });
             }
-            let values = resolve_with_cache(&config, &req.profile, secrets, &req, state).await?;
+            let best_effort = req.purpose == Purpose::Check.as_str();
+            let values =
+                resolve_with_cache(&config, &req.profile, secrets, &req, best_effort, state)
+                    .await?;
             Ok(Response::Resolved { values })
         }
         Request::ResolveOne(req) => {
@@ -987,8 +1001,15 @@ async fn process_request(
                     keys: foreground.keys,
                 });
             }
-            let values =
-                resolve_with_cache(&config, &batch_req.profile, secrets, &batch_req, state).await?;
+            let values = resolve_with_cache(
+                &config,
+                &batch_req.profile,
+                secrets,
+                &batch_req,
+                false,
+                state,
+            )
+            .await?;
             Ok(Response::Resolved { values })
         }
     }
@@ -1101,6 +1122,7 @@ async fn resolve_with_cache(
     profile: &[String],
     secrets: IndexMap<String, SecretConfig>,
     req: &ResolveBatchRequest,
+    best_effort: bool,
     state: std::sync::Arc<Mutex<DaemonState>>,
 ) -> Result<IndexMap<String, Option<String>>> {
     let fingerprint = config_fingerprint(config, &req.env)?;
@@ -1127,7 +1149,11 @@ async fn resolve_with_cache(
     }
 
     if !misses.is_empty() {
-        let resolved = resolve_secrets_batch(config, profile, &misses).await?;
+        let resolved = if best_effort {
+            resolve_secrets_batch_best_effort(config, profile, &misses).await?
+        } else {
+            resolve_secrets_batch(config, profile, &misses).await?
+        };
         let mut state = state.lock().await;
         for (key, value) in resolved {
             if let Some(cache_key) = miss_keys.remove(&key) {
@@ -1743,6 +1769,7 @@ mod tests {
             &req.profile,
             IndexMap::from([("API_KEY".to_string(), secret)]),
             &req,
+            false,
             state,
         )
         .await
@@ -1793,9 +1820,10 @@ mod tests {
                 .is_none(),
             "cached requests should stay in the daemon"
         );
-        let resolved = resolve_with_cache(&config, &req.profile, secrets, &req, state.clone())
-            .await
-            .unwrap();
+        let resolved =
+            resolve_with_cache(&config, &req.profile, secrets, &req, false, state.clone())
+                .await
+                .unwrap();
         assert_eq!(
             resolved.get("API_KEY").and_then(|value| value.as_deref()),
             Some("from-foreground")
@@ -1854,6 +1882,7 @@ mod tests {
             &req.profile,
             IndexMap::from([("API_KEY".to_string(), secret)]),
             &req,
+            false,
             state,
         )
         .await
@@ -1894,6 +1923,7 @@ daemon_cache = false
             &req.profile,
             IndexMap::from([("API_KEY".to_string(), secret)]),
             &req,
+            false,
             state,
         )
         .await
@@ -1920,6 +1950,7 @@ daemon_cache = false
             &req.profile,
             IndexMap::from([("API_KEY".to_string(), secret)]),
             &req,
+            false,
             state,
         )
         .await
@@ -1947,6 +1978,7 @@ daemon_cache = false
             &req.profile,
             IndexMap::from([("API_KEY".to_string(), secret)]),
             &req,
+            false,
             state,
         )
         .await
@@ -1974,6 +2006,7 @@ daemon_cache = false
             &req.profile,
             IndexMap::from([("API_KEY".to_string(), secret)]),
             &req,
+            false,
             state,
         )
         .await

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2,7 +2,7 @@ use crate::commands::Cli;
 use crate::config::{Config, ProviderConfig, SecretConfig};
 use crate::error::{FnoxError, Result};
 use crate::secret_resolver::{
-    resolve_secrets_batch, resolve_secrets_batch_best_effort,
+    BestEffortBatchResolution, resolve_secrets_batch, resolve_secrets_batch_best_effort,
     resolve_secrets_batch_with_pre_resolved,
 };
 use indexmap::IndexMap;
@@ -151,6 +151,8 @@ struct StoreResolvedRequest {
 enum Response {
     Resolved {
         values: IndexMap<String, Option<String>>,
+        #[serde(default)]
+        errors: IndexMap<String, String>,
     },
     ResolveInForeground {
         fingerprint: String,
@@ -226,6 +228,24 @@ pub async fn resolve_batch(
     .await
 }
 
+pub async fn resolve_batch_for_check(
+    cli: &Cli,
+    config: &Config,
+    profile: &[String],
+    secrets: &IndexMap<String, SecretConfig>,
+    include_all_modes: bool,
+) -> Result<BestEffortBatchResolution> {
+    resolve_batch_resolution_with_context(
+        &ResolveContext::from_cli(cli),
+        config,
+        profile,
+        secrets,
+        Purpose::Check,
+        include_all_modes,
+    )
+    .await
+}
+
 pub async fn resolve_batch_with_context(
     ctx: &ResolveContext,
     config: &Config,
@@ -234,6 +254,26 @@ pub async fn resolve_batch_with_context(
     purpose: Purpose,
     include_all_modes: bool,
 ) -> Result<IndexMap<String, Option<String>>> {
+    Ok(resolve_batch_resolution_with_context(
+        ctx,
+        config,
+        profile,
+        secrets,
+        purpose,
+        include_all_modes,
+    )
+    .await?
+    .values)
+}
+
+async fn resolve_batch_resolution_with_context(
+    ctx: &ResolveContext,
+    config: &Config,
+    profile: &[String],
+    secrets: &IndexMap<String, SecretConfig>,
+    purpose: Purpose,
+    include_all_modes: bool,
+) -> Result<BestEffortBatchResolution> {
     if !should_use_daemon(ctx, config) {
         let secrets = if include_all_modes {
             secrets.clone()
@@ -247,7 +287,10 @@ pub async fn resolve_batch_with_context(
         return if purpose == Purpose::Check {
             resolve_secrets_batch_best_effort(config, profile, &secrets).await
         } else {
-            resolve_secrets_batch(config, profile, &secrets).await
+            Ok(BestEffortBatchResolution {
+                values: resolve_secrets_batch(config, profile, &secrets).await?,
+                errors: IndexMap::new(),
+            })
         };
     }
 
@@ -268,7 +311,7 @@ pub async fn resolve_batch_with_context(
     };
 
     match call_or_start(ctx, config, Request::ResolveBatch(batch_request.clone())).await? {
-        Response::Resolved { values } => Ok(values),
+        Response::Resolved { values, errors } => Ok(BestEffortBatchResolution { values, errors }),
         Response::ResolveInForeground {
             fingerprint,
             mut cached_values,
@@ -289,22 +332,25 @@ pub async fn resolve_batch_with_context(
                 .filter(|(key, _)| foreground_keys.contains(*key))
                 .map(|(key, secret)| (key.clone(), secret.clone()))
                 .collect();
-            let mut foreground_values = if purpose == Purpose::Check {
+            let mut foreground_resolution = if purpose == Purpose::Check {
                 resolve_secrets_batch_best_effort(config, profile, &foreground_secrets).await?
             } else {
-                resolve_secrets_batch_with_pre_resolved(
-                    config,
-                    profile,
-                    &foreground_secrets,
-                    &cached_values,
-                )
-                .await?
+                BestEffortBatchResolution {
+                    values: resolve_secrets_batch_with_pre_resolved(
+                        config,
+                        profile,
+                        &foreground_secrets,
+                        &cached_values,
+                    )
+                    .await?,
+                    errors: IndexMap::new(),
+                }
             };
             let mut values = IndexMap::new();
             for key in secrets.keys() {
                 if let Some(value) = cached_values.swap_remove(key) {
                     values.insert(key.clone(), value);
-                } else if let Some(value) = foreground_values.swap_remove(key) {
+                } else if let Some(value) = foreground_resolution.values.swap_remove(key) {
                     values.insert(key.clone(), value);
                 }
             }
@@ -314,7 +360,10 @@ pub async fn resolve_batch_with_context(
             {
                 tracing::warn!("failed to fill daemon cache after foreground resolution: {error}");
             }
-            Ok(values)
+            Ok(BestEffortBatchResolution {
+                values,
+                errors: foreground_resolution.errors,
+            })
         }
         Response::Error { message } => Err(FnoxError::Config(message)),
         _ => Err(FnoxError::Config(
@@ -369,7 +418,7 @@ pub async fn resolve_one_with_context(
     };
 
     match call_or_start(ctx, config, Request::ResolveOne(one_request.clone())).await? {
-        Response::Resolved { mut values } => Ok(values.swap_remove(key).flatten()),
+        Response::Resolved { mut values, .. } => Ok(values.swap_remove(key).flatten()),
         Response::ResolveInForeground { fingerprint, .. } => {
             let value =
                 crate::secret_resolver::resolve_secret(config, profile, key, secret_config).await?;
@@ -950,10 +999,13 @@ async fn process_request(
                 });
             }
             let best_effort = req.purpose == Purpose::Check.as_str();
-            let values =
+            let resolution =
                 resolve_with_cache(&config, &req.profile, secrets, &req, best_effort, state)
                     .await?;
-            Ok(Response::Resolved { values })
+            Ok(Response::Resolved {
+                values: resolution.values,
+                errors: resolution.errors,
+            })
         }
         Request::ResolveOne(req) => {
             let _guard = request_lock.lock().await;
@@ -970,6 +1022,7 @@ async fn process_request(
             let Some(secret_config) = config.get_secret(&req.profile, &req.key)?.cloned() else {
                 return Ok(Response::Resolved {
                     values: [(req.key, None)].into_iter().collect(),
+                    errors: IndexMap::new(),
                 });
             };
             let batch_req = ResolveBatchRequest {
@@ -1001,7 +1054,7 @@ async fn process_request(
                     keys: foreground.keys,
                 });
             }
-            let values = resolve_with_cache(
+            let resolution = resolve_with_cache(
                 &config,
                 &batch_req.profile,
                 secrets,
@@ -1010,7 +1063,10 @@ async fn process_request(
                 state,
             )
             .await?;
-            Ok(Response::Resolved { values })
+            Ok(Response::Resolved {
+                values: resolution.values,
+                errors: resolution.errors,
+            })
         }
     }
 }
@@ -1124,11 +1180,12 @@ async fn resolve_with_cache(
     req: &ResolveBatchRequest,
     best_effort: bool,
     state: std::sync::Arc<Mutex<DaemonState>>,
-) -> Result<IndexMap<String, Option<String>>> {
+) -> Result<BestEffortBatchResolution> {
     let fingerprint = config_fingerprint(config, &req.env)?;
     let providers = config.get_providers(profile)?;
     let default_provider = cache_policy_default_provider(config, profile, &providers);
     let mut results = IndexMap::new();
+    let mut errors = IndexMap::new();
     let mut misses = IndexMap::new();
     let mut miss_keys = HashMap::new();
 
@@ -1149,18 +1206,22 @@ async fn resolve_with_cache(
     }
 
     if !misses.is_empty() {
-        let resolved = if best_effort {
+        let mut resolution = if best_effort {
             resolve_secrets_batch_best_effort(config, profile, &misses).await?
         } else {
-            resolve_secrets_batch(config, profile, &misses).await?
+            BestEffortBatchResolution {
+                values: resolve_secrets_batch(config, profile, &misses).await?,
+                errors: IndexMap::new(),
+            }
         };
         let mut state = state.lock().await;
-        for (key, value) in resolved {
+        for (key, value) in resolution.values {
             if let Some(cache_key) = miss_keys.remove(&key) {
                 state.cache.insert(cache_key, value.clone());
             }
             results.insert(key, value);
         }
+        errors.append(&mut resolution.errors);
     }
 
     let mut ordered = IndexMap::new();
@@ -1169,7 +1230,10 @@ async fn resolve_with_cache(
             ordered.insert(key.clone(), value);
         }
     }
-    Ok(ordered)
+    Ok(BestEffortBatchResolution {
+        values: ordered,
+        errors,
+    })
 }
 
 fn cache_policy_default_provider<'a>(
@@ -1322,7 +1386,7 @@ fn socket_path(cli: &Cli) -> Result<PathBuf> {
 /// Wire-protocol version tag included in the socket path hash.
 /// Incrementing this ensures new clients don't connect to stale daemons
 /// running an incompatible wire format.
-const WIRE_VERSION: u8 = 3;
+const WIRE_VERSION: u8 = 4;
 
 fn socket_path_for_context(ctx: &ResolveContext) -> Result<PathBuf> {
     let mut hasher = blake3::Hasher::new();
@@ -1622,8 +1686,9 @@ pub fn parse_duration(value: &str) -> Result<Duration> {
 #[cfg(test)]
 mod tests {
     use super::{
-        CacheKey, DaemonState, Purpose, ResolveBatchRequest, cache_key, config_fingerprint,
-        foreground_resolution_if_needed, parse_duration, resolve_with_cache, store_resolved_values,
+        CacheKey, DaemonState, Purpose, ResolveBatchRequest, Response, cache_key,
+        config_fingerprint, foreground_resolution_if_needed, parse_duration, resolve_with_cache,
+        store_resolved_values,
     };
     use fnox_core::config::{Config, ProviderConfig, SecretConfig};
     use indexmap::IndexMap;
@@ -1652,6 +1717,31 @@ mod tests {
 
         let decoded: ResolveBatchRequest = serde_json::from_str(&json).unwrap();
         assert!(decoded.include_all_modes);
+    }
+
+    #[test]
+    fn resolved_response_carries_check_diagnostics() {
+        let response = Response::Resolved {
+            values: IndexMap::from([("API_KEY".to_string(), None)]),
+            errors: IndexMap::from([("API_KEY".to_string(), "not found".to_string())]),
+        };
+        let json = serde_json::to_string(&response).unwrap();
+        let decoded: Response = serde_json::from_str(&json).unwrap();
+
+        match decoded {
+            Response::Resolved { values, errors } => {
+                assert_eq!(values["API_KEY"], None);
+                assert_eq!(errors["API_KEY"], "not found");
+            }
+            _ => panic!("expected resolved response"),
+        }
+
+        let decoded: Response =
+            serde_json::from_str(r#"{"status":"resolved","values":{}}"#).unwrap();
+        assert!(matches!(
+            decoded,
+            Response::Resolved { errors, .. } if errors.is_empty()
+        ));
     }
 
     #[test]
@@ -1776,7 +1866,10 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            resolved.get("API_KEY").and_then(|value| value.as_deref()),
+            resolved
+                .values
+                .get("API_KEY")
+                .and_then(|value| value.as_deref()),
             Some("fresh")
         );
     }
@@ -1825,7 +1918,10 @@ mod tests {
                 .await
                 .unwrap();
         assert_eq!(
-            resolved.get("API_KEY").and_then(|value| value.as_deref()),
+            resolved
+                .values
+                .get("API_KEY")
+                .and_then(|value| value.as_deref()),
             Some("from-foreground")
         );
 
@@ -1889,7 +1985,10 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            resolved.get("API_KEY").and_then(|value| value.as_deref()),
+            resolved
+                .values
+                .get("API_KEY")
+                .and_then(|value| value.as_deref()),
             Some("fresh")
         );
     }
@@ -1930,7 +2029,10 @@ daemon_cache = false
         .unwrap();
 
         assert_eq!(
-            resolved.get("API_KEY").and_then(|value| value.as_deref()),
+            resolved
+                .values
+                .get("API_KEY")
+                .and_then(|value| value.as_deref()),
             Some("fresh")
         );
     }
@@ -1957,7 +2059,10 @@ daemon_cache = false
         .unwrap();
 
         assert_eq!(
-            resolved.get("API_KEY").and_then(|value| value.as_deref()),
+            resolved
+                .values
+                .get("API_KEY")
+                .and_then(|value| value.as_deref()),
             Some("fresh")
         );
     }
@@ -1985,7 +2090,10 @@ daemon_cache = false
         .unwrap();
 
         assert_eq!(
-            resolved.get("API_KEY").and_then(|value| value.as_deref()),
+            resolved
+                .values
+                .get("API_KEY")
+                .and_then(|value| value.as_deref()),
             Some("cached")
         );
     }
@@ -2013,7 +2121,10 @@ daemon_cache = false
         .unwrap();
 
         assert_eq!(
-            resolved.get("API_KEY").and_then(|value| value.as_deref()),
+            resolved
+                .values
+                .get("API_KEY")
+                .and_then(|value| value.as_deref()),
             Some("cached")
         );
     }

--- a/test/age.bats
+++ b/test/age.bats
@@ -72,19 +72,40 @@ EOF
 	local private_key
 	private_key=$(grep "^AGE-SECRET-KEY" key.txt)
 
-	# Create config with single provider
+	mkdir -p "$TEST_TEMP_DIR/bin"
+	cat >"$TEST_TEMP_DIR/bin/pass" <<'EOF'
+#!/bin/sh
+printf 'called\n' >>"$PASS_CALLS_FILE"
+printf 'secret is not in the password store\n' >&2
+exit 1
+EOF
+	chmod +x "$TEST_TEMP_DIR/bin/pass"
+	export PATH="$TEST_TEMP_DIR/bin:$PATH"
+	export PASS_CALLS_FILE="$TEST_TEMP_DIR/pass-calls"
+	: >"$PASS_CALLS_FILE"
+
 	cat >fnox.toml <<EOF
 root = true
 
 [providers.age]
 type = "age"
 recipients = ["$public_key"]
+identity = { provider = "identity", value = "unused" }
 
-[secrets]
+[providers.identity]
+type = "1password"
+
+[providers.optional]
+type = "password-store"
+
+[secrets.OP_SERVICE_ACCOUNT_TOKEN]
+provider = "optional"
+value = "missing"
+if_missing = "ignore"
+env = false
 EOF
 
-	# Set a secret without specifying provider - should use the only one available
-	run "$FNOX_BIN" set MY_SECRET "secret-value"
+	run "$FNOX_BIN" set MY_SECRET "secret-value" --provider age
 	assert_success
 
 	# Verify the secret was encrypted with the age provider
@@ -96,6 +117,9 @@ EOF
 	run "$FNOX_BIN" get MY_SECRET
 	assert_success
 	assert_output "secret-value"
+
+	assert_fnox_success check
+	assert_equal "$(wc -l <"$PASS_CALLS_FILE" | tr -d ' ')" "0"
 }
 
 @test "decrypts using provider-backed identity" {

--- a/test/check.bats
+++ b/test/check.bats
@@ -77,6 +77,83 @@ EOF
 	assert_output --partial "No secrets"
 }
 
+@test "fnox check preserves cross-provider dependency order" {
+	mkdir -p "$TEST_TEMP_DIR/bin"
+	cat >"$TEST_TEMP_DIR/bin/op" <<'EOF'
+#!/bin/sh
+printf 'called\n' >>"$OP_CALLS_FILE"
+if [ "${OP_SERVICE_ACCOUNT_TOKEN:-}" != "token" ]; then
+	printf 'service account token is missing\n' >&2
+	exit 1
+fi
+printf 'value\n'
+EOF
+	chmod +x "$TEST_TEMP_DIR/bin/op"
+	export PATH="$TEST_TEMP_DIR/bin:$PATH"
+	export OP_CALLS_FILE="$TEST_TEMP_DIR/op-calls"
+	unset FNOX_OP_SERVICE_ACCOUNT_TOKEN OP_SERVICE_ACCOUNT_TOKEN
+	: >"$OP_CALLS_FILE"
+
+	cat >fnox.toml <<'EOF'
+root = true
+default_provider = "plain"
+
+[providers.op]
+type = "1password"
+vault = "test"
+
+[providers.plain]
+type = "plain"
+
+[secrets]
+TARGET = { provider = "op", value = "target", if_missing = "error" }
+OP_SERVICE_ACCOUNT_TOKEN = { value = "token", if_missing = "ignore", env = false }
+EOF
+
+	assert_fnox_success check
+	assert_equal "$(wc -l <"$OP_CALLS_FILE" | tr -d ' ')" "1"
+}
+
+@test "fnox check daemon fallback preserves dependency context" {
+	export XDG_RUNTIME_DIR="$TEST_TEMP_DIR/runtime"
+	mkdir -p "$XDG_RUNTIME_DIR" "$TEST_TEMP_DIR/bin"
+	cat >"$TEST_TEMP_DIR/bin/op" <<'EOF'
+#!/bin/sh
+if [ "${OP_SERVICE_ACCOUNT_TOKEN:-}" != "token" ]; then
+	printf 'service account token is missing\n' >&2
+	exit 1
+fi
+printf 'target secret is missing\n' >&2
+exit 1
+EOF
+	chmod +x "$TEST_TEMP_DIR/bin/op"
+	export PATH="$TEST_TEMP_DIR/bin:$PATH"
+	unset FNOX_OP_SERVICE_ACCOUNT_TOKEN OP_SERVICE_ACCOUNT_TOKEN
+
+	cat >fnox.toml <<'EOF'
+root = true
+default_provider = "plain"
+
+[daemon]
+enabled = true
+
+[providers.op]
+type = "1password"
+vault = "test"
+
+[providers.plain]
+type = "plain"
+
+[secrets]
+TARGET = { provider = "op", value = "target", if_missing = "error" }
+OP_SERVICE_ACCOUNT_TOKEN = { value = "token", if_missing = "ignore", env = false }
+EOF
+
+	assert_fnox_failure --non-interactive check
+	assert_output --partial "target secret is missing"
+	refute_output --partial "service account token is missing"
+}
+
 @test "fnox check batch resolves secrets sharing an age key" {
 	if ! command -v age-keygen >/dev/null 2>&1; then
 		skip "age-keygen not installed"
@@ -127,6 +204,18 @@ EOF
 	assert_fnox_success check
 	assert_equal "$(grep -c '^age-key$' "$PASS_CALLS_FILE")" "1"
 
+	: >"$PASS_CALLS_FILE"
+	local second_line second_value shared_prefix
+	second_line=$(grep 'SECOND.*sync = ' fnox.toml)
+	second_value=${second_line##*value = \"}
+	second_value=${second_value%%\"*}
+	shared_prefix=${second_value%:*}
+	sed -i.bak "s|$second_value|$shared_prefix:invalid|" fnox.toml
+	assert_fnox_failure check
+	assert_output --partial "SECOND"
+	assert_equal "$(grep -c '^age-key$' "$PASS_CALLS_FILE")" "2"
+
+	assert_fnox_success sync -p age --force
 	: >"$PASS_CALLS_FILE"
 	echo 'THIRD = { provider = "identity", value = "missing", if_missing = "error" }' >>fnox.toml
 	assert_fnox_failure check
@@ -197,8 +286,13 @@ EOF
 	mkdir -p "$XDG_RUNTIME_DIR" "$TEST_TEMP_DIR/bin"
 	cat >"$TEST_TEMP_DIR/bin/pass" <<'EOF'
 #!/bin/sh
-printf 'called\n' >>"$PASS_CALLS_FILE"
-printf 'value\n'
+printf '%s\n' "$2" >>"$PASS_CALLS_FILE"
+if [ "$2" = "good" ]; then
+	printf 'value\n'
+	exit 0
+fi
+printf 'secret is not in the password store\n' >&2
+exit 1
 EOF
 	chmod +x "$TEST_TEMP_DIR/bin/pass"
 	export PATH="$TEST_TEMP_DIR/bin:$PATH"
@@ -215,12 +309,16 @@ enabled = true
 type = "password-store"
 
 [secrets]
-REQUIRED = { provider = "pass", value = "required", if_missing = "error" }
+GOOD = { provider = "pass", value = "good", if_missing = "error" }
+BAD = { provider = "pass", value = "bad", if_missing = "error" }
 EOF
 
-	assert_fnox_success check
-	assert_fnox_success check
-	assert_equal "$(wc -l <"$PASS_CALLS_FILE" | tr -d ' ')" "2"
+	assert_fnox_failure --non-interactive check
+	assert_output --partial "Secret 'BAD' failed to resolve: Configuration error: password-store: secret 'bad' not found"
+	assert_fnox_failure check
+	assert_output --partial "BAD"
+	assert_equal "$(grep -c '^good$' "$PASS_CALLS_FILE")" "2"
+	assert_equal "$(grep -c '^bad$' "$PASS_CALLS_FILE")" "4"
 
 	assert_fnox_success daemon status
 	assert_output --partial "cached_entries: 0"

--- a/test/check.bats
+++ b/test/check.bats
@@ -6,6 +6,7 @@ setup() {
 }
 
 teardown() {
+	"$FNOX_BIN" daemon stop >/dev/null 2>&1 || true
 	_common_teardown
 }
 
@@ -74,4 +75,153 @@ EOF
 
 	assert_fnox_success check
 	assert_output --partial "No secrets"
+}
+
+@test "fnox check batch resolves secrets sharing an age key" {
+	if ! command -v age-keygen >/dev/null 2>&1; then
+		skip "age-keygen not installed"
+	fi
+
+	local keygen_output public_key
+	keygen_output=$(age-keygen -o key.txt 2>&1)
+	public_key=$(echo "$keygen_output" | grep "^Public key:" | cut -d' ' -f3)
+	export AGE_IDENTITY
+	AGE_IDENTITY=$(grep "^AGE-SECRET-KEY" key.txt)
+
+	mkdir -p "$TEST_TEMP_DIR/bin"
+	cat >"$TEST_TEMP_DIR/bin/pass" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$2" >>"$PASS_CALLS_FILE"
+if [ "$2" = "age-key" ]; then
+	printf '%s\n' "$AGE_IDENTITY"
+	exit 0
+fi
+printf '%s\n' "secret is not in the password store" >&2
+exit 1
+EOF
+	chmod +x "$TEST_TEMP_DIR/bin/pass"
+	export PATH="$TEST_TEMP_DIR/bin:$PATH"
+	export PASS_CALLS_FILE="$TEST_TEMP_DIR/pass-calls"
+	: >"$PASS_CALLS_FILE"
+
+	cat >fnox.toml <<EOF
+root = true
+
+[providers.source]
+type = "plain"
+
+[providers.identity]
+type = "password-store"
+
+[providers.age]
+type = "age"
+recipients = ["$public_key"]
+identity = { provider = "identity", value = "age-key" }
+
+[secrets]
+FIRST = { provider = "source", value = "first", if_missing = "error", env = "exec" }
+SECOND = { provider = "source", value = "second", if_missing = "error", env = false }
+EOF
+
+	assert_fnox_success sync -p age --force
+	assert_fnox_success check
+	assert_equal "$(grep -c '^age-key$' "$PASS_CALLS_FILE")" "1"
+
+	: >"$PASS_CALLS_FILE"
+	echo 'THIRD = { provider = "identity", value = "missing", if_missing = "error" }' >>fnox.toml
+	assert_fnox_failure check
+	assert_output --partial "THIRD"
+	assert_equal "$(grep -c '^age-key$' "$PASS_CALLS_FILE")" "1"
+}
+
+@test "fnox check retains diagnostics when batch resolution fails" {
+	mkdir -p "$TEST_TEMP_DIR/bin"
+	cat >"$TEST_TEMP_DIR/bin/pass" <<'EOF'
+#!/bin/sh
+printf '%s\n' "secret is not in the password store" >&2
+exit 1
+EOF
+	chmod +x "$TEST_TEMP_DIR/bin/pass"
+	export PATH="$TEST_TEMP_DIR/bin:$PATH"
+
+	cat >fnox.toml <<'EOF'
+root = true
+
+[providers.pass]
+type = "password-store"
+
+[secrets]
+FIRST = { provider = "pass", value = "first", if_missing = "error" }
+SECOND = { provider = "pass", value = "second", if_missing = "error" }
+EOF
+
+	assert_fnox_failure check
+	assert_output --partial "Secret 'FIRST' failed to resolve: password-store: secret 'first' not found"
+	assert_output --partial "Secret 'SECOND' failed to resolve: password-store: secret 'second' not found"
+}
+
+@test "fnox check all includes optional provider secrets" {
+	mkdir -p "$TEST_TEMP_DIR/bin"
+	cat >"$TEST_TEMP_DIR/bin/pass" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$2" >>"$PASS_CALLS_FILE"
+printf 'value\n'
+EOF
+	chmod +x "$TEST_TEMP_DIR/bin/pass"
+	export PATH="$TEST_TEMP_DIR/bin:$PATH"
+	export PASS_CALLS_FILE="$TEST_TEMP_DIR/pass-calls"
+	: >"$PASS_CALLS_FILE"
+
+	cat >fnox.toml <<'EOF'
+root = true
+
+[providers.pass]
+type = "password-store"
+
+[secrets]
+REQUIRED = { provider = "pass", value = "required", if_missing = "error" }
+WARN = { provider = "pass", value = "warn", if_missing = "warn" }
+IGNORE = { provider = "pass", value = "ignore", if_missing = "ignore" }
+EOF
+
+	assert_fnox_success check
+	assert_equal "$(wc -l <"$PASS_CALLS_FILE" | tr -d ' ')" "1"
+
+	: >"$PASS_CALLS_FILE"
+	assert_fnox_success check --all
+	assert_equal "$(wc -l <"$PASS_CALLS_FILE" | tr -d ' ')" "3"
+}
+
+@test "fnox check does not use the daemon cache" {
+	export XDG_RUNTIME_DIR="$TEST_TEMP_DIR/runtime"
+	mkdir -p "$XDG_RUNTIME_DIR" "$TEST_TEMP_DIR/bin"
+	cat >"$TEST_TEMP_DIR/bin/pass" <<'EOF'
+#!/bin/sh
+printf 'called\n' >>"$PASS_CALLS_FILE"
+printf 'value\n'
+EOF
+	chmod +x "$TEST_TEMP_DIR/bin/pass"
+	export PATH="$TEST_TEMP_DIR/bin:$PATH"
+	export PASS_CALLS_FILE="$TEST_TEMP_DIR/pass-calls"
+	: >"$PASS_CALLS_FILE"
+
+	cat >fnox.toml <<'EOF'
+root = true
+
+[daemon]
+enabled = true
+
+[providers.pass]
+type = "password-store"
+
+[secrets]
+REQUIRED = { provider = "pass", value = "required", if_missing = "error" }
+EOF
+
+	assert_fnox_success check
+	assert_fnox_success check
+	assert_equal "$(wc -l <"$PASS_CALLS_FILE" | tr -d ' ')" "2"
+
+	assert_fnox_success daemon status
+	assert_output --partial "cached_entries: 0"
 }

--- a/test/check.bats
+++ b/test/check.bats
@@ -86,12 +86,16 @@ if [ "${OP_SERVICE_ACCOUNT_TOKEN:-}" != "token" ]; then
 	printf 'service account token is missing\n' >&2
 	exit 1
 fi
+if [ -n "${UNRELATED:-}" ]; then
+	printf 'unrelated secret was exposed\n' >&2
+	exit 1
+fi
 printf 'value\n'
 EOF
 	chmod +x "$TEST_TEMP_DIR/bin/op"
 	export PATH="$TEST_TEMP_DIR/bin:$PATH"
 	export OP_CALLS_FILE="$TEST_TEMP_DIR/op-calls"
-	unset FNOX_OP_SERVICE_ACCOUNT_TOKEN OP_SERVICE_ACCOUNT_TOKEN
+	unset FNOX_OP_SERVICE_ACCOUNT_TOKEN OP_SERVICE_ACCOUNT_TOKEN UNRELATED
 	: >"$OP_CALLS_FILE"
 
 	cat >fnox.toml <<'EOF'
@@ -108,6 +112,7 @@ type = "plain"
 [secrets]
 TARGET = { provider = "op", value = "target", if_missing = "error" }
 OP_SERVICE_ACCOUNT_TOKEN = { value = "token", if_missing = "ignore", env = false }
+UNRELATED = { provider = "plain", value = "sibling", if_missing = "error" }
 EOF
 
 	assert_fnox_success check
@@ -123,12 +128,16 @@ if [ "${OP_SERVICE_ACCOUNT_TOKEN:-}" != "token" ]; then
 	printf 'service account token is missing\n' >&2
 	exit 1
 fi
+if [ -n "${UNRELATED:-}" ]; then
+	printf 'unrelated secret was exposed\n' >&2
+	exit 1
+fi
 printf 'target secret is missing\n' >&2
 exit 1
 EOF
 	chmod +x "$TEST_TEMP_DIR/bin/op"
 	export PATH="$TEST_TEMP_DIR/bin:$PATH"
-	unset FNOX_OP_SERVICE_ACCOUNT_TOKEN OP_SERVICE_ACCOUNT_TOKEN
+	unset FNOX_OP_SERVICE_ACCOUNT_TOKEN OP_SERVICE_ACCOUNT_TOKEN UNRELATED
 
 	cat >fnox.toml <<'EOF'
 root = true
@@ -147,11 +156,77 @@ type = "plain"
 [secrets]
 TARGET = { provider = "op", value = "target", if_missing = "error" }
 OP_SERVICE_ACCOUNT_TOKEN = { value = "token", if_missing = "ignore", env = false }
+UNRELATED = { provider = "plain", value = "sibling", if_missing = "error" }
 EOF
 
 	assert_fnox_failure --non-interactive check
 	assert_output --partial "target secret is missing"
 	refute_output --partial "service account token is missing"
+	refute_output --partial "unrelated secret was exposed"
+}
+
+@test "fnox check isolates dependencies from nested provider resolution" {
+	mkdir -p "$TEST_TEMP_DIR/bin"
+	cat >"$TEST_TEMP_DIR/bin/op" <<'EOF'
+#!/bin/sh
+printf 'called\n' >>"$OP_CALLS_FILE"
+if [ "${OP_SERVICE_ACCOUNT_TOKEN:-}" != "nested-token" ]; then
+	printf 'nested provider dependency is missing\n' >&2
+	exit 1
+fi
+if [ -n "${VAULT_ADDR:-}" ] || [ -n "${UNRELATED:-}" ]; then
+	printf 'nested provider inherited outer secrets\n' >&2
+	exit 1
+fi
+printf 'nested-token\n'
+EOF
+	cat >"$TEST_TEMP_DIR/bin/vault" <<'EOF'
+#!/bin/sh
+if [ "${VAULT_ADDR:-}" != "outer-address" ]; then
+	printf 'vault address is missing\n' >&2
+	exit 1
+fi
+if [ -n "${OP_SERVICE_ACCOUNT_TOKEN:-}" ] || [ -n "${UNRELATED:-}" ]; then
+	printf 'vault inherited unrelated secrets\n' >&2
+	exit 1
+fi
+printf 'target secret is missing\n' >&2
+exit 1
+EOF
+	chmod +x "$TEST_TEMP_DIR/bin/op" "$TEST_TEMP_DIR/bin/vault"
+	export PATH="$TEST_TEMP_DIR/bin:$PATH"
+	export OP_CALLS_FILE="$TEST_TEMP_DIR/op-calls"
+	unset FNOX_OP_SERVICE_ACCOUNT_TOKEN FNOX_VAULT_ADDR FNOX_VAULT_TOKEN OP_SERVICE_ACCOUNT_TOKEN VAULT_ADDR VAULT_TOKEN UNRELATED
+	: >"$OP_CALLS_FILE"
+
+	cat >fnox.toml <<'EOF'
+root = true
+
+[providers.op]
+type = "1password"
+vault = "test"
+
+[providers.plain]
+type = "plain"
+
+[providers.vault]
+type = "vault"
+token = { secret = "NESTED_TOKEN" }
+
+[secrets]
+TARGET = { provider = "vault", value = "target", if_missing = "error" }
+VAULT_ADDR = { provider = "plain", value = "outer-address", if_missing = "ignore", env = false }
+NESTED_TOKEN = { provider = "op", value = "nested-token", if_missing = "error", env = false }
+OP_SERVICE_ACCOUNT_TOKEN = { provider = "plain", value = "nested-token", if_missing = "ignore", env = false }
+UNRELATED = { provider = "plain", value = "sibling", if_missing = "error" }
+EOF
+
+	assert_fnox_failure check
+	assert_output --partial "target secret is missing"
+	refute_output --partial "nested provider dependency is missing"
+	refute_output --partial "nested provider inherited outer secrets"
+	refute_output --partial "vault inherited unrelated secrets"
+	assert_equal "$(wc -l <"$OP_CALLS_FILE" | tr -d ' ')" "1"
 }
 
 @test "fnox check batch resolves secrets sharing an age key" {
@@ -166,20 +241,31 @@ EOF
 	AGE_IDENTITY=$(grep "^AGE-SECRET-KEY" key.txt)
 
 	mkdir -p "$TEST_TEMP_DIR/bin"
-	cat >"$TEST_TEMP_DIR/bin/pass" <<'EOF'
+	cat >"$TEST_TEMP_DIR/bin/op" <<'EOF'
 #!/bin/sh
-printf '%s\n' "$2" >>"$PASS_CALLS_FILE"
-if [ "$2" = "age-key" ]; then
+printf '%s\n' "$2" >>"$OP_CALLS_FILE"
+if [ "${OP_SERVICE_ACCOUNT_TOKEN:-}" != "identity-token" ]; then
+	printf 'identity provider dependency is missing\n' >&2
+	exit 1
+fi
+if [ -n "${UNRELATED:-}" ]; then
+	printf 'unrelated secret was exposed\n' >&2
+	exit 1
+fi
+case "$2" in
+*age-key*)
 	printf '%s\n' "$AGE_IDENTITY"
 	exit 0
-fi
-printf '%s\n' "secret is not in the password store" >&2
+	;;
+esac
+printf '%s\n' "secret is not in 1Password" >&2
 exit 1
 EOF
-	chmod +x "$TEST_TEMP_DIR/bin/pass"
+	chmod +x "$TEST_TEMP_DIR/bin/op"
 	export PATH="$TEST_TEMP_DIR/bin:$PATH"
-	export PASS_CALLS_FILE="$TEST_TEMP_DIR/pass-calls"
-	: >"$PASS_CALLS_FILE"
+	export OP_CALLS_FILE="$TEST_TEMP_DIR/op-calls"
+	unset FNOX_OP_SERVICE_ACCOUNT_TOKEN OP_SERVICE_ACCOUNT_TOKEN UNRELATED
+	: >"$OP_CALLS_FILE"
 
 	cat >fnox.toml <<EOF
 root = true
@@ -188,7 +274,8 @@ root = true
 type = "plain"
 
 [providers.identity]
-type = "password-store"
+type = "1password"
+vault = "test"
 
 [providers.age]
 type = "age"
@@ -198,13 +285,15 @@ identity = { provider = "identity", value = "age-key" }
 [secrets]
 FIRST = { provider = "source", value = "first", if_missing = "error", env = "exec" }
 SECOND = { provider = "source", value = "second", if_missing = "error", env = false }
+OP_SERVICE_ACCOUNT_TOKEN = { provider = "source", value = "identity-token", if_missing = "ignore", env = false }
+UNRELATED = { provider = "source", value = "sibling", if_missing = "error" }
 EOF
 
-	assert_fnox_success sync -p age --force
+	assert_fnox_success sync FIRST SECOND -p age --force
 	assert_fnox_success check
-	assert_equal "$(grep -c '^age-key$' "$PASS_CALLS_FILE")" "1"
+	assert_equal "$(grep -c 'age-key' "$OP_CALLS_FILE")" "1"
 
-	: >"$PASS_CALLS_FILE"
+	: >"$OP_CALLS_FILE"
 	local second_line second_value shared_prefix
 	second_line=$(grep 'SECOND.*sync = ' fnox.toml)
 	second_value=${second_line##*value = \"}
@@ -213,14 +302,14 @@ EOF
 	sed -i.bak "s|$second_value|$shared_prefix:invalid|" fnox.toml
 	assert_fnox_failure check
 	assert_output --partial "SECOND"
-	assert_equal "$(grep -c '^age-key$' "$PASS_CALLS_FILE")" "2"
+	assert_equal "$(grep -c 'age-key' "$OP_CALLS_FILE")" "1"
 
-	assert_fnox_success sync -p age --force
-	: >"$PASS_CALLS_FILE"
+	assert_fnox_success sync FIRST SECOND -p age --force
+	: >"$OP_CALLS_FILE"
 	echo 'THIRD = { provider = "identity", value = "missing", if_missing = "error" }' >>fnox.toml
 	assert_fnox_failure check
 	assert_output --partial "THIRD"
-	assert_equal "$(grep -c '^age-key$' "$PASS_CALLS_FILE")" "1"
+	assert_equal "$(grep -c 'age-key' "$OP_CALLS_FILE")" "1"
 }
 
 @test "fnox check retains diagnostics when batch resolution fails" {
@@ -314,11 +403,11 @@ BAD = { provider = "pass", value = "bad", if_missing = "error" }
 EOF
 
 	assert_fnox_failure --non-interactive check
-	assert_output --partial "Secret 'BAD' failed to resolve: Configuration error: password-store: secret 'bad' not found"
+	assert_output --partial "Secret 'BAD' failed to resolve: password-store: secret 'bad' not found"
 	assert_fnox_failure check
 	assert_output --partial "BAD"
 	assert_equal "$(grep -c '^good$' "$PASS_CALLS_FILE")" "2"
-	assert_equal "$(grep -c '^bad$' "$PASS_CALLS_FILE")" "4"
+	assert_equal "$(grep -c '^bad$' "$PASS_CALLS_FILE")" "2"
 
 	assert_fnox_success daemon status
 	assert_output --partial "cached_entries: 0"


### PR DESCRIPTION
## Summary

Follow up to #755, which introduced provider batch encryption for `fnox sync`, stored age sync caches with one shared age-wrapped key, and made `AgeEncryptionProvider::get_secrets_batch` unwrap that key once per batch.

Route `fnox check` roots and their transitive provider environment, provider configuration, nested provider, and interpolated-default dependencies through one dependency-aware batch. Best-effort resolution now returns successful values together with per-secret diagnostics for provider failures and terminal no-provider misses, so `check` can report failures directly without resolving failed secrets again. The daemon transports those diagnostics while caching only successful values, and `Purpose::Check` remains uncached.

Resolved dependency values are exposed only to provider commands that declare them. A process-wide access guard serializes temporary environment overlays, ordinary environment reads, provider authentication commands, and fail-fast environment exports. Authentication confirmation happens before acquiring that guard; a confirmed command then runs under its scoped dependency overlay. Age identities are prepared before taking the guard, preserving nested provider resolution and cycle detection without re-entrant deadlocks; `FNOX_AGE_KEY` continues to bypass configured identity providers.

Regression coverage verifies one identity lookup for shared age keys, successful sibling retention and diagnostics, missing no-provider dependency diagnostics with downstream continuation, cross-provider and provider-configuration ordering, nested provider environment isolation, daemon behavior, environment restoration and concurrency, auth prompt lock ordering, optional-secret selection, repeated check cache bypass, Age override precedence, and concurrent Age identity reads.

*AI-assisted — Tool: OpenCode; model: openai/gpt-5.6-sol; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved `check` performance with dependency-aware batch resolution.
  * Preserved detailed missing-value and provider error reporting.
  * Continued resolving unaffected secrets when individual provider entries fail.
  * Included dependent and optional-provider secrets during comprehensive checks.
  * Improved provider isolation to avoid resolving unrelated secrets.
  * Enhanced age-encrypted secret handling for provider- or environment-based identities.
  * Checks now bypass stale daemon results while retaining dependency context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->