### PR TITLE
chore(ci): bump packslip to v1.1.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,7 +224,7 @@ jobs:
       # lets an installer check a download against jdx/fnox's identity
       # rather than against a key this project would have to hold. See
       # https://packslip.dev.
-      - uses: jdx/packslip@a6eddff2d884891faa2efbec374b48e7053df2c4 # v1.0.1
+      - uses: jdx/packslip@a0d434ad57571c62dbd0ab5095b4eff607a71fd3 # v1.1.1
         with:
           tag: ${{ inputs.version != '' && format('v{0}', inputs.version) || github.ref_name }}
           artifacts: release-assets/fnox-*.tar.gz release-assets/fnox-*.tar.xz release-assets/fnox-*.zip


### PR DESCRIPTION
Update the release workflow to use packslip v1.1.1 at its immutable commit SHA. This release pins the nested provenance action, so repositories enforcing full-length action SHAs can load the composite action.

Validation: `git diff --check`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI dependency pin in the release provenance step; no application or runtime code changes.
> 
> **Overview**
> Updates the **create-release** job in `.github/workflows/release.yml` to pin **`jdx/packslip`** from **v1.0.1** (`a6eddff…`) to **v1.1.1** (`a0d434a…`). Inputs (`tag`, `artifacts`, `bin`, `resources`, `token`) are unchanged; only the action reference moves.
> 
> The bump is meant to pick up **v1.1.1** behavior (including pinning nested provenance so workflows that require full-length action SHAs can load the composite action).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de10ec409eea76dbaae46d7d80ae37cf7041af65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release automation tooling to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->