### PR TITLE
fix(config): clarify ci matrix job names

### DIFF
--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -21,6 +21,7 @@ env:
 
 jobs:
   build:
+    name: build (${{ matrix.os }})
     strategy:
       fail-fast: false
       matrix:
@@ -62,6 +63,7 @@ jobs:
           path: target/debug/fnox
 
   ci-bats:
+    name: ci-bats (${{ matrix.os }}, tranche ${{ matrix.tranche }})
     needs: build
     permissions:
       contents: read
@@ -250,6 +252,7 @@ jobs:
         run: cargo check --workspace
 
   ci-other:
+    name: ci-other (${{ matrix.os }})
     needs: build
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

- give matrix CI jobs explicit names containing only the active OS and tranche
- keep trusted maintainer jobs on Namespace runners
- keep untrusted and forked PR jobs on GitHub-hosted runners

This prevents the inactive Namespace runner value from appearing in GitHub’s default matrix job name for untrusted runs.

## Audit

The same potentially confusing default matrix naming appears in `jdx/hk`; the other audited CLI workflows mostly use scalar runner expressions or matrices without an alternate runner field. Those repositories are unchanged by this PR.

## Validation

- `mise x actionlint@1.7.12 -- actionlint .github/workflows/ci-impl.yml`
- `git diff --check`

_AI-generated by OpenAI Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only job display names with no change to runner selection, build steps, or secrets handling.
> 
> **Overview**
> Adds explicit **`name`** fields to the **`build`**, **`ci-bats`**, and **`ci-other`** matrix jobs in `ci-impl.yml` so GitHub shows labels like `build (ubuntu-latest)` and `ci-bats (macos-latest, tranche 0)` instead of auto-generated names that include the unused **`matrix.runner`** Namespace profile on untrusted/fork PRs.
> 
> **`runs-on`** and trusted vs GitHub-hosted runner selection are unchanged; this is display-only clarity for the Actions UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c17398c384170c935f7b403e527ac13b8b6d88a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI workflow job labels to clearly show the operating system and test tranche for each matrix run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->