### PR TITLE
fix(env): retry incomplete shell secret loads

### DIFF
--- a/src/commands/hook_env.rs
+++ b/src/commands/hook_env.rs
@@ -91,6 +91,7 @@ impl HookEnvCommand {
                     LoadedSecrets {
                         secrets: HashMap::new(),
                         temp_files: HashMap::new(),
+                        needs_retry: true,
                     }
                 }
             }
@@ -98,6 +99,7 @@ impl HookEnvCommand {
             LoadedSecrets {
                 secrets: HashMap::new(),
                 temp_files: HashMap::new(),
+                needs_retry: false,
             }
         };
 
@@ -114,12 +116,14 @@ impl HookEnvCommand {
 
         // Create new session
         let current_dir = std::env::current_dir().ok();
-        let session = HookEnvSession::new(
+        let mut session = HookEnvSession::new(
             current_dir,
             config_path,
             loaded_data.secrets,
             loaded_data.temp_files,
         )?;
+
+        session.needs_retry = loaded_data.needs_retry;
 
         // Export session state for next invocation
         let session_encoded = session.encode()?;
@@ -221,6 +225,8 @@ struct LoadedSecrets {
     secrets: HashMap<String, String>,
     /// Temp file paths for file-based secrets
     temp_files: HashMap<String, String>,
+    /// At least one shell secret could not be loaded.
+    needs_retry: bool,
 }
 
 /// Load all secrets from a fnox.toml config file
@@ -271,9 +277,12 @@ async fn load_secrets_from_config(cli: &Cli) -> Result<LoadedSecrets> {
         .get_secrets(profile_name)
         .map_err(|e| anyhow::anyhow!("Failed to get secrets: {}", e))?;
 
-    // Use batch resolution for better performance
-    let resolved = match crate::daemon::resolve_batch(
-        cli,
+    // A daemon may have cached missing values from the failed attempt.
+    // Retry in the foreground so recovery does not depend on clearing its cache.
+    let mut context = crate::daemon::ResolveContext::from_cli(cli);
+    context.no_daemon |= PREV_SESSION.needs_retry;
+    let resolved = match crate::daemon::resolve_batch_with_context(
+        &context,
         &config,
         profile_name,
         &profile_secrets,
@@ -289,6 +298,7 @@ async fn load_secrets_from_config(cli: &Cli) -> Result<LoadedSecrets> {
             return Ok(LoadedSecrets {
                 secrets: HashMap::new(),
                 temp_files: HashMap::new(),
+                needs_retry: true,
             });
         }
     };
@@ -296,6 +306,7 @@ async fn load_secrets_from_config(cli: &Cli) -> Result<LoadedSecrets> {
     // Process secrets: create temp files for file-based secrets
     let mut loaded_secrets = HashMap::new();
     let mut temp_files = HashMap::new();
+    let mut needs_retry = false;
 
     for (key, value_opt) in resolved {
         // Skip secrets unless their env mode allows shell injection —
@@ -318,6 +329,7 @@ async fn load_secrets_from_config(cli: &Cli) -> Result<LoadedSecrets> {
                             temp_files.insert(key, file_path);
                         }
                         Err(e) => {
+                            needs_retry = true;
                             tracing::warn!(
                                 "failed to create temp file for secret '{}': {}",
                                 key,
@@ -332,12 +344,15 @@ async fn load_secrets_from_config(cli: &Cli) -> Result<LoadedSecrets> {
             } else {
                 loaded_secrets.insert(key, value);
             }
+        } else {
+            needs_retry = true;
         }
     }
 
     Ok(LoadedSecrets {
         secrets: loaded_secrets,
         temp_files,
+        needs_retry,
     })
 }
 

--- a/src/commands/hook_env.rs
+++ b/src/commands/hook_env.rs
@@ -277,12 +277,9 @@ async fn load_secrets_from_config(cli: &Cli) -> Result<LoadedSecrets> {
         .get_secrets(profile_name)
         .map_err(|e| anyhow::anyhow!("Failed to get secrets: {}", e))?;
 
-    // A daemon may have cached missing values from the failed attempt.
-    // Retry in the foreground so recovery does not depend on clearing its cache.
-    let mut context = crate::daemon::ResolveContext::from_cli(cli);
-    context.no_daemon |= PREV_SESSION.needs_retry;
-    let resolved = match crate::daemon::resolve_batch_with_context(
-        &context,
+    // Use batch resolution for better performance.
+    let resolved = match crate::daemon::resolve_batch(
+        cli,
         &config,
         profile_name,
         &profile_secrets,

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1301,8 +1301,9 @@ fn socket_path(cli: &Cli) -> Result<PathBuf> {
 
 /// Wire-protocol version tag included in the socket path hash.
 /// Incrementing this ensures new clients don't connect to stale daemons
-/// running an incompatible wire format.
-const WIRE_VERSION: u8 = 3;
+/// running an incompatible wire format or resolution behavior.
+/// Version 4 requires missing values to remain cache misses, including after upgrades.
+const WIRE_VERSION: u8 = 4;
 
 fn socket_path_for_context(ctx: &ResolveContext) -> Result<PathBuf> {
     let mut hasher = blake3::Hasher::new();

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -201,6 +201,7 @@ struct CacheKey(String);
 
 #[derive(Default)]
 struct DaemonState {
+    // Missing values are not cache hits: a provider may recover between requests.
     cache: HashMap<CacheKey, Option<String>>,
 }
 
@@ -1031,12 +1032,12 @@ async fn foreground_resolution_if_needed(
     let mut keys = Vec::new();
     for (key, secret) in secrets {
         if secret_is_cacheable(&providers, default_provider, secret, req)
-            && let Some(value) =
+            && let Some(Some(value)) =
                 state
                     .cache
                     .get(&cache_key(&fingerprint, profile, key, secret, req))
         {
-            cached_values.insert(key.clone(), value.clone());
+            cached_values.insert(key.clone(), Some(value.clone()));
         } else {
             keys.push(key.clone());
         }
@@ -1072,10 +1073,10 @@ async fn store_resolved_values(
     let mut state = state.lock().await;
     for (key, secret) in secrets {
         if secret_is_cacheable(&providers, default_provider, secret, req)
-            && let Some(value) = values.swap_remove(key)
+            && let Some(Some(value)) = values.swap_remove(key)
         {
             let cache_key = cache_key(&fingerprint, profile, key, secret, req);
-            state.cache.insert(cache_key, value);
+            state.cache.insert(cache_key, Some(value));
         }
     }
     Ok(())
@@ -1118,8 +1119,8 @@ async fn resolve_with_cache(
             let cacheable = secret_is_cacheable(&providers, default_provider, secret, req);
             if cacheable {
                 let cache_key = cache_key(&fingerprint, profile, key, secret, req);
-                if let Some(value) = state.cache.get(&cache_key) {
-                    results.insert(key.clone(), value.clone());
+                if let Some(Some(value)) = state.cache.get(&cache_key) {
+                    results.insert(key.clone(), Some(value.clone()));
                     continue;
                 }
                 miss_keys.insert(key.clone(), cache_key);
@@ -1133,7 +1134,9 @@ async fn resolve_with_cache(
             resolve_secrets_batch_with_pre_resolved(config, profile, &misses, &results).await?;
         let mut state = state.lock().await;
         for (key, value) in resolved {
-            if let Some(cache_key) = miss_keys.remove(&key) {
+            if let Some(cache_key) = miss_keys.remove(&key)
+                && value.is_some()
+            {
                 state.cache.insert(cache_key, value.clone());
             }
             results.insert(key, value);

--- a/src/hook_env.rs
+++ b/src/hook_env.rs
@@ -40,6 +40,9 @@ pub struct HookEnvSession {
     /// Temp directory used to create file-based secrets
     #[serde(default)]
     pub hook_temp_dir: Option<PathBuf>,
+    /// Retry incomplete loads even when config and environment are unchanged.
+    #[serde(default)]
+    pub needs_retry: bool,
 }
 
 /// Global previous session state, loaded from __FNOX_SESSION env var
@@ -115,6 +118,7 @@ impl HookEnvSession {
             config_files_hash,
             temp_files,
             hook_temp_dir,
+            needs_retry: false,
         })
     }
 
@@ -154,6 +158,11 @@ pub fn hash_secret_value_with_session(session: &HookEnvSession, key: &str, value
 /// Check if we should exit early (optimization)
 /// Returns true if nothing changed and we can skip work
 pub fn should_exit_early() -> bool {
+    if PREV_SESSION.needs_retry {
+        tracing::debug!("previous secret load was incomplete, must run hook-env");
+        return false;
+    }
+
     // Check if fnox.toml was modified
     if has_config_been_modified() {
         tracing::debug!("fnox.toml modified, must run hook-env");

--- a/test/hook_env_retry.bats
+++ b/test/hook_env_retry.bats
@@ -1,0 +1,99 @@
+#!/usr/bin/env bats
+
+setup() {
+	load 'test_helper/common_setup'
+	_common_setup
+	export FNOX_DAEMON=off FNOX_PROMPT_AUTH=false
+	export XDG_RUNTIME_DIR="$TEST_TEMP_DIR/runtime"
+	mkdir -p "$XDG_RUNTIME_DIR"
+	unset OP_SERVICE_ACCOUNT_TOKEN FNOX_OP_SERVICE_ACCOUNT_TOKEN PROXMOX_URL
+	mkdir -p bin
+	export PATH="$PWD/bin:$PATH"
+	cat >bin/pass <<'MOCK'
+#!/bin/sh
+printf 'test-token\n'
+MOCK
+	cat >bin/op <<'MOCK'
+#!/bin/sh
+printf 'called\n' >> op-calls
+[ "$OP_SERVICE_ACCOUNT_TOKEN" = test-token ] || exit 2
+[ -f provider-ready ] || exit 1
+printf 'mock-url\n'
+MOCK
+	chmod +x bin/pass bin/op
+	cat >fnox.toml <<'CONFIG'
+root = true
+[providers.pass]
+type = "password-store"
+[providers.op]
+type = "1password"
+vault = "test"
+[secrets]
+OP_SERVICE_ACCOUNT_TOKEN = { provider = "pass", value = "token" }
+PROXMOX_URL = { provider = "op", value = "proxmox/url" }
+CONFIG
+}
+
+teardown() {
+	"$FNOX_BIN" daemon stop >/dev/null 2>&1 || true
+	_common_teardown
+}
+
+@test "hook retries a partial load and resumes early exit after recovery" {
+	eval "$("$FNOX_BIN" hook-env -s bash)"
+	[ "$OP_SERVICE_ACCOUNT_TOKEN" = test-token ]
+	[ -z "${PROXMOX_URL:-}" ]
+	[ -n "$__FNOX_SESSION" ]
+
+	# Provider readiness changes without touching config or FNOX_* variables.
+	touch provider-ready
+	eval "$("$FNOX_BIN" hook-env -s bash)"
+	[ "$PROXMOX_URL" = mock-url ]
+	local calls
+	calls=$(wc -l <op-calls)
+	run "$FNOX_BIN" hook-env -s bash
+	assert_success
+	assert_output ""
+	[ "$(wc -l <op-calls)" = "$calls" ]
+}
+
+@test "hook retries after a fail-fast resolution error" {
+	cat >>fnox.toml <<'CONFIG'
+[secrets.PROXMOX_URL]
+provider = "op"
+value = "proxmox/url"
+if_missing = "error"
+CONFIG
+	# Replace the inline entry to avoid defining the same key twice.
+	sed -i.bak '/^PROXMOX_URL = /d' fnox.toml
+	eval "$("$FNOX_BIN" hook-env -s bash)"
+	[ -z "${PROXMOX_URL:-}" ]
+	[ -n "$__FNOX_SESSION" ]
+	touch provider-ready
+	eval "$("$FNOX_BIN" hook-env -s bash)"
+	[ "$PROXMOX_URL" = mock-url ]
+}
+
+@test "hook does not retry an unresolved secret excluded from the shell" {
+	sed -i.bak 's/value = "proxmox\/url" }/value = "proxmox\/url", env = false }/' fnox.toml
+	eval "$("$FNOX_BIN" hook-env -s bash)"
+	run "$FNOX_BIN" hook-env -s bash
+	assert_success
+	assert_output ""
+}
+
+@test "hook retry bypasses a daemon-cached missing value" {
+	export FNOX_DAEMON=auto
+	cat >>fnox.toml <<'CONFIG'
+[daemon]
+enabled = true
+CONFIG
+	eval "$("$FNOX_BIN" hook-env -s bash)"
+	[ -z "${PROXMOX_URL:-}" ]
+	run "$FNOX_BIN" daemon status
+	assert_success
+	assert_output --partial "cached_entries: 2"
+	touch provider-ready
+	eval "$("$FNOX_BIN" hook-env -s bash)"
+	[ "$PROXMOX_URL" = mock-url ]
+}

--- a/test/hook_env_retry.bats
+++ b/test/hook_env_retry.bats
@@ -1,5 +1,6 @@
 #!/usr/bin/env bats
 
+# Create isolated mock providers and configuration for hook recovery tests.
 setup() {
 	load 'test_helper/common_setup'
 	_common_setup
@@ -34,6 +35,7 @@ PROXMOX_URL = { provider = "op", value = "proxmox/url" }
 CONFIG
 }
 
+# Stop the test daemon before removing its temporary directory.
 teardown() {
 	"$FNOX_BIN" daemon stop >/dev/null 2>&1 || true
 	_common_teardown
@@ -82,7 +84,10 @@ CONFIG
 	assert_output ""
 }
 
-@test "hook retry bypasses a daemon-cached missing value" {
+# Exercise recovery and a subsequent reload against the same daemon cache.
+daemon_retry() {
+	# Keep credential-dependent cache fingerprints identical across attempts.
+	export OP_SERVICE_ACCOUNT_TOKEN=test-token
 	export FNOX_DAEMON=auto
 	cat >>fnox.toml <<'CONFIG'
 [daemon]
@@ -92,8 +97,27 @@ CONFIG
 	[ -z "${PROXMOX_URL:-}" ]
 	run "$FNOX_BIN" daemon status
 	assert_success
-	assert_output --partial "cached_entries: 2"
+	assert_output --partial "cached_entries: 1"
 	touch provider-ready
 	eval "$("$FNOX_BIN" hook-env -s bash)"
 	[ "$PROXMOX_URL" = mock-url ]
+	run "$FNOX_BIN" daemon status
+	assert_success
+	assert_output --partial "cached_entries: 2"
+
+	# Force a later reload with the same daemon cache key. The recovered
+	# value must remain available even if the provider goes offline again.
+	rm provider-ready
+	unset __FNOX_SESSION
+	eval "$("$FNOX_BIN" hook-env -s bash)"
+	[ "$PROXMOX_URL" = mock-url ]
+}
+
+@test "hook retry fills the daemon cache and survives a later reload" {
+	daemon_retry
+}
+
+@test "non-interactive hook retry fills the daemon cache and survives a later reload" {
+	export FNOX_NON_INTERACTIVE=true
+	daemon_retry
 }

--- a/test/shell-integration.bats
+++ b/test/shell-integration.bats
@@ -280,6 +280,8 @@ teardown() {
 @test "fnox hook-env with same directory and config exits early" {
 	cd "$TEST_TEMP_DIR"
 	cat >fnox.toml <<-EOF
+		root = true
+
 		[providers.plain]
 		type = "plain"
 
@@ -308,6 +310,8 @@ teardown() {
 	mkdir -p "$project_dir/inner"
 	cd "$project_dir"
 	cat >fnox.toml <<-EOF
+		root = true
+
 		[providers.plain]
 		type = "plain"
 


### PR DESCRIPTION
When a shell hook loads a credential but fails to retrieve dependent secrets, it records the partial result as an unchanged session. Subsequent prompts skip resolution even after the provider becomes available; direct `fnox exec` can succeed while the shell stays incomplete.

Record whether the shell load is incomplete and retry on the next hook invocation. Keep session hashes and temporary-file ownership intact, and resume the normal early exit after a successful load. The daemon no longer caches missing values, so retries resolve and cache recovered secrets normally instead of leaving stale failures behind. The daemon socket compatibility tag also changes so upgraded clients cannot reuse an old daemon that still caches misses. Unresolved secrets excluded from shell injection do not trigger retries.

This retries missing shell values (including optional ones) on subsequent hooks until resolved; persistently unavailable providers can therefore add prompt latency and repeat warnings. It also covers whole-load errors and temporary-file creation failures.

Related: https://github.com/jdx/fnox/discussions/837#discussioncomment-18375088. This fixes the reproduced recovery bug, not the still-unidentified reason `op` initially exits unsuccessfully during the reporter's shell startup.

Validation: debug build; 59 Rust tests; 60 passing Bats tests across `hook_env_retry`, `daemon`, `shell-integration`, and `env_mode` (one existing age test skipped); Cargo formatting, Clippy with warnings denied, shfmt, and ShellCheck. Regression coverage includes partial failure, fail-fast failure, daemon recovery and subsequent reload with the provider offline (both foreground and non-interactive paths), restored early exit after success, and excluded secrets. The two existing early-exit fixtures now use `root = true` so repository credentials cannot make those loads incomplete.

*AI-assisted — Tool: Codex; model: OpenAI/GPT-6; version: unavailable.*



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Secret loading now retries automatically after temporary configuration, provider, or resolution failures.
  * Incomplete secret loads no longer prevent subsequent hook-environment runs from recovering.
  * Unresolved secrets are excluded from the shell environment instead of being treated as valid empty results.
  * Cached missing values are no longer reused, allowing secrets to recover when providers become available again.
* **Tests**
  * Added coverage for interactive and non-interactive retry and recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->