### PR TITLE
fix(env): preserve dependencies across daemon cache hits

### DIFF
--- a/crates/fnox-core/src/secret_resolver.rs
+++ b/crates/fnox-core/src/secret_resolver.rs
@@ -834,11 +834,13 @@ pub async fn resolve_secrets_batch_with_pre_resolved(
 
     // Build dependency graph and compute resolution levels using Kahn's algorithm.
     let mut deps_for_secret: HashMap<String, Vec<String>> = HashMap::new();
+    let mut provider_env_dependencies = HashSet::new();
     for (key, (provider_name, _)) in &secret_provider {
         let deps = providers
             .get(provider_name)
             .map(|pc| pc.env_dependencies())
             .unwrap_or(&[]);
+        provider_env_dependencies.extend(deps.iter().copied());
         deps_for_secret.insert(
             key.clone(),
             deps.iter().map(|dep| dep.to_string()).collect(),
@@ -866,7 +868,9 @@ pub async fn resolve_secrets_batch_with_pre_resolved(
     let mut temp_results: HashMap<String, Option<String>> =
         pre_resolved.clone().into_iter().collect();
     for (key, value) in pre_resolved {
-        if let Some(value) = value {
+        if provider_env_dependencies.contains(key.as_str())
+            && let Some(value) = value
+        {
             env::set_var(key, value);
         }
     }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1128,7 +1128,8 @@ async fn resolve_with_cache(
     }
 
     if !misses.is_empty() {
-        let resolved = resolve_secrets_batch(config, profile, &misses).await?;
+        let resolved =
+            resolve_secrets_batch_with_pre_resolved(config, profile, &misses, &results).await?;
         let mut state = state.lock().await;
         for (key, value) in resolved {
             if let Some(cache_key) = miss_keys.remove(&key) {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1097,6 +1097,7 @@ fn apply_request_settings(
     crate::env::set_non_interactive(non_interactive);
 }
 
+/// Resolve cache misses while making cached dependency values available to providers.
 async fn resolve_with_cache(
     config: &Config,
     profile: &[String],

--- a/test/daemon.bats
+++ b/test/daemon.bats
@@ -107,12 +107,16 @@ EOF
 	assert_equal "$(wc -l <"$PASS_PPID_FILE" | tr -d ' ')" "1"
 }
 
-@test "daemon cache hits satisfy provider dependencies for cache misses" {
+@test "daemon cache hits satisfy provider dependencies without exposing unrelated secrets" {
 	mkdir -p "$TEST_TEMP_DIR/bin"
 	cat >"$TEST_TEMP_DIR/bin/op" <<'EOF'
 #!/bin/sh
 if [ -z "${OP_SERVICE_ACCOUNT_TOKEN:-}" ]; then
 	echo "not signed in" >&2
+	exit 1
+fi
+if [ -n "${HIDDEN:-}" ]; then
+	echo "unrelated hidden secret leaked" >&2
 	exit 1
 fi
 printf 'remote-value\n'
@@ -136,17 +140,20 @@ vault = "test"
 [secrets]
 OP_SERVICE_ACCOUNT_TOKEN = { provider = "bootstrap", value = "token-from-provider" }
 REMOTE = { provider = "op", value = "item/password", daemon_cache = false }
+HIDDEN = { default = "${REMOTE}", env = false }
 EOF
 
-	# The first resolution caches the provider credential but not REMOTE.
-	run env -u OP_SERVICE_ACCOUNT_TOKEN "$FNOX_BIN" hook-env -s bash
+	# The first resolution caches the provider credential and hidden interpolation,
+	# but not REMOTE.
+	run env -u OP_SERVICE_ACCOUNT_TOKEN "$FNOX_BIN" exec -- sh -c 'printf "%s\n" "$REMOTE"'
 	assert_success
-	assert_output --partial "export REMOTE=remote-value"
+	assert_output "remote-value"
 
-	# The cached credential must be available while resolving the REMOTE cache miss.
-	run env -u OP_SERVICE_ACCOUNT_TOKEN "$FNOX_BIN" hook-env -s bash
+	# Only the cached credential, not the unrelated hidden secret, may be exposed
+	# while resolving the REMOTE cache miss.
+	run env -u OP_SERVICE_ACCOUNT_TOKEN "$FNOX_BIN" exec -- sh -c 'printf "%s\n" "$REMOTE"'
 	assert_success
-	assert_output --partial "export REMOTE=remote-value"
+	assert_output "remote-value"
 }
 
 @test "daemon clear removes cached entries" {

--- a/test/daemon.bats
+++ b/test/daemon.bats
@@ -107,6 +107,48 @@ EOF
 	assert_equal "$(wc -l <"$PASS_PPID_FILE" | tr -d ' ')" "1"
 }
 
+@test "daemon cache hits satisfy provider dependencies for cache misses" {
+	mkdir -p "$TEST_TEMP_DIR/bin"
+	cat >"$TEST_TEMP_DIR/bin/op" <<'EOF'
+#!/bin/sh
+if [ -z "${OP_SERVICE_ACCOUNT_TOKEN:-}" ]; then
+	echo "not signed in" >&2
+	exit 1
+fi
+printf 'remote-value\n'
+EOF
+	chmod +x "$TEST_TEMP_DIR/bin/op"
+	export PATH="$TEST_TEMP_DIR/bin:$PATH"
+
+	cat >fnox.toml <<'EOF'
+root = true
+
+[daemon]
+enabled = true
+
+[providers.bootstrap]
+type = "plain"
+
+[providers.op]
+type = "1password"
+vault = "test"
+
+[secrets]
+OP_SERVICE_ACCOUNT_TOKEN = { provider = "bootstrap", value = "token-from-provider" }
+REMOTE = { provider = "op", value = "item/password", daemon_cache = false }
+EOF
+
+	# The first resolution caches the provider credential but not REMOTE.
+	run env -u OP_SERVICE_ACCOUNT_TOKEN "$FNOX_BIN" hook-env -s bash
+	assert_success
+	assert_output --partial "export REMOTE=remote-value"
+
+	# The cached credential must be available while resolving the REMOTE cache miss.
+	run env -u OP_SERVICE_ACCOUNT_TOKEN "$FNOX_BIN" hook-env -s bash
+	assert_success
+	assert_output --partial "export REMOTE=remote-value"
+}
+
 @test "daemon clear removes cached entries" {
 	daemon_config
 


### PR DESCRIPTION
## Summary

- make cached secret values available while resolving daemon cache misses
- preserve provider dependency ordering when a credential is already cached
- add a regression test covering a cached 1Password service-account token with an uncached dependent secret

## Testing

- `mise run build`
- `mise run test:bats -- test/daemon.bats`
- `mise run test:cargo`
- `mise run lint`

Found while investigating Discussion #837. The reporter’s follow-up confirms their non-daemon case is separate and is still under investigation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches secret resolution and process environment during daemon cache misses; behavior change is scoped to provider env deps but affects auth-sensitive paths like 1Password.
> 
> **Overview**
> Fixes daemon secret resolution when some values are **cache hits** and others are **cache misses** (e.g. a cached 1Password service-account token while `REMOTE` has `daemon_cache = false`).
> 
> The daemon now resolves misses via `resolve_secrets_batch_with_pre_resolved`, passing already-cached entries as `pre_resolved` so provider dependency ordering still works on partial cache hits. In batch resolution, only **provider-declared env dependencies** from `pre_resolved` are written with `env::set_var`, so unrelated cached secrets (e.g. `env = false` interpolations) are not leaked into the environment while resolving misses.
> 
> Adds a bats regression that runs `exec` twice with `OP_SERVICE_ACCOUNT_TOKEN` unset: the mock `op` CLI must see the cached token but must not see an unrelated hidden secret.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d303323e1711a77e608045b19a564d45e8f9579. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved secret resolution when combining cached and uncached values.
  - Cached provider credentials are now available when resolving secrets that require additional providers.
  - Limited environment exposure during resolution to only the values required by those providers.
  - Repeated environment setup commands now succeed consistently when required provider credentials are cached.

- **Tests**
  - Added coverage for resolving uncached secrets with cached provider credentials while keeping unrelated secrets hidden.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->