### PR TITLE
ci(perf): move benchmarks to dedicated runner

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,3 +1,4 @@
 self-hosted-runner:
   labels:
+    - jdx-perf-v1
     - bamboo-perf

--- a/.github/workflows/perf-pr-preflight.yml
+++ b/.github/workflows/perf-pr-preflight.yml
@@ -1,0 +1,14 @@
+name: perf-pr-preflight
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  complete:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "The default-branch controller will independently validate this pull request."

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -214,6 +214,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
+      checks: write # attach the regression gate to the measured PR head SHA
       pull-requests: write # the sticky comment, and nothing else
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -258,6 +259,29 @@ jobs:
       # after it, and the gate is the reason this workflow exists. Without it a
       # `gh api` hiccup would skip the gate — red for the wrong reason, and with
       # no regression error to read.
+      - name: Publish the pull request check
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          status=$(cat /tmp/tak-out/status 2>/dev/null || echo 2)
+          if [ "$status" -eq 0 ]; then
+            conclusion=success
+            title='Instruction counts passed'
+          else
+            conclusion=failure
+            title='Instruction-count regression or measurement failure'
+          fi
+          test -f /tmp/tak-out/report.md || echo 'The comparison did not produce a report.' > /tmp/tak-out/report.md
+          jq -n --arg head_sha "$HEAD_SHA" --arg conclusion "$conclusion" \
+            --arg title "$title" --arg details_url "$RUN_URL" \
+            --rawfile summary /tmp/tak-out/report.md \
+            '{name:"perf / instruction-count",head_sha:$head_sha,status:"completed",conclusion:$conclusion,details_url:$details_url,output:{title:$title,summary:$summary}}' \
+            | gh api --method POST "repos/$GH_REPO/check-runs" --input -
+
       - name: Fail on a regression
         if: always()
         run: |

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -13,15 +13,17 @@ name: perf-pr
 # main contributes to the history — a branch's numbers are not the trunk's, and
 # a series that mixes them cannot be read.
 
-on:
-  pull_request_target:
-    types: [opened, synchronize, reopened]
+on: # zizmor: ignore[dangerous-triggers] validates live PR metadata before any self-hosted job
+  workflow_run:
+    workflows: [perf-pr-preflight]
+    types: [completed]
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: true
 
 env:
@@ -32,9 +34,48 @@ env:
   # comparing incompatible counts with the old hosted-runner baseline.
 
 jobs:
+  authorize:
+    runs-on: ubuntu-latest
+    outputs:
+      authorized: ${{ steps.pr.outputs.authorized }}
+      base_ref: ${{ steps.pr.outputs.base_ref }}
+      head_sha: ${{ steps.pr.outputs.head_sha }}
+      pr_number: ${{ steps.pr.outputs.pr_number }}
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - id: pr
+        name: Validate the pull request from the trusted default branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          TRIGGER_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          TRIGGER_EVENT: ${{ github.event.workflow_run.event }}
+          TRIGGER_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          exec 3>>"$GITHUB_OUTPUT"
+          echo 'authorized=false' >&3
+          [ "$TRIGGER_EVENT" = pull_request ] || exit 0
+          [ "$TRIGGER_CONCLUSION" = success ] || exit 0
+          [[ "$PR_NUMBER" =~ ^[0-9]+$ ]] || exit 0
+          pr="$(gh api "repos/$REPOSITORY/pulls/$PR_NUMBER")"
+          [ "$(jq -r .state <<<"$pr")" = open ] || exit 0
+          [ "$(jq -r .user.login <<<"$pr")" = jdx ] || exit 0
+          [ "$(jq -r .head.repo.full_name <<<"$pr")" = "$REPOSITORY" ] || exit 0
+          [ "$(jq -r .base.repo.full_name <<<"$pr")" = "$REPOSITORY" ] || exit 0
+          head_sha="$(jq -r .head.sha <<<"$pr")"
+          [ "$head_sha" = "$TRIGGER_SHA" ] || exit 0
+          echo 'authorized=true' >&3
+          echo "base_ref=$(jq -r .base.ref <<<"$pr")" >&3
+          echo "head_sha=$head_sha" >&3
+          echo "pr_number=$PR_NUMBER" >&3
+
   measure:
     name: Compare instruction counts
-    if: github.event.pull_request.user.login == 'jdx' && github.event.pull_request.head.repo.full_name == github.repository
+    needs: authorize
+    if: needs.authorize.outputs.authorized == 'true'
     # Same pinned environment as perf.yml. Absolute counts shift when the
     # runner image or compiler changes, even within one GitHub runner class.
     runs-on: [self-hosted, jdx-perf-v1]
@@ -54,7 +95,7 @@ jobs:
           # for the run, changes whenever main advances, and measuring it would
           # attribute a number to a commit nobody can check out. It would also
           # make the footer below name a commit the measurement is not of.
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ needs.authorize.outputs.head_sha }}
           # Needed twice over: to find the merge base, and for the sparkline,
           # which walks twenty commits of trunk history.
           fetch-depth: 0
@@ -87,7 +128,7 @@ jobs:
           {
             echo '### Runner metadata'
             echo '```text'
-            echo 'environment-revision: perf-runner@d7c0e81'
+            echo 'environment-revision: perf-runner@78e4231'
             echo 'image: ghcr.io/jdx/perf-runner@sha256:1b44fc9f1c93fc1b7a2db56a1ef743bbf8a8df60035121d455c9834fe8001922'
             uname -a
             lscpu
@@ -111,7 +152,7 @@ jobs:
       - name: Find the base commit
         id: base
         env:
-          BASE_REF: ${{ github.base_ref }}
+          BASE_REF: ${{ needs.authorize.outputs.base_ref }}
         run: |
           git fetch --quiet origin "$BASE_REF"
           # The merge base, not the branch tip: comparing against a moving
@@ -139,7 +180,7 @@ jobs:
         if: always()
         env:
           BASE_SHA: ${{ steps.base.outputs.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
         run: |
           mkdir -p /tmp/tak-out
           # A missing report means an earlier step died. Say so, rather than
@@ -168,8 +209,8 @@ jobs:
   # code: it reads an artifact and talks to the API.
   report:
     name: Report and gate
-    needs: measure
-    if: always() && github.event.pull_request.user.login == 'jdx'
+    needs: [authorize, measure]
+    if: always() && needs.authorize.outputs.authorized == 'true' && needs.measure.result != 'cancelled'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -183,11 +224,10 @@ jobs:
       # Skipped for pull requests from forks, which get a read-only token. The
       # comparison and the gate still run there; only the comment is missing.
       - name: Comment on the pull request
-        if: github.event.pull_request.head.repo.full_name == github.repository
         env:
           GH_TOKEN: ${{ github.token }}
           GH_fnox: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ needs.authorize.outputs.pr_number }}
         run: |
           marker='<!-- fnox-perf-pr -->'
           read -r head_sha base_sha < /tmp/tak-out/shas

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -14,7 +14,7 @@ name: perf-pr
 # a series that mixes them cannot be read.
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 permissions:
@@ -27,17 +27,20 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
-  TAK_RUNNER: bamboo-v2-ubuntu24.04-x64-30vcpu-24gb-rust1.97.1-tokio1
+  TAK_RUNNER: jdx-perf-v1-ubuntu24.04-x64-fnox-rust1.97.1-tokio1
   # Changing the measuring environment starts a new series rather than
   # comparing incompatible counts with the old hosted-runner baseline.
 
 jobs:
   measure:
     name: Compare instruction counts
-    if: github.event.pull_request.user.login == 'jdx'
+    if: github.event.pull_request.user.login == 'jdx' && github.event.pull_request.head.repo.full_name == github.repository
     # Same pinned environment as perf.yml. Absolute counts shift when the
     # runner image or compiler changes, even within one GitHub runner class.
-    runs-on: bamboo-perf
+    runs-on: [self-hosted, jdx-perf-v1]
+    container:
+      image: ghcr.io/jdx/perf-runner@sha256:1b44fc9f1c93fc1b7a2db56a1ef743bbf8a8df60035121d455c9834fe8001922
+      options: --cpuset-cpus 0-7
     timeout-minutes: 40
     permissions:
       # Read only. This job builds and runs code from the pull request, so it
@@ -57,8 +60,8 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      # Compile inside this disposable VM. Restoring target/ can relabel a
-      # binary built on a different runner class as a Bamboo measurement.
+      # Compile inside the pinned job container. Restoring target/ could relabel
+      # a binary built on another runner class as a jdx-perf-v1 measurement.
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
         with:
           cache: false
@@ -79,10 +82,31 @@ jobs:
           command -v valgrind || sudo apt-get install -y --no-install-recommends valgrind
           valgrind --version
 
+      - name: Runner metadata
+        run: |
+          {
+            echo '### Runner metadata'
+            echo '```text'
+            echo 'environment-revision: perf-runner@d7c0e81'
+            echo 'image: ghcr.io/jdx/perf-runner@sha256:1b44fc9f1c93fc1b7a2db56a1ef743bbf8a8df60035121d455c9834fe8001922'
+            uname -a
+            lscpu
+            mise --version
+            rustc --version
+            cargo --version
+            valgrind --version
+            for zone in /sys/class/thermal/thermal_zone*/temp; do
+              [ -r "$zone" ] && printf '%s: %s\n' "$zone" "$(cat "$zone")"
+            done
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
       # `--record` writes a git note locally and nothing more. There is no
       # `tak push` in this workflow and there should never be one.
       - name: Measure this pull request
-        run: mise run perf:record
+        run: |
+          cargo build --release
+          taskset -c 0-3 mise run perf:record
 
       - name: Find the base commit
         id: base

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -77,7 +77,7 @@ jobs:
           {
             echo '### Runner metadata'
             echo '```text'
-            echo 'environment-revision: perf-runner@d7c0e81'
+            echo 'environment-revision: perf-runner@78e4231'
             echo 'image: ghcr.io/jdx/perf-runner@sha256:1b44fc9f1c93fc1b7a2db56a1ef743bbf8a8df60035121d455c9834fe8001922'
             uname -a
             lscpu

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -27,7 +27,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
-  TAK_RUNNER: bamboo-v2-ubuntu24.04-x64-30vcpu-24gb-rust1.97.1-tokio1
+  TAK_RUNNER: jdx-perf-v1-ubuntu24.04-x64-fnox-rust1.97.1-tokio1
   # This is a new measurement series: the compiler, runner image and Tokio
   # worker count are part of the benchmark environment, not incidental details.
 
@@ -36,17 +36,20 @@ jobs:
     name: Measure
     # Pin the image as well as tak and Rust. Absolute instruction counts shift
     # when any part of the measuring environment moves.
-    runs-on: bamboo-perf
+    runs-on: [self-hosted, jdx-perf-v1]
+    container:
+      image: ghcr.io/jdx/perf-runner@sha256:1b44fc9f1c93fc1b7a2db56a1ef743bbf8a8df60035121d455c9834fe8001922
+      options: --cpuset-cpus 0-7
     timeout-minutes: 30
     permissions:
-      contents: write # pushing refs/notes/tak is a write to this repository
+      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
-      # Compile inside this disposable VM. Restoring target/ can relabel a
-      # binary built on a different runner class as a Bamboo measurement.
+      # Compile inside the pinned job container. Restoring target/ could relabel
+      # a binary built on another runner class as a jdx-perf-v1 measurement.
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
         with:
           cache: false
@@ -69,27 +72,74 @@ jobs:
           command -v valgrind || sudo apt-get install -y --no-install-recommends valgrind
           valgrind --version
 
-      - name: Measure and record
-        run: mise run perf:record
+      - name: Runner metadata
+        run: |
+          {
+            echo '### Runner metadata'
+            echo '```text'
+            echo 'environment-revision: perf-runner@d7c0e81'
+            echo 'image: ghcr.io/jdx/perf-runner@sha256:1b44fc9f1c93fc1b7a2db56a1ef743bbf8a8df60035121d455c9834fe8001922'
+            uname -a
+            lscpu
+            mise --version
+            rustc --version
+            cargo --version
+            valgrind --version
+            for zone in /sys/class/thermal/thermal_zone*/temp; do
+              [ -r "$zone" ] && printf '%s: %s\n' "$zone" "$(cat "$zone")"
+            done
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
 
-      # persist-credentials: false means the push needs its own auth. Same
-      # pattern as bench-refresh.yml: re-point origin rather than pushing to a
-      # one-shot URL, so tak's retry path has a remote to fetch from when it
-      # loses a race.
-      #
-      # Only main publishes. workflow_dispatch can be pointed at any branch or
-      # tag, and refs/notes/tak is a shared baseline that should hold main's
-      # history and nothing else. Gating the push rather than the whole job
-      # means a dispatch on a branch still measures and still prints its
-      # numbers in the summary — it just keeps them local.
-      - name: Push measurements
+      - name: Measure and record
+        run: |
+          cargo build --release
+          taskset -c 0-3 mise run perf:record
+      - name: Package measurement note
         if: github.ref == 'refs/heads/main'
+        run: |
+          mkdir -p /tmp/tak-out
+          git notes --ref=tak show HEAD > /tmp/tak-out/note
+          git rev-parse HEAD > /tmp/tak-out/sha
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        if: github.ref == 'refs/heads/main'
+        with:
+          name: tak-measurement
+          path: /tmp/tak-out
+          retention-days: 1
+          if-no-files-found: error
+
+      - name: Summary
+        run: tak history >> "$GITHUB_STEP_SUMMARY"
+
+  publish:
+    name: Publish measurement note
+    needs: measure
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: tak-measurement
+          path: /tmp/tak-out
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Publish refs/notes/tak
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPOSITORY: ${{ github.repository }}
         run: |
-          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPOSITORY}.git"
-          tak push
-
-      - name: Summary
-        run: tak history >> "$GITHUB_STEP_SUMMARY"
+          sha=$(cat /tmp/tak-out/sha)
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin refs/notes/tak:refs/notes/tak || true
+          git notes --ref=tak add -f -F /tmp/tak-out/note "$sha"
+          git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPOSITORY}.git" refs/notes/tak

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -140,6 +140,25 @@ jobs:
           sha=$(cat /tmp/tak-out/sha)
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git fetch origin refs/notes/tak:refs/notes/tak || true
-          git notes --ref=tak add -f -F /tmp/tak-out/note "$sha"
-          git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPOSITORY}.git" refs/notes/tak
+          git fetch origin +refs/notes/tak:refs/notes/tak-remote || true
+          if git rev-parse --verify --quiet refs/notes/tak-remote >/dev/null; then
+            git update-ref refs/notes/tak refs/notes/tak-remote
+          fi
+          {
+            git notes --ref=tak show "$sha" 2>/dev/null || true
+            cat /tmp/tak-out/note
+          } | LC_ALL=C sort -u > /tmp/tak-out/merged-note
+          git notes --ref=tak add -f -F /tmp/tak-out/merged-note "$sha"
+
+          remote="https://x-access-token:${GITHUB_TOKEN}@github.com/${REPOSITORY}.git"
+          for attempt in 1 2 3 4 5; do
+            if git push --quiet "$remote" refs/notes/tak:refs/notes/tak; then
+              exit 0
+            fi
+            if [ "$attempt" -eq 5 ]; then
+              echo "::error::could not publish refs/notes/tak after five attempts"
+              exit 1
+            fi
+            git fetch --quiet "$remote" +refs/notes/tak:refs/notes/tak-remote
+            git notes --ref=tak merge -s cat_sort_uniq refs/notes/tak-remote
+          done


### PR DESCRIPTION
Routes Cachegrind benchmarks to the dedicated `jdx-perf-v1` appliance. PRs use a GitHub-hosted `pull_request` preflight and a trusted default-branch `workflow_run` controller that revalidates the live PR author, repository, state, and exact head SHA before scheduling the read-only measurement job. The appliance independently rejects workflow refs outside the approved performance controllers on `main`. Write operations remain in separate GitHub-hosted jobs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the CI security boundary (untrusted PR builds on self-hosted hardware) and how `refs/notes/tak` is published, though writes are isolated to GitHub-hosted jobs and PR execution is gated on live API validation.
> 
> **Overview**
> **Moves instruction-count benchmarks from `bamboo-perf` to the dedicated `jdx-perf-v1` self-hosted runner**, with a pinned `ghcr.io/jdx/perf-runner` container, CPU affinity (`--cpuset-cpus` / `taskset`), explicit `cargo build --release`, and a new `TAK_RUNNER` series string. Both `perf.yml` and `perf-pr.yml` now log runner/toolchain metadata into the job summary.
> 
> **PR perf is re-wired for safer triggering:** a new GitHub-hosted `perf-pr-preflight` workflow still listens on `pull_request`, while `perf-pr` runs on `workflow_run` and adds an **`authorize` job** that re-fetches live PR metadata (open state, author `jdx`, same-repo head/base, head SHA matches the trigger) before scheduling measurement. The self-hosted **`measure` job stays read-only**; reporting moves to a separate Ubuntu job that posts the sticky comment and a new **`perf / instruction-count` check** on the PR head SHA.
> 
> **Main-branch publishing is split:** the appliance only measures and uploads the `tak` git note as an artifact; a follow-up **`publish` job** on `ubuntu-latest` (with `contents: write`) merges and pushes `refs/notes/tak` with retries instead of running `tak push` on the runner. Actionlint gains the `jdx-perf-v1` runner label.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fdaf1335145719e7b53af9ad82bd791bed9d1e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Performance measurements now run in a standardized, pinned environment for more consistent results.
  * Measurement jobs capture additional runner, toolchain, and system metadata.
  * Performance builds and recordings use dedicated CPU allocation and release-mode builds.
  * Results are packaged and published through a separate, controlled reporting step with retry handling.
  * Pull request performance checks validate request details before running and publish results to the pull request.
  * Added an automated preflight step to coordinate pull request performance validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->