### PR TITLE
ci: enforce conventional commits

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,0 +1,27 @@
+name: conventional-commits
+
+on: # zizmor: ignore[dangerous-triggers] reads only the PR title and executes no untrusted code
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check pull request title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          pattern='^(chore|ci|docs|feat|fix|perf|refactor|revert|security|style|test)(\([[:alnum:]][[:alnum:]./_-]*\))?!?: [[:lower:]](.*[[:graph:]])?$'
+          if [[ ! "$PR_TITLE" =~ $pattern ]]; then
+            echo "::error title=Invalid pull request title::The title does not match the required format."
+            printf 'Received title: %q\n' "$PR_TITLE"
+            echo "Use: <type>[optional scope][optional !]: <description starting lowercase>"
+            exit 1
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,13 +16,20 @@ and do not post externally without user authorization.
 
 ## Conventional Commits
 
-Format: `<type>(<scope>): <description>` (lowercase, imperative mood)
+PR titles must use `<type>[optional scope][optional !]: <description>`. Intermediate commit
+subjects should use the same format. Start the description with a lowercase
+character and use imperative mood.
 
-**Types:** `feat`, `fix`, `refactor`, `docs`, `style`, `perf`, `test`, `chore`, `security`
+**Types:** `feat`, `fix`, `refactor`, `docs`, `style`, `perf`, `test`, `chore`, `ci`, `revert`, `security`
 
 **Scopes:** command names (`get`, `set`, `exec`, `list`, `provider`), provider names (`age`, `1password`, `bitwarden`, `bitwarden-sm`, `aws-kms`, `aws-sm`, `aws-ps`, `keychain`, `keepass`, `infisical`, `passwordstate`, `pass`, `proton-pass`), subsystems (`config`, `encryption`, `env`, `deps`)
 
 Examples: `fix(aws-sm): handle pagination for large secret lists`, `feat(exec): add --no-inherit flag`
+
+CI validates the pull request title and re-runs when it is edited. Intermediate
+commit subjects are not checked because pull requests are squash-merged. CI
+mechanically checks the allowed type, syntax, and lowercase-leading description;
+imperative mood remains a review rule.
 
 ## Minimum Supported Rust Version (MSRV)
 
@@ -137,7 +144,7 @@ All providers follow the same pattern: config in `fnox.toml` stores references/n
 
 ## GitHub Interactions
 
-Pull request titles must follow the same Conventional Commit format as commits: `<type>(<scope>): <description>` in lowercase imperative mood. Do not prefix PR titles with agent/tool labels such as `[codex]` or `[claude]`.
+Pull request titles must follow the same Conventional Commit format as commits: `<type>[optional scope][optional !]: <description>` in lowercase imperative mood. Do not prefix PR titles with agent/tool labels such as `[codex]` or `[claude]`.
 
 When AI contributes GitHub content—including a pull request description, review, pull request
 comment, or discussion post—append this disclosure:


### PR DESCRIPTION
## Summary

- document or connect the repository’s Conventional Commits policy for pull request titles
- validate the title on creation and every edit with the repository’s allowed types
- use a permissionless `pull_request_target` workflow with no checkout, so pull request code cannot bypass the check
- intentionally ignore intermediate commit subjects because pull requests are squash-merged using their titles

## Testing

- `actionlint .github/workflows/conventional-commits.yml`
- exercised valid, breaking-change, invalid-type, uppercase-description, and trailing-space title cases locally

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated pull request title validation using the Conventional Commits format.
  * Validation runs when pull requests are opened, edited, reopened, or updated.
  * Titles that do not match the accepted format receive an error and fail validation until corrected.

* **Documentation**
  * Updated contribution guidance with optional scopes and support for `ci` and `revert` types.
  * Documented the pull request title validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a read-only CI gate on PR metadata and doc updates; no application code or secrets handling changes.
> 
> **Overview**
> Adds **automated PR title validation** via a new GitHub Actions workflow that runs on `pull_request_target` (open, edit, reopen, sync) with **empty permissions** and **no checkout**, so only the event title is checked and fork PR code cannot influence the job.
> 
> Titles must match the repo’s Conventional Commits pattern: allowed types (including **`ci`** and **`revert`**), optional scope, optional **`!`** for breaking changes, and a **lowercase-leading** description. Invalid titles fail the check with a formatted error message; concurrency cancels in-flight runs per PR.
> 
> **AGENTS.md** is updated to document the same title format, the expanded type list, that **CI enforces syntax mechanically** while imperative mood stays a human review rule, and that **individual commit messages are not validated** because merges are squash-based on the PR title.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdcf06afabdf1543fa1bd6e4d2b6d8a319dbf79d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->