### PR TITLE
chore: release v1.35.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [1.35.1](https://github.com/jdx/fnox/compare/v1.35.0..v1.35.1) - 2026-09-05
+
+### 📚 Documentation
+
+- complete social and search metadata by [@jdx](https://github.com/jdx) in [#806](https://github.com/jdx/fnox/pull/806)
+- generate page-specific social preview images by [@jdx](https://github.com/jdx) in [#811](https://github.com/jdx/fnox/pull/811)
+
+### 🛡️ Security
+
+- add open graph share image by [@jdx](https://github.com/jdx) in [#803](https://github.com/jdx/fnox/pull/803)
+- configure Entire search by [@jdx](https://github.com/jdx) in [#805](https://github.com/jdx/fnox/pull/805)
+
+### 🔍 Other Changes
+
+- **(release)** publish a signed packslip with each release by [@jdx](https://github.com/jdx) in [#807](https://github.com/jdx/fnox/pull/807)
+- **(release)** bump packslip action to v1.0.0 by [@jdx](https://github.com/jdx) in [#810](https://github.com/jdx/fnox/pull/810)
+- enforce conventional commits by [@jdx](https://github.com/jdx) in [#809](https://github.com/jdx/fnox/pull/809)
+
+### 📦️ Dependency Updates
+
+- bump mr-boxington to 1.8.1 by [@jdx](https://github.com/jdx) in [#808](https://github.com/jdx/fnox/pull/808)
+
 ## [1.35.0](https://github.com/jdx/fnox/compare/v1.34.1..v1.35.0) - 2026-09-03
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2332,7 +2332,7 @@ dependencies = [
 
 [[package]]
 name = "fnox"
-version = "1.35.0"
+version = "1.35.1"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -2382,7 +2382,7 @@ dependencies = [
 
 [[package]]
 name = "fnox-core"
-version = "1.35.0"
+version = "1.35.1"
 dependencies = [
  "aes-gcm 0.11.1",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "crates/fnox-core"]
 resolver = "3"
 
 [workspace.package]
-version = "1.35.0"
+version = "1.35.1"
 edition = "2024"
 authors = ["@jdx"]
 license = "MIT"

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -3043,7 +3043,7 @@
     "sources": {},
     "files": []
   },
-  "version": "1.35.0",
+  "version": "1.35.1",
   "usage": "",
   "complete": {
     "key": {

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -4,7 +4,7 @@
 
 **Usage:** `fnox [FLAGS] <SUBCOMMAND>`
 
-**Version:** 1.35.0
+**Version:** 1.35.1
 
 - **Usage:** `fnox [FLAGS] <SUBCOMMAND>`
 

--- a/fnox.usage.kdl
+++ b/fnox.usage.kdl
@@ -1,7 +1,7 @@
 min_usage_version "1.3"
 name fnox
 bin fnox
-version "1.35.0"
+version "1.35.1"
 about "A flexible secret management tool by @jdx"
 unknown_flags error
 subcommand_required #true


### PR DESCRIPTION
### 📚 Documentation

- complete social and search metadata by [@jdx](https://github.com/jdx) in [#806](https://github.com/jdx/fnox/pull/806)
- generate page-specific social preview images by [@jdx](https://github.com/jdx) in [#811](https://github.com/jdx/fnox/pull/811)

### 🛡️ Security

- add open graph share image by [@jdx](https://github.com/jdx) in [#803](https://github.com/jdx/fnox/pull/803)
- configure Entire search by [@jdx](https://github.com/jdx) in [#805](https://github.com/jdx/fnox/pull/805)

### 🔍 Other Changes

- **(release)** publish a signed packslip with each release by [@jdx](https://github.com/jdx) in [#807](https://github.com/jdx/fnox/pull/807)
- **(release)** bump packslip action to v1.0.0 by [@jdx](https://github.com/jdx) in [#810](https://github.com/jdx/fnox/pull/810)
- enforce conventional commits by [@jdx](https://github.com/jdx) in [#809](https://github.com/jdx/fnox/pull/809)

### 📦️ Dependency Updates

- bump mr-boxington to 1.8.1 by [@jdx](https://github.com/jdx) in [#808](https://github.com/jdx/fnox/pull/808)