### PR TITLE
docs: complete social and search metadata

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -33,12 +33,16 @@ if (!versionMatch) {
   console.warn("Unable to find package version in Cargo.toml");
 }
 const latestVersion = versionMatch?.[1] ?? "0.0.0";
+const siteUrl = "https://fnox.jdx.dev";
+const siteDescription =
+  "Manage development secrets with encrypted files or cloud providers, fast local sync, shell integration, profiles, and hardware-backed keys.";
 
 export default defineConfig({
   title: "fnox",
-  description: "Fort Knox for your secrets",
+  description: siteDescription,
   base: "/",
   appearance: "force-dark",
+  sitemap: { hostname: siteUrl },
 
   themeConfig: {
     logo: "/logo.svg",
@@ -247,12 +251,55 @@ export default defineConfig({
       },
     ],
     ["link", { rel: "manifest", href: "/site.webmanifest" }],
+    ["meta", { name: "theme-color", content: "#0d0221" }],
     ["meta", { property: "og:site_name", content: "fnox" }],
     ["meta", { property: "og:type", content: "website" }],
+    ["meta", { property: "og:locale", content: "en_US" }],
     ["meta", { property: "og:image", content: "https://fnox.jdx.dev/og.png" }],
     ["meta", { property: "og:image:width", content: "1200" }],
     ["meta", { property: "og:image:height", content: "630" }],
+    [
+      "meta",
+      {
+        property: "og:image:alt",
+        content: "fnox — secure secrets for development workflows",
+      },
+    ],
     ["meta", { name: "twitter:card", content: "summary_large_image" }],
+    ["meta", { name: "twitter:site", content: "@jdxcode" }],
     ["meta", { name: "twitter:image", content: "https://fnox.jdx.dev/og.png" }],
+    [
+      "meta",
+      {
+        name: "twitter:image:alt",
+        content: "fnox — secure secrets for development workflows",
+      },
+    ],
   ],
+  transformHead({ pageData, title, description }) {
+    const url = `${siteUrl}/${pageData.relativePath}`
+      .replace(/index\.md$/, "")
+      .replace(/\.md$/, ".html");
+
+    return [
+      ["link", { rel: "canonical", href: url }],
+      ["meta", { property: "og:url", content: url }],
+      ["meta", { property: "og:title", content: title }],
+      ["meta", { property: "og:description", content: description }],
+      ["meta", { name: "twitter:title", content: title }],
+      ["meta", { name: "twitter:description", content: description }],
+      [
+        "script",
+        { type: "application/ld+json" },
+        JSON.stringify({
+          "@context": "https://schema.org",
+          "@type": "WebPage",
+          name: title,
+          description,
+          url,
+          isPartOf: { "@type": "WebSite", name: "fnox", url: siteUrl },
+        }),
+      ],
+    ];
+  },
 });

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,6 @@
 ---
 layout: home
+title: Secure secrets for development workflows
 
 hero:
   name: fnox


### PR DESCRIPTION
## Summary

- add per-page canonical, Open Graph, Twitter, and structured data metadata
- publish locale, image alt text, theme color, and existing icon assets
- improve homepage title and description signals

## Testing

- bun run docs:build
- verified generated homepage and nested-page metadata

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only VitePress config and homepage front matter; no runtime or security-sensitive code paths.
> 
> **Overview**
> Expands the VitePress docs site **SEO and social sharing** setup by centralizing `siteUrl` and a richer global `siteDescription`, enabling a **sitemap** with the production hostname.
> 
> Adds static head tags for **theme color**, **Open Graph locale**, **Twitter site handle**, and **image alt text** for OG/Twitter cards. Introduces **`transformHead`** so every page gets a **canonical URL**, per-page **OG/Twitter title and description**, and **JSON-LD `WebPage`** structured data tied to the fnox site.
> 
> The homepage front matter gains an explicit **`title`** (“Secure secrets for development workflows”) to improve the default page title signal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a669f31064bdd7c4a901c82e3e3e6d351b1abf2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a clear title to the documentation home page.
  * Added sitemap generation and canonical page links to improve navigation and indexing.
  * Enhanced page metadata for social sharing, including Open Graph and Twitter previews.
  * Added structured page information for better search engine interpretation.
  * Added theme and locale metadata for improved presentation across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->