### PR TITLE
chore(release): publish native completions in packslip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,6 +205,10 @@ jobs:
       # A consumer that has this file can generate completions, a man page,
       # and documentation with its own copy of usage, so nothing of fnox's
       # runs on the machine it is installed on.
+      - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+        with:
+          install: false
+          cache: false
       - name: Install completion syntax checkers
         run: |
           sudo apt-get update

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,6 +205,11 @@ jobs:
       # A consumer that has this file can generate completions, a man page,
       # and documentation with its own copy of usage, so nothing of fnox's
       # runs on the machine it is installed on.
+      - name: Install completion syntax checkers
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y zsh fish
+          mise install github:PowerShell/PowerShell@7.5.4
       - name: Publish the CLI specification and completions
         env:
           INPUTS_VERSION: ${{ inputs.version }}
@@ -224,6 +229,16 @@ jobs:
             bin/fnox __complete_word__ --shell "$shell" --line 'fnox ge' | grep -Fq -- 'get'
           done
           bash -n fnox.bash
+          zsh -n fnox.zsh
+          fish --no-execute fnox.fish
+          mise exec github:PowerShell/PowerShell@7.5.4 -- pwsh -NoProfile -Command - <<'POWERSHELL'
+          $ErrorActionPreference = 'Stop'
+          foreach ($script in Get-ChildItem -LiteralPath "." -Filter '*.powershell') {
+            $parseErrors = $null
+            [void][System.Management.Automation.Language.Parser]::ParseFile($script.FullName, [ref]$null, [ref]$parseErrors)
+            if ($parseErrors.Count) { $parseErrors | Write-Error; exit 1 }
+          }
+          POWERSHELL
           gh release upload "$TAG_NAME" fnox.usage.kdl fnox.bash fnox.zsh fnox.fish fnox.powershell --clobber
       # The packslip is this release's signed inventory: every archive's
       # digest, the executable inside it, the shared objects it needs from

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,7 +205,7 @@ jobs:
       # A consumer that has this file can generate completions, a man page,
       # and documentation with its own copy of usage, so nothing of fnox's
       # runs on the machine it is installed on.
-      - name: Publish the CLI specification
+      - name: Publish the CLI specification and completions
         env:
           INPUTS_VERSION: ${{ inputs.version }}
         run: |
@@ -217,7 +217,14 @@ jobs:
           mkdir -p bin
           tar -xzf release-assets/fnox-x86_64-unknown-linux-gnu.tar.gz -C bin
           bin/fnox usage > fnox.usage.kdl
-          gh release upload "$TAG_NAME" fnox.usage.kdl --clobber
+          for shell in bash zsh fish powershell; do
+            bin/fnox completion "$shell" > fnox.$shell
+            test -s fnox.$shell
+            grep -Fq '__complete_word__' fnox.$shell
+            bin/fnox __complete_word__ --shell "$shell" --line 'fnox ge' | grep -Fq -- 'get'
+          done
+          bash -n fnox.bash
+          gh release upload "$TAG_NAME" fnox.usage.kdl fnox.bash fnox.zsh fnox.fish fnox.powershell --clobber
       # The packslip is this release's signed inventory: every archive's
       # digest, the executable inside it, the shared objects it needs from
       # the host, and the workflow identity that signed for all of it. It
@@ -229,7 +236,12 @@ jobs:
           tag: ${{ inputs.version != '' && format('v{0}', inputs.version) || github.ref_name }}
           artifacts: release-assets/fnox-*.tar.gz release-assets/fnox-*.tar.xz release-assets/fnox-*.zip
           bin: fnox
-          resources: cli-spec/usage=asset:fnox.usage.kdl
+          resources: |
+            cli-spec/usage=asset:fnox.usage.kdl
+            completion/bash=asset:fnox.bash
+            completion/zsh=asset:fnox.zsh
+            completion/fish=asset:fnox.fish
+            completion/powershell=asset:fnox.powershell
           token: ${{ secrets.FNOX_GH_TOKEN }}
 
   enhance-release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,18 +202,20 @@ jobs:
             release-assets/*
         env:
           INPUTS_VERSION: ${{ inputs.version }}
-      # A consumer that has this file can generate completions, a man page,
-      # and documentation with its own copy of usage, so nothing of fnox's
-      # runs on the machine it is installed on.
-      - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
-        with:
-          install: false
-          cache: false
+      # The spec supports documentation generation without running the binary.
+      # Native completion scripts call the installed binary on each completion.
       - name: Install completion syntax checkers
+        timeout-minutes: 5
         run: |
-          sudo apt-get update
-          sudo apt-get install -y zsh fish
-          mise install github:PowerShell/PowerShell@7.5.4
+          if [[ -f /etc/apt/apt-mirrors.txt ]]; then
+            sudo sed -i 's|http://azure.archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' /etc/apt/apt-mirrors.txt
+          fi
+          sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=15 -o Acquire::https::Timeout=15 update
+          sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=15 -o Acquire::https::Timeout=15 install -y zsh fish
+          # Hosted runners include PowerShell; Namespace images have its signed apt repository.
+          if ! command -v pwsh >/dev/null 2>&1; then
+            sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=15 -o Acquire::https::Timeout=15 install -y powershell
+          fi
       - name: Publish the CLI specification and completions
         env:
           INPUTS_VERSION: ${{ inputs.version }}
@@ -235,7 +237,7 @@ jobs:
           bash -n fnox.bash
           zsh -n fnox.zsh
           fish --no-execute fnox.fish
-          mise exec github:PowerShell/PowerShell@7.5.4 -- pwsh -NoProfile -Command - <<'POWERSHELL'
+          cat > completion-syntax-check.ps1 <<'POWERSHELL'
           $ErrorActionPreference = 'Stop'
           foreach ($script in Get-ChildItem -LiteralPath "." -Filter '*.powershell') {
             $parseErrors = $null
@@ -243,6 +245,7 @@ jobs:
             if ($parseErrors.Count) { $parseErrors | Write-Error; exit 1 }
           }
           POWERSHELL
+          pwsh -NoProfile -NonInteractive -File completion-syntax-check.ps1
           gh release upload "$TAG_NAME" fnox.usage.kdl fnox.bash fnox.zsh fnox.fish fnox.powershell --clobber
       # The packslip is this release's signed inventory: every archive's
       # digest, the executable inside it, the shared objects it needs from


### PR DESCRIPTION
Publish native Bash, Zsh, Fish, and PowerShell scripts alongside fnox's usage specification and declare them as signed Packslip completion resources. Installers such as mise can register completions automatically from the release inventory. The scripts call fnox itself and need no separate usage executable.

Release generation checks each script for the native callback, exercises that callback for each shell, and validates Bash syntax. Local generation, callback checks, and Bash/Zsh syntax checks passed with fnox 1.35.1; workflow actionlint/ShellCheck and Prettier passed.

Companion installer support: https://github.com/jdx/mise/pull/12848. Registry adoption: https://github.com/jdx/mise/pull/12845.

*AI-assisted — Tool: Codex; model: OpenAI/GPT-6; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the release workflow and published assets; no runtime application code, with added CI gates that reduce bad completion scripts shipping.
> 
> **Overview**
> Release CI now **generates Bash, Zsh, Fish, and PowerShell completion scripts** from the Linux release binary (alongside the existing `fnox.usage.kdl`), **uploads them to the GitHub release**, and **registers them in the Packslip inventory** so installers (e.g. mise) can wire up shell completions from the signed release metadata.
> 
> The `create-release` job adds a step to install **zsh, fish, and PowerShell** on the runner, then validates each completion file (non-empty, includes the `__complete_word__` hook, and the `__complete_word__` callback returns `get` for `fnox ge`) before **syntax-checking** all four shells. Packslip `resources` grows from `cli-spec/usage` only to four `completion/*` asset mappings in addition to the usage spec.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89afdff1a29dcaca7a0d004b96c2cee329138864. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI releases include shell completions for Bash, Zsh, Fish, and PowerShell.
  * Completion files are published alongside the CLI usage specification for easier setup across supported shells.

* **Bug Fixes**
  * Release validation checks Bash, Zsh, Fish, and PowerShell completion files for syntax errors before publication, helping ensure downloadable shell integrations work as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->