### PR TITLE
chore(deps): ignore aws sdk renovate updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>jdx/renovate-config"]
+  "extends": ["local>jdx/renovate-config"],
+  "ignoreDeps": [
+    "aws-config",
+    "aws-sdk-kms",
+    "aws-sdk-secretsmanager",
+    "aws-sdk-ssm",
+    "aws-sdk-sts"
+  ]
 }


### PR DESCRIPTION
## Summary

- exclude the five AWS Rust dependencies grouped in #796 from Renovate
- keep their upgrades intentional and coordinated

## Validation

- parsed `.github/renovate.json` with `jq`
- verified `ignoreDeps` against the current Renovate JSON schema
- ran `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Renovate-only configuration; no runtime or dependency version changes in this PR.
> 
> **Overview**
> Adds an **`ignoreDeps`** list to `.github/renovate.json` so Renovate stops opening PRs for five Rust AWS crates: `aws-config`, `aws-sdk-kms`, `aws-sdk-secretsmanager`, `aws-sdk-ssm`, and `aws-sdk-sts`.
> 
> Those dependencies stay on the shared Renovate config extend; only automated bumps for this set are turned off so upgrades can be handled together instead of as separate Renovate PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04f8dd1ff95d85859156a94626e6f3665d929e3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency update settings to exclude selected AWS-related packages from automated update proposals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->