### PR TITLE
chore(ci): pin mr-boxington-action v1.0.1

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -14,11 +14,11 @@ runs:
   steps:
     - name: Restore the fork PR cache mirror
       if: inputs.mirror-github-cache == 'true' && github.actor == 'jdx' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-      uses: jdx/mr-boxington-action@d311086f3b4337b7ad305330ff77ea716d372fc1 # v1
+      uses: jdx/mr-boxington-action@203ebddb3bdb1b3832473207d0a837b23b660563 # v1.0.1
       with:
         version: 0.5.4
         backend: github
-    - uses: jdx/mr-boxington-action@d311086f3b4337b7ad305330ff77ea716d372fc1 # v1
+    - uses: jdx/mr-boxington-action@203ebddb3bdb1b3832473207d0a837b23b660563 # v1.0.1
       with:
         version: 0.5.4
         backend: ${{ inputs.backend != 'auto' && inputs.backend || ((github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'github' || 'server') }}


### PR DESCRIPTION
Pin the mbx setup composite to the tagged v1.0.1 action commit. This release authenticates release-metadata lookups with the workflow token, preventing the intermittent GitHub API 403s seen when many CLI jobs start together. The matching tag annotation also satisfies Zizmor’s ref-version check.

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only dependency pin with no application or runtime behavior changes.
> 
> **Overview**
> Updates the **mbx** composite action so both `jdx/mr-boxington-action` steps point at **v1.0.1** (`203ebddb…`) instead of the previous floating **v1** commit.
> 
> That pin pulls in release-metadata lookups authenticated with the workflow token, which should stop intermittent GitHub API **403**s when many CLI jobs start at once. The tagged ref also satisfies Zizmor’s ref-version check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b201e74b49fd4973873896eb47694e3361a6eaad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated merge request workflow to use the latest approved action version.
  * No user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->