### PR TITLE
fix(check): batch Age secret resolution

### DIFF
--- a/src/commands/check.rs
+++ b/src/commands/check.rs
@@ -1,6 +1,7 @@
-use crate::config::Config;
+use crate::config::{Config, ProviderConfig, SecretConfig};
 use crate::error::Result;
 use crate::secret_resolver;
+use indexmap::IndexMap;
 
 use crate::commands::Cli;
 
@@ -30,6 +31,9 @@ impl CheckCommand {
                 warnings.push("No secrets defined in profile(s)".to_string());
             } else {
                 println!("Found {} secret(s) in profile(s)", secrets.len());
+                let providers = config.get_providers(&profile)?;
+                let mut age_batches: IndexMap<String, IndexMap<String, SecretConfig>> =
+                    IndexMap::new();
 
                 for (name, secret_config) in secrets {
                     // Check if secret has a value source
@@ -52,7 +56,6 @@ impl CheckCommand {
 
                     // Check provider configuration
                     if let Some(provider) = secret_config.provider() {
-                        let providers = config.get_providers(&profile)?;
                         if !providers.contains_key(provider) {
                             warnings.push(format!(
                                 "Secret '{}' references unknown provider '{}'",
@@ -73,6 +76,30 @@ impl CheckCommand {
                                         | crate::config::IfMissing::Ignore
                                 )
                             {
+                                continue;
+                            }
+
+                            let resolution_provider = secret_config
+                                .sync
+                                .as_ref()
+                                .map(|sync| sync.provider.as_str())
+                                .unwrap_or(provider);
+                            let has_provider_value =
+                                secret_config.sync.is_some() || secret_config.value().is_some();
+                            if matches!(if_missing, crate::config::IfMissing::Error)
+                                && secret_config.default.is_none()
+                                && secret_config.json_path.is_none()
+                                && secret_config.line.is_none()
+                                && has_provider_value
+                                && matches!(
+                                    providers.get(resolution_provider),
+                                    Some(ProviderConfig::AgeEncryption { .. })
+                                )
+                            {
+                                age_batches
+                                    .entry(resolution_provider.to_string())
+                                    .or_default()
+                                    .insert(name, secret_config);
                                 continue;
                             }
 
@@ -130,6 +157,56 @@ impl CheckCommand {
                                         }
                                     }
                                 }
+                            }
+                        }
+                    }
+                }
+
+                for (provider, batch) in age_batches {
+                    let provider_secrets = batch
+                        .iter()
+                        .map(|(name, secret_config)| {
+                            let value = secret_config
+                                .sync
+                                .as_ref()
+                                .map(|sync| sync.value.clone())
+                                .or_else(|| secret_config.value().map(ToOwned::to_owned))
+                                .expect("batched secrets have a provider value");
+                            (name.clone(), value)
+                        })
+                        .collect::<Vec<_>>();
+                    let provider_config = providers
+                        .get(&provider)
+                        .expect("batched secrets use a configured age provider");
+                    match crate::providers::get_provider_resolved(
+                        &config,
+                        &profile,
+                        &provider,
+                        provider_config,
+                    )
+                    .await
+                    {
+                        Ok(age_provider) => {
+                            let mut values =
+                                age_provider.get_secrets_batch(&provider_secrets).await;
+                            for name in batch.keys() {
+                                match values.remove(name) {
+                                    Some(Ok(_)) => {}
+                                    Some(Err(err)) => issues.push(format!(
+                                        "Secret '{}' failed to resolve: {}",
+                                        name, err
+                                    )),
+                                    None => issues.push(format!(
+                                        "Secret '{}' could not be resolved from provider '{}'",
+                                        name, provider
+                                    )),
+                                }
+                            }
+                        }
+                        Err(err) => {
+                            for name in batch.keys() {
+                                issues
+                                    .push(format!("Secret '{}' failed to resolve: {}", name, err));
                             }
                         }
                     }

--- a/test/check.bats
+++ b/test/check.bats
@@ -75,3 +75,133 @@ EOF
 	assert_fnox_success check
 	assert_output --partial "No secrets"
 }
+
+@test "fnox check resolves a direct age batch with one identity read" {
+	if ! command -v age-keygen >/dev/null 2>&1; then
+		skip "age-keygen not installed"
+	fi
+
+	local keygen_output public_key
+	keygen_output=$(age-keygen -o key.txt 2>&1)
+	public_key=$(echo "$keygen_output" | grep "^Public key:" | cut -d' ' -f3)
+	export AGE_IDENTITY
+	AGE_IDENTITY=$(grep "^AGE-SECRET-KEY" key.txt)
+
+	mkdir -p "$TEST_TEMP_DIR/bin"
+	cat >"$TEST_TEMP_DIR/bin/pass" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$2" >>"$PASS_CALLS_FILE"
+if [ "$2" = "age-key" ]; then
+	printf '%s\n' "$AGE_IDENTITY"
+	exit 0
+fi
+printf '%s\n' "secret is not in the password store" >&2
+exit 1
+EOF
+	chmod +x "$TEST_TEMP_DIR/bin/pass"
+	export PATH="$TEST_TEMP_DIR/bin:$PATH"
+	export PASS_CALLS_FILE="$TEST_TEMP_DIR/pass-calls"
+	unset FNOX_AGE_KEY FNOX_AGE_KEY_FILE
+	unset FIRST SECOND
+	: >"$PASS_CALLS_FILE"
+
+	cat >fnox.toml <<EOF
+root = true
+
+[providers.identity]
+type = "password-store"
+
+[providers.source]
+type = "plain"
+
+[providers.age]
+type = "age"
+recipients = ["$public_key"]
+identity = { provider = "identity", value = "age-key" }
+
+[secrets]
+FIRST = { provider = "source", value = "first", if_missing = "error" }
+SECOND = { provider = "source", value = "second", if_missing = "error" }
+EOF
+
+	assert_fnox_success sync -p age --force
+	perl -i -pe 'if (/^(FIRST|SECOND) = .*sync = \{ provider = "age", value = "([^"]+)" \}.*$/) { $_ = "$1 = { provider = \"age\", value = \"$2\", if_missing = \"error\" }\n" }' fnox.toml
+	assert_equal "$(grep -c 'provider = "age", value = "fnox-age-batch-v1:' fnox.toml)" "2"
+	: >"$PASS_CALLS_FILE"
+	assert_fnox_success check
+	assert_equal "$(grep -c '^age-key$' "$PASS_CALLS_FILE")" "1"
+
+	: >"$PASS_CALLS_FILE"
+	local second_line second_value shared_prefix
+	second_line=$(grep 'SECOND.*value = ' fnox.toml)
+	second_value=${second_line##*value = \"}
+	second_value=${second_value%%\"*}
+	shared_prefix=${second_value%:*}
+	sed -i.bak "s|$second_value|$shared_prefix:invalid|" fnox.toml
+	assert_fnox_failure check
+	assert_output --partial "Found 1 error(s):"
+	assert_output --partial "SECOND"
+	assert_output --partial "Invalid base64"
+	refute_output --partial "Secret 'FIRST' failed to resolve"
+	assert_equal "$(grep -c '^age-key$' "$PASS_CALLS_FILE")" "1"
+}
+
+@test "fnox check isolates sequential age sync batches" {
+	if ! command -v age-keygen >/dev/null 2>&1; then
+		skip "age-keygen not installed"
+	fi
+
+	local keygen_output public_key
+	keygen_output=$(age-keygen -o key.txt 2>&1)
+	public_key=$(echo "$keygen_output" | grep "^Public key:" | cut -d' ' -f3)
+	export AGE_IDENTITY
+	AGE_IDENTITY=$(grep "^AGE-SECRET-KEY" key.txt)
+
+	mkdir -p "$TEST_TEMP_DIR/bin"
+	cat >"$TEST_TEMP_DIR/bin/pass" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$2" >>"$PASS_CALLS_FILE"
+if [ "$2" = "second-age-key" ] && [ -n "${FIRST+x}" ]; then
+	printf '%s\n' "FIRST was exposed to the second identity provider" >&2
+	exit 1
+fi
+printf '%s\n' "$AGE_IDENTITY"
+EOF
+	chmod +x "$TEST_TEMP_DIR/bin/pass"
+	export PATH="$TEST_TEMP_DIR/bin:$PATH"
+	export PASS_CALLS_FILE="$TEST_TEMP_DIR/pass-calls"
+	unset FNOX_AGE_KEY FNOX_AGE_KEY_FILE
+	unset FIRST SECOND
+	: >"$PASS_CALLS_FILE"
+
+	cat >fnox.toml <<EOF
+root = true
+
+[providers.source]
+type = "plain"
+
+[providers.identity]
+type = "password-store"
+
+[providers.first-age]
+type = "age"
+recipients = ["$public_key"]
+identity = { provider = "identity", value = "first-age-key" }
+
+[providers.second-age]
+type = "age"
+recipients = ["$public_key"]
+identity = { provider = "identity", value = "second-age-key" }
+
+[secrets]
+FIRST = { provider = "source", value = "first", if_missing = "error" }
+SECOND = { provider = "source", value = "second", if_missing = "error" }
+EOF
+
+	assert_fnox_success sync FIRST -p first-age --force
+	assert_fnox_success sync SECOND -p second-age --force
+	: >"$PASS_CALLS_FILE"
+	assert_fnox_success check
+	assert_equal "$(grep -c '^first-age-key$' "$PASS_CALLS_FILE")" "1"
+	assert_equal "$(grep -c '^second-age-key$' "$PASS_CALLS_FILE")" "1"
+}


### PR DESCRIPTION
## Summary

Supersedes #773 with a narrower check-only implementation.

`fnox check` currently resolves each secret separately. For batch-encrypted Age values backed by a hardware or plugin identity, this repeatedly unwraps the same shared key and can require one authorization per secret.

This change:

- resolves eligible Age-backed secrets in batches by provider
- unwraps each shared batch key once across direct and synced ciphertexts
- preserves per-secret errors when an individual ciphertext is invalid
- keeps `check` uncached

Secrets using defaults, non-error missing policies, or post-processing continue through the existing single-secret resolution path.

*AI-assisted. Tool: OpenCode; model: openai/gpt-5.6-sol; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * The `check` command now resolves age-encrypted secrets in batches, improving efficiency when validating multiple secrets.
  * Provider credentials are loaded only once per check, reducing unnecessary identity reads.
  * Secrets configured with separate age providers are resolved independently to prevent cross-provider interference.

* **Bug Fixes**
  * Improved failure handling so an invalid secret is identified clearly while other secrets can still be checked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->