### PR TITLE
chore: update mr-boxington to 1.3.0

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -6,6 +6,6 @@ runs:
   steps:
     - uses: jdx/mr-boxington-action@203ebddb3bdb1b3832473207d0a837b23b660563
       with:
-        version: 1.1.0
+        version: 1.3.0
         backend: github
         cache-generation: v2

--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Install Rust components
         run: rustup component add rustfmt clippy
       - name: Build
-        run: mbx build
+        run: cargo build
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: fnox-${{ matrix.os }}
@@ -243,7 +243,7 @@ jobs:
           fetch_from_github: false
       - uses: ./.github/actions/mbx
       - name: Check Windows build
-        run: mbx check --workspace
+        run: cargo check --workspace
 
   ci-other:
     needs: build
@@ -307,7 +307,7 @@ jobs:
       - name: Clean cached Rust build artifacts
         run: cargo clean
       - name: Run tests
-        run: mbx test --workspace
+        run: cargo test --workspace
       - name: mise run render
         run: mise run render
       - name: assert render produces no diff
@@ -325,7 +325,7 @@ jobs:
           max_attempts: 3
           command: mise run lint
       - name: Run clippy
-        run: mbx clippy --workspace --all-targets -- -D warnings
+        run: cargo clippy --workspace --all-targets -- -D warnings
 
   msrv:
     runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
@@ -348,7 +348,7 @@ jobs:
           sudo apt-get install -y libudev-dev
       # cargo-msrv doesn't accept --workspace; verifying the binary's MSRV
       # transitively covers fnox-core because the binary depends on it.
-      - run: mbx msrv verify
+      - run: cargo msrv verify
 
   final:
     permissions: {}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,8 +2,9 @@
 
 ## mbx build cache
 
-Mise installs mbx 1.3 and activates its transparent Cargo wrapper, so
-compilation-heavy mise tasks and hk checks use ordinary `cargo` commands. If
+`mise install` installs mbx 1.3. `mise run` activates the project's transparent
+Cargo wrapper, so compilation-heavy mise tasks and hk checks use ordinary
+`cargo` commands. Standalone Cargo commands require an activated mise shell. If
 the wrapper fails or creates a development papercut, rerun the exact equivalent
 command from `CONTRIBUTING.md` with `MBX_DISABLE=1`; this unblocks work without
 weakening the check. If bypassed Cargo succeeds, surface the mismatch and recommend a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,15 +2,15 @@
 
 ## mbx build cache
 
-Mise installs mbx 1.1 and activates its transparent Cargo shim, so
+Mise installs mbx 1.3 and activates its transparent Cargo wrapper, so
 compilation-heavy mise tasks and hk checks use ordinary `cargo` commands. If
-the shim fails or creates a development papercut, rerun the exact equivalent
+the wrapper fails or creates a development papercut, rerun the exact equivalent
 command from `CONTRIBUTING.md` with `MBX_DISABLE=1`; this unblocks work without
 weakening the check. If bypassed Cargo succeeds, surface the mismatch and recommend a
 [mr-boxington Discussion](https://github.com/jdx/mr-boxington/discussions) with
 the repository and commit, OS, `mbx --version`, `mbx doctor`, and both commands
 and outputs. Redact secrets, absolute cache paths, remote URLs, namespaces, and
-other sensitive or identifying details. Do not permanently disable the shim,
+other sensitive or identifying details. Do not permanently disable the wrapper,
 and do not post externally without user authorization.
 
 ## Conventional Commits

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,8 @@ See the [contributing guide](https://fnox.jdx.dev/contributing).
 
 ## mbx build cache
 
-`mise install` installs [mbx](https://mr-boxington.jdx.dev) 1.1 and activates
-its transparent Cargo shim. The normal `mise run build`, `mise run test:cargo`,
+`mise install` installs [mbx](https://mr-boxington.jdx.dev) 1.3 and activates
+its transparent Cargo wrapper. The normal `mise run build`, `mise run test:cargo`,
 and `mise run lint` workflows therefore use the cache while invoking Cargo
 normally. To bypass mbx without skipping or weakening a check, prefix the
 equivalent Cargo command with `MBX_DISABLE=1`:
@@ -20,7 +20,7 @@ MBX_DISABLE=1 cargo clippy --workspace --all-targets -- -D warnings
 MBX_DISABLE=1 cargo msrv verify
 ```
 
-If bypassed Cargo succeeds where the shim fails, or mbx introduces a papercut, please start a
+If bypassed Cargo succeeds where the wrapper fails, or mbx introduces a papercut, please start a
 [mr-boxington Discussion](https://github.com/jdx/mr-boxington/discussions).
 Include the repository and commit, operating system, `mbx --version`,
 `mbx doctor`, and both commands and their output. Before posting, redact

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,10 +4,11 @@ See the [contributing guide](https://fnox.jdx.dev/contributing).
 
 ## mbx build cache
 
-`mise install` installs [mbx](https://mr-boxington.jdx.dev) 1.3 and activates
-its transparent Cargo wrapper. The normal `mise run build`, `mise run test:cargo`,
-and `mise run lint` workflows therefore use the cache while invoking Cargo
-normally. To bypass mbx without skipping or weakening a check, prefix the
+`mise install` installs [mbx](https://mr-boxington.jdx.dev) 1.3. The normal
+`mise run build`, `mise run test:cargo`, and `mise run lint` workflows activate
+its transparent Cargo wrapper and therefore use the cache while invoking Cargo
+normally. Standalone Cargo commands require an activated mise shell. To bypass
+mbx without skipping or weakening a check, prefix the
 equivalent Cargo command with `MBX_DISABLE=1`:
 
 ```sh

--- a/mise.lock
+++ b/mise.lock
@@ -516,44 +516,44 @@ url = "https://github.com/jdx/hk/releases/download/v1.56.1/hk-x86_64-pc-windows-
 url_api = "https://api.github.com/repos/jdx/hk/releases/assets/525632118"
 
 [[tools.mr-boxington]]
-version = "1.1.0"
+version = "1.3.0"
 backend = "github:jdx/mr-boxington"
 
 [tools.mr-boxington."platforms.linux-arm64"]
-checksum = "sha256:ded60221f2217a6e0abfe0ba3583674bae63e5a7b696c4fa145827a3a0e352af"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232514"
+checksum = "sha256:92a8544d26324b7803eeb1d2f1c276e322e474d45e7f40b6f6a1e72ce99d6fdc"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561463"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-arm64-musl"]
-checksum = "sha256:70a882277389bd6e6b606fc291083a857a7ef0c742b60ba5a7822cc49fe7c4ac"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232511"
+checksum = "sha256:db505d360e8c1dfc6fb31ecf8172329ae2fa2417b14508e306626c6c1dba3514"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561466"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-x64"]
-checksum = "sha256:8e718ff25e71057f758d02f3039481258cd531be914afd3f77198811d0113a74"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232519"
+checksum = "sha256:0717a7dc93fdd9712d648ddab0f7e0871b50b626568c62a5c1033396f50e3940"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561483"
 provenance = "github-attestations"
 provenance_verified = true
 
 [tools.mr-boxington."platforms.linux-x64-musl"]
-checksum = "sha256:9f590a0fd0fc0a5896791257863980fe9c6035458414575749cc43e68e7ff0cf"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232518"
+checksum = "sha256:385b25699ba7429fe7cd36668667c45ff8d38f4491ebb4164e95021b22374ed0"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561484"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.macos-arm64"]
-checksum = "sha256:da96661534480fff35ec78e598124d208ac1f2624c6d3c287c9ae2a5852b0b29"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232513"
+checksum = "sha256:0d2e9d6e7d8228faafda68e2cd4190ce977a332821833c19a853c4a9dd91a82f"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561462"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.windows-x64"]
-checksum = "sha256:4adbb02bf97f00644d2e1e3930e154df39a07df1e574e0829b5d6e34474a3c95"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232517"
+checksum = "sha256:e102e3e1dd0777fc7a39c91a7805cbc8636bc4ab0c5cdc30a51b7962b8a524a7"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561482"
 provenance = "github-attestations"
 
 [[tools.node]]

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,5 @@
+min_version = "2026.8.16"
+
 [env]
 _.path = ["target/debug", "test/bats/bin"]
 

--- a/mise.toml
+++ b/mise.toml
@@ -2,7 +2,7 @@
 _.path = ["target/debug", "test/bats/bin"]
 
 [tools]
-mr-boxington = { version = "1.1.0", postinstall = "mbx setup --global" }
+mr-boxington = "1.3.0"
 usage = "6.4.1"
 # Pinned rather than "latest" because tak is the measuring instrument: an
 # upgrade that changes how it samples would land in the series as a step change
@@ -27,6 +27,10 @@ bitwarden-secrets-manager = "latest"
 vault = "latest"
 "github:Infisical/cli" = "latest"
 node = "24"
+
+[wrappers.cargo]
+command = "mbx"
+env = { MBX_CARGO_SHIM_MODE = "1" }
 
 [tasks.test]
 description = "Run both cargo and bats tests"


### PR DESCRIPTION
## Summary
- update mr-boxington to 1.3.0 and refresh its lock entry
- commit the project-scoped Cargo wrapper instead of running global setup
- update mbx contributor and agent guidance for command wrappers

## Validation
- `mise lock --dry-run --json mr-boxington`
- verified `mbx 1.3.0` and Cargo resolution through mise command wrappers

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling and CI wiring only; no application runtime or security-sensitive code changes, with modest risk if the new wrapper or CI cargo paths diverge from local mise behavior.
> 
> **Overview**
> Bumps **mr-boxington (mbx)** from **1.1.0** to **1.3.0** in the GitHub composite action, `mise.toml`, and `mise.lock`, and requires **mise** `min_version = "2026.8.16"`.
> 
> Local dev no longer runs **`mbx setup --global` on install**. Instead, **`[wrappers.cargo]`** routes `cargo` through `mbx` with `MBX_CARGO_SHIM_MODE=1` when mise is active; contributor docs now say bare `cargo` needs an activated mise shell and rename “shim” to “wrapper”.
> 
> **CI** still uses the mbx setup action for caching but invokes **`cargo build` / `check` / `test` / `clippy` / `msrv verify`** directly instead of `mbx` subcommands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef8cb93c782fac6e9abb77aae52e7538cfeda81a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated build-cache setup and troubleshooting guidance to reflect the latest tooling terminology and version.

- **Improvements**
  - Updated the development environment to use the latest build-cache tooling.
  - Improved Cargo command integration for more consistent build workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->