### PR TITLE
chore(ci): use mbx server cache for trusted builds

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -5,10 +5,20 @@ inputs:
   backend:
     description: Backend selected by the structurally trusted caller
     default: github
+  mirror-github-cache:
+    description: Mirror a trusted main build into the restore-only cache used by fork PRs
+    default: "false"
 
 runs:
   using: composite
   steps:
+    - name: Restore the fork PR cache mirror
+      if: inputs.mirror-github-cache == 'true' && inputs.backend == 'server' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+      uses: jdx/mr-boxington-action@203ebddb3bdb1b3832473207d0a837b23b660563
+      with:
+        version: 1.3.0
+        backend: github
+        cache-generation: v2
     - uses: jdx/mr-boxington-action@203ebddb3bdb1b3832473207d0a837b23b660563
       with:
         version: 1.3.0

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -1,5 +1,10 @@
 name: Set up mbx
-description: Set up mbx with the GitHub Actions cache backend
+description: Select the trusted jdx server or fork-safe GitHub cache backend
+
+inputs:
+  backend:
+    description: Explicit backend for structurally trusted or untrusted callers
+    default: auto
 
 runs:
   using: composite
@@ -7,5 +12,8 @@ runs:
     - uses: jdx/mr-boxington-action@203ebddb3bdb1b3832473207d0a837b23b660563
       with:
         version: 1.3.0
-        backend: github
         cache-generation: v2
+        backend: ${{ inputs.backend != 'auto' && inputs.backend || ((github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'github' || 'server') }}
+        server-url: https://cache.mise.jdx.dev
+        namespace: jdx/fnox
+        oidc-audience: https://cache.mise.jdx.dev

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -3,8 +3,8 @@ description: Select the trusted jdx server or fork-safe GitHub cache backend
 
 inputs:
   backend:
-    description: Explicit backend for structurally trusted or untrusted callers
-    default: auto
+    description: Backend selected by the structurally trusted caller
+    default: github
 
 runs:
   using: composite
@@ -13,7 +13,7 @@ runs:
       with:
         version: 1.3.0
         cache-generation: v2
-        backend: ${{ inputs.backend != 'auto' && inputs.backend || ((github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'github' || 'server') }}
+        backend: ${{ inputs.backend }}
         server-url: https://cache.mise.jdx.dev
         namespace: jdx/fnox
         oidc-audience: https://cache.mise.jdx.dev

--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -46,6 +46,7 @@ jobs:
       - uses: ./.github/actions/mbx
         with:
           backend: ${{ inputs.trusted && 'server' || 'github' }}
+          mirror-github-cache: "true"
       - name: Install system dependencies (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
         run: |
@@ -246,6 +247,7 @@ jobs:
       - uses: ./.github/actions/mbx
         with:
           backend: ${{ inputs.trusted && 'server' || 'github' }}
+          mirror-github-cache: "true"
       - name: Check Windows build
         run: cargo check --workspace
 

--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -44,6 +44,8 @@ jobs:
         with:
           cache: false
       - uses: ./.github/actions/mbx
+        with:
+          backend: ${{ inputs.trusted && 'server' || 'github' }}
       - name: Install system dependencies (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
         run: |
@@ -242,6 +244,8 @@ jobs:
           cache: false
           fetch_from_github: false
       - uses: ./.github/actions/mbx
+        with:
+          backend: ${{ inputs.trusted && 'server' || 'github' }}
       - name: Check Windows build
         run: cargo check --workspace
 
@@ -266,6 +270,8 @@ jobs:
         with:
           cache: false
       - uses: ./.github/actions/mbx
+        with:
+          backend: ${{ inputs.trusted && 'server' || 'github' }}
       - name: Install system dependencies (Ubuntu)
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
@@ -339,6 +345,8 @@ jobs:
         with:
           cache: false
       - uses: ./.github/actions/mbx
+        with:
+          backend: ${{ inputs.trusted && 'server' || 'github' }}
       - name: Install system dependencies
         run: |
           if [ -f /etc/apt/apt-mirrors.txt ]; then


### PR DESCRIPTION
## Summary

- route trusted jdx builds through cache.mise.jdx.dev with OIDC
- retain the GitHub Actions cache backend for forks and untrusted callers
- isolate cache entries under the repository namespace

## Validation

- actionlint -shellcheck= .github/workflows/*.yml
- git diff --check

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI cache routing and OIDC-backed remote cache access; trusted/untrusted split is intentional but misconfiguration could affect cache isolation or fork PR restore behavior.
> 
> **Overview**
> **Trusted CI** now passes `backend: server` into `./.github/actions/mbx` so `mr-boxington` uses `cache.mise.jdx.dev` with OIDC (`namespace: jdx/fnox`); **untrusted/fork** runs keep `backend: github`.
> 
> The **mbx composite action** gains `backend` and `mirror-github-cache` inputs. When mirroring is enabled on trusted **main** pushes, it runs an extra GitHub-backend restore step before the primary step so fork PRs can hit a warmed GitHub cache.
> 
> `ci-impl` wires this on **build**, **windows-check** (with mirroring), and **ci-other** / **msrv** (backend only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f92dfd6d5d7ec4633345bb388eab0299d8e9cf9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable backend selection for the action.
  * Automatically selects the trusted server backend for trusted workflow runs and the GitHub backend otherwise.
  * Added support for configuring the server URL, namespace, and OIDC audience.
  * Added optional mirroring of the GitHub cache for supported trusted builds, helping preserve cache availability across backend configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->