### PR TITLE
chore(ci): isolate mise state in performance jobs

### DIFF
--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -107,8 +107,15 @@ jobs:
 
       # Compile inside the pinned job container. Restoring target/ could relabel
       # a binary built on another runner class as a jdx-perf-v1 measurement.
-      - name: Remove the stale runner mise binary
-        run: sudo rm -f /github/home/.local/share/mise/bin/mise
+      - name: Prepare writable mise directories
+        run: |
+          # The shared home can contain state owned by another runner user.
+          mise_root="$(mktemp -d "$RUNNER_TEMP/fnox-perf-mise.XXXXXX")"
+          {
+            echo "MISE_DATA_DIR=$mise_root/data"
+            echo "MISE_CACHE_DIR=$mise_root/cache"
+            echo "MISE_STATE_DIR=$mise_root/state"
+          } >> "$GITHUB_ENV"
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
           cache: false

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -51,8 +51,15 @@ jobs:
 
       # Compile inside the pinned job container. Restoring target/ could relabel
       # a binary built on another runner class as a jdx-perf-v1 measurement.
-      - name: Remove the stale runner mise binary
-        run: sudo rm -f /github/home/.local/share/mise/bin/mise
+      - name: Prepare writable mise directories
+        run: |
+          # The shared home can contain state owned by another runner user.
+          mise_root="$(mktemp -d "$RUNNER_TEMP/fnox-perf-mise.XXXXXX")"
+          {
+            echo "MISE_DATA_DIR=$mise_root/data"
+            echo "MISE_CACHE_DIR=$mise_root/cache"
+            echo "MISE_STATE_DIR=$mise_root/state"
+          } >> "$GITHUB_ENV"
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
           cache: false


### PR DESCRIPTION
The delayed performance check on #814 fails before building fnox because mise-action cannot write `/github/home/.local/share/mise/bin/mise`. Removing the old executable leaves its parent directory unwritable. [Failing run](https://github.com/jdx/fnox/actions/runs/33999025035).

Give both performance workflows fresh mise data, cache, and state directories beneath `RUNNER_TEMP`, shared with subsequent steps through `GITHUB_ENV`. The pinned runner image, Rust toolchain, and benchmark commands stay the same.

Validation: Actionlint and ShellCheck pass for both workflows; the extracted setup step successfully creates and exports three writable directories. The self-hosted performance run needs to validate the full setup after merge because its trusted workflow comes from the default branch.

*AI-assisted — Tool: Codex; model: OpenAI/GPT-6; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow setup change; no application code, auth, or data paths affected.
> 
> **Overview**
> Fixes self-hosted performance jobs failing when **mise-action** cannot write under the shared runner home (e.g. after removing a stale `mise` binary left directories owned by another user).
> 
> In **`perf.yml`** and **`perf-pr.yml`**, the `sudo rm` mise cleanup step is replaced with **Prepare writable mise directories**: a temp tree under `RUNNER_TEMP` and `MISE_DATA_DIR`, `MISE_CACHE_DIR`, and `MISE_STATE_DIR` appended to `GITHUB_ENV` so later steps (including **jdx/mise-action**) use isolated, writable state. Benchmark pinning, Rust toolchain, and measurement commands are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5a2c6ab8d689cef0b90d048fbe0f2f3cdbaf8f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved performance test workflow reliability by isolating temporary tool configuration and state for each run.
  * Removed cleanup of a shared runner-level tool installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->