### PR TITLE
fix(daemon): detach background daemon from client cwd

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -548,6 +548,7 @@ async fn start_background_for_context(
     {
         cmd.env("FNOX_DAEMON_IDLE_TIMEOUT", daemon.idle_timeout());
     }
+    cmd.current_dir("/");
     #[cfg(unix)]
     {
         use std::os::unix::process::CommandExt;

--- a/test/daemon.bats
+++ b/test/daemon.bats
@@ -45,6 +45,22 @@ EOF
 	assert_output --partial "cached_entries: 1"
 }
 
+@test "daemon survives deletion of its spawn directory" {
+	daemon_config
+	mkdir spawn request
+
+	cd spawn
+	run "$FNOX_BIN" get FOO
+	assert_success
+	assert_output "bar"
+
+	cd ../request
+	rmdir ../spawn
+	run "$FNOX_BIN" get FOO
+	assert_success
+	assert_output "bar"
+}
+
 @test "daemon resolves cache misses in the foreground client" {
 	mkdir -p "$TEST_TEMP_DIR/bin"
 	cat >"$TEST_TEMP_DIR/bin/pass" <<'EOF'

--- a/test/daemon.bats
+++ b/test/daemon.bats
@@ -53,12 +53,19 @@ EOF
 	run "$FNOX_BIN" get FOO
 	assert_success
 	assert_output "bar"
+	run "$FNOX_BIN" daemon status
+	assert_success
+	first_pid="$(printf '%s\n' "$output" | sed -n 's/^pid: //p')"
 
 	cd ../request
 	rmdir ../spawn
 	run "$FNOX_BIN" get FOO
 	assert_success
 	assert_output "bar"
+	run "$FNOX_BIN" daemon status
+	assert_success
+	second_pid="$(printf '%s\n' "$output" | sed -n 's/^pid: //p')"
+	assert_equal "$second_pid" "$first_pid"
 }
 
 @test "daemon resolves cache misses in the foreground client" {


### PR DESCRIPTION
## Summary

- start background daemons from `/` instead of inheriting the client working directory
- cover requests after the daemon spawn directory is deleted

Addresses discussion #793.

## Testing

- `mise run build`
- `mise run test:bats -- test/daemon.bats`
- `mise run lint`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized spawn change with regression test; request handling still uses explicit per-request cwd.
> 
> **Overview**
> Fixes a reliability bug where the background **fnox** daemon could break after the directory that auto-started it was removed.
> 
> **`start_background_for_context`** now sets the daemon child’s working directory to **`/`** before `spawn`, instead of inheriting the client’s cwd. Per-request resolution is unchanged—clients still send **`cwd`** on IPC and the daemon switches with **`CwdGuard`** for each request.
> 
> Adds a bats test that starts the daemon from a temp directory, deletes that directory, and asserts **`get`** still works and **`daemon status`** reports the **same PID**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88c577d7ce6549656c77f4818ccd5742afeeb6b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved daemon reliability when its launch directory is removed.
  * Cached values remain available after the daemon’s original directory is deleted.

* **Tests**
  * Added coverage confirming the daemon continues serving requests with the same process after the spawn directory is removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->