### PR TITLE
chore(release): improve sponsor message

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -249,9 +249,9 @@ jobs:
 
           ## 💚 Sponsor fnox
 
-          fnox is maintained by [@jdx](https://github.com/jdx), an open source developer for [**entire.io**](https://entire.io), the title sponsor of the [jdx.dev](https://jdx.dev) open source tools including [mise](https://mise.jdx.dev/), [aube](https://aube.jdx.dev/), hk, and more. Keeping fnox secure, maintained, and free is funded by sponsors.
+          fnox is built and maintained by [@jdx](https://github.com/jdx), an open source developer at [**entire.io**](https://entire.io/), the title sponsor of his open source work.
 
-          If fnox is handling secrets or config for you or your team, please consider [sponsoring at jdx.dev](https://jdx.dev/sponsors.html). Sponsorships are what let fnox stay independent and the project keep moving.
+          If fnox handles secrets or config for you or your team, please consider becoming an [individual or company sponsor](https://jdx.dev/sponsors.html). Your support funds ongoing development and helps keep fnox secure, free, and independent.
           EOF
           gh release edit "$TAG_NAME" --notes-file /tmp/release-notes.md
 


### PR DESCRIPTION
## Summary

- clarify Entire's sponsorship of jdx's open source work
- link the sponsorship call to action directly to the individual and company sponsor page
- tighten the release-note copy while preserving each CLI's tailored message

## Testing

- git diff --check
- parsed the updated workflow as YAML

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only change in the release workflow’s appended notes; no build, publish, or runtime behavior changes.
> 
> **Overview**
> Updates the **Sponsor fnox** block that the `enhance-release` job appends to GitHub release notes after stripping any prior copy of that section.
> 
> The blurb now describes [@jdx](https://github.com/jdx) as building and maintaining fnox **at** [**entire.io**](https://entire.io/) as title sponsor of his open source work, instead of the longer list of jdx.dev tools (mise, aube, hk, etc.). The sponsorship ask is shortened and points readers to become an **individual or company sponsor** on [jdx.dev/sponsors.html](https://jdx.dev/sponsors.html), with slightly reframed wording about funding development and keeping fnox secure, free, and independent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3af031fdcd64ed568ef801cc121f3c099432d68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the release notes’ sponsor messaging to highlight ongoing open-source development.
  * Added a call to support development through individual or company sponsorships.
  * Clarified that sponsorship helps keep fnox secure, free, and independent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->