### PR TITLE
ci(release): publish a signed packslip with each release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,6 +166,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      # The packslip is signed with this job's OIDC identity and its
+      # artifacts are attested; neither is possible without these.
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -198,6 +202,35 @@ jobs:
             release-assets/*
         env:
           INPUTS_VERSION: ${{ inputs.version }}
+      # A consumer that has this file can generate completions, a man page,
+      # and documentation with its own copy of usage, so nothing of fnox's
+      # runs on the machine it is installed on.
+      - name: Publish the CLI specification
+        env:
+          INPUTS_VERSION: ${{ inputs.version }}
+        run: |
+          if [[ -n "${INPUTS_VERSION}" ]]; then
+            TAG_NAME="v${INPUTS_VERSION}"
+          else
+            TAG_NAME="${GITHUB_REF_NAME}"
+          fi
+          mkdir -p bin
+          tar -xzf release-assets/fnox-x86_64-unknown-linux-gnu.tar.gz -C bin
+          bin/fnox usage > fnox.usage.kdl
+          gh release upload "$TAG_NAME" fnox.usage.kdl --clobber
+      # The packslip is this release's signed inventory: every archive's
+      # digest, the executable inside it, the shared objects it needs from
+      # the host, and the workflow identity that signed for all of it. It
+      # lets an installer check a download against jdx/fnox's identity
+      # rather than against a key this project would have to hold. See
+      # https://packslip.dev.
+      - uses: jdx/packslip@433c0c0f033e64c22f12433471768c255ef2bd93 # v0.3.0
+        with:
+          tag: ${{ inputs.version != '' && format('v{0}', inputs.version) || github.ref_name }}
+          artifacts: release-assets/fnox-*.tar.gz release-assets/fnox-*.tar.xz release-assets/fnox-*.zip
+          bin: fnox
+          resources: cli-spec/usage=asset:fnox.usage.kdl
+          token: ${{ secrets.FNOX_GH_TOKEN }}
 
   enhance-release:
     needs: [create-release]


### PR DESCRIPTION
Part of adopting [packslip](https://packslip.dev) across the jdx.dev CLIs.

Each release now publishes `packslip.sigstore.json` beside the archives — one signed document listing:

- every archive's sha256 and sha512
- the executable inside each one (`fnox`, `fnox.exe` on Windows)
- the shared objects each build needs from the host, read out of the binaries: `libudev.so.1` on the gnu builds, `vcruntime140.dll` on Windows, nothing on musl and macOS
- a build-provenance attestation per file, linked by digest
- the source repo, tag, and commit

signed keylessly with this workflow's OIDC identity, so an installer verifies a download against the identity `github.com/jdx/fnox` instead of a signing key this project would have to hold and rotate.

`fnox usage` is run against the freshly built Linux binary and uploaded as `fnox.usage.kdl`, listed as a `cli-spec` resource. A consumer generates completions, a man page, and docs from it with its own copy of usage — nothing of fnox's runs on the installing machine.

### Changes

- `create-release` gains `id-token: write` and `attestations: write` (needed to sign and to attest).
- A step that extracts the linux-gnu tarball, runs `fnox usage`, and uploads the spec.
- The `jdx/packslip` action, pinned to v0.3.0, after the release is created and while it is still a draft.

### Verification

Rehearsed locally against the real v1.35.0 assets — all eight artifacts resolved their platform, format, and `bin`, host requirements were read out of the binaries, and the `cli-spec` resource landed with the right asset URL. `zizmor --offline` reports no findings on the changed workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release pipeline and grants OIDC/attestation permissions on `create-release`, which affects how downloads are verified but does not alter application runtime behavior.
> 
> **Overview**
> Each GitHub release now ships a **keyless signed packslip** (`packslip.sigstore.json`) and a **`fnox.usage.kdl` CLI spec**, both added in the `create-release` job after the draft release and binaries are uploaded.
> 
> The **`create-release`** job gains **`id-token: write`** and **`attestations: write`** so the workflow can sign the packslip and attach build-provenance attestations via OIDC (no long-lived signing key in the repo).
> 
> A new step unpacks the **linux-gnu** tarball, runs **`fnox usage`**, and uploads **`fnox.usage.kdl`** so installers can generate completions/docs without executing fnox locally.
> 
> The pinned **`jdx/packslip@v0.3.0`** step inventories all release archives (digests, bundled binary, host shared-library requirements), registers the usage file as a **`cli-spec/usage`** resource, and publishes the signed manifest to the same tag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9bb01b53033bd9f2e0daef38634d9ce02a814a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Release downloads now include a CLI usage specification file (`fnox.usage.kdl`).
  - Release archives and related assets now include a signed inventory for improved verification and provenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->