### PR TITLE
chore(ci): fail closed without notarization credentials

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,8 +94,8 @@ jobs:
           set -euo pipefail
 
           if [ -z "$APPLE_API_KEY_P8" ] || [ -z "$APPLE_API_KEY_ID" ] || [ -z "$APPLE_API_ISSUER_ID" ]; then
-            echo "::warning title=Not notarized::App Store Connect credentials are unset, so this release ships signed but un-notarized macOS binaries. Gatekeeper will block them for anyone who downloads an archive through a browser."
-            exit 0
+            echo "::error title=Notarization credentials missing::App Store Connect credentials are required for macOS releases."
+            exit 1
           fi
 
           # Outside the workspace, so no later step can sweep the key into an


### PR DESCRIPTION
## Summary
- fail the macOS release job when any App Store Connect notarization credential is missing
- prevent releases from silently publishing signed but unnotarized binaries

## Testing
- `actionlint .github/workflows/release.yml`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * macOS release builds now fail when required App Store Connect credentials are missing, preventing distribution of signed but unnotarized binaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->