### PR TITLE
chore(release): bump packslip action to v1.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,7 +224,7 @@ jobs:
       # lets an installer check a download against jdx/fnox's identity
       # rather than against a key this project would have to hold. See
       # https://packslip.dev.
-      - uses: jdx/packslip@0121abf6972fe6ca13633233402439a715f4cc0e # v1.0.0
+      - uses: jdx/packslip@a6eddff2d884891faa2efbec374b48e7053df2c4 # v1.0.1
         with:
           tag: ${{ inputs.version != '' && format('v{0}', inputs.version) || github.ref_name }}
           artifacts: release-assets/fnox-*.tar.gz release-assets/fnox-*.tar.xz release-assets/fnox-*.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,7 +224,7 @@ jobs:
       # lets an installer check a download against jdx/fnox's identity
       # rather than against a key this project would have to hold. See
       # https://packslip.dev.
-      - uses: jdx/packslip@433c0c0f033e64c22f12433471768c255ef2bd93 # v0.3.0
+      - uses: jdx/packslip@0121abf6972fe6ca13633233402439a715f4cc0e # v1.0.0
         with:
           tag: ${{ inputs.version != '' && format('v{0}', inputs.version) || github.ref_name }}
           artifacts: release-assets/fnox-*.tar.gz release-assets/fnox-*.tar.xz release-assets/fnox-*.zip


### PR DESCRIPTION
## Summary
- Bumps the pinned `jdx/packslip` action from v0.3.0 to v1.0.0.
- v1.0.0 declares the manifest format stable, fixes the `packslip.dev/releases/v1` predicate URL that previously 404d, and requires every artifact to declare a format (already satisfied here — every artifact is an archive, which infers its format from the file name).

## Test plan
- [ ] Next tagged release runs the packslip step successfully and uploads `packslip.sigstore.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-only CI dependency bump with no application or runtime code changes; main risk is a failed packslip step on the next tagged release if the new action behaves differently.
> 
> **Overview**
> Updates the **create-release** workflow to pin **`jdx/packslip`** from **v0.3.0** to **v1.0.1** (new commit SHA). Inputs (`tag`, `artifacts`, `bin`, `resources`, `token`) are unchanged; only the action version used to produce and upload the signed release inventory (`packslip.sigstore.json`) moves to the v1 line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0de05bba53a854488d44cd1deb7771b39324fea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the release packaging workflow to use a newer version of its release tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

*AI-assisted — Tool: Claude Code; model: anthropic/claude-sonnet-5; version: unavailable.*
