### PR TITLE
ci: route mbx caching by runner provider

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -12,6 +12,12 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Set up mise for the local mbx install
+      if: inputs.backend == 'local'
+      uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+      with:
+        install: false
+        cache: false
     - name: Mount the local mbx store on the Namespace cache volume
       if: inputs.backend == 'local'
       uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
@@ -20,7 +26,8 @@ runs:
     - name: Install mbx for local caching
       if: inputs.backend == 'local'
       shell: bash
-      run: | # zizmor: ignore[github-env] mise where returns the trusted tool install directory
+      run:
+        | # zizmor: ignore[github-env] mise where returns the trusted tool install directory
         mise install mr-boxington
         echo "$(mise where mr-boxington)" >> "$GITHUB_PATH"
         echo "MBX_REMOTE_URL=" >> "$GITHUB_ENV"

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -10,10 +10,17 @@ runs:
   using: composite
   steps:
     - name: Set up mise for the mbx install
+      if: runner.os != 'Windows'
+      uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+      with:
+        install: false
+        cache: false
+    - name: Set up mise for the mbx install on Windows
+      if: runner.os == 'Windows'
       uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
       env:
-        MISE_DATA_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-data', runner.tool_cache) || env.MISE_DATA_DIR }}
-        MISE_CACHE_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-cache', runner.tool_cache) || env.MISE_CACHE_DIR }}
+        MISE_DATA_DIR: ${{ format('{0}/mise-data', runner.tool_cache) }}
+        MISE_CACHE_DIR: ${{ format('{0}/mise-cache', runner.tool_cache) }}
       with:
         install: false
         cache: false
@@ -26,10 +33,12 @@ runs:
       shell: bash
       env:
         MBX_BACKEND: ${{ inputs.backend }}
-        MISE_DATA_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-data', runner.tool_cache) || env.MISE_DATA_DIR }}
-        MISE_CACHE_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-cache', runner.tool_cache) || env.MISE_CACHE_DIR }}
       run:
         | # zizmor: ignore[github-env] mise where returns the trusted tool install directory
+        if [[ "$RUNNER_OS" == Windows ]]; then
+          export MISE_DATA_DIR="$RUNNER_TOOL_CACHE/mise-data"
+          export MISE_CACHE_DIR="$RUNNER_TOOL_CACHE/mise-cache"
+        fi
         mise install mr-boxington
         mise reshim -f
         mise where mr-boxington >> "$GITHUB_PATH"

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -12,8 +12,8 @@ runs:
     - name: Set up mise for the mbx install
       uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
       env:
-        MISE_DATA_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-data', runner.temp) || env.MISE_DATA_DIR }}
-        MISE_CACHE_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-cache', runner.temp) || env.MISE_CACHE_DIR }}
+        MISE_DATA_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-data', runner.tool_cache) || env.MISE_DATA_DIR }}
+        MISE_CACHE_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-cache', runner.tool_cache) || env.MISE_CACHE_DIR }}
       with:
         install: false
         cache: false
@@ -26,8 +26,8 @@ runs:
       shell: bash
       env:
         MBX_BACKEND: ${{ inputs.backend }}
-        MISE_DATA_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-data', runner.temp) || env.MISE_DATA_DIR }}
-        MISE_CACHE_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-cache', runner.temp) || env.MISE_CACHE_DIR }}
+        MISE_DATA_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-data', runner.tool_cache) || env.MISE_DATA_DIR }}
+        MISE_CACHE_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-cache', runner.tool_cache) || env.MISE_CACHE_DIR }}
       run:
         | # zizmor: ignore[github-env] mise where returns the trusted tool install directory
         mise install mr-boxington

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -12,6 +12,21 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Mount the local mbx store on the Namespace cache volume
+      if: inputs.backend == 'local'
+      uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
+      with:
+        path: ${{ runner.os == 'macOS' && '~/Library/Caches/mbx' || '~/.cache/mbx' }}
+    - name: Install mbx for local caching
+      if: inputs.backend == 'local'
+      shell: bash
+      run: |
+        mise install mr-boxington
+        echo "$(mise where mr-boxington)" >> "$GITHUB_PATH"
+        echo "MBX_REMOTE_URL=" >> "$GITHUB_ENV"
+        if [[ "$RUNNER_OS" == Linux ]]; then
+          echo "MBX_CACHE_LINKS=1" >> "$GITHUB_ENV"
+        fi
     - name: Restore the fork PR cache mirror
       if: inputs.mirror-github-cache == 'true' && inputs.backend == 'local' && github.event_name == 'push' && github.ref == 'refs/heads/main'
       uses: jdx/mr-boxington-action@adc5c234c02592f7edd008bf81d5bc0e9584dc03 # v1.2.0

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -29,6 +29,7 @@ runs:
       run:
         | # zizmor: ignore[github-env] mise where returns the trusted tool install directory
         mise install mr-boxington
+        mise reshim -f
         echo "$(mise where mr-boxington)" >> "$GITHUB_PATH"
         echo "MBX_REMOTE_URL=" >> "$GITHUB_ENV"
         if [[ "$RUNNER_OS" == Linux ]]; then

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -20,7 +20,7 @@ runs:
     - name: Install mbx for local caching
       if: inputs.backend == 'local'
       shell: bash
-      run: |
+      run: | # zizmor: ignore[github-env] mise where returns the trusted tool install directory
         mise install mr-boxington
         echo "$(mise where mr-boxington)" >> "$GITHUB_PATH"
         echo "MBX_REMOTE_URL=" >> "$GITHUB_ENV"

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -11,6 +11,9 @@ runs:
   steps:
     - name: Set up mise for the mbx install
       uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+      env:
+        MISE_DATA_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-data', runner.temp) || env.MISE_DATA_DIR }}
+        MISE_CACHE_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-cache', runner.temp) || env.MISE_CACHE_DIR }}
       with:
         install: false
         cache: false
@@ -23,6 +26,8 @@ runs:
       shell: bash
       env:
         MBX_BACKEND: ${{ inputs.backend }}
+        MISE_DATA_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-data', runner.temp) || env.MISE_DATA_DIR }}
+        MISE_CACHE_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-cache', runner.temp) || env.MISE_CACHE_DIR }}
       run:
         | # zizmor: ignore[github-env] mise where returns the trusted tool install directory
         mise install mr-boxington

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -24,6 +24,8 @@ runs:
       with:
         install: false
         cache: false
+        env: false
+        add_shims_to_path: false
     - name: Mount the local mbx store on the Namespace cache volume
       if: inputs.backend == 'local'
       uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -1,9 +1,9 @@
 name: Set up mbx
-description: Select the trusted jdx server or fork-safe GitHub cache backend
+description: Use the local Namespace volume or fork-safe GitHub cache backend
 
 inputs:
   backend:
-    description: Backend selected by the structurally trusted caller
+    description: Backend selected by the structurally trusted caller; local skips transport
     default: github
   mirror-github-cache:
     description: Mirror a trusted main build into the restore-only cache used by fork PRs
@@ -13,12 +13,13 @@ runs:
   using: composite
   steps:
     - name: Restore the fork PR cache mirror
-      if: inputs.mirror-github-cache == 'true' && inputs.backend == 'server' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+      if: inputs.mirror-github-cache == 'true' && inputs.backend == 'local' && github.event_name == 'push' && github.ref == 'refs/heads/main'
       uses: jdx/mr-boxington-action@adc5c234c02592f7edd008bf81d5bc0e9584dc03 # v1.2.0
       with:
         backend: github
         cache-generation: v2
-    - uses: jdx/mr-boxington-action@adc5c234c02592f7edd008bf81d5bc0e9584dc03 # v1.2.0
+    - if: inputs.backend != 'local'
+      uses: jdx/mr-boxington-action@adc5c234c02592f7edd008bf81d5bc0e9584dc03 # v1.2.0
       with:
         cache-generation: v2
         backend: ${{ inputs.backend }}

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -1,10 +1,10 @@
 name: Set up mbx
-description: Install mbx with a local Namespace, remote server, or ephemeral store
+description: Install mbx with a local Namespace store or the GitHub Actions cache server
 
 inputs:
   backend:
-    description: Store selected by the structurally trusted caller
-    default: github
+    description: Use local on Namespace runners and server on GitHub-hosted runners
+    default: server
 
 runs:
   using: composite
@@ -45,10 +45,12 @@ runs:
         mise reshim -f
         mise where mr-boxington >> "$GITHUB_PATH"
         {
-          if [[ "$MBX_BACKEND" == server ]]; then
-            echo "MBX_REMOTE_URL=https://cache.mise.jdx.dev"
+          if [[ "$MBX_BACKEND" == server && -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]]; then
+            echo "MBX_REMOTE_URL=https://cache.jdx.dev"
             echo "MBX_REMOTE_NAMESPACE=jdx/fnox"
-            echo "MBX_REMOTE_OIDC_AUDIENCE=https://cache.mise.jdx.dev"
+            echo "MBX_REMOTE_OIDC_AUDIENCE=https://cache.jdx.dev"
+          elif [[ "$MBX_BACKEND" == server ]]; then
+            echo "::notice::GitHub OIDC is unavailable; using an ephemeral local mbx store"
           fi
           if [[ "$RUNNER_OS" == Linux ]]; then
             echo "MBX_CACHE_LINKS=1"

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -45,12 +45,14 @@ runs:
         mise reshim -f
         mise where mr-boxington >> "$GITHUB_PATH"
         {
-          if [[ "$MBX_BACKEND" == server && -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]]; then
+          if [[ "$MBX_BACKEND" == server ]]; then
             echo "MBX_REMOTE_URL=https://cache.jdx.dev"
             echo "MBX_REMOTE_NAMESPACE=jdx/fnox"
-            echo "MBX_REMOTE_OIDC_AUDIENCE=https://cache.jdx.dev"
-          elif [[ "$MBX_BACKEND" == server ]]; then
-            echo "::notice::GitHub OIDC is unavailable; using an ephemeral local mbx store"
+            if [[ -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]]; then
+              echo "MBX_REMOTE_OIDC_AUDIENCE=https://cache.jdx.dev"
+            else
+              echo "::notice::GitHub OIDC is unavailable; using public read-only cache access" >&2
+            fi
           fi
           if [[ "$RUNNER_OS" == Linux ]]; then
             echo "MBX_CACHE_LINKS=1"

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -1,19 +1,15 @@
 name: Set up mbx
-description: Use the local Namespace volume or fork-safe GitHub cache backend
+description: Install mbx with a local Namespace, remote server, or ephemeral store
 
 inputs:
   backend:
-    description: Backend selected by the structurally trusted caller; local skips transport
+    description: Store selected by the structurally trusted caller
     default: github
-  mirror-github-cache:
-    description: Mirror a trusted main build into the restore-only cache used by fork PRs
-    default: "false"
 
 runs:
   using: composite
   steps:
-    - name: Set up mise for the local mbx install
-      if: inputs.backend == 'local'
+    - name: Set up mise for the mbx install
       uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
       with:
         install: false
@@ -23,29 +19,22 @@ runs:
       uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
       with:
         path: ${{ runner.os == 'macOS' && '~/Library/Caches/mbx' || '~/.cache/mbx' }}
-    - name: Install mbx for local caching
-      if: inputs.backend == 'local'
+    - name: Install and configure mbx
       shell: bash
+      env:
+        MBX_BACKEND: ${{ inputs.backend }}
       run:
         | # zizmor: ignore[github-env] mise where returns the trusted tool install directory
         mise install mr-boxington
         mise reshim -f
-        echo "$(mise where mr-boxington)" >> "$GITHUB_PATH"
-        echo "MBX_REMOTE_URL=" >> "$GITHUB_ENV"
-        if [[ "$RUNNER_OS" == Linux ]]; then
-          echo "MBX_CACHE_LINKS=1" >> "$GITHUB_ENV"
-        fi
-    - name: Restore the fork PR cache mirror
-      if: inputs.mirror-github-cache == 'true' && inputs.backend == 'local' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-      uses: jdx/mr-boxington-action@adc5c234c02592f7edd008bf81d5bc0e9584dc03 # v1.2.0
-      with:
-        backend: github
-        cache-generation: v2
-    - if: inputs.backend != 'local'
-      uses: jdx/mr-boxington-action@adc5c234c02592f7edd008bf81d5bc0e9584dc03 # v1.2.0
-      with:
-        cache-generation: v2
-        backend: ${{ inputs.backend }}
-        server-url: https://cache.mise.jdx.dev
-        namespace: jdx/fnox
-        oidc-audience: https://cache.mise.jdx.dev
+        mise where mr-boxington >> "$GITHUB_PATH"
+        {
+          if [[ "$MBX_BACKEND" == server ]]; then
+            echo "MBX_REMOTE_URL=https://cache.mise.jdx.dev"
+            echo "MBX_REMOTE_NAMESPACE=jdx/fnox"
+            echo "MBX_REMOTE_OIDC_AUDIENCE=https://cache.mise.jdx.dev"
+          fi
+          if [[ "$RUNNER_OS" == Linux ]]; then
+            echo "MBX_CACHE_LINKS=1"
+          fi
+        } >> "$GITHUB_ENV"

--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -25,9 +25,9 @@ jobs:
       matrix:
         include:
           - os: macos-latest
-            runner: namespace-profile-endev-macos-arm64
+            runner: namespace-profile-endev-macos-arm64;overrides.cache-tag=cache
           - os: ubuntu-latest
-            runner: namespace-profile-endev-linux-amd64
+            runner: namespace-profile-endev-linux-amd64;overrides.cache-tag=cache
     runs-on: ${{ !inputs.trusted && matrix.os || matrix.runner }}
     timeout-minutes: 10
     steps:
@@ -73,16 +73,16 @@ jobs:
       matrix:
         include:
           - os: macos-latest
-            runner: namespace-profile-endev-macos-arm64
+            runner: namespace-profile-endev-macos-arm64;overrides.cache-tag=cache
             tranche: 0
           - os: macos-latest
-            runner: namespace-profile-endev-macos-arm64
+            runner: namespace-profile-endev-macos-arm64;overrides.cache-tag=cache
             tranche: 1
           - os: ubuntu-latest
-            runner: namespace-profile-endev-linux-amd64
+            runner: namespace-profile-endev-linux-amd64;overrides.cache-tag=cache
             tranche: 0
           - os: ubuntu-latest
-            runner: namespace-profile-endev-linux-amd64
+            runner: namespace-profile-endev-linux-amd64;overrides.cache-tag=cache
             tranche: 1
     runs-on: ${{ !inputs.trusted && matrix.os || matrix.runner }}
     timeout-minutes: 20
@@ -258,9 +258,9 @@ jobs:
       matrix:
         include:
           - os: macos-latest
-            runner: namespace-profile-endev-macos-arm64
+            runner: namespace-profile-endev-macos-arm64;overrides.cache-tag=cache
           - os: ubuntu-latest
-            runner: namespace-profile-endev-linux-amd64
+            runner: namespace-profile-endev-linux-amd64;overrides.cache-tag=cache
     runs-on: ${{ !inputs.trusted && matrix.os || matrix.runner }}
     timeout-minutes: 20
     steps:
@@ -336,7 +336,7 @@ jobs:
         run: cargo clippy --workspace --all-targets -- -D warnings
 
   msrv:
-    runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64;overrides.cache-tag=cache' }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -46,7 +46,6 @@ jobs:
       - uses: ./.github/actions/mbx
         with:
           backend: ${{ inputs.trusted && 'local' || 'github' }}
-          mirror-github-cache: "true"
       - name: Install system dependencies (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
         run: |
@@ -247,7 +246,6 @@ jobs:
       - uses: ./.github/actions/mbx
         with:
           backend: github
-          mirror-github-cache: "true"
       - name: Check Windows build
         run: cargo check --workspace
 

--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -246,7 +246,7 @@ jobs:
           fetch_from_github: false
       - uses: ./.github/actions/mbx
         with:
-          backend: ${{ inputs.trusted && 'local' || 'github' }}
+          backend: github
           mirror-github-cache: "true"
       - name: Check Windows build
         run: cargo check --workspace

--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -31,11 +31,6 @@ jobs:
     runs-on: ${{ !inputs.trusted && matrix.os || matrix.runner }}
     timeout-minutes: 10
     steps:
-      - name: Assert OIDC is unavailable to untrusted CI
-        if: ${{ !inputs.trusted }}
-        run: |
-          test -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}"
-          test -z "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}"
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
@@ -45,7 +40,7 @@ jobs:
           cache: false
       - uses: ./.github/actions/mbx
         with:
-          backend: ${{ inputs.trusted && 'local' || 'github' }}
+          backend: ${{ inputs.trusted && 'local' || 'server' }}
       - name: Install system dependencies (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
         run: |
@@ -245,7 +240,7 @@ jobs:
           fetch_from_github: false
       - uses: ./.github/actions/mbx
         with:
-          backend: github
+          backend: server
       - name: Check Windows build
         run: cargo check --workspace
 
@@ -271,7 +266,7 @@ jobs:
           cache: false
       - uses: ./.github/actions/mbx
         with:
-          backend: ${{ inputs.trusted && 'local' || 'github' }}
+          backend: ${{ inputs.trusted && 'local' || 'server' }}
       - name: Install system dependencies (Ubuntu)
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
@@ -346,7 +341,7 @@ jobs:
           cache: false
       - uses: ./.github/actions/mbx
         with:
-          backend: ${{ inputs.trusted && 'local' || 'github' }}
+          backend: ${{ inputs.trusted && 'local' || 'server' }}
       - name: Install system dependencies
         run: |
           if [ -f /etc/apt/apt-mirrors.txt ]; then

--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -45,7 +45,7 @@ jobs:
           cache: false
       - uses: ./.github/actions/mbx
         with:
-          backend: ${{ inputs.trusted && 'server' || 'github' }}
+          backend: ${{ inputs.trusted && 'local' || 'github' }}
           mirror-github-cache: "true"
       - name: Install system dependencies (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
@@ -246,7 +246,7 @@ jobs:
           fetch_from_github: false
       - uses: ./.github/actions/mbx
         with:
-          backend: ${{ inputs.trusted && 'server' || 'github' }}
+          backend: ${{ inputs.trusted && 'local' || 'github' }}
           mirror-github-cache: "true"
       - name: Check Windows build
         run: cargo check --workspace
@@ -273,7 +273,7 @@ jobs:
           cache: false
       - uses: ./.github/actions/mbx
         with:
-          backend: ${{ inputs.trusted && 'server' || 'github' }}
+          backend: ${{ inputs.trusted && 'local' || 'github' }}
       - name: Install system dependencies (Ubuntu)
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
@@ -348,7 +348,7 @@ jobs:
           cache: false
       - uses: ./.github/actions/mbx
         with:
-          backend: ${{ inputs.trusted && 'server' || 'github' }}
+          backend: ${{ inputs.trusted && 'local' || 'github' }}
       - name: Install system dependencies
         run: |
           if [ -f /etc/apt/apt-mirrors.txt ]; then

--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -40,7 +40,7 @@ jobs:
           cache: false
       - uses: ./.github/actions/mbx
         with:
-          backend: ${{ inputs.trusted && 'local' || 'server' }}
+          backend: ${{ inputs.trusted && 'local' || 'github' }}
       - name: Install system dependencies (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
         run: |
@@ -266,7 +266,7 @@ jobs:
           cache: false
       - uses: ./.github/actions/mbx
         with:
-          backend: ${{ inputs.trusted && 'local' || 'server' }}
+          backend: ${{ inputs.trusted && 'local' || 'github' }}
       - name: Install system dependencies (Ubuntu)
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
@@ -341,7 +341,7 @@ jobs:
           cache: false
       - uses: ./.github/actions/mbx
         with:
-          backend: ${{ inputs.trusted && 'local' || 'server' }}
+          backend: ${{ inputs.trusted && 'local' || 'github' }}
       - name: Install system dependencies
         run: |
           if [ -f /etc/apt/apt-mirrors.txt ]; then

--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -40,7 +40,7 @@ jobs:
           cache: false
       - uses: ./.github/actions/mbx
         with:
-          backend: ${{ inputs.trusted && 'local' || 'github' }}
+          backend: ${{ inputs.trusted && 'local' || 'server' }}
       - name: Install system dependencies (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
         run: |
@@ -266,7 +266,7 @@ jobs:
           cache: false
       - uses: ./.github/actions/mbx
         with:
-          backend: ${{ inputs.trusted && 'local' || 'github' }}
+          backend: ${{ inputs.trusted && 'local' || 'server' }}
       - name: Install system dependencies (Ubuntu)
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
@@ -341,7 +341,7 @@ jobs:
           cache: false
       - uses: ./.github/actions/mbx
         with:
-          backend: ${{ inputs.trusted && 'local' || 'github' }}
+          backend: ${{ inputs.trusted && 'local' || 'server' }}
       - name: Install system dependencies
         run: |
           if [ -f /etc/apt/apt-mirrors.txt ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
     if: ${{ github.actor == 'jdx' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'jdx')) }}
     permissions:
       contents: read
-      id-token: write
     uses: ./.github/workflows/ci-impl.yml
     with:
       trusted: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
     if: ${{ github.actor == 'jdx' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'jdx')) }}
     permissions:
       contents: read
+      id-token: write
     uses: ./.github/workflows/ci-impl.yml
     with:
       trusted: true
@@ -24,6 +25,7 @@ jobs:
     if: ${{ github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx')) }}
     permissions:
       contents: read
+      id-token: write
     uses: ./.github/workflows/ci-impl.yml
     with:
       trusted: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,6 @@ jobs:
     if: ${{ github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx')) }}
     permissions:
       contents: read
-      id-token: write
     uses: ./.github/workflows/ci-impl.yml
     with:
       trusted: false

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -113,6 +113,8 @@ jobs:
 
       # Compile inside the pinned job container. mise's cache remains disabled:
       # mbx uses the appliance-local content-addressed store mounted above.
+      - name: Remove the stale runner mise binary
+        run: rm -f /github/home/.local/share/mise/bin/mise
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
           cache: false

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -54,6 +54,8 @@ jobs:
 
       # Compile inside the pinned job container. mise's cache remains disabled:
       # mbx uses the appliance-local content-addressed store mounted above.
+      - name: Remove the stale runner mise binary
+        run: rm -f /github/home/.local/share/mise/bin/mise
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
           cache: false

--- a/mise.lock
+++ b/mise.lock
@@ -123,46 +123,38 @@ backend = "github:endevco/aube"
 
 [tools.aube."platforms.linux-arm64"]
 checksum = "sha256:167bf3749f1eac646b0096e6113e29ac154294c8fe5f8ff5ce3a440b3f73dfe2"
-url = "https://github.com/jdx/aube/releases/download/v2.0.1/aube-v2.0.1-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/aube/releases/assets/525718579"
-provenance = "github-attestations"
+url = "https://github.com/aubepkg/aube/releases/download/v2.0.1/aube-v2.0.1-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/525718579"
 
 [tools.aube."platforms.linux-arm64-musl"]
 checksum = "sha256:720514470b025d3aee2eae25a5cbc354c22875e24f546146ad9a73ac95dc5443"
-url = "https://github.com/jdx/aube/releases/download/v2.0.1/aube-v2.0.1-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/aube/releases/assets/525682625"
-provenance = "github-attestations"
+url = "https://github.com/aubepkg/aube/releases/download/v2.0.1/aube-v2.0.1-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/525682625"
 
 [tools.aube."platforms.linux-x64"]
 checksum = "sha256:320696667be8d64c04f559d730cea84a953e0d553d7fdb2d1dd6830e5266623d"
-url = "https://github.com/jdx/aube/releases/download/v2.0.1/aube-v2.0.1-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/aube/releases/assets/525694267"
-provenance = "github-attestations"
-provenance_verified = true
+url = "https://github.com/aubepkg/aube/releases/download/v2.0.1/aube-v2.0.1-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/525694267"
 
 [tools.aube."platforms.linux-x64-musl"]
 checksum = "sha256:530ecdf99cc52fa6e603f7a69ed82ba82667a51143d9a8294cfe2755295db82e"
-url = "https://github.com/jdx/aube/releases/download/v2.0.1/aube-v2.0.1-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/aube/releases/assets/525697493"
-provenance = "github-attestations"
+url = "https://github.com/aubepkg/aube/releases/download/v2.0.1/aube-v2.0.1-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/525697493"
 
 [tools.aube."platforms.macos-arm64"]
 checksum = "sha256:61eb75b7fc5e83c7a09666673c7a6310169cb49e44db3d923a27207e7b461371"
-url = "https://github.com/jdx/aube/releases/download/v2.0.1/aube-v2.0.1-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/aube/releases/assets/525744752"
-provenance = "github-attestations"
+url = "https://github.com/aubepkg/aube/releases/download/v2.0.1/aube-v2.0.1-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/525744752"
 
 [tools.aube."platforms.macos-x64"]
 checksum = "sha256:d578debdd912047fae06f71ef1c2faeb7d34d378305a473a5468a79bf0928603"
-url = "https://github.com/jdx/aube/releases/download/v2.0.1/libaube-x86_64-apple-darwin.dylib"
-url_api = "https://api.github.com/repos/jdx/aube/releases/assets/525699067"
-provenance = "github-attestations"
+url = "https://github.com/aubepkg/aube/releases/download/v2.0.1/libaube-x86_64-apple-darwin.dylib"
+url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/525699067"
 
 [tools.aube."platforms.windows-x64"]
 checksum = "sha256:5383e428dc7ab02853bb37ceec1a5d72894b6455471c8d02ce9d84ed82430ab6"
-url = "https://github.com/jdx/aube/releases/download/v2.0.1/aube-v2.0.1-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/aube/releases/assets/525700617"
-provenance = "github-attestations"
+url = "https://github.com/aubepkg/aube/releases/download/v2.0.1/aube-v2.0.1-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/525700617"
 
 [[tools.bitwarden]]
 version = "2026.8.0"

--- a/mise.lock
+++ b/mise.lock
@@ -516,44 +516,44 @@ url = "https://github.com/jdx/hk/releases/download/v1.56.1/hk-x86_64-pc-windows-
 url_api = "https://api.github.com/repos/jdx/hk/releases/assets/525632118"
 
 [[tools.mr-boxington]]
-version = "1.4.1"
+version = "1.5.0"
 backend = "github:jdx/mr-boxington"
 
 [tools.mr-boxington."platforms.linux-arm64"]
-checksum = "sha256:7ca1deeb64ad22bd5ddc9f45c749c78d3eb32608562c363727de3f0c595df0f0"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.1/mbx-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540505948"
+checksum = "sha256:3782db0c07a47334d01d426896e9f6af2480b311def2d0f0a3ab1327b57247b2"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.5.0/mbx-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/541628921"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-arm64-musl"]
-checksum = "sha256:3113dfce87c8ee6d3485f7eb99f87ae130b9b9f2c73224720edf2cef7279b5d1"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.1/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540505946"
+checksum = "sha256:95e189127cf22f6586b0e7337893896dfb18b2018c7226e60844955e237234b8"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.5.0/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/541628922"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-x64"]
-checksum = "sha256:5bc7434333a941f664bbe73ae229edf6111c9fb5f771f959ca411a11358baf8a"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.1/mbx-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540505965"
+checksum = "sha256:83a5f4cb83a62cf028256c482a9f579911cc0793f79f1c2c06b83291c5c723d0"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.5.0/mbx-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/541629161"
 provenance = "github-attestations"
 provenance_verified = true
 
 [tools.mr-boxington."platforms.linux-x64-musl"]
-checksum = "sha256:7277ceabefae1b444b39200c2cb944018a87da628ff77aa94291a8cc338546e6"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.1/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540505964"
+checksum = "sha256:8ffd1ffc4b53ce10ed1d0271e24d9d264e843b7be3f0a076389c4475a16e4132"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.5.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/541629170"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.macos-arm64"]
-checksum = "sha256:57f1cac111d9972ad675aa80cbedf4c86b3423dfb11091383175db0f6341847e"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.1/mbx-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540505945"
+checksum = "sha256:d88ebea6ebf1a5b8b4a51a440a91baeb1214fdea49a6013dfe9b56e4bd4a6c84"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.5.0/mbx-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/541628925"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.windows-x64"]
-checksum = "sha256:346cb0405129bbca4f7a24fc916b036cfd806d497d52ba47fc8bb0a0531b4382"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.1/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540505963"
+checksum = "sha256:970f974d3ee56b089c34a4b03fdb80dfcc0b260b3de950009a77240c9187a4c7"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.5.0/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/541629146"
 provenance = "github-attestations"
 
 [[tools.node]]

--- a/mise.toml
+++ b/mise.toml
@@ -4,7 +4,7 @@ min_version = "2026.8.16"
 _.path = ["target/debug", "test/bats/bin"]
 
 [tools]
-mr-boxington = "1.4.1"
+mr-boxington = "1.5.0"
 usage = "6.6.1"
 # Pinned rather than "latest" because tak is the measuring instrument: an
 # upgrade that changes how it samples would land in the series as a step change


### PR DESCRIPTION
Route mbx storage according to the runner provider.

- Namespace jobs keep the local backend on the shared Namespace cache volume.
- GitHub-hosted Linux, macOS, and Windows jobs use the Azure-backed cache at `https://cache.jdx.dev` with GitHub OIDC.
- GitHub-hosted fork jobs use public, namespace-scoped read access when GitHub withholds OIDC; they receive no cache credential and cannot write.
- Authenticated pull requests and tags are also read-only; only protected `main` pushes may publish.
- No mbx cache tarballs are mirrored through GitHub Actions Cache.

Validation: actionlint; git diff --check

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how CI caches build artifacts and authenticates to remote cache (OIDC vs public read), which can affect fork PRs and build times if misconfigured; no application runtime code changes.
> 
> **Overview**
> **Reworks CI mbx setup** so trusted Namespace jobs use a **local** store on a mounted cache volume, while GitHub-hosted jobs use the **remote server** at `https://cache.jdx.dev` (with OIDC when available, otherwise a read-only notice). The composite action no longer uses `jdx/mr-boxington-action` or the fork **GitHub Actions cache mirror** (`mirror-github-cache`); it installs **mr-boxington 1.5.0** via mise and sets `MBX_*` env vars directly.
> 
> **Workflow wiring:** `ci-impl` flips trusted vs untrusted backends (`local` / `server`), drops the untrusted OIDC assertion step, adds `overrides.cache-tag=cache` on Namespace runner labels, and pins Windows to `server`. Perf workflows delete a stale container `mise` binary before `mise-action`.
> 
> **Lockfile:** `aube` download URLs move from `jdx/aube` to `aubepkg/aube` (provenance fields trimmed on those entries).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 682e62dfcfbf7bfc098e0516800110c02762f395. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->